### PR TITLE
bgp: withdraw a deleted VRF's VPN exports, fix unreachable despawn

### DIFF
--- a/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-2.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-2.yaml
@@ -1,0 +1,20 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_vrf_vpnv6_export/z1-novrf.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv6_export/z1-novrf.yaml
@@ -1,0 +1,20 @@
+vrf:
+- name: vrf-blue
+  ipv6:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    neighbor:
+    - remote-address: 2001:db8::2
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_vrf_vpnv4_export.feature
+++ b/bdd/tests/features/bgp_vrf_vpnv4_export.feature
@@ -58,6 +58,24 @@ Feature: BGP per-VRF VPNv4 export to a remote PE
     Then show command "show bgp vpnv4 10.1.0.1" in namespace "z2" should contain "BGP routing table entry for 10.1.0.0/24"
     And show command "show bgp vpnv4 10.1.0.0/24" in namespace "z2" should contain "Route Distinguisher: 65001:100"
 
+  Scenario: Deleting the VRF withdraws its VPNv4 exports from the remote PE
+    Given the test topology exists
+    # z1-2.yaml is z1-1.yaml minus `router bgp vrf vrf-blue` — the BGP
+    # VRF despawn path. The exported row must leave both the local
+    # VPNv4 Loc-RIB and the remote PE; a stale advertisement here plus
+    # the immediately-reused service label would decap remote traffic
+    # into the wrong VRF.
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then show command "show bgp vpnv4" in namespace "z1" should not contain "10.1.0.0/24"
+    And show command "show bgp vpnv4" in namespace "z2" should not contain "10.1.0.0/24"
+
+  Scenario: Re-adding the VRF re-exports the network
+    Given the test topology exists
+    When I apply config "z1-1.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp vpnv4" in namespace "z2" should contain "10.1.0.0/24"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/bdd/tests/features/bgp_vrf_vpnv6_export.feature
+++ b/bdd/tests/features/bgp_vrf_vpnv6_export.feature
@@ -33,6 +33,22 @@ Feature: BGP per-VRF VPNv6 origination (network) + receive on a remote PE
     And show command "show bgp vpnv6" in namespace "z2" should contain "2001:db8:b::/64"
     And show command "show bgp vpnv6" in namespace "z2" should contain "65001:100"
 
