### PR TITLE
ospf-packet: fix Unknown Router-Information TLV round-trip

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -1193,17 +1193,6 @@ pub struct RouterInfoTlvUnknown {
     pub values: Vec<u8>,
 }
 
-impl RouterInfoTlvUnknown {
-    pub fn parse_tlv(input: &[u8], tl: TlvTypeLen) -> IResult<&[u8], Self> {
-        let tlv = Self {
-            typ: tl.typ,
-            len: tl.len,
-            values: Vec::new(),
-        };
-        Ok((input, tlv))
-    }
-}
-
 // TLV
 impl RouterInfoTlv {
     pub fn parse_tlv(input: &[u8]) -> IResult<&[u8], Self> {
@@ -1211,7 +1200,19 @@ impl RouterInfoTlv {
         let typ: RouterInfoTlvType = tl.typ.into();
         let len = tl.len as usize;
         let (input, tlv) = packet_utils::safe_split_at(input, len)?;
-        let (_, val) = Self::parse_be(tlv, typ)?;
+        // Unknown top-level TLVs keep their header type/length verbatim and
+        // carry the whole value slice, so re-emit reproduces the wire bytes.
+        // The derived `Self::parse_be` would instead misread type/len from the
+        // first four value octets — mirror the ExtPrefix / ExtLink / ASLA
+        // sub-TLV Unknown arms, which already build it correctly.
+        let val = match typ {
+            RouterInfoTlvType::Unknown(_) => RouterInfoTlv::Unknown(RouterInfoTlvUnknown {
+                typ: tl.typ,
+                len: tl.len,
+                values: tlv.to_vec(),
+            }),
+            _ => Self::parse_be(tlv, typ)?.1,
+        };
         // Skip padding to 4-byte alignment.
         let padded = (len + 3) & !3;
         let (input, _) = take(padded - len)(input)?;
@@ -2924,6 +2925,31 @@ mod tests {
         // A received NP flag (0x40) decodes as NP, not M.
         let f = PrefixSidFlags::from_bits(0x40);
         assert!(f.np_flag() && !f.m_flag());
+    }
+
+    #[test]
+    fn router_info_unknown_tlv_roundtrips() {
+        // Unknown top-level RI TLV: type=100, len=6, value AA..FF, padded to 8.
+        let bytes = [
+            0x00, 100, 0x00, 6, // header: typ=100, len=6
+            0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, // 6-byte value
+            0x00, 0x00, // pad 6 -> 8
+        ];
+        let (rest, tlv) = RouterInfoTlv::parse_tlv(&bytes).expect("parse");
+        assert!(rest.is_empty());
+        match &tlv {
+            RouterInfoTlv::Unknown(u) => {
+                // type/len come from the header, not the value bytes.
+                assert_eq!(u.typ, 100);
+                assert_eq!(u.len, 6);
+                assert_eq!(u.values, vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+        // Re-emit reproduces the exact wire bytes (type, length, value, pad).
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(&buf[..], &bytes[..]);
     }
 
     /// RFC 2328 §D.4.1-D.4.2: the checksum excludes the 64-bit

--- a/docs/design/ospf-packet-code-review.md
+++ b/docs/design/ospf-packet-code-review.md
@@ -24,7 +24,7 @@ most-severe first.
 | 5 | **Interop** | `parser.rs:1691` | `PrefixSidFlags` every flag one bit too high | ✅ #1966 |
 | 6 | **Interop** | `v3.rs:1708` (+`1769`) | OSPFv3 Adj-SID Weight is 16-bit at the wrong offset | ✅ #1970 |
 | 7 | **Interop** | `v3.rs:3149` (+`3210`) | SRv6 End.X SID header is 8 bytes; RFC 9513 is 6 | ✅ #1974 |
-| 8 | **Round-trip** | `parser.rs:1214` | Unknown RouterInfo TLV reads type/len from value bytes | ⬜ open |
+| 8 | **Round-trip** | `parser.rs:1214` | Unknown RouterInfo TLV reads type/len from value bytes | ✅ #1982 |
 | 9 | **Security** | `zebra-rs/.../network_v6.rs:124` | v3 checksum skipped when any trailing bytes present | ✅ #1979 |
 | 10 | **Correctness** | `parser.rs:557` | `verify_checksum` re-emits typed form, ignores `raw` | ⬜ open |
 | 11 | **Robustness** | `parser.rs:693` | `parse_lsa_with_length` swallows all errors into `Unknown` | ⬜ open |
@@ -38,8 +38,9 @@ most-severe first.
 ## Status (2026-07-18)
 
 All seven top findings — the three remote-DoS parse bugs and all four silent
-interop wire-format bugs — plus the security finding #9 are fixed and merged to
-`main`. The review document itself landed in #1955.
+interop wire-format bugs — plus the security finding #9 and the round-trip
+finding #8 are fixed and merged to `main`. The review document itself landed in
+#1955.
 
 | PR | Findings | Summary |
 |----|----------|---------|
@@ -49,6 +50,7 @@ interop wire-format bugs — plus the security finding #9 are fixed and merged t
 | [#1970](https://github.com/zebra-rs/zebra-rs/pull/1970) | 6 | Adj-SID / LAN-Adj-SID `weight` → `u8` at offset 1 (RFC 8666 §6.1/§6.2) |
 | [#1974](https://github.com/zebra-rs/zebra-rs/pull/1974) | 7 | End.X / LAN-End.X SID head → 6 bytes (RFC 9513 §9.1/§9.2) |
 | [#1979](https://github.com/zebra-rs/zebra-rs/pull/1979) | 9 | v3 receive checksum verified over `input[..pkt_len]` unconditionally, closing the trailing-bytes bypass; **validated by `ospfv3_auth` BDD** |
+| [#1982](https://github.com/zebra-rs/zebra-rs/pull/1982) | 8 (part of 15) | Unknown Router-Information TLV built from the header, not the value bytes; dead `RouterInfoTlvUnknown::parse_tlv` removed |
 
 Each fix carries a regression test: byte-offset unit tests where a `show`-based
 check could not discriminate the bug, plus live BDD features for the Prefix-SID
@@ -64,36 +66,30 @@ meaningful lock.
 The remaining findings are all lower-severity than the merged set (no DoS, no
 silent interop break in a shipped datapath). Suggested order:
 
-> Finding 9 (v3 checksum-skip integrity bypass) — the previous Tier-1 item —
-> was fixed in [#1979](https://github.com/zebra-rs/zebra-rs/pull/1979).
+> Findings 8 and 9 — the previous Tier-1 items — are fixed: #9 (v3 checksum-skip
+> bypass) in [#1979](https://github.com/zebra-rs/zebra-rs/pull/1979), #8 (Unknown
+> RouterInfo TLV round-trip) in [#1982](https://github.com/zebra-rs/zebra-rs/pull/1982).
 
-**Tier 1 — highest remaining value**
-1. **Finding 8 (+ part of 15) — Unknown RouterInfo TLV round-trip corruption.**
-   Self-contained and testable: wire the already-present (but dead)
-   `RouterInfoTlvUnknown::parse_tlv` into the `Unknown` arm so `typ`/`len` come
-   from the header, not the value bytes. This also removes one of finding 15's
-   dead items. Add a round-trip unit test over an unknown RI TLV.
-
-**Tier 2 — correctness / robustness, moderate effort**
-2. **Finding 12 — derive `num_adv` / `num_links` at emit.** Mirror the v3 codec
+**Tier 1 — correctness / robustness, moderate effort**
+1. **Finding 12 — derive `num_adv` / `num_links` at emit.** Mirror the v3 codec
    (`Ospfv3LsUpdate::emit`), then delete the manual sync lines in the daemon
    (`inst.rs:1983`, `inst.rs:5404/5502/5571`). Touches daemon call sites.
-3. **Finding 11 — `parse_lsa_with_length` should not swallow parse failures.**
+2. **Finding 11 — `parse_lsa_with_length` should not swallow parse failures.**
    Distinguish "unknown LS type" (→ `Unknown`, keep tolerant flooding) from
    "known type, body failed to parse" (→ propagate `Err`). Needs care to avoid
    regressing the intentional unmodeled-sub-TLV tolerance.
-4. **Finding 10 — `verify_checksum` should use `self.raw`.** Low effort; latent
+3. **Finding 10 — `verify_checksum` should use `self.raw`.** Low effort; latent
    today (only the crate's tests call it), so low urgency until it is wired into
    an ingress path. Pairs with the non-bijective `From<u8>` note below.
 
-**Tier 3 — low-severity / cleanup**
-5. **Finding 13 — Unknown v2 payload emit drops body / `typ()` → Hello.** Latent
+**Tier 2 — low-severity / cleanup**
+4. **Finding 13 — Unknown v2 payload emit drops body / `typ()` → Hello.** Latent
    (daemon never re-emits unknown-type packets); fix the public-API trap when
    convenient.
-6. **Finding 15 (remainder) — delete dead `pub` items** (`is_known`,
-   `Ospfv3ExtTlv::wire_len`; `RouterInfoTlvUnknown::parse_tlv` gets consumed by
-   finding 8). Trivial deletions.
-7. **Finding 14 — hoist duplicated codecs into `packet-utils`** (Fletcher
+5. **Finding 15 (remainder) — delete dead `pub` items** (`is_known`,
+   `Ospfv3ExtTlv::wire_len`; `RouterInfoTlvUnknown::parse_tlv` was already removed
+   with finding 8). Trivial deletions.
+6. **Finding 14 — hoist duplicated codecs into `packet-utils`** (Fletcher
    checksum shared with `isis-packet`; FAD and SID/Label dispatch shared v2/v3).
    Larger refactor; best done the next time those codecs are touched.
 
@@ -274,6 +270,8 @@ because emit/parse agree and tests use `weight=0`.
 ---
 
 ### 8. Unknown RouterInfo TLV reads type/len from the value bytes — round-trip corruption
+> ✅ **Fixed in [#1982](https://github.com/zebra-rs/zebra-rs/pull/1982)** — build the Unknown variant from the header; dead `parse_tlv` deleted.
+
 **`crates/ospf-packet/src/parser.rs:1208`**
 
 ```rust


### PR DESCRIPTION
## Summary

`RouterInfoTlv::parse_tlv` consumed the 4-byte TLV header, then for an unrecognized type let the derived nom parser of `RouterInfoTlvUnknown` read `typ`/`len` from the first four **value** octets instead of the header. So a Router-Information LSA with an unknown top-level TLV re-emitted a different type, length, and payload — and an unknown TLV shorter than 4 value bytes errored, dropping every remaining RI TLV via `many0_complete`.

Fix: build the `Unknown` variant directly from the header (`typ = tl.typ`, `len = tl.len`, `values = tlv.to_vec()`), exactly as the ExtPrefix / ExtLink / ASLA sub-TLV `Unknown` arms already do — this was the lone outlier. Also deletes the never-wired, itself-buggy `RouterInfoTlvUnknown::parse_tlv` helper (`values: Vec::new()`), clearing one of finding #15's dead-code items.

Found in the ospf-packet crate code review (`docs/design/ospf-packet-code-review.md`, finding #8). Also marks that finding fixed in the doc.

## Test plan

- New round-trip unit test: an unknown RI TLV (type 100, len 6) decodes with the correct type/len/value and re-emits the exact wire bytes.
- `cargo test -p ospf-packet`: 76 pass. `cargo test -p zebra-rs ospf::`: 84 pass.
- `cargo fmt` applied; `cargo clippy --workspace`: clean.

Generated with [Claude Code](https://claude.com/claude-code)