### PR TITLE
isis-packet: dispatch classic Admin Group sub-TLV 3; fix admin_group()

### DIFF
--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -20,12 +20,12 @@ pub mod cap_disp;
 
 pub mod neigh;
 pub use neigh::{
-    AdjSidFlags, IsisSubAdminGrp, IsisSubAsla, IsisSubAvailableBw, IsisSubBandwidthMetric,
-    IsisSubDelayVariation, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr, IsisSubIpv6IfAddr,
-    IsisSubIpv6NeighAddr, IsisSubLanAdjSid, IsisSubLinkLoss, IsisSubMinMaxLinkDelay,
-    IsisSubResidualBw, IsisSubSrv6EndXSid, IsisSubSrv6LanEndXSid, IsisSubTeMetric,
-    IsisSubUniLinkDelay, IsisSubUtilizedBw, IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
-    IsisTlvMtIsReach,
+    AdjSidFlags, IsisSubAdminGroup, IsisSubAdminGrp, IsisSubAsla, IsisSubAvailableBw,
+    IsisSubBandwidthMetric, IsisSubDelayVariation, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr,
+    IsisSubIpv6IfAddr, IsisSubIpv6NeighAddr, IsisSubLanAdjSid, IsisSubLinkLoss,
+    IsisSubMinMaxLinkDelay, IsisSubResidualBw, IsisSubSrv6EndXSid, IsisSubSrv6LanEndXSid,
+    IsisSubTeMetric, IsisSubUniLinkDelay, IsisSubUtilizedBw, IsisTlvExtIsReach,
+    IsisTlvExtIsReachEntry, IsisTlvMtIsReach,
 };
 pub mod neigh_code;
 pub use neigh_code::IsisNeighCode;

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -151,11 +151,22 @@ impl IsisTlvExtIsReachEntry {
         })
     }
 
-    /// Administrative group / link-color bitmask (sub-TLV 3), if present.
-    /// IS-IS carries it as a single 32-bit mask; the first word is returned.
+    /// Administrative group / link-color bitmask (sub-TLV 3,
+    /// RFC 5305 §3.1) — the classic fixed 32-bit mask. Maps to BGP-LS
+    /// Administrative Group (TLV 1088).
     pub fn admin_group(&self) -> Option<u32> {
         self.subs.iter().find_map(|s| match s {
-            IsisSubTlv::AdminGrp(a) => a.groups.first().copied(),
+            IsisSubTlv::AdminGroup(a) => Some(a.group),
+            _ => None,
+        })
+    }
+
+    /// Extended Administrative Groups (sub-TLV 14, RFC 7308), if
+    /// present — a variable-length list of 32-bit words. Maps to
+    /// BGP-LS Extended Administrative Group (TLV 1173), not TLV 1088.
+    pub fn ext_admin_group(&self) -> Option<&[u32]> {
+        self.subs.iter().find_map(|s| match s {
+            IsisSubTlv::AdminGrp(a) => Some(a.groups.as_slice()),
             _ => None,
         })
     }
@@ -219,6 +230,8 @@ pub enum IsisSubTlv {
     Ipv6IfAddr(IsisSubIpv6IfAddr),
     #[nom(Selector = "IsisNeighCode::Ipv6NeighAddr")]
     Ipv6NeighAddr(IsisSubIpv6NeighAddr),
+    #[nom(Selector = "IsisNeighCode::AdminGroup")]
+    AdminGroup(IsisSubAdminGroup),
     #[nom(Selector = "IsisNeighCode::AdminGrp")]
     AdminGrp(IsisSubAdminGrp),
     #[nom(Selector = "IsisNeighCode::Asla")]
@@ -280,6 +293,7 @@ impl IsisSubTlv {
             Ipv4NeighAddr(v) => v.len(),
             Ipv6IfAddr(v) => v.len(),
             Ipv6NeighAddr(v) => v.len(),
+            AdminGroup(v) => v.len(),
             AdminGrp(v) => v.len(),
             Asla(v) => v.len(),
             TeMetric(v) => v.len(),
@@ -309,6 +323,7 @@ impl IsisSubTlv {
             Ipv4NeighAddr(v) => v.tlv_emit(buf),
             Ipv6IfAddr(v) => v.tlv_emit(buf),
             Ipv6NeighAddr(v) => v.tlv_emit(buf),
+            AdminGroup(v) => v.tlv_emit(buf),
             AdminGrp(v) => v.tlv_emit(buf),
             Asla(v) => v.tlv_emit(buf),
             TeMetric(v) => v.tlv_emit(buf),
@@ -401,6 +416,35 @@ impl TlvEmitter for IsisSubIpv6NeighAddr {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put(&self.addr.octets()[..]);
+    }
+}
+
+/// RFC 5305 §3.1 Administrative Group / link color (sub-TLV 3) — the
+/// classic fixed 4-octet mask, distinct from the RFC 7308 Extended
+/// Administrative Groups (sub-TLV 14, [`IsisSubAdminGrp`]). BGP-LS
+/// keeps them distinct too (TLV 1088 vs TLV 1173).
+#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubAdminGroup {
+    pub group: u32,
+}
+
+impl TlvEmitter for IsisSubAdminGroup {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::AdminGroup.into()
+    }
+
+    fn len(&self) -> u8 {
+        4
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u32(self.group);
+    }
+}
+
+impl From<IsisSubAdminGroup> for IsisSubTlv {
+    fn from(value: IsisSubAdminGroup) -> Self {
+        IsisSubTlv::AdminGroup(value)
     }
 }
 