+  Scenario: Deleting the VRF withdraws its VPNv6 exports from the remote PE
+    Given the test topology exists
+    # z1-novrf.yaml is z1.yaml minus `router bgp vrf vrf-blue` — the
+    # BGP VRF despawn path must withdraw the exported rows from the
+    # local VPNv6 Loc-RIB and the remote PE (finding #3: they used to
+    # stay advertised while the freed service label was reused).
+    When I apply config "z1-novrf.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then show command "show bgp vpnv6" in namespace "z1" should not contain "2001:db8:a::/64"
+    And show command "show bgp vpnv6" in namespace "z2" should not contain "2001:db8:a::/64"
+    And show command "show bgp vpnv6" in namespace "z2" should not contain "2001:db8:b::/64"
+    # Restore for the following scenarios.
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp vpnv6" in namespace "z2" should contain "2001:db8:a::/64"
+
   Scenario: z1 dies; z2 withdraws the VPNv6 routes it learned from it
     Given the test topology exists
     Then show command "show bgp vpnv6" in namespace "z2" should contain "2001:db8:a::/64"

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2441,6 +2441,12 @@ impl Bgp {
             if let Some(handle) = self.vrf_registry.remove(&name) {
                 super::vrf::despawn_bgp_vrf(&name, &handle, &self.rib_subscriber);
                 self.unregister_vrf_show(&name);
+                // Withdraw everything this VRF exported into the
+                // VPNv4/v6 Loc-RIBs from PE peers and sibling VRFs —
+                // BEFORE the ILM delete and label free below, whose
+                // reuse of the label is what turns a stale
+                // advertisement into a cross-VRF decap.
+                self.purge_vrf_exports(&name, &handle);
                 // Withdraw the AF_MPLS DecapVrf ILM ahead of
                 // returning the label. The netlink delete keys off
                 // the label alone so the IlmEntry contents are
@@ -2528,6 +2534,258 @@ impl Bgp {
         // Originate / withdraw config-driven MUP DSD segment routes now the
         // VRF set (and its SIDs / kernel context) may have changed.
         self.reconcile_mup_segment();
+    }
+
+    /// Withdraw every export a despawning VRF left in the VPNv4/v6
+    /// Loc-RIBs (its `ORIGINATED_PEER` rows under its RD) and fan the
+    /// withdrawals to PE peers and sibling VRFs.
+    ///
+    /// Without this, deleting a VRF left its exported rows advertised
+    /// forever: the per-VRF task's `Shutdown` is a bare loop-break, and
+    /// any `WithdrawExport` still in flight is dropped because the
+    /// VRF's cfg — and with it the RD lookup — is gone by the time the
+    /// message is handled. The despawn arm then frees the VRF's
+    /// service label for immediate reuse, so a remote PE still
+    /// forwarding on the stale advertisement would decap into whichever
+    /// VRF picked the label up next — a cross-VRF traffic leak. Must
+    /// run before the label goes back to the pool.
+    ///
+    /// `rd` / the Type-5 flags come from the handle's spawn-time
+    /// snapshot, not `self.vrfs` (see above). Two VRFs configured with
+    /// the same RD alias in these tables — the purge removes the
+    /// shared rows exactly like a live `WithdrawExport` would.
+    fn purge_vrf_exports(&mut self, name: &str, handle: &super::vrf::BgpVrfHandle) {
+        let Some(rd) = handle.rd else {
+            return;
+        };
+        let v4: Vec<ipnet::Ipv4Net> = self
+            .shard
+            .v4vpn
+            .get(&rd)
+            .map(|t| {
+                t.0.iter()
+                    .filter(|(_, ribs)| {
+                        ribs.iter()
+                            .any(|r| r.ident == super::route::ORIGINATED_PEER)
+                    })
+                    .map(|(p, _)| p)
+                    .collect()
+            })
+            .unwrap_or_default();
+        for prefix in v4 {
+            self.withdraw_vrf_export_v4(name, rd, prefix, handle.evpn_advertise_v4);
+        }
+        let v6: Vec<ipnet::Ipv6Net> = self
+            .shard
+            .v6vpn
+            .get(&rd)
+            .map(|t| {
+                t.0.iter()
+                    .filter(|(_, ribs)| {
+                        ribs.iter()
+                            .any(|r| r.ident == super::route::ORIGINATED_PEER)
+                    })
+                    .map(|(p, _)| p)
+                    .collect()
+            })
+            .unwrap_or_default();
+        for prefix in v6 {
+            self.withdraw_vrf_export_v6(name, rd, prefix, handle.evpn_advertise_v6);
+        }
+    }
+
+    /// Remove one VRF-originated row from the VPNv4 Loc-RIB and
+    /// propagate everywhere the matching `Export` went: re-run
+    /// best-path, re-import (or withdraw-import) into sibling VRFs,
+    /// advertise/withdraw to PE peers, and mirror the EVPN Type-5
+    /// withdrawal. Shared by the `WithdrawExport` message arm and the
+    /// despawn-time [`Self::purge_vrf_exports`], whose caller supplies
+    /// `rd` / `advertise_type5` from its own snapshot (the cfg is gone
+    /// by then).
+    fn withdraw_vrf_export_v4(
+        &mut self,
+        vrf: &str,
+        rd: bgp_packet::RouteDistinguisher,
+        prefix: ipnet::Ipv4Net,
+        advertise_type5: bool,
+    ) {
+        // VRF-originated routes always carry `ident == ORIGINATED_PEER`
+        // and `local_id == 0` (the values used in the matching Export);
+        // the remove path uses that tuple to identify the row.
+        let removed = self
+            .shard
+            .remove(Some(rd), prefix, 0, super::route::ORIGINATED_PEER);
+
+        // Re-run best-path so any remaining candidate at (rd, prefix)
+        // becomes the new selected winner. Pass that result to
+        // `route_advertise_to_peers` — empty `selected` triggers the
+        // Withdraw branch there (`peer.adj_out` cleanup, MP_UNREACH
+        // emit).
+        let selected = self.shard.select_best_path_vpn(&rd, prefix);
+
+        // Local intra-router leak, symmetric with the Export handler.
+        // If a replacement candidate survives at (rd, prefix),
+        // re-import it into sibling VRFs with the new attr; otherwise
+        // flood a withdraw using the removed row's attr to resolve the
+        // matching-VRF set. Skip the originating VRF (self-import
+        // guard).
+        {
+            let dispatcher = super::vrf::VrfImportDispatcher {
+                rib_known_vrfs: &self.rib_known_vrfs,
+                vrf_registry: &self.vrf_registry,
+            };
+            if let Some(winner) = selected.first() {
+                super::vrf::dispatch_import_v4(
+                    &dispatcher,
+                    rd,
+                    prefix,
+                    &winner.attr,
+                    0,
+                    &[],
+                    Some(vrf),
+                );
+            } else if let Some(gone) = removed.first() {
+                super::vrf::dispatch_withdraw_import_v4(
+                    &dispatcher,
+                    rd,
+                    prefix,
+                    &gone.attr,
+                    Some(vrf),
+                );
+            }
+        }
+
+        let mut top = super::peer::BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_export: None,
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
+        };
+        super::route::route_advertise_to_peers(
+            Some(rd),
+            prefix,
+            &selected,
+            /* source peer */ 0,
+            &mut top,
+            &mut self.peers,
+        );
+
+        bgp_vpn_trace!(
+            self.tracing,
+            vrf = %vrf,
+            %prefix,
+            rd = %rd,
+            removed = removed.len(),
+            winners = selected.len(),
+            "bgp: export withdrawn from LocalRib.v4vpn and PE peers",
+        );
+
+        // Mirror the EVPN Type-5 withdrawal.
+        if advertise_type5 {
+            self.evpn_withdraw_type5(rd, ipnet::IpNet::V4(prefix));
+        }
+    }
+
+    /// VPNv6 twin of [`Self::withdraw_vrf_export_v4`].
+    fn withdraw_vrf_export_v6(
+        &mut self,
+        vrf: &str,
+        rd: bgp_packet::RouteDistinguisher,
+        prefix: ipnet::Ipv6Net,
+        advertise_type5: bool,
+    ) {
+        let removed = self
+            .shard
+            .remove_v6vpn(rd, prefix, 0, super::route::ORIGINATED_PEER);
+        let selected = self.shard.select_best_path_vpn_v6(&rd, prefix);
+
+        // Local intra-router leak, symmetric with the ExportV6 handler:
+        // a surviving winner re-imports into sibling VRFs; otherwise
+        // flood a withdraw from the removed row's RTs. Skip the
+        // originating VRF.
+        {
+            let dispatcher = super::vrf::VrfImportDispatcher {
+                rib_known_vrfs: &self.rib_known_vrfs,
+                vrf_registry: &self.vrf_registry,
+            };
+            if let Some(winner) = selected.first() {
+                super::vrf::dispatch_import_v6(
+                    &dispatcher,
+                    rd,
+                    prefix,
+                    &winner.attr,
+                    0,
+                    &[],
+                    Some(vrf),
+                );
+            } else if let Some(gone) = removed.first() {
+                super::vrf::dispatch_withdraw_import_v6(
+                    &dispatcher,
+                    rd,
+                    prefix,
+                    &gone.attr,
+                    Some(vrf),
+                );
+            }
+        }
+
+        let mut top = super::peer::BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_export: None,
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
+        };
+        super::route::route_advertise_to_peers_vpnv6(
+            rd,
+            prefix,
+            &selected,
+            &mut top,
+            &mut self.peers,
+        );
+
+        bgp_vpn_trace!(
+            self.tracing,
+            vrf = %vrf,
+            %prefix,
+            rd = %rd,
+            winners = selected.len(),
+            "bgp: v6 export withdrawn from LocalRib.v6vpn and PE peers",
+        );
+
+        // Mirror the EVPN Type-5 (IPv6) withdrawal.
+        if advertise_type5 {
+            self.evpn_withdraw_type5(rd, ipnet::IpNet::V6(prefix));
+        }
     }
 
     /// Reconcile the MUP controller against `mup_c_config` at every
