### PR TITLE
isis-packet: SRv6 wire-correctness tail (follow-up items 1-3)

### DIFF
--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1419,6 +1419,35 @@ impl SidLabelValue {
             Index(v) => *v,
         }
     }
+
+    /// RFC 8667 §2.1.1.1 / §2.2.1: in the Prefix-/Adj-/LAN-Adj-SID
+    /// sub-TLVs the V/L flags are authoritative for the SID form —
+    /// V=L=1 is a 3-octet label, V=L=0 a 4-octet index, and any other
+    /// combination is invalid. A flag/width mismatch is an error (the
+    /// registry degrades the sub-TLV to Unknown) rather than a silent
+    /// reinterpretation of an index as a label or vice versa. The
+    /// width-by-length `parse_be` remains for the SID/Label sub-TLV of
+    /// Binding TLV 149, where RFC 8667 §2.3 keys the form on the
+    /// length alone.
+    pub fn parse_be_flags(input: &[u8], v_flag: bool, l_flag: bool) -> IResult<&[u8], Self> {
+        match (v_flag, l_flag) {
+            (true, true) if input.len() == 3 => {
+                let (input, label) = be_u24(input)?;
+                Ok((
+                    input,
+                    SidLabelValue::Label(label & SidLabelValue::LABEL_MASK),
+                ))
+            }
+            (false, false) if input.len() == 4 => {
+                let (input, index) = be_u32(input)?;
+                Ok((input, SidLabelValue::Index(index)))
+            }
+            _ => Err(Err::Error(nom::error::make_error(
+                input,
+                nom::error::ErrorKind::Verify,
+            ))),
+        }
+    }
 }
 
 impl ParseBe<SidLabelValue> for SidLabelValue {

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -123,7 +123,9 @@ impl TlvEmitter for IsisSubSegmentRoutingCap {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags.into());
-        buf.put(&u32_u8_3(self.range)[..]);
+        // Range is a 24-bit wire field: saturate instead of letting
+        // u32_u8_3 silently drop the high bits of an over-large range.
+        buf.put(&u32_u8_3(self.range.min(0x00FF_FFFF))[..]);
         self.sid_label.emit(buf);
     }
 }
@@ -189,7 +191,8 @@ impl TlvEmitter for IsisSubSegmentRoutingLB {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags);
-        buf.put(&u32_u8_3(self.range)[..]);
+        // See IsisSubSegmentRoutingCap — saturate the 24-bit range.
+        buf.put(&u32_u8_3(self.range.min(0x00FF_FFFF))[..]);
         self.sid_label.emit(buf);
     }
 }