@@ -1066,6 +1110,39 @@ impl TlvEmitter for IsisSubSrv6LanEndXSid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Finding #13: the classic RFC 5305 §3.1 Administrative Group
+    /// (sub-TLV 3) had no dispatch arm, so a standards-compliant link
+    /// color landed in Unknown and `admin_group()` returned None —
+    /// while the accessor actually read the RFC 7308 *Extended* Admin
+    /// Group (sub-TLV 14), which BGP-LS maps to a different TLV.
+    #[test]
+    fn classic_admin_group_subtlv3_dispatches() {
+        let raw = [3u8, 4, 0x00, 0x00, 0x00, 0x14];
+        let (rest, sub) = IsisSubTlv::parse_subs(&raw).expect("parse");
+        assert!(rest.is_empty());
+        let IsisSubTlv::AdminGroup(g) = &sub else {
+            panic!("expected AdminGroup, got {sub:?}");
+        };
+        assert_eq!(g.group, 0x14);
+
+        let mut buf = BytesMut::new();
+        sub.emit(&mut buf);
+        assert_eq!(&buf[..], &raw[..]);
+
+        // The accessors keep the two group flavors distinct.
+        let entry = IsisTlvExtIsReachEntry {
+            subs: vec![
+                IsisSubTlv::AdminGroup(IsisSubAdminGroup { group: 0x14 }),
+                IsisSubTlv::AdminGrp(IsisSubAdminGrp {
+                    groups: vec![0xAA, 0xBB],
+                }),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(entry.admin_group(), Some(0x14));
+        assert_eq!(entry.ext_admin_group(), Some(&[0xAA, 0xBB][..]));
+    }
 
     fn oversized_entry() -> IsisTlvExtIsReachEntry {
         // 50 IPv4 interface-address sub-TLVs = 50 * (4+2) = 300 bytes,

--- a/crates/isis-packet/src/sub/neigh_code.rs
+++ b/crates/isis-packet/src/sub/neigh_code.rs
@@ -5,6 +5,10 @@ use nom_derive::*;
 #[repr(u8)]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub enum IsisNeighCode {
+    /// RFC 5305 §3.1 — classic Administrative Group / link color
+    /// (fixed 4 octets). Distinct from the RFC 7308 Extended
+    /// Administrative Groups at code 14.
+    AdminGroup = 3,
     #[default]
     Ipv4IfAddr = 6,
     Ipv4NeighAddr = 8,
@@ -39,6 +43,7 @@ impl From<IsisNeighCode> for u8 {
     fn from(typ: IsisNeighCode) -> Self {
         use IsisNeighCode::*;
         match typ {
+            AdminGroup => 3,
             Ipv4IfAddr => 6,
             Ipv4NeighAddr => 8,
             Ipv6IfAddr => 12,
@@ -66,6 +71,7 @@ impl From<u8> for IsisNeighCode {
     fn from(typ: u8) -> Self {
         use IsisNeighCode::*;
         match typ {
+            3 => AdminGroup,
             6 => Ipv4IfAddr,
             8 => Ipv4NeighAddr,
             12 => Ipv6IfAddr,

--- a/crates/isis-packet/src/sub/neigh_disp.rs
+++ b/crates/isis-packet/src/sub/neigh_disp.rs
@@ -1,9 +1,9 @@
 use std::fmt::{Display, Formatter, Result};
 
 use super::neigh::{
-    IsisSubAdjSid, IsisSubAdminGrp, IsisSubAsla, IsisSubAvailableBw, IsisSubDelayVariation,
-    IsisSubLinkLoss, IsisSubMinMaxLinkDelay, IsisSubResidualBw, IsisSubTlv, IsisSubUniLinkDelay,
-    IsisSubUtilizedBw,
+    IsisSubAdjSid, IsisSubAdminGroup, IsisSubAdminGrp, IsisSubAsla, IsisSubAvailableBw,
+    IsisSubDelayVariation, IsisSubLinkLoss, IsisSubMinMaxLinkDelay, IsisSubResidualBw, IsisSubTlv,
+    IsisSubUniLinkDelay, IsisSubUtilizedBw,
 };
 use super::{
     AdjSidFlags, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr, IsisSubIpv6IfAddr, IsisSubIpv6NeighAddr,
@@ -43,6 +43,7 @@ impl Display for IsisSubTlv {
             Ipv4NeighAddr(v) => write!(f, "{}", v),
             Ipv6IfAddr(v) => write!(f, "{}", v),
             Ipv6NeighAddr(v) => write!(f, "{}", v),
+            AdminGroup(v) => write!(f, "{}", v),
             AdminGrp(v) => write!(f, "{}", v),
             TeMetric(v) => write!(f, "{}", v),
             AdjSid(v) => write!(f, "{}", v),
@@ -166,9 +167,15 @@ impl Display for IsisSubIpv6NeighAddr {
     }
 }
 
+impl Display for IsisSubAdminGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "    Admin Group: 0x{:08x}", self.group)
+    }
+}
+
 impl Display for IsisSubAdminGrp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "    Admin Group:")?;
+        write!(f, "    Ext Admin Group:")?;
         for (i, group) in self.groups.iter().enumerate() {
             write!(f, " [{}] 0x{:08x}", i, group)?;
         }

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -310,7 +310,7 @@ misassign. All daemon builders were already prefix-closed, so no wire output
 changes. Unit tests pin the gapped-struct emit (only the leading fields) and
 every prefix-closed `P2p3Way` form round-tripping exactly.
 
-### 13. 🟡 `admin_group()` doc claims sub-TLV 3 but reads sub-TLV 14; sub-TLV 3 undispatched — PLAUSIBLE
+### 13. 🟡 `admin_group()` doc claims sub-TLV 3 but reads sub-TLV 14; sub-TLV 3 undispatched — PLAUSIBLE — ✅ FIXED
 `crates/isis-packet/src/sub/neigh.rs:154`
 
 The accessor is documented as returning the sub-TLV 3 Administrative Group but
@@ -324,8 +324,12 @@ color is lost. BGP-LS also distinguishes Administrative Group (TLV 1088) from
 Extended Administrative Group (TLV 1173), so mapping one to the other is
 semantically wrong.
 
-**Fix:** add a dispatch arm for sub-TLV 3 and fix the accessor doc (or fold both
-into one accessor with the correct BGP-LS mapping).
+**Fixed:** sub-TLV 3 now has a dedicated `IsisSubAdminGroup` codec (fixed
+4-octet mask) and dispatch arm; `admin_group()` reads it (BGP-LS TLV 1088),
+and a new `ext_admin_group()` exposes the RFC 7308 sub-TLV 14 list (BGP-LS
+TLV 1173 when the producer grows support for it). Display labels the two
+flavors distinctly. Unit test pins the dispatch, round-trip, and both
+accessors on an entry carrying both flavors.
 
 ### 14. 🟡 ASLA parse forces SABM/UDABM to ≥1 byte when L-flag set — PLAUSIBLE
 `crates/isis-packet/src/sub/neigh.rs:764`


### PR DESCRIPTION
## Summary

Fixes finding #13 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

The classic RFC 5305 §3.1 Administrative Group (link color, sub-TLV 3,
fixed 4 octets) had no dispatch arm in `IsisNeighCode`, so a
standards-compliant color advertisement landed in `Unknown`. Meanwhile
the `admin_group()` accessor was documented as returning sub-TLV 3 but
actually read the RFC 7308 *Extended* Administrative Groups
(sub-TLV 14), so the BGP-LS producer mapped the wrong attribute onto
Administrative Group (TLV 1088) — BGP-LS keeps the two distinct
(1088 vs 1173).

- New `IsisSubAdminGroup` codec (code 3, single u32 mask) with dispatch
  arm, Display, and From impl.
- `admin_group()` now reads sub-TLV 3, matching its documentation and
  the BGP-LS TLV 1088 semantics; a new `ext_admin_group()` accessor
  exposes the sub-TLV 14 word list for a future TLV 1173 producer.
- Display labels the two flavors distinctly ("Admin Group" vs
  "Ext Admin Group").

Behavior note: a link advertising *only* the extended group no longer
produces BGP-LS TLV 1088 — that mapping was the semantically wrong one
the review called out.

Review doc: finding #13 marked fixed.

## Test plan

- New unit test pins the code-3 dispatch, wire round-trip, and both
  accessors on an entry carrying both group flavors.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)