@@ -5458,102 +5716,12 @@ impl Bgp {
                     );
                     return;
                 };
-                // VRF-originated routes always carry `ident ==
-                // ORIGINATED_PEER` and `local_id == 0` (the values used in
-                // the matching Export); the remove path uses that tuple to
-                // identify the row.
-                let removed = self
-                    .shard
-                    .remove(Some(rd), prefix, 0, super::route::ORIGINATED_PEER);
-
-                // Re-run best-path so any remaining candidate at
-                // (rd, prefix) becomes the new selected winner.
-                // Pass that result to `route_advertise_to_peers` —
-                // empty `selected` triggers the Withdraw branch
-                // there (`peer.adj_out` cleanup, MP_UNREACH emit).
-                let selected = self.shard.select_best_path_vpn(&rd, prefix);
-
-                // Local intra-router leak, symmetric with the Export
-                // handler. If a replacement candidate survives at
-                // (rd, prefix), re-import it into sibling VRFs with
-                // the new attr; otherwise flood a withdraw using the
-                // removed row's attr to resolve the matching-VRF set.
-                // Skip the originating VRF (self-import guard).
-                {
-                    let dispatcher = super::vrf::VrfImportDispatcher {
-                        rib_known_vrfs: &self.rib_known_vrfs,
-                        vrf_registry: &self.vrf_registry,
-                    };
-                    if let Some(winner) = selected.first() {
-                        super::vrf::dispatch_import_v4(
-                            &dispatcher,
-                            rd,
-                            prefix,
-                            &winner.attr,
-                            0,
-                            &[],
-                            Some(vrf.as_str()),
-                        );
-                    } else if let Some(gone) = removed.first() {
-                        super::vrf::dispatch_withdraw_import_v4(
-                            &dispatcher,
-                            rd,
-                            prefix,
-                            &gone.attr,
-                            Some(vrf.as_str()),
-                        );
-                    }
-                }
-
-                let mut top = super::peer::BgpTop {
-                    router_id: &self.router_id,
-                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
-                    local_rib: &mut self.local_rib,
-                    shard: &mut self.shard,
-                    tx: &self.tx,
-                    rib_client: &self.ctx.rib,
-                    attr_store: &mut self.attr_store,
-                    update_groups: &mut self.update_groups,
-                    interface_addrs: &self.interface_addrs,
-                    color_policy: Some(&self.color_policy),
-                    flex_algo_routes: Some(&self.flex_algo_routes),
-                    flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
-                    vrf_export: None,
-                    vrf_import: None,
-                    nexthop_cache: None,
-                    vrf_transport_v4: None,
-                    vrf_transport_v6: None,
-                    central_label_alloc: None,
-                    as_sets_withdraw: self.as_sets_withdraw,
-                };
-                super::route::route_advertise_to_peers(
-                    Some(rd),
-                    prefix,
-                    &selected,
-                    /* source peer */ 0,
-                    &mut top,
-                    &mut self.peers,
-                );
-
-                bgp_vpn_trace!(
-                    self.tracing,
-                    vrf = %vrf,
-                    %prefix,
-                    rd = %rd,
-                    removed = removed.len(),
-                    winners = selected.len(),
-                    "bgp: export withdrawn from LocalRib.v4vpn and PE peers",
-                );
-
-                // Mirror the EVPN Type-5 withdrawal.
                 let advertise_type5 = self
                     .vrfs
                     .get(&vrf)
                     .map(|c| c.evpn_advertise_v4)
                     .unwrap_or(false);