@@ -711,6 +714,21 @@ mod tests {
         assert_eq!(emitted, 0x01);
         let emitted: u8 = RouterCapFlags::new().with_d_flag(true).into();
         assert_eq!(emitted, 0x02);
+    }
+
+    /// Follow-up #3: the SRGB/SRLB range is a 24-bit wire field — an
+    /// over-large u32 saturates instead of wrapping to garbage.
+    #[test]
+    fn srgb_range_saturates_at_24_bits() {
+        let cap = IsisSubSegmentRoutingCap {
+            flags: SegmentRoutingCapFlags::from(0),
+            range: 0x0100_0001, // 2^24 + 1 would wrap to 1
+            sid_label: SidLabelTlv::Label(16000),
+        };
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf);
+        // Flags(1), then the saturated 24-bit range.
+        assert_eq!(&buf[1..4], &[0xFF, 0xFF, 0xFF]);
     }
 
     #[test]

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -939,11 +939,22 @@ impl AdjSidFlags {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisSubAdjSid {
     pub flags: AdjSidFlags,
     pub weight: u8,
     pub sid: SidLabelValue,
+}
+
+impl ParseBe<IsisSubAdjSid> for IsisSubAdjSid {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = AdjSidFlags::parse_be(input)?;
+        let (input, weight) = be_u8(input)?;
+        // RFC 8667 §2.2.1: the V/L flags decide the SID form — see
+        // `SidLabelValue::parse_be_flags`.
+        let (input, sid) = SidLabelValue::parse_be_flags(input, flags.v_flag(), flags.l_flag())?;
+        Ok((input, Self { flags, weight, sid }))
+    }
 }
 
 impl TlvEmitter for IsisSubAdjSid {
@@ -956,18 +967,42 @@ impl TlvEmitter for IsisSubAdjSid {
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put_u8(self.flags.into());
+        // Derive V/L from the SID form so the emitted flags can never
+        // disagree with the width that follows (see IsisSubPrefixSid).
+        let flags = match self.sid {
+            SidLabelValue::Label(_) => self.flags.with_v_flag(true).with_l_flag(true),
+            SidLabelValue::Index(_) => self.flags.with_v_flag(false).with_l_flag(false),
+        };
+        buf.put_u8(flags.into());
         buf.put_u8(self.weight);
         self.sid.emit(buf);
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisSubLanAdjSid {
     pub flags: AdjSidFlags,
     pub weight: u8,
     pub system_id: IsisSysId,
     pub sid: SidLabelValue,
+}
+
+impl ParseBe<IsisSubLanAdjSid> for IsisSubLanAdjSid {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = AdjSidFlags::parse_be(input)?;
+        let (input, weight) = be_u8(input)?;
+        let (input, system_id) = IsisSysId::parse_be(input)?;
+        let (input, sid) = SidLabelValue::parse_be_flags(input, flags.v_flag(), flags.l_flag())?;
+        Ok((
+            input,
+            Self {
+                flags,
+                weight,
+                system_id,
+                sid,
+            },
+        ))
+    }
 }
 
 impl TlvEmitter for IsisSubLanAdjSid {
@@ -980,7 +1015,12 @@ impl TlvEmitter for IsisSubLanAdjSid {
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put_u8(self.flags.into());
+        // Derive V/L from the SID form (see IsisSubAdjSid).
+        let flags = match self.sid {
+            SidLabelValue::Label(_) => self.flags.with_v_flag(true).with_l_flag(true),
+            SidLabelValue::Index(_) => self.flags.with_v_flag(false).with_l_flag(false),
+        };
+        buf.put_u8(flags.into());
         buf.put_u8(self.weight);
         buf.put(&self.system_id.id[..]);
         self.sid.emit(buf);
@@ -1118,6 +1158,29 @@ impl TlvEmitter for IsisSubSrv6LanEndXSid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Follow-up #1 (Adj-SID flavor): the V/L flags are authoritative
+    /// for the SID form — a flag/width mismatch degrades to Unknown
+    /// instead of misreading an index as a label.
+    #[test]
+    fn adj_sid_width_follows_v_l_flags() {
+        // V|L (0x30) claiming a label but carrying 4 SID octets.
+        let raw = [31u8, 6, 0x30, 0, 0, 0, 0, 100];
+        let (_, sub) = IsisSubTlv::parse_subs(&raw).expect("parse");
+        assert!(matches!(sub, IsisSubTlv::Unknown(_)));
+
+        // The conformant label form round-trips.
+        let label = IsisSubAdjSid {
+            flags: AdjSidFlags::from(0x30),
+            weight: 1,
+            sid: SidLabelValue::Label(16001),
+        };
+        let mut buf = BytesMut::new();
+        IsisSubTlv::AdjSid(label.clone()).emit(&mut buf);
+        let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("re-parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed, IsisSubTlv::AdjSid(label));
+    }
 
     /// Finding #14: RFC 9479 §4.2 mask lengths are actual octet counts
     /// (0-8), L-flag or not. The parser used to force L=1 masks to

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -56,11 +56,22 @@ impl ParseBe<PrefixSidFlags> for PrefixSidFlags {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisSubPrefixSid {
     pub flags: PrefixSidFlags,
     pub algo: Algo,
     pub sid: SidLabelValue,
+}
+
+impl ParseBe<IsisSubPrefixSid> for IsisSubPrefixSid {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = PrefixSidFlags::parse_be(input)?;
+        let (input, algo) = Algo::parse_be(input)?;
+        // RFC 8667 §2.1.1.1: the V/L flags decide the SID form — see
+        // `SidLabelValue::parse_be_flags`.
+        let (input, sid) = SidLabelValue::parse_be_flags(input, flags.v_flag(), flags.l_flag())?;
+        Ok((input, Self { flags, algo, sid }))
+    }
 }
 
 impl TlvEmitter for IsisSubPrefixSid {
@@ -73,7 +84,14 @@ impl TlvEmitter for IsisSubPrefixSid {
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put_u8(self.flags.into());
+        // Derive V/L from the SID form (RFC 8667: V=L=1 label, V=L=0
+        // index) so the emitted flags can never disagree with the
+        // width that follows.
+        let flags = match self.sid {
+            SidLabelValue::Label(_) => self.flags.with_v_flag(true).with_l_flag(true),
+            SidLabelValue::Index(_) => self.flags.with_v_flag(false).with_l_flag(false),
+        };
+        buf.put_u8(flags.into());
         buf.put_u8(self.algo.into());
         self.sid.emit(buf);
     }
@@ -279,12 +297,40 @@ impl IsisMirrorSub2Tlv {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisSub2SidStructure {
     pub lb_len: u8,
     pub ln_len: u8,
     pub fun_len: u8,
     pub arg_len: u8,
+}
+
+impl ParseBe<IsisSub2SidStructure> for IsisSub2SidStructure {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, lb_len) = be_u8(input)?;
+        let (input, ln_len) = be_u8(input)?;
+        let (input, fun_len) = be_u8(input)?;
+        let (input, arg_len) = be_u8(input)?;
+        // The four parts describe one 128-bit SID (RFC 9352 §9 /
+        // RFC 8986 §3.1); a sum over 128 bits is malformed — reject so
+        // the registry degrades it to Unknown rather than handing
+        // consumers an impossible layout.
+        if lb_len as usize + ln_len as usize + fun_len as usize + arg_len as usize > 128 {
+            return Err(nom::Err::Error(nom::error::make_error(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        Ok((
+            input,
+            Self {
+                lb_len,
+                ln_len,
+                fun_len,
+                arg_len,
+            },
+        ))
+    }
 }
 
 impl TlvEmitter for IsisSub2SidStructure {
@@ -1376,6 +1422,82 @@ mod tests {
         assert!(rest.is_empty());
         assert_eq!(tlv.entries.len(), 1);
         assert_eq!(tlv.entries[0].prefix, "2001:db8::/64".parse().unwrap());
+    }
+
+    /// Follow-up #1: RFC 8667 §2.1.1.1 — the V/L flags are
+    /// authoritative for the SID form. A flag/width mismatch or an
+    /// invalid combination is rejected (degrading to Unknown) instead
+    /// of silently reinterpreted.
+    #[test]
+    fn prefix_sid_width_follows_v_l_flags() {
+        // V=L=1 (0x0C) + 3-octet label 16001.
+        let raw = [3u8, 5, 0x0C, 0, 0x00, 0x3E, 0x81];
+        let (rest, sub) = IsisSubTlv::parse_subs(&raw).expect("label parse");
+        assert!(rest.is_empty());
+        let IsisSubTlv::PrefixSid(p) = &sub else {
+            panic!("expected PrefixSid, got {sub:?}");
+        };
+        assert_eq!(p.sid, SidLabelValue::Label(16001));
+
+        // V=L=0 (here with N=0x40) + 4-octet index.
+        let raw = [3u8, 6, 0x40, 0, 0, 0, 0, 100];
+        let (rest, sub) = IsisSubTlv::parse_subs(&raw).expect("index parse");
+        assert!(rest.is_empty());
+        let IsisSubTlv::PrefixSid(p) = &sub else {
+            panic!("expected PrefixSid, got {sub:?}");
+        };
+        assert_eq!(p.sid, SidLabelValue::Index(100));
+
+        // Flag/width mismatch: V=L=1 claiming a label but carrying 4
+        // SID octets → Unknown; the following sub-TLV still parses.
+        let raw = [3u8, 6, 0x0C, 0, 0, 0, 0, 100, 11, 4, 10, 0, 0, 1];
+        let (rest, first) = IsisSubTlv::parse_subs(&raw).expect("first");
+        assert!(matches!(first, IsisSubTlv::Unknown(_)));
+        let (rest, second) = IsisSubTlv::parse_subs(rest).expect("second");
+        assert!(matches!(second, IsisSubTlv::Ipv4SourceRouterId(_)));
+        assert!(rest.is_empty());
+
+        // Invalid combination V=1/L=0 (0x08) → Unknown.
+        let raw = [3u8, 5, 0x08, 0, 0x00, 0x3E, 0x81];
+        let (_, sub) = IsisSubTlv::parse_subs(&raw).expect("parse");
+        assert!(matches!(sub, IsisSubTlv::Unknown(_)));
+    }
+
+    /// Emit derives V/L from the SID variant, so a hand-built entry
+    /// with blank flags still round-trips.
+    #[test]
+    fn prefix_sid_emit_derives_v_l_flags() {
+        let sid = IsisSubPrefixSid {
+            flags: 0.into(),
+            algo: Algo::Spf,
+            sid: SidLabelValue::Label(16001),
+        };
+        let mut buf = BytesMut::new();
+        IsisSubTlv::PrefixSid(sid).emit(&mut buf);
+        // V|L = 0x0C set in the emitted flags byte.
+        assert_eq!(buf[2] & 0x0C, 0x0C);
+        let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("re-parse");
+        assert!(rest.is_empty());
+        let IsisSubTlv::PrefixSid(p) = parsed else {
+            panic!("expected PrefixSid");
+        };
+        assert_eq!(p.sid, SidLabelValue::Label(16001));
+    }
+
+    /// Follow-up #3: the SID Structure's four parts must fit one
+    /// 128-bit SID; an over-128 claim degrades to Unknown.
+    #[test]
+    fn sid_structure_over_128_bits_degrades_to_unknown() {
+        // Valid: 32+16+16+0 = 64 bits.
+        let raw = [1u8, 4, 32, 16, 16, 0];
+        let (rest, sub2) = IsisSub2Tlv::parse_subs(&raw).expect("parse");
+        assert!(rest.is_empty());
+        assert!(matches!(sub2, IsisSub2Tlv::SidStructure(_)));
+
+        // Malformed: 64+64+8+0 = 136 bits.
+        let raw = [1u8, 4, 64, 64, 8, 0];
+        let (_, sub2) = IsisSub2Tlv::parse_subs(&raw).expect("parse");
+        assert!(matches!(sub2, IsisSub2Tlv::Unknown(_)));
     }
 
     /// Finding #11: the receiver keys the sub-TLV block on the S bit,

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -387,20 +387,22 @@ single-header TLV emit via both `tlv_emit` and the dispatcher.
 
 From the SRv6 deep-dive, worth tracking but below the bar for the ranked list:
 
-- **SID width from byte-count, not flags** (`parser.rs:1338`): `SidLabelValue`
-  decides Label(3) vs Index(4) from the remaining byte count, ignoring the
-  RFC 8667 V/L flags that are authoritative; a flag/width mismatch is silently
-  reinterpreted rather than rejected.
-- **SRGB/SRLB `range` truncation** (`cap.rs:116`, `:182`): the `range: u32` is
-  emitted via `u32_u8_3`, silently discarding bits above 24; origination-only, but
-  no overflow check.
-- **SID Structure bounds** (`prefix.rs:274`): `IsisSub2SidStructure` accepts
-  LB/LN/Fun/Arg lengths with no validation that they sum to ≤ 128 bits or are
-  consistent with the 16-byte SID.
-- **`End.M = 74`** (`srv6.rs:334`): a draft
-  (`draft-ietf-rtgwg-srv6-egress-protection`) codepoint the finder could not
-  corroborate against a stable IANA assignment — double-check against the current
-  registry.
+- **SID width from byte-count, not flags** (`parser.rs:1338`) — ✅ FIXED:
+  `SidLabelValue::parse_be_flags` makes the RFC 8667 V/L flags authoritative at
+  the Prefix-/Adj-/LAN-Adj-SID sites (V=L=1 label, V=L=0 index; any other
+  combination or a flag/width mismatch degrades the sub-TLV to `Unknown`), and
+  the three emitters derive V/L from the SID variant (the finding-#11 policy).
+  The width-by-length `parse_be` remains only for Binding TLV 149's SID/Label
+  sub-TLV, where RFC 8667 §2.3 keys the form on the length.
+- **SRGB/SRLB `range` truncation** (`cap.rs:116`, `:182`) — ✅ FIXED: emit
+  saturates the range at `0x00FF_FFFF` instead of letting `u32_u8_3` wrap it.
+- **SID Structure bounds** (`prefix.rs:274`) — ✅ FIXED: `IsisSub2SidStructure`
+  rejects LB+LN+Fun+Arg sums over 128 bits; the registry degrades the claim to
+  `Unknown`.
+- **`End.M = 74`** (`srv6.rs:334`) — ✅ VERIFIED (2026-07-18): the IANA "SRv6
+  Endpoint Behaviors" registry assigns value 74 (0x004A) to "End.M (Mirror
+  SID)" with reference `draft-ietf-rtgwg-srv6-egress-protection-02`; the
+  crate's codepoint is correct.
 
 ---
 
@@ -457,6 +459,11 @@ Correctness outranks these for the ranked list, but they're worth scheduling:
 
 ## Suggested priority
 
+**All 15 ranked findings are fixed** — PRs #1952 (#1), #1957 (#2), #1961
+(#3/#5), #1964 (#4/#7/#8), #1967 (#6/#9/#10), #1969 (#11), #1971 (#12),
+#1975 (#13), #1977 (#14), #1978 (#15). The original triage order is kept
+below for the record:
+
 1. ~~Fix #1 (LspEntries wrap) first~~ — **done** (PR #1952): builders capped at
    15 entries per TLV; unit + BDD regression coverage in place.
 2. ~~Fix #2 (RouterCap S/D) and #5 (Srv6TlvFlags MTID)~~ — **done**: both
@@ -467,3 +474,44 @@ Correctness outranks these for the ranked list, but they're worth scheduling:
    TLV 6 capped + sharded, all per-entry length sums are `usize`-with-`min(255)`,
    and `emit_sub_tlvs` asserts/truncates instead of mislabeling an over-full
    block.
+
+---
+
+## Follow-up work (priority order)
+
+What remains after the ranked findings: the SRv6-note tail and the cleanup
+backlog, ordered by risk and value.
+
+1. ~~**`SidLabelValue` width from the V/L flags, not byte count**~~ — **done**:
+   `parse_be_flags` (flags-authoritative, mismatch → `Unknown`) wired into the
+   Prefix-/Adj-/LAN-Adj-SID parsers; emit derives V/L from the variant. The
+   byte-count parse remains only for Binding TLV 149 per RFC 8667 §2.3.
+2. ~~**Verify `End.M = 74` against IANA**~~ — **done**: IANA assigns 74 to
+   "End.M (Mirror SID)" (`draft-ietf-rtgwg-srv6-egress-protection-02`); the
+   crate is correct, no code change.
+3. ~~**Parse-hardening pair**~~ — **done**: `IsisSub2SidStructure` rejects
+   >128-bit sums (degrades to `Unknown`); SRGB/SRLB emit saturates the 24-bit
+   range instead of wrapping.
+4. **O(n²) `wire_len()` packer probe** — the LSP packer measures a growing TLV
+   by cloning and fully serializing it after every entry pushed, so LSP
+   regeneration is quadratic in entries — exactly the production-sized-LSDB
+   regime where #1 used to hide. Fix: a `usize`-returning value-length summing
+   the per-entry math (already `usize` since #7), making it
+   `2 + value_len()` with zero allocation; the unsaturated sum must stay the
+   packer's source of truth.
+5. **Dedup the six sub-TLV dispatch registries** — the #10 fix made each copy
+   bigger (the degrade-to-Unknown match is pasted six times); one generic
+   helper removes ~250 lines and the risk that a seventh registry forgets the
+   Unknown patch or the degrade.
+6. **BGP-LS Extended Admin Group (TLV 1173) producer** — enabled by #13:
+   `ext_admin_group()` exists, but there is no `BGPLS_ATTR_EXT_ADMIN_GROUP`
+   constant, so links advertising only the RFC 7308 group export no color at
+   all (the old, wrong 1088 mapping was removed deliberately).
+7. **Small-cleanup sweep (one PR)** — the duplicated ~55-line padding function
+   (`IsisHello`/`IsisP2pHello`), the three identical RFC 8570 bandwidth
+   wrappers, and the seven dead `is_empty()` methods.
+8. **Optional: live interop validation** — the flag/bit fixes (#2, #5, #13,
+   #14) are unit-tested against FRR's *source*; a BDD or lab run against a
+   real FRR/IOS neighbor exercising RouterCap S-flag, multi-area TLV 1, and
+   MT SRv6 would close the loop the way the Cisco interop work did for TLV
+   parsing.


### PR DESCRIPTION
## Summary

Adds the prioritized follow-up list to the review doc
(`docs/design/isis-packet-code-review.md`) and completes its first three
items.

**Item 1 — SID width from the V/L flags, not byte count.** RFC 8667
§2.1.1.1/§2.2.1 make the V/L flags authoritative for the SID form
(V=L=1 → 3-octet label, V=L=0 → 4-octet index; anything else invalid).
`SidLabelValue` decided the form from the remaining byte count, so a
peer whose flags and length disagreed was silently reinterpreted — an
index read as a label can reach the FIB. New
`SidLabelValue::parse_be_flags` is wired into the Prefix-SID, Adj-SID,
and LAN-Adj-SID parsers; a mismatch or invalid combination degrades the
sub-TLV to `Unknown`. The three emitters derive V/L from the SID
variant (the finding-#11 policy). The width-by-length `parse_be`
remains only for Binding TLV 149's SID/Label sub-TLV, where RFC 8667
§2.3 keys the form on the length. Daemon builders already conform
(Index with V/L clear; Adj-SID V|L baseline), so no local wire output
changes.

**Item 2 — `End.M = 74` verified, no code change.** The IANA "SRv6
Endpoint Behaviors" registry assigns 74 (0x004A) to "End.M (Mirror
SID)" per `draft-ietf-rtgwg-srv6-egress-protection-02`, matching the
crate.

**Item 3 — parse hardening.** `IsisSub2SidStructure` rejects
LB+LN+Fun+Arg sums over 128 bits (degrades to `Unknown` via the
finding-#10 machinery); SRGB/SRLB emit saturates the 24-bit range at
`0x00FF_FFFF` instead of letting `u32_u8_3` wrap it.

## Test plan

- New unit tests pin: label/index forms by flags, the flag/width
  mismatch and invalid-combination degrades (prefix and adj flavors)
  with followers surviving, emit-side V/L derivation, the >128-bit SID
  structure degrade, and the range saturation.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)