### PR TITLE
pim: assert election and LAN Join/Prune behaviors

### DIFF
--- a/bdd/tests/configs/pim_assert/r0.yaml
+++ b/bdd/tests/configs/pim_assert/r0.yaml
@@ -1,0 +1,14 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.6.1.1/24
+- if-name: eth2
+  ipv4:
+    address: 10.6.0.1/24
+router:
+  pim:
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth2
+      dr-priority: 1

--- a/bdd/tests/configs/pim_assert/r1.yaml
+++ b/bdd/tests/configs/pim_assert/r1.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.6.1.2/24
+- if-name: eth2
+  ipv4:
+    address: 10.6.2.2/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.6.0.0/24
+        nexthop:
+        - address: 10.6.1.1
+  pim:
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth2
+      igmp:
+        enabled: true

--- a/bdd/tests/configs/pim_assert/r2.yaml
+++ b/bdd/tests/configs/pim_assert/r2.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.6.1.3/24
+- if-name: eth2
+  ipv4:
+    address: 10.6.2.3/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.6.0.0/24
+        nexthop:
+        - address: 10.6.1.1
+  pim:
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth2
+      igmp:
+        enabled: true

--- a/bdd/tests/features/pim_assert.feature
+++ b/bdd/tests/features/pim_assert.feature
@@ -1,0 +1,106 @@
+@serial
+@pim_assert
+Feature: PIM assert election and LAN Join/Prune behaviors
+  As a network operator
+  I want duplicate forwarders on a shared LAN to elect a single
+  assert winner, routers sharing an upstream LAN to suppress each
+  other's periodic Joins, and a Prune overheard on a LAN to be
+  overridden by routers that still want the traffic — the RFC 7761
+  multi-access behaviors that keep exactly one copy of each packet
+  on every LAN.
+
+  r1 and r2 both connect the upstream LAN (swA, toward r0 and the
+  source) and the receiver LAN (swB). Both track h2's IGMPv3 join
+  (no DR gating on local membership), so both join (S,G) toward r0 —
+  each must log the other's Join as suppressing — and both forward
+  onto swB, where the duplicate data triggers the assert election.
+  Metrics tie, so the higher address (r2, 10.6.2.3) must win; r1
+  must step down, and with its only outgoing interface assert-lost
+  its JoinDesired collapses — it prunes toward r0. r2 must overhear
+  that Prune and send the override Join, keeping r0 forwarding, and
+  h2 must keep receiving through r2.
+
+  Test Topology:
+  ```
+    h1 --- r0 --- [swA LAN 10.6.1.0/24] --- r1 --- [swB LAN 10.6.2.0/24] --- h2
+   (src)           .1(r0) .2(r1) .3(r2)     r2          .2(r1) .3(r2)      (rcv)
+  ```
+
+  Scenario: Assert election, join suppression and prune override on LANs
+    Given a clean test environment
+    When I create namespace "swa"
+    And I create namespace "swb"
+    And I create namespace "r0"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "r0" interface "eth1" to namespace "swa" interface "pa0"
+    And I connect namespace "r1" interface "eth1" to namespace "swa" interface "pa1"
+    And I connect namespace "r2" interface "eth1" to namespace "swa" interface "pa2"
+    And I connect namespace "r1" interface "eth2" to namespace "swb" interface "pb1"
+    And I connect namespace "r2" interface "eth2" to namespace "swb" interface "pb2"
+    And I connect namespace "h2" interface "eth0" to namespace "swb" interface "pb3"
+    And I connect namespace "r0" interface "eth2" to namespace "h1" interface "eth0"
+    And I execute "ip link add bra type bridge mcast_snooping 0" in namespace "swa"
+    And I execute "ip link set pa0 master bra" in namespace "swa"
+    And I execute "ip link set pa1 master bra" in namespace "swa"
+    And I execute "ip link set pa2 master bra" in namespace "swa"
+    And I execute "ip link set bra up" in namespace "swa"
+    And I execute "ip link add brb type bridge mcast_snooping 0" in namespace "swb"
+    And I execute "ip link set pb1 master brb" in namespace "swb"
+    And I execute "ip link set pb2 master brb" in namespace "swb"
+    And I execute "ip link set pb3 master brb" in namespace "swb"
+    And I execute "ip link set brb up" in namespace "swb"
+    And I start zebra-rs in namespace "r0"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r0.yaml" to namespace "r0"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "10.6.0.10/24" to interface "eth0" in namespace "h1"
+    And I add address "10.6.2.10/24" to interface "eth0" in namespace "h2"
+
+    # Full neighborship on the upstream LAN.
+    Then show command "show pim neighbor" in namespace "r0" should eventually contain "10.6.1.2"
+    And show command "show pim neighbor" in namespace "r0" should eventually contain "10.6.1.3"
+
+    # h2 joins (10.6.0.10, 232.6.6.6): both r1 and r2 track the
+    # membership and join toward r0 — each overhears the other's Join
+    # on swA and suppresses its own refresh.
+    When I spawn "timeout 200 python3 tests/scripts/ssm_recv.py 232.6.6.6 10.6.0.10 10.6.2.10 5001 /tmp/pim_assert_rx" in namespace "h2"
+    Then show command "show pim upstream" in namespace "r1" should eventually contain "Joined"
+    And show command "show pim upstream" in namespace "r2" should eventually contain "Joined"
+    And daemon log in namespace "r1" should eventually contain "join suppressed"
+    And daemon log in namespace "r2" should eventually contain "join suppressed"
+
+    # The sender starts: both forward onto swB, the duplicates
+    # trigger the assert election, and the higher address (r2) wins.
+    When I spawn "timeout 150 python3 tests/scripts/mcast_send.py 232.6.6.6 5001 10.6.0.10 120" in namespace "h1"
+    Then daemon log in namespace "r1" should eventually contain "assert loser"
+    And show command "show pim assert" in namespace "r1" should eventually contain "Loser"
+    And show command "show pim assert" in namespace "r1" should contain "10.6.2.3"
+    And show command "show pim assert" in namespace "r2" should eventually contain "Winner"
+
+    # The loser's only outgoing interface is gone: it withdraws from
+    # the source tree; r2 overhears the Prune and overrides it.
+    And daemon log in namespace "r1" should eventually contain "pruned toward"
+    And daemon log in namespace "r2" should eventually contain "prune override"
+
+    # Steady state: r0 still forwards, r2 carries the LAN, h2 receives.
+    And command "ip mroute show" in namespace "r0" should eventually contain "Iif: eth2"
+    And command "cat /tmp/pim_assert_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim_assert_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r0"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r0"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "swa"
+    And I delete namespace "swb"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/zebra-rs/src/pim/assert_fsm.rs
+++ b/zebra-rs/src/pim/assert_fsm.rs
@@ -1,0 +1,320 @@
+//! PIM Assert (RFC 7761 §4.6): when two routers forward the same
+//! (S,G) onto one LAN, the duplicate data (a WRONGVIF upcall on an
+//! interface we forward to) triggers an assert election. Metrics
+//! compare as (rpt_bit, preference, route metric) — lower wins —
+//! with the higher IP address as the tiebreak. The loser withdraws
+//! the interface from its forwarding set until the assert state
+//! expires or the winner goes quiet.
+//!
+//! State lives per (entry, interface) in [`TibEntry::asserts`]. The
+//! winner refreshes its assert shortly before losers would age it
+//! out; a loser whose state expires simply resumes forwarding and
+//! the next duplicate re-runs the election.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{Duration, Instant};
+
+use pim_packet::{EncodedGroup, EncodedUnicast, PimAssert, PimPacket, PimPayload};
+
+use super::inst::{Pim, PimSend};
+use super::macros::inherited_olist;
+use super::socket::ALL_PIM_ROUTERS;
+use super::tib::SgKey;
+
+/// Assert Time (RFC 7761 §4.11): loser state lifetime.
+pub const ASSERT_TIME: Duration = Duration::from_secs(180);
+
+/// Winner refresh: re-send the assert three seconds (the assert
+/// override interval) before losers would expire.
+pub const ASSERT_REFRESH: Duration = Duration::from_secs(177);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AssertMetric {
+    pub rpt_bit: bool,
+    pub pref: u32,
+    pub metric: u32,
+    pub addr: Ipv4Addr,
+}
+
+impl AssertMetric {
+    /// RFC 7761 §4.6.3: lower (rpt, pref, metric) wins; the higher
+    /// address breaks ties.
+    pub fn better_than(&self, other: &AssertMetric) -> bool {
+        if self.rpt_bit != other.rpt_bit {
+            return !self.rpt_bit;
+        }
+        if self.pref != other.pref {
+            return self.pref < other.pref;
+        }
+        if self.metric != other.metric {
+            return self.metric < other.metric;
+        }
+        self.addr > other.addr
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssertRole {
+    Winner,
+    Loser { winner: Ipv4Addr },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AssertState {
+    pub role: AssertRole,
+    /// The winning metric (ours as winner, the winner's as loser).
+    pub winner_metric: AssertMetric,
+    pub expires: Instant,
+}
+
+impl Pim {
+    /// Our assert metric for `key` on `ifindex`: RPF cost toward the
+    /// source, our address on the contested interface as tiebreak.
+    fn assert_my_metric(&self, key: SgKey, ifindex: u32) -> Option<AssertMetric> {
+        let addr = self.links.get(&ifindex)?.primary_addr()?;
+        let entry = self.tib.get(&key)?;
+        let (pref, metric) = match entry.rpf_target {
+            Some(target) => self.rpf_pref_metric(target),
+            None => (u32::MAX, u32::MAX),
+        };
+        Some(AssertMetric {
+            rpt_bit: false,
+            pref,
+            metric,
+            addr,
+        })
+    }
+
+    fn assert_send(&self, key: SgKey, ifindex: u32, metric: &AssertMetric) {
+        let SgKey::Sg { src, grp } = key else {
+            return;
+        };
+        let packet = PimPacket::new(PimPayload::Assert(PimAssert {
+            group: EncodedGroup::new(IpAddr::V4(grp)),
+            source: EncodedUnicast::new(IpAddr::V4(src)),
+            rpt_bit: metric.rpt_bit,
+            metric_preference: metric.pref,
+            metric: metric.metric,
+        }));
+        let _ = self.send_tx.send(PimSend {
+            packet,
+            ifindex,
+            dst: ALL_PIM_ROUTERS,
+        });
+    }
+
+    /// Duplicate data seen on an interface we forward to (WRONGVIF on
+    /// an OIL member): assert ourselves.
+    pub(crate) fn assert_data_trigger(&mut self, key: SgKey, ifindex: u32) {
+        let Some(mine) = self.assert_my_metric(key, ifindex) else {
+            return;
+        };
+        let now = Instant::now();
+        let Some(entry) = self.tib.get_mut(&key) else {
+            return;
+        };
+        match entry.asserts.get(&ifindex).map(|a| a.role) {
+            Some(AssertRole::Loser { .. }) => {}
+            Some(AssertRole::Winner) => {
+                // Rate-limit: skip if we asserted within the last
+                // few seconds (the kernel already throttles upcalls).
+                let recently = entry
+                    .asserts
+                    .get(&ifindex)
+                    .map(|a| a.expires > now + ASSERT_REFRESH - Duration::from_secs(3))
+                    .unwrap_or(false);
+                if !recently {
+                    entry.asserts.insert(
+                        ifindex,
+                        AssertState {
+                            role: AssertRole::Winner,
+                            winner_metric: mine,
+                            expires: now + ASSERT_REFRESH,
+                        },
+                    );
+                    self.assert_send(key, ifindex, &mine);
+                }
+            }
+            None => {
+                entry.asserts.insert(
+                    ifindex,
+                    AssertState {
+                        role: AssertRole::Winner,
+                        winner_metric: mine,
+                        expires: now + ASSERT_REFRESH,
+                    },
+                );
+                tracing::info!(
+                    "pim: {} assert winner on {} (data trigger)",
+                    key,
+                    self.ifname(ifindex)
+                );
+                self.assert_send(key, ifindex, &mine);
+            }
+        }
+    }
+
+    /// Assert packet RX: run the election on the receiving interface.
+    pub(crate) fn assert_recv(&mut self, ifindex: u32, sender: Ipv4Addr, assert: &PimAssert) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        if !link.enabled || link.is_my_addr(&sender) {
+            return;
+        }
+        if assert.rpt_bit {
+            tracing::debug!(
+                "pim: (*,G) assert from {} ignored (rpt asserts later)",
+                sender
+            );
+            return;
+        }
+        let (IpAddr::V4(grp), IpAddr::V4(src)) = (assert.group.addr, assert.source.addr) else {
+            return;
+        };
+        let key = SgKey::Sg { src, grp };
+        if !self.tib.contains_key(&key) {
+            return;
+        }
+        // Only contest interfaces we would actually forward to (the
+        // raw olist, before assert exclusions — a loser keeps
+        // contesting state alive from the winner's refreshes).
+        let could_assert = {
+            let raw = inherited_olist(&self.tib, key);
+            let iif = self.tib.get(&key).and_then(|e| e.rpf.ifindex());
+            raw.contains(&ifindex) && iif != Some(ifindex)
+        };
+        if !could_assert {
+            return;
+        }
+        let Some(mine) = self.assert_my_metric(key, ifindex) else {
+            return;
+        };
+        let theirs = AssertMetric {
+            rpt_bit: assert.rpt_bit,
+            pref: assert.metric_preference,
+            metric: assert.metric,
+            addr: sender,
+        };
+        let now = Instant::now();
+        let entry = self.tib.get_mut(&key).unwrap();
+        let current = entry.asserts.get(&ifindex).copied();
+        match current.map(|a| a.role) {
+            None | Some(AssertRole::Winner) => {
+                if theirs.better_than(&mine) {
+                    entry.asserts.insert(
+                        ifindex,
+                        AssertState {
+                            role: AssertRole::Loser { winner: sender },
+                            winner_metric: theirs,
+                            expires: now + ASSERT_TIME,
+                        },
+                    );
+                    tracing::info!(
+                        "pim: {} assert loser on {} (winner {})",
+                        key,
+                        self.ifname(ifindex),
+                        sender
+                    );
+                    self.tib_update(key);
+                } else {
+                    // Inferior assert: challenge with our metric.
+                    entry.asserts.insert(
+                        ifindex,
+                        AssertState {
+                            role: AssertRole::Winner,
+                            winner_metric: mine,
+                            expires: now + ASSERT_REFRESH,
+                        },
+                    );
+                    if current.is_none() {
+                        tracing::info!("pim: {} assert winner on {}", key, self.ifname(ifindex));
+                    }
+                    self.assert_send(key, ifindex, &mine);
+                }
+            }
+            Some(AssertRole::Loser { winner }) => {
+                let stored = current.unwrap().winner_metric;
+                if sender == winner || theirs.better_than(&stored) {
+                    entry.asserts.insert(
+                        ifindex,
+                        AssertState {
+                            role: AssertRole::Loser { winner: sender },
+                            winner_metric: theirs,
+                            expires: now + ASSERT_TIME,
+                        },
+                    );
+                } else if mine.better_than(&theirs) {
+                    // A third router with a worse metric asserted:
+                    // contest it.
+                    entry.asserts.insert(
+                        ifindex,
+                        AssertState {
+                            role: AssertRole::Winner,
+                            winner_metric: mine,
+                            expires: now + ASSERT_REFRESH,
+                        },
+                    );
+                    tracing::info!(
+                        "pim: {} re-asserting on {} against {}",
+                        key,
+                        self.ifname(ifindex),
+                        sender
+                    );
+                    self.assert_send(key, ifindex, &mine);
+                    self.tib_update(key);
+                }
+            }
+        }
+    }
+
+    /// Assert deadlines: winners refresh, expired losers resume
+    /// forwarding.
+    pub(crate) fn assert_tick(&mut self, now: Instant) {
+        let due: Vec<(SgKey, u32, AssertRole)> = self
+            .tib
+            .iter()
+            .flat_map(|(key, e)| {
+                e.asserts
+                    .iter()
+                    .filter(|(_, a)| a.expires <= now)
+                    .map(|(ifindex, a)| (*key, *ifindex, a.role))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        for (key, ifindex, role) in due {
+            match role {
+                AssertRole::Winner => {
+                    let Some(mine) = self.assert_my_metric(key, ifindex) else {
+                        if let Some(entry) = self.tib.get_mut(&key) {
+                            entry.asserts.remove(&ifindex);
+                        }
+                        continue;
+                    };
+                    if let Some(entry) = self.tib.get_mut(&key) {
+                        entry.asserts.insert(
+                            ifindex,
+                            AssertState {
+                                role: AssertRole::Winner,
+                                winner_metric: mine,
+                                expires: now + ASSERT_REFRESH,
+                            },
+                        );
+                    }
+                    self.assert_send(key, ifindex, &mine);
+                }
+                AssertRole::Loser { .. } => {
+                    if let Some(entry) = self.tib.get_mut(&key) {
+                        entry.asserts.remove(&ifindex);
+                    }
+                    tracing::info!(
+                        "pim: {} assert expired on {} — resuming forwarding",
+                        key,
+                        self.ifname(ifindex)
+                    );
+                    self.tib_update(key);
+                }
+            }
+        }
+    }
+}

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -279,6 +279,7 @@ impl Pim {
             PimPayload::JoinPrune(jp) => self.jp_recv(ifindex, src, jp),
             PimPayload::Register(register) => self.register_recv(src, register),
             PimPayload::RegisterStop(stop) => self.register_stop_recv(stop),
+            PimPayload::Assert(assert) => self.assert_recv(ifindex, src, assert),
             other => {
                 // Assert / Bootstrap handling arrives with later
                 // phases.

--- a/zebra-rs/src/pim/jp.rs
+++ b/zebra-rs/src/pim/jp.rs
@@ -20,6 +20,11 @@ use super::tib::{JP_HOLDTIME, JoinState, SgKey};
 /// Periodic J/P refresh interval (t_periodic, RFC 7761 §4.11).
 pub const JP_PERIOD: Duration = Duration::from_secs(60);
 
+/// Suppressed refresh interval after overhearing another router's
+/// Join to our upstream (≈ 1.25 × t_periodic, inside the RFC's
+/// 1.1–1.4 randomization band).
+pub const JP_SUPPRESS: Duration = Duration::from_secs(75);
+
 impl Pim {
     // ---- RX ----
 
@@ -37,12 +42,9 @@ impl Pim {
             return;
         };
         if !link.is_my_addr(&upstream) {
-            tracing::debug!(
-                "pim: J/P from {} on {} targets {} (not us) — ignored",
-                src,
-                link.name,
-                upstream
-            );
+            // Overheard LAN traffic toward another upstream router:
+            // feeds join suppression and prune override.
+            self.jp_overhear(ifindex, src, upstream, jp);
             return;
         }
         let holdtime = jp.holdtime;
@@ -91,6 +93,79 @@ impl Pim {
                     (true, false) => {}
                 }
             }
+        }
+    }
+
+    /// A J/P on a shared LAN addressed to a router that is our own
+    /// RPF neighbor for matching state (RFC 7761 §4.5.2):
+    ///   * another router's Join for state we also joined suppresses
+    ///     our next periodic refresh;
+    ///   * another router's Prune for state we still want triggers an
+    ///     override Join so the upstream keeps forwarding.
+    fn jp_overhear(
+        &mut self,
+        ifindex: u32,
+        sender: Ipv4Addr,
+        upstream: Ipv4Addr,
+        jp: &PimJoinPrune,
+    ) {
+        let bucket = RpfState::Gateway {
+            ifindex,
+            nexthop: upstream,
+        };
+        let mut overrides: Vec<SgKey> = vec![];
+        let mut suppress = false;
+        for group in &jp.groups {
+            let IpAddr::V4(grp) = group.group.addr else {
+                continue;
+            };
+            let key_of = |source: &EncodedSource| -> Option<SgKey> {
+                let IpAddr::V4(addr) = source.addr else {
+                    return None;
+                };
+                match (source.wildcard, source.rpt) {
+                    (true, true) => Some(SgKey::StarG { grp }),
+                    (false, false) => Some(SgKey::Sg { src: addr, grp }),
+                    _ => None,
+                }
+            };
+            for join in &group.joins {
+                let Some(key) = key_of(join) else { continue };
+                if let Some(entry) = self.tib.get(&key)
+                    && entry.join_state == JoinState::Joined
+                    && entry.rpf == bucket
+                {
+                    suppress = true;
+                    tracing::info!(
+                        "pim: {} join suppressed by {} toward {}",
+                        key,
+                        sender,
+                        upstream
+                    );
+                }
+            }
+            for prune in &group.prunes {
+                let Some(key) = key_of(prune) else { continue };
+                if let Some(entry) = self.tib.get(&key)
+                    && entry.join_state == JoinState::Joined
+                    && entry.rpf == bucket
+                {
+                    overrides.push(key);
+                }
+            }
+        }
+        if suppress {
+            // RFC t_suppressed ≈ 1.1–1.4 × t_periodic; one fixed
+            // bump per overheard refresh keeps one joiner per LAN.
+            let deadline = Instant::now() + JP_SUPPRESS;
+            self.jp_refresh
+                .entry((ifindex, upstream))
+                .and_modify(|t| *t = (*t).max(deadline))
+                .or_insert(deadline);
+        }
+        for key in overrides {
+            tracing::info!("pim: {} prune override join toward {}", key, upstream);
+            self.jp_send_entry(ifindex, upstream, key, true);
         }
     }
 

--- a/zebra-rs/src/pim/macros.rs
+++ b/zebra-rs/src/pim/macros.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use super::assert_fsm::AssertRole;
 use super::tib::{DsState, SgKey, TibEntry};
 
 /// `immediate_olist(key)`: interfaces with local (IGMP) membership
@@ -44,18 +45,45 @@ pub fn inherited_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<
     olist
 }
 
-/// `JoinDesired(key)` — someone wants the traffic on this tree.
-/// Whether a Join can actually be *sent* additionally requires an
-/// upstream PIM neighbor (and, for (*,G), a known RP) — those gates
-/// live in the upstream FSM, not here.
-pub fn join_desired(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> bool {
-    !immediate_olist(tib, key).is_empty()
+/// Interfaces where this entry lost an assert election — excluded
+/// from forwarding and from JoinDesired while the winner is alive
+/// (RFC 7761 `lost_assert(S,G,I)`).
+pub fn assert_losers(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+    let Some(entry) = tib.get(&key) else {
+        return BTreeSet::new();
+    };
+    entry
+        .asserts
+        .iter()
+        .filter(|(_, a)| matches!(a.role, AssertRole::Loser { .. }))
+        .map(|(ifindex, _)| *ifindex)
+        .collect()
 }
 
-/// The (S,G) MFC outgoing set: the inherited olist minus the
-/// incoming interface (loop-free guard — never emit OIF == IIF).
+/// The inherited olist minus assert-lost interfaces — what actually
+/// counts for JoinDesired's traffic-driven clause and the MFC.
+pub fn inherited_effective(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+    let mut olist = inherited_olist(tib, key);
+    for ifindex in assert_losers(tib, key) {
+        olist.remove(&ifindex);
+    }
+    olist
+}
+
+/// `JoinDesired` restricted to interfaces we would actually forward
+/// to (immediate olist minus assert losses).
+pub fn join_desired_effective(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> bool {
+    let mut olist = immediate_olist(tib, key);
+    for ifindex in assert_losers(tib, key) {
+        olist.remove(&ifindex);
+    }
+    !olist.is_empty()
+}
+
+/// The (S,G) MFC outgoing set: the effective inherited olist minus
+/// the incoming interface (loop-free guard — never emit OIF == IIF).
 pub fn mfc_oifs(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
-    let mut oifs = inherited_olist(tib, key);
+    let mut oifs = inherited_effective(tib, key);
     if let Some(iif) = tib.get(&key).and_then(|e| e.rpf.ifindex()) {
         oifs.remove(&iif);
     }
@@ -109,8 +137,8 @@ mod tests {
             immediate_olist(&tib, sg()).into_iter().collect::<Vec<_>>(),
             vec![3, 5]
         );
-        assert!(join_desired(&tib, sg()));
-        assert!(!join_desired(&tib, star()));
+        assert!(join_desired_effective(&tib, sg()));
+        assert!(!join_desired_effective(&tib, star()));
     }
 
     #[test]
@@ -127,7 +155,7 @@ mod tests {
             },
         );
         tib.insert(sg(), e);
-        assert!(join_desired(&tib, sg()));
+        assert!(join_desired_effective(&tib, sg()));
     }
 
     #[test]
@@ -151,6 +179,64 @@ mod tests {
         assert!(inherited.contains(&5));
         assert!(inherited.contains(&6));
         assert!(!inherited.contains(&7));
+    }
+
+    #[test]
+    fn lost_assert_excluded_from_forwarding_and_jd() {
+        use crate::pim::assert_fsm::{AssertMetric, AssertRole, AssertState};
+        let mut tib = BTreeMap::new();
+        let mut e = TibEntry::new();
+        e.local.insert(5);
+        e.asserts.insert(
+            5,
+            AssertState {
+                role: AssertRole::Loser {
+                    winner: Ipv4Addr::new(10, 0, 2, 3),
+                },
+                winner_metric: AssertMetric {
+                    rpt_bit: false,
+                    pref: 0,
+                    metric: 0,
+                    addr: Ipv4Addr::new(10, 0, 2, 3),
+                },
+                expires: Instant::now() + Duration::from_secs(180),
+            },
+        );
+        tib.insert(sg(), e);
+        // Membership remains visible raw, but neither forwarding nor
+        // JoinDesired count the lost interface.
+        assert!(immediate_olist(&tib, sg()).contains(&5));
+        assert!(!inherited_effective(&tib, sg()).contains(&5));
+        assert!(!join_desired_effective(&tib, sg()));
+        assert!(!mfc_oifs(&tib, sg()).contains(&5));
+    }
+
+    #[test]
+    fn assert_metric_ordering() {
+        use crate::pim::assert_fsm::AssertMetric;
+        let base = AssertMetric {
+            rpt_bit: false,
+            pref: 100,
+            metric: 10,
+            addr: Ipv4Addr::new(10, 0, 2, 2),
+        };
+        // Lower preference wins.
+        let better_pref = AssertMetric { pref: 0, ..base };
+        assert!(better_pref.better_than(&base));
+        // Equal metrics: higher address wins.
+        let higher_addr = AssertMetric {
+            addr: Ipv4Addr::new(10, 0, 2, 3),
+            ..base
+        };
+        assert!(higher_addr.better_than(&base));
+        assert!(!base.better_than(&higher_addr));
+        // rpt loses to spt.
+        let rpt = AssertMetric {
+            rpt_bit: true,
+            pref: 0,
+            ..base
+        };
+        assert!(base.better_than(&rpt));
     }
 
     #[test]

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -1,6 +1,7 @@
 //! PIM-SM (RFC 7761). Phase 2: instance skeleton — Hello, neighbors,
 //! DR election. Architecture: docs/design/pim-sm-ssm-architecture.md.
 
+pub mod assert_fsm;
 pub mod config;
 pub mod igmp;
 pub mod inst;

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -114,6 +114,25 @@ impl Pim {
         }
     }
 
+    /// Assert-metric inputs for a tracked address: (preference,
+    /// metric). Connected beats any gateway route; unresolved is
+    /// infinitely bad.
+    pub(crate) fn rpf_pref_metric(&self, addr: Ipv4Addr) -> (u32, u32) {
+        match self.rpf.get(&addr).map(|e| e.state) {
+            Some(RpfState::Connected { .. }) => (0, 0),
+            Some(RpfState::Gateway { .. }) => {
+                let metric = self
+                    .rpf
+                    .get(&addr)
+                    .and_then(|e| e.resolution.as_ref())
+                    .map(|r| r.metric)
+                    .unwrap_or(0);
+                (100, metric)
+            }
+            _ => (u32::MAX, u32::MAX),
+        }
+    }
+
     /// Propagate an RPF change into every TIB entry tracking that
     /// address ((S,G) sources and (*,G) RPs alike): prune off the old
     /// upstream, adopt the new state, re-evaluate.

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 
 use crate::config::{Args, Builder};
 
+use super::assert_fsm::AssertRole;
 use super::igmp::{FilterMode, QuerierState};
 use super::inst::{Pim, ShowCallback};
 use super::macros::mfc_oifs;
@@ -32,6 +33,8 @@ impl Pim {
             .set(show_pim_upstream)
             .path("/show/pim/rp-info")
             .set(show_pim_rp_info)
+            .path("/show/pim/assert")
+            .set(show_pim_assert)
             .path("/show/mroute")
             .set(show_mroute)
             .map();
@@ -348,6 +351,52 @@ fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::
             buf,
             "{:<35}{:<13}{:<17}{:<11}{:<11}{}",
             row.sg, row.iif, row.rpf_neighbor, row.state, row.reg, row.uptime,
+        )?;
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct AssertBrief {
+    entry: String,
+    interface: String,
+    role: String,
+    winner: String,
+    expires: u64,
+}
+
+fn show_pim_assert(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let now = Instant::now();
+    let mut rows: Vec<AssertBrief> = vec![];
+    for (key, entry) in pim.tib.iter() {
+        for (ifindex, assert) in entry.asserts.iter() {
+            let (role, winner) = match assert.role {
+                AssertRole::Winner => ("Winner".to_string(), assert.winner_metric.addr.to_string()),
+                AssertRole::Loser { winner } => ("Loser".to_string(), winner.to_string()),
+            };
+            rows.push(AssertBrief {
+                entry: key.to_string(),
+                interface: pim.ifname(*ifindex),
+                role,
+                winner,
+                expires: assert.expires.saturating_duration_since(now).as_secs(),
+            });
+        }
+    }
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    buf.push_str(
+        "Entry                              Interface    Role     Winner           Expires\n",
+    );
+    for row in &rows {
+        writeln!(
+            buf,
+            "{:<35}{:<13}{:<9}{:<17}{}",
+            row.entry, row.interface, row.role, row.winner, row.expires,
         )?;
     }
     Ok(buf)

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -18,8 +18,9 @@ use std::fmt;
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
+use super::assert_fsm::AssertState;
 use super::inst::Pim;
-use super::macros::{inherited_olist, join_desired, mfc_oifs};
+use super::macros::{inherited_effective, inherited_olist, join_desired_effective, mfc_oifs};
 use super::mroute::{REG_VIF, Upcall, UpcallKind};
 use super::rpf::RpfState;
 
@@ -122,6 +123,8 @@ pub struct TibEntry {
     /// Downstream per-interface state, keyed by ifindex. On SgRpt
     /// entries presence means "rpt-pruned on this interface".
     pub downstream: BTreeMap<u32, Downstream>,
+    /// Assert election state per contested interface (Sg entries).
+    pub asserts: BTreeMap<u32, AssertState>,
     /// Kernel MFC shadow — `Some` while installed (Sg entries only).
     pub installed: Option<InstalledMfc>,
     /// Keepalive deadline for traffic-created state (NOCACHE at any
@@ -143,6 +146,7 @@ impl TibEntry {
             rpf_target: None,
             local: BTreeSet::new(),
             downstream: BTreeMap::new(),
+            asserts: BTreeMap::new(),
             installed: None,
             stream_expires: None,
             reg_state: RegState::NoInfo,
@@ -280,16 +284,25 @@ impl Pim {
                 self.tib_update(key);
             }
             UpcallKind::WrongVif | UpcallKind::WrVifWhole => {
-                // Data on a non-IIF interface. Full assert machinery
-                // is a later phase; here it serves as the SPT-bit
-                // signal at routers that joined the source tree: the
-                // shared-tree copy still arriving proves the SPT is
-                // live, so the (S,G,rpt) prune can go out.
+                // Data on a non-IIF interface. On an interface we
+                // forward to, another forwarder exists on that LAN —
+                // run the assert election. Anywhere else it is the
+                // SPT-bit signal: the shared-tree copy still arriving
+                // proves the source tree is live, so the (S,G,rpt)
+                // prune can go out.
                 let key = SgKey::Sg {
                     src: upcall.src,
                     grp: upcall.grp,
                 };
-                self.spt_bit_set(key);
+                let arrival = self.fp.ifindex_of(upcall.vif);
+                let contested = arrival
+                    .map(|ifindex| mfc_oifs(&self.tib, key).contains(&ifindex))
+                    .unwrap_or(false);
+                if contested {
+                    self.assert_data_trigger(key, arrival.unwrap());
+                } else {
+                    self.spt_bit_set(key);
+                }
             }
             UpcallKind::WholePkt => {
                 self.register_wholepkt(upcall);
@@ -406,6 +419,7 @@ impl Pim {
             if let Some(entry) = self.tib.get_mut(&key) {
                 let touched = entry.local.remove(&ifindex)
                     | entry.downstream.remove(&ifindex).is_some()
+                    | entry.asserts.remove(&ifindex).is_some()
                     | (entry.rpf.ifindex() == Some(ifindex));
                 if touched {
                     self.tib_update(key);
@@ -462,11 +476,19 @@ impl Pim {
         //          non-empty inherited olist (the RP / LHR SPT-join
         //          clause).
         // Sending additionally requires a live PIM gateway neighbor.
+        // Interfaces that fell out of the raw olist no longer host a
+        // contest (CouldAssert false) — drop their assert state.
+        {
+            let raw = inherited_olist(&self.tib, key);
+            let entry = self.tib.get_mut(&key).unwrap();
+            entry.asserts.retain(|ifindex, _| raw.contains(ifindex));
+        }
+
         let jd = match key {
-            SgKey::StarG { grp } => join_desired(&self.tib, key) && !self.i_am_rp(grp),
+            SgKey::StarG { grp } => join_desired_effective(&self.tib, key) && !self.i_am_rp(grp),
             SgKey::Sg { .. } => {
-                join_desired(&self.tib, key)
-                    || (stream_alive && !inherited_olist(&self.tib, key).is_empty())
+                join_desired_effective(&self.tib, key)
+                    || (stream_alive && !inherited_effective(&self.tib, key).is_empty())
             }
             SgKey::SgRpt { .. } => false,
         };
@@ -606,6 +628,9 @@ impl Pim {
                     consider(until);
                 }
             }
+            for a in entry.asserts.values() {
+                consider(a.expires);
+            }
         }
         for t in self.jp_refresh.values() {
             consider(*t);
@@ -637,6 +662,7 @@ impl Pim {
         for key in touched {
             self.tib_update(key);
         }
+        self.assert_tick(now);
         self.register_tick(now);
         self.jp_tick(now);
     }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1017,6 +1017,10 @@ module exec {
         ext:help "PIM group-to-RP mappings";
         presence "PIM RP info";
       }
+      container assert {
+        ext:help "PIM assert election state";
+        presence "PIM assert";
+      }
     }
 
     container mroute {


### PR DESCRIPTION
## Summary

Phase 6 of the PIM-SM/SSM arc (architecture: `docs/design/pim-sm-ssm-architecture.md`; Phases 1–5: #1951 / #1956 / #1960 / #1965 / #1973) — the RFC 7761 multi-access behaviors:

- **`assert_fsm.rs`** — §4.6 assert election: `AssertMetric` with the exact ordering (rpt bit → preference → metric → higher-address tiebreak, unit-tested), Winner/Loser state per (entry, interface), data-triggered asserts from WRONGVIF upcalls on forwarding interfaces, packet-RX election with challenge-on-inferior, winner refresh at 177 s, loser expiry at 180 s. Metrics derive from the RPF cache (connected beats gateway; gateway carries the RIB's resolved metric).
- **`lost_assert` in `macros.rs`** — assert-lost interfaces stay in raw membership but drop out of `mfc_oifs`, the traffic-driven JoinDesired clause and `join_desired_effective`, so an assert loser withdraws from the source tree upstream (unit-tested).
- **WRONGVIF dispatch split** — arrival on an interface we forward to runs the assert; anywhere else remains the SPT-bit signal from Phase 5.
- **LAN behaviors in `jp.rs`** (§4.5.2) — the not-addressed-to-us branch now: suppresses our periodic Join when another router refreshes the same upstream state (75 s, inside the RFC randomization band), and answers an overheard Prune for state we still want with an immediate override Join.
- `show pim assert` (text + JSON) + exec.yang node.

## Test plan

- Live BDD under sudo (fresh binary + YANG, md5-checked): `--tags @pim_assert` — 7-namespace dual-LAN topology (switch namespaces with internal `mcast_snooping 0` bridges; existing harness steps only). One scenario proves the causal chain: both routers join and **mutually log join suppression** → duplicate forwarding triggers the **assert election, higher address wins deterministically** → the loser logs `assert loser` then `pruned toward` (JoinDesired collapse) → the winner logs `prune override` → r0 keeps forwarding and the receiver keeps getting payload. All 61 steps ✔. This also exercises the Phase-4 multi-neighbor PrunePending window for real.
- Regressions: `@pim_adjacency` + `@pim_igmp` + `@pim_ssm` + `@pim_asm` re-run — all pass.
- `cargo test --workspace --exclude bdd`: green (1,600 zebra-rs tests incl. new assert-metric and lost-assert tests). Forced-fresh `cargo clean -p zebra-rs && cargo clippy --workspace --all-targets -- -D warnings`: exit 0. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)