-                if advertise_type5 {
-                    self.evpn_withdraw_type5(rd, ipnet::IpNet::V4(prefix));
-                }
+                self.withdraw_vrf_export_v4(&vrf, rd, prefix, advertise_type5);
             }
             super::vrf::BgpGlobalMsg::ExportV6 {
                 vrf,
@@ -5730,88 +5898,12 @@ impl Bgp {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
                     return;
                 };
-                let removed = self
-                    .shard
-                    .remove_v6vpn(rd, prefix, 0, super::route::ORIGINATED_PEER);
-                let selected = self.shard.select_best_path_vpn_v6(&rd, prefix);
-
-                // Local intra-router leak, symmetric with the ExportV6
-                // handler: a surviving winner re-imports into sibling
-                // VRFs; otherwise flood a withdraw from the removed
-                // row's RTs. Skip the originating VRF.
-                {
-                    let dispatcher = super::vrf::VrfImportDispatcher {
-                        rib_known_vrfs: &self.rib_known_vrfs,
-                        vrf_registry: &self.vrf_registry,
-                    };
-                    if let Some(winner) = selected.first() {
-                        super::vrf::dispatch_import_v6(
-                            &dispatcher,
-                            rd,
-                            prefix,
-                            &winner.attr,
-                            0,
-                            &[],
-                            Some(vrf.as_str()),
-                        );
-                    } else if let Some(gone) = removed.first() {
-                        super::vrf::dispatch_withdraw_import_v6(
-                            &dispatcher,
-                            rd,
-                            prefix,
-                            &gone.attr,
-                            Some(vrf.as_str()),
-                        );
-                    }
-                }
-
-                let mut top = super::peer::BgpTop {
-                    router_id: &self.router_id,
-                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
-                    local_rib: &mut self.local_rib,
-                    shard: &mut self.shard,
-                    tx: &self.tx,
-                    rib_client: &self.ctx.rib,
-                    attr_store: &mut self.attr_store,
-                    update_groups: &mut self.update_groups,
-                    interface_addrs: &self.interface_addrs,
-                    color_policy: Some(&self.color_policy),
-                    flex_algo_routes: Some(&self.flex_algo_routes),
-                    flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
-                    vrf_export: None,
-                    vrf_import: None,
-                    nexthop_cache: None,
-                    vrf_transport_v4: None,
-                    vrf_transport_v6: None,
-                    central_label_alloc: None,
-                    as_sets_withdraw: self.as_sets_withdraw,
-                };
-                super::route::route_advertise_to_peers_vpnv6(
-                    rd,
-                    prefix,
-                    &selected,
-                    &mut top,
-                    &mut self.peers,
-                );
-
-                bgp_vpn_trace!(
-                    self.tracing,
-                    vrf = %vrf,
-                    %prefix,
-                    rd = %rd,
-                    winners = selected.len(),
-                    "bgp: v6 export withdrawn from LocalRib.v6vpn and PE peers",
-                );
-
-                // Mirror the EVPN Type-5 (IPv6) withdrawal.
                 let advertise_type5 = self
                     .vrfs
                     .get(&vrf)
                     .map(|c| c.evpn_advertise_v6)
                     .unwrap_or(false);
-                if advertise_type5 {
-                    self.evpn_withdraw_type5(rd, ipnet::IpNet::V6(prefix));
-                }
+                self.withdraw_vrf_export_v6(&vrf, rd, prefix, advertise_type5);
             }
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -69,6 +69,17 @@ pub struct BgpVrfHandle {
     /// `Message::SidDel` withdrawal. `None` for MPLS-mode VRFs and for
     /// srv6 VRFs spawned before their locator resolved.
     pub srv6_sid: Option<(Ipv6Addr, u16)>,
+    /// Snapshot of the VRF's RD at spawn. The despawn-time export
+    /// purge needs it, and by then the cfg (`Bgp::vrfs[name]`) is
+    /// already gone — despawn is exactly the "removed from intent"
+    /// case.
+    pub rd: Option<bgp_packet::RouteDistinguisher>,
+    /// Snapshots of `evpn advertise-ipv4` / `advertise-ipv6` for the
+    /// same reason: the despawn purge mirrors each withdrawn export's
+    /// EVPN Type-5 withdrawal exactly when the live withdraw would
+    /// have.
+    pub evpn_advertise_v4: bool,
+    pub evpn_advertise_v6: bool,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -305,6 +316,9 @@ pub fn spawn_bgp_vrf(
         label,
         ilm_decap_ifindex,
         srv6_sid,
+        rd: cfg.rd,
+        evpn_advertise_v4: cfg.evpn_advertise_v4,
+        evpn_advertise_v6: cfg.evpn_advertise_v6,
     }
 }
 

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -275,11 +275,21 @@ pub struct BgpVrfConfig {
     pub mobile_uplane: BgpVrfMobileUplane,
 }
 
