### PR TITLE
isis-packet: honor advertised ASLA mask lengths; bound them at 8

### DIFF
--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -817,16 +817,24 @@ impl ParseBe<IsisSubAsla> for IsisSubAsla {
         let (input, udabm_len) = be_u8(input)?;
         let udabm_len = udabm_len as usize;
 
-        // RFC 9479 §4: When L-flag is set, SABM and UDABM are each 1 byte
-        // (legacy format) regardless of the length fields.
-        let (eff_sabm_len, eff_udabm_len) = if l_flag {
-            (sabm_len.max(1), udabm_len.max(1))
-        } else {
-            (sabm_len, udabm_len)
-        };
+        // RFC 9479 §4.2: each mask length is the actual octet count of
+        // the mask that follows (0-8); zero means the mask is absent,
+        // L-flag or not. The parser used to force L=1 masks to >= 1
+        // byte "regardless of the length fields", which consumed the
+        // first bytes of the nested sub-TLVs as fabricated masks when a
+        // peer sent L=1 with zero-length masks — and made our own emit
+        // (which writes the actual lengths) unreadable to ourselves.
+        // Honor the advertised lengths; reject out-of-range ones so the
+        // sub-TLV degrades to Unknown instead of desyncing.
+        if sabm_len > 8 || udabm_len > 8 {
+            return Err(nom::Err::Error(nom::error::make_error(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
 
-        let (input, sabm) = take(eff_sabm_len)(input)?;
-        let (input, udabm) = take(eff_udabm_len)(input)?;
+        let (input, sabm) = take(sabm_len)(input)?;
+        let (input, udabm) = take(udabm_len)(input)?;
         let (input, subs) = many0_complete(IsisSubTlv::parse_subs).parse(input)?;
 
         Ok((
@@ -1110,6 +1118,46 @@ impl TlvEmitter for IsisSubSrv6LanEndXSid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Finding #14: RFC 9479 §4.2 mask lengths are actual octet counts
+    /// (0-8), L-flag or not. The parser used to force L=1 masks to
+    /// ≥ 1 byte, consuming the first two bytes of the nested sub-TLVs
+    /// as fabricated masks — and making our own emitted L=1/empty-mask
+    /// ASLA unreadable to ourselves.
+    #[test]
+    fn asla_l_flag_with_zero_length_masks_round_trips() {
+        let asla = IsisSubAsla {
+            l_flag: true,
+            sabm: vec![],
+            udabm: vec![],
+            subs: vec![IsisSubTlv::TeMetric(IsisSubTeMetric { metric: 100 })],
+        };
+        let mut buf = BytesMut::new();
+        asla.tlv_emit(&mut buf);
+        // code 16, len 7: first byte 0x80 (L set, SABM len 0), UDABM
+        // len 0, then the nested TE metric <18, 3, 0, 0, 100>.
+        assert_eq!(&buf[..], &[16, 7, 0x80, 0, 18, 3, 0, 0, 100]);
+        let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse");
+        assert!(rest.is_empty());
+        let IsisSubTlv::Asla(a) = parsed else {
+            panic!("expected Asla");
+        };
+        assert_eq!(a, asla);
+    }
+
+    /// RFC 9479 §4.2 bounds each mask at 8 octets; a longer claim is
+    /// rejected so the registry degrades the sub-TLV to Unknown and the
+    /// sub-TLVs after it survive.
+    #[test]
+    fn asla_oversized_mask_length_degrades_to_unknown() {
+        // ASLA (code 16) claiming SABM Length 9, then a valid TE metric.
+        let raw = [16u8, 2, 0x09, 0, 18, 3, 0, 0, 100];
+        let (rest, first) = IsisSubTlv::parse_subs(&raw).expect("first");
+        assert!(matches!(first, IsisSubTlv::Unknown(_)));
+        let (rest, second) = IsisSubTlv::parse_subs(rest).expect("second");
+        assert!(matches!(second, IsisSubTlv::TeMetric(_)));
+        assert!(rest.is_empty());
+    }
 
     /// Finding #13: the classic RFC 5305 §3.1 Administrative Group
     /// (sub-TLV 3) had no dispatch arm, so a standards-compliant link

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -331,7 +331,7 @@ TLV 1173 when the producer grows support for it). Display labels the two
 flavors distinctly. Unit test pins the dispatch, round-trip, and both
 accessors on an entry carrying both flavors.
 
-### 14. 🟡 ASLA parse forces SABM/UDABM to ≥1 byte when L-flag set — PLAUSIBLE
+### 14. 🟡 ASLA parse forces SABM/UDABM to ≥1 byte when L-flag set — PLAUSIBLE — ✅ FIXED
 `crates/isis-packet/src/sub/neigh.rs:764`
 
 `parse_be` forces `eff_sabm_len`/`eff_udabm_len` to `max(1)` when the L-flag is
@@ -348,8 +348,14 @@ consumes the first two bytes of the first nested sub-TLV (its type and length) a
 fabricated masks, then parses the rest at a shifted offset — nested TE attributes
 are garbled and re-emission differs from the wire.
 
-**Fix:** make emit enforce the same L-flag ⇒ ≥1-byte-mask invariant the parser
-assumes, or make the parser honor the advertised lengths.
+**Fixed:** the parser now honors the advertised lengths (the RFC 9479 §4.2
+mask lengths are actual octet counts 0–8 with no L⇒1-byte rule — the `max(1)`
+comment's claim doesn't match the RFC text, and FRR's 1-byte constant is its
+*send*-side choice, not a parse rule), and rejects lengths > 8 so a
+non-conformant claim degrades the sub-TLV to `Unknown` (finding #10 machinery)
+instead of desyncing. Emit is unchanged; the daemon only builds `l_flag:
+false` 1-byte-SABM ASLAs, so no local wire output changes. Unit tests pin the
+L=1/empty-mask round-trip (nested sub-TLV intact) and the >8 length degrade.
 
 ### 15. 🟡 `IsisPacket::emit` drops Unknown PDU payload; `IsisTlvUnknown` emit doubles the header — CONFIRMED
 `crates/isis-packet/src/parser.rs:98` and `:1271`


### PR DESCRIPTION
## Summary

Fixes finding #14 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

The ASLA (RFC 9479, link sub-TLV 16) parser forced the SABM/UDABM
lengths to ≥ 1 byte when the L-flag was set — "regardless of the length
fields" — while emit wrote the actual mask lengths. RFC 9479 §4.2
defines each length as the actual octet count of the mask that follows
(0–8, zero = mask absent) with no L⇒1-byte rule; FRR's 1-byte
`ASLA_APP_IDENTIFIER_BIT_LENGTH` is its send-side choice, not a parse
rule. The asymmetry meant a conformant peer's L=1 / zero-length-mask
ASLA had the first two bytes of its nested sub-TLVs consumed as
fabricated masks, and our own emitted L=1 / empty-mask ASLA could not
be read back by our own parser.

- The parser now honors the advertised lengths.
- Lengths > 8 are rejected, so a non-conformant claim degrades the
  sub-TLV to `Unknown` (the finding-#10 machinery) and the sub-TLVs
  after it survive.
- Emit is unchanged; the daemon only builds `l_flag=false` 1-byte-SABM
  ASLAs, so no local wire output changes.

Review doc: finding #14 marked fixed.

## Test plan

- New unit tests pin the L=1/empty-mask round-trip (byte-exact, nested
  TE-metric sub-TLV intact) and the >8 mask-length claim degrading to
  Unknown with the following sub-TLV surviving.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)