-/// Borrow-or-create the per-VRF entry on `Bgp::vrfs`. Used by every
-/// leaf callback; promotes the "set leaf before set list-key" race
-/// to a no-op rather than a `None` return.
-fn vrf_entry(bgp: &mut Bgp, name: String) -> &mut BgpVrfConfig {
-    bgp.vrfs.entry(name).or_default()
+/// Borrow the per-VRF entry on `Bgp::vrfs`, creating it for Set (the
+/// "set leaf before set list-key" firing order makes lazy creation
+/// necessary) but NEVER for Delete. A whole-subtree delete fires the
+/// list-entry callback — which removes the map entry — before the
+/// child-leaf delete callbacks, so a lazily re-created entry here
+/// resurrected the VRF as a default config: `compute_vrf_diff` then
+/// saw the name as still desired and the despawn (task teardown,
+/// export purge, ILM withdraw, label reclaim) never ran. `None` on a
+/// Delete for a gone VRF means "nothing left to mutate" — callbacks
+/// early-return.
+fn vrf_entry(bgp: &mut Bgp, name: String, op: ConfigOp) -> Option<&mut BgpVrfConfig> {
+    match op {
+        ConfigOp::Delete => bgp.vrfs.get_mut(&name),
+        _ => Some(bgp.vrfs.entry(name).or_default()),
+    }
 }
 
 /// `set router bgp vrf <NAME>` — list-key handler.
@@ -300,7 +310,7 @@ pub fn config_vrf(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 /// `set router bgp vrf <NAME> rd <RD>`.
 pub fn config_vrf_rd(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let rd_str = args.string()?;
@@ -315,7 +325,7 @@ pub fn config_vrf_rd(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
 /// `set router bgp vrf <NAME> router-id <IPv4>`.
 pub fn config_vrf_router_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.router_id = Some(args.v4addr()?),
         ConfigOp::Delete => cfg.router_id = None,
@@ -327,7 +337,7 @@ pub fn config_vrf_router_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
 /// `set router bgp vrf <NAME> label-mode {per-vrf|per-route|per-nexthop}`.
 pub fn config_vrf_label_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let raw = args.string()?;
@@ -342,7 +352,7 @@ pub fn config_vrf_label_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 /// `set router bgp vrf <NAME> encapsulation {mpls|srv6}`.
 pub fn config_vrf_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let raw = args.string()?;
@@ -359,7 +369,7 @@ pub fn config_vrf_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
 /// this VRF (see [`BgpVrfConfig::inter_as_hybrid`]).
 pub fn config_vrf_inter_as_hybrid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.inter_as_hybrid = args.boolean()?,
         ConfigOp::Delete => cfg.inter_as_hybrid = false,
@@ -401,7 +411,7 @@ fn mup_route_binding(cfg: &mut BgpVrfConfig, direction: MupSrv6Direction) -> &mu
 pub fn config_vrf_mup_route(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let direction = mup_route_direction(&args.string()?)?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             mup_route_binding(cfg, direction);
@@ -433,7 +443,7 @@ pub fn config_vrf_mup_route_network_instance(
 ) -> Option<()> {
     let name = args.string()?;
     let direction = mup_route_direction(&args.string()?)?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let ni = args.string()?;
@@ -462,7 +472,7 @@ pub fn config_vrf_mup_route_mup_ext_comm(
 ) -> Option<()> {
     let name = args.string()?;
     let direction = mup_route_direction(&args.string()?)?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let raw = args.string()?;
@@ -492,7 +502,7 @@ pub fn config_vrf_mup_route_mup_ext_comm(
 pub fn config_vrf_mup_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let mode = MupSegmentMode::parse(&args.string()?)?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.mobile_uplane.segment = Some(mode),
         ConfigOp::Delete if cfg.mobile_uplane.segment == Some(mode) => {
@@ -509,7 +519,7 @@ pub fn config_vrf_mup_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
 pub fn config_vrf_mup_dataplane(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let mode = MupDataplane::parse(&args.string()?)?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.mobile_uplane.dataplane = mode,
         ConfigOp::Delete => cfg.mobile_uplane.dataplane = MupDataplane::default(),
@@ -528,7 +538,7 @@ pub fn config_vrf_mup_dataplane(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
 pub fn config_vrf_mup_ext_comm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let _segment = args.string()?; // segment list key (direct|interwork)
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let raw = args.string()?;
@@ -550,7 +560,7 @@ pub fn config_vrf_mup_ext_comm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
 pub fn config_vrf_mup_segment_prefix(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let _segment = args.string()?; // segment list key (direct|interwork)
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let raw = args.string()?;
@@ -566,7 +576,7 @@ pub fn config_vrf_mup_segment_prefix(bgp: &mut Bgp, mut args: Args, op: ConfigOp
 pub fn config_vrf_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let addr = args.addr()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             cfg.neighbors.entry(addr).or_default();
@@ -583,7 +593,7 @@ pub fn config_vrf_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 pub fn config_vrf_neighbor_remote_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let addr = args.addr()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     let nbr = cfg.neighbors.entry(addr).or_default();
     match op {
         ConfigOp::Set => nbr.remote_as = Some(args.u32()?),
@@ -597,7 +607,7 @@ pub fn config_vrf_neighbor_remote_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp
 pub fn config_vrf_neighbor_peer_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let addr = args.addr()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     let nbr = cfg.neighbors.entry(addr).or_default();
     match op {
         ConfigOp::Set => nbr.peer_group = Some(args.string()?),
@@ -611,7 +621,7 @@ pub fn config_vrf_neighbor_peer_group(bgp: &mut Bgp, mut args: Args, op: ConfigO
 pub fn config_vrf_neighbor_description(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let addr = args.addr()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     let nbr = cfg.neighbors.entry(addr).or_default();
     match op {
         ConfigOp::Set => nbr.description = Some(args.string()?),
@@ -637,7 +647,7 @@ pub fn config_vrf_neighbor_afi_safi_enabled(
     let name = args.string()?;
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     let nbr = cfg.neighbors.entry(addr).or_default();
     match op {
         ConfigOp::Set => {
@@ -657,7 +667,7 @@ pub fn config_vrf_afi_ipv4(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     let name = args.string()?;
     match op {
         ConfigOp::Set => {
-            vrf_entry(bgp, name)
+            vrf_entry(bgp, name, op)?
                 .ipv4_unicast
                 .get_or_insert_with(Default::default);
         }
@@ -680,7 +690,9 @@ pub fn config_vrf_afi_ipv4(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
                     let _ = handle.inbox.send(BgpVrfMsg::WithdrawNetwork { prefix });
                 }
             }
-            vrf_entry(bgp, name).ipv4_unicast = None;
+            if let Some(cfg) = vrf_entry(bgp, name, op) {
+                cfg.ipv4_unicast = None;
+            }
         }
         _ => {}
     }
@@ -697,7 +709,7 @@ pub fn config_vrf_afi_ipv4_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
         _ => return Some(()),
     };
     {
-        let af = vrf_entry(bgp, name.clone())
+        let af = vrf_entry(bgp, name.clone(), op)?
             .ipv4_unicast
             .get_or_insert_with(Default::default);
         if set {
@@ -728,7 +740,7 @@ pub fn config_vrf_afi_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     let name = args.string()?;
     match op {
         ConfigOp::Set => {
-            vrf_entry(bgp, name)
+            vrf_entry(bgp, name, op)?
                 .ipv6_unicast
                 .get_or_insert_with(Default::default);
         }
@@ -748,7 +760,9 @@ pub fn config_vrf_afi_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
                     let _ = handle.inbox.send(BgpVrfMsg::WithdrawNetworkV6 { prefix });
                 }
             }
-            vrf_entry(bgp, name).ipv6_unicast = None;
+            if let Some(cfg) = vrf_entry(bgp, name, op) {
+                cfg.ipv6_unicast = None;
+            }
         }
         _ => {}
     }
@@ -765,7 +779,7 @@ pub fn config_vrf_afi_ipv6_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
         _ => return Some(()),
     };
     {
-        let af = vrf_entry(bgp, name.clone())
+        let af = vrf_entry(bgp, name.clone(), op)?
             .ipv6_unicast
             .get_or_insert_with(Default::default);
         if set {
@@ -808,7 +822,9 @@ fn vrf_redist_set(
         _ => return Some(()),
     };
     {
-        let cfg = vrf_entry(bgp, name.clone());
+        let Some(cfg) = vrf_entry(bgp, name.clone(), op) else {
+            return Some(());
+        };
         let redist = match afi {
             RedistAfi::Ipv4 => {
                 &mut cfg
@@ -846,7 +862,10 @@ fn vrf_redist_set(
 /// rationale as `config_vrf_afi_ipv4`'s network sweep).
 fn vrf_redist_clear(bgp: &mut Bgp, name: String, afi: RedistAfi) {
     let sources: Vec<BgpRedistSource> = {
-        let cfg = vrf_entry(bgp, name.clone());
+        // Delete-only path: never create the entry (see `vrf_entry`).
+        let Some(cfg) = bgp.vrfs.get_mut(&name) else {
+            return;
+        };
         let redist = match afi {
             RedistAfi::Ipv4 => cfg.ipv4_unicast.as_mut().map(|af| &mut af.redistribute),
             RedistAfi::Ipv6 => cfg.ipv6_unicast.as_mut().map(|af| &mut af.redistribute),
@@ -970,7 +989,7 @@ pub fn config_vrf_afi_ipv6_redistribute_isis(
 /// `set router bgp vrf <NAME> evpn advertise-ipv4 <bool>`.
 pub fn config_vrf_evpn_advertise_ipv4(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.evpn_advertise_v4 = args.boolean()?,
         ConfigOp::Delete => cfg.evpn_advertise_v4 = false,
@@ -982,7 +1001,7 @@ pub fn config_vrf_evpn_advertise_ipv4(bgp: &mut Bgp, mut args: Args, op: ConfigO
 /// `set router bgp vrf <NAME> evpn advertise-ipv6 <bool>`.
 pub fn config_vrf_evpn_advertise_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.evpn_advertise_v6 = args.boolean()?,
         ConfigOp::Delete => cfg.evpn_advertise_v6 = false,
@@ -994,7 +1013,7 @@ pub fn config_vrf_evpn_advertise_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigO
 /// `set router bgp vrf <NAME> evpn l3vni <VNI>`.
 pub fn config_vrf_evpn_l3vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => cfg.l3vni = Some(args.u32()?),
         ConfigOp::Delete => cfg.l3vni = None,
@@ -1006,7 +1025,7 @@ pub fn config_vrf_evpn_l3vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 /// `set router bgp vrf <NAME> evpn router-mac <MAC>` (symmetric IRB).
 pub fn config_vrf_evpn_router_mac(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
+    let cfg = vrf_entry(bgp, name, op)?;
     match op {
         ConfigOp::Set => {
             let mac: crate::rib::MacAddr = args.string()?.parse().ok()?;


### PR DESCRIPTION
## Summary
Fixes review finding #3 of `docs/design/bgp-code-review-findings.md` (VRF delete → cross-VRF traffic leak). Two stacked bugs:

1. **Despawn never cleaned the exports.** The despawn arm freed (and immediately made reusable) the VRF's MPLS label but left the VRF's exported rows (`ORIGINATED_PEER` under its RD) in `shard.v4vpn`/`v6vpn` and advertised to PE peers — a remote PE still forwarding on the stale advertisement would decap into whichever VRF picked the label up next. New `Bgp::purge_vrf_exports` runs in the despawn arm before the label returns to the pool: each row is removed, best-path re-run, withdrawn from PE peers and sibling VRFs, with the EVPN Type-5 mirror. The RD / Type-5 flags come from spawn-time snapshots on `BgpVrfHandle` (the cfg is gone by despawn — exactly why late `WithdrawExport`s were dropped). The `WithdrawExport`/`WithdrawExportV6` arm bodies are extracted into shared `withdraw_vrf_export_v4/_v6`.
2. **The despawn arm was unreachable via config apply.** A whole-subtree delete fires the `router bgp vrf <name>` list-entry callback (removing `bgp.vrfs[name]`) before the child-leaf deletes, and every leaf callback lazily `or_default()`'d the entry back — resurrecting the VRF as a default config, so `compute_vrf_diff` never despawned it (task, ILM, label and SID cleanup silently skipped too). `vrf_entry` is now op-aware: Delete never creates.

## Test plan
- Reproduced live on a throwaway daemon: apply VRF config → VPNv4 row present; apply config without the VRF → row stayed (bug) / row gone (fixed); re-apply → re-exported with a fresh label.
- BDD: `bgp_vrf_vpnv4_export` / `bgp_vrf_vpnv6_export` gain VRF-delete + re-add scenarios asserting the export leaves BOTH the local Loc-RIB and the remote PE. Both features failed against the unfixed build and pass with the fix (run live, teardown clean).
- Full workspace suite (`--exclude bdd`) 39/39 green; 619 BGP unit tests; workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)