### PR TITLE
isis: compute wire_len arithmetically; clone-free packer probe

### DIFF
--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -576,20 +576,57 @@ pub enum IsisTlv {
 
 impl IsisTlv {
     /// On-wire byte cost of this TLV: 2 bytes of TL header plus the
-    /// serialized value. Used by the send-side fragmentation packer
-    /// to decide whether a TLV instance fits in the current
-    /// fragment's remaining budget.
+    /// value. Used by the send-side fragmentation packer to decide
+    /// whether a TLV instance fits in the current fragment's
+    /// remaining budget, and to detect oversize instances that must
+    /// be split at an entry boundary before they reach `tlv_emit`.
     ///
-    /// `TlvEmitter::len()` returns the same byte count as a `u8`,
-    /// which silently wraps for malformed TLVs whose value exceeds
-    /// 255 bytes. This helper emits into a scratch buffer and
-    /// reports the true length so the packer can detect oversize
-    /// instances and split them at the entry boundary before they
-    /// reach `tlv_emit`.
+    /// Computed arithmetically — no allocation, no serialization.
+    /// (The previous implementation emitted into a scratch buffer;
+    /// the packer probes a growing TLV after every entry pushed, so
+    /// LSP regeneration paid O(n²) alloc+serialize.) The
+    /// entry-bearing variants use their unsaturated
+    /// `value_wire_len()` — their u8 `len()` saturates at 255 by
+    /// design — so a not-yet-split TLV probes at its true size; the
+    /// remaining variants' `len()` is exact (bounded ≤ 255 by
+    /// construction or truncating consistently with `emit`).
     pub fn wire_len(&self) -> usize {
-        let mut buf = BytesMut::new();
-        self.emit(&mut buf);
-        buf.len()
+        use IsisTlv::*;
+        let value = match self {
+            // Entry-bearing: unsaturated usize sums from the codec.
+            ExtIsReach(v) => v.value_wire_len(),
+            MtIsReach(v) => v.value_wire_len(),
+            ExtIpReach(v) => v.value_wire_len(),
+            MtIpReach(v) => v.value_wire_len(),
+            Ipv6Reach(v) => v.value_wire_len(),
+            MtIpv6Reach(v) => v.value_wire_len(),
+            Srv6(v) => v.value_wire_len(),
+            RouterCap(v) => v.value_wire_len(),
+            // Fixed-stride lists whose u8 `len()` would wrap.
+            LspEntries(v) => v.entries.len() * 16,
+            MultiTopology(v) => v.entries.len() * 2,
+            Unknown(v) => v.values.len(),
+            // Everything else: `len()` is exact.
+            AreaAddr(v) => v.len() as usize,
+            IsNeighbor(v) => v.len() as usize,
+            Padding(v) => v.len() as usize,
+            Auth(v) => v.len() as usize,
+            PurgeOrigId(v) => v.len() as usize,
+            LspBufferSize(v) => v.len() as usize,
+            ProtoSupported(v) => v.len() as usize,
+            Ipv4IfAddr(v) => v.len() as usize,
+            TeRouterId(v) => v.len() as usize,
+            SidLabelBinding(v) => v.len() as usize,
+            Hostname(v) => v.len() as usize,
+            Srlg(v) => v.len() as usize,
+            Ipv6Srlg(v) => v.len() as usize,
+            Ipv6TeRouterId(v) => v.len() as usize,
+            Ipv6IfAddr(v) => v.len() as usize,
+            Ipv6GlobalIfAddr(v) => v.len() as usize,
+            P2p3Way(v) => v.len() as usize,
+            Restart(v) => v.len() as usize,
+        };
+        2 + value
     }
 
     pub fn emit(&self, buf: &mut BytesMut) {
@@ -1652,6 +1689,71 @@ mod tests {
         let mut buf = BytesMut::new();
         full.emit(&mut buf);
         assert_eq!(buf.len(), 252);
+    }
+
+    /// Follow-up #4: `wire_len` is computed arithmetically (the old
+    /// implementation serialized into a scratch buffer, which the
+    /// packer invoked per entry pushed — O(n²) per LSP regeneration).
+    /// It must equal the actual emitted byte count for within-budget
+    /// TLVs, and report the true unsaturated size of an over-full
+    /// entry-bearing TLV so the packer still detects what to split.
+    #[test]
+    fn wire_len_matches_emitted_bytes() {
+        use crate::sub::prefix::{IsisTlvExtIpReach, IsisTlvExtIpReachEntry};
+
+        fn emitted(tlv: &IsisTlv) -> usize {
+            let mut buf = BytesMut::new();
+            tlv.emit(&mut buf);
+            buf.len()
+        }
+
+        let samples: Vec<IsisTlv> = vec![
+            IsisTlvAreaAddr {
+                area_addrs: vec![vec![0x49, 0, 1]],
+            }
+            .into(),
+            IsisTlvHostname {
+                hostname: "r1".into(),
+            }
+            .into(),
+            IsisTlvLspBufferSize { size: 1492 }.into(),
+            IsisTlvP2p3Way {
+                state: 2,
+                circuit_id: Some(9),
+                neighbor_id: None,
+                neighbor_circuit_id: None,
+            }
+            .into(),
+            IsisTlv::Unknown(IsisTlvUnknown {
+                typ: 200.into(),
+                len: 3,
+                values: vec![1, 2, 3],
+            }),
+        ];
+        for tlv in &samples {
+            assert_eq!(
+                tlv.wire_len(),
+                emitted(tlv),
+                "wire_len mismatch for {tlv:?}"
+            );
+        }
+
+        // Over-full TLV 135: 33 entries × 8 bytes = 264 value bytes.
+        // wire_len must report the unsaturated size (and still match
+        // the bytes emit actually writes) so the splitter triggers.
+        let over: IsisTlv = IsisTlvExtIpReach {
+            entries: (0..33u8)
+                .map(|i| IsisTlvExtIpReachEntry {
+                    metric: 10,
+                    flags: 0.into(),
+                    prefix: format!("10.0.{i}.0/24").parse().unwrap(),
+                    subs: vec![],
+                })
+                .collect(),
+        }
+        .into();
+        assert_eq!(over.wire_len(), 2 + 33 * 8);
+        assert_eq!(over.wire_len(), emitted(&over));
     }
 
     /// Sanity-check `IsisTlv::wire_len` for a small fixed-size TLV.

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -274,6 +274,12 @@ impl IsisTlvRouterCap {
     fn sub_len(&self) -> usize {
         self.subs.iter().map(|sub| sub.len() as usize + 2).sum()
     }
+
+    /// True value length in bytes, unsaturated (the u8 `len()`
+    /// saturates at 255) — used by `IsisTlv::wire_len`.
+    pub fn value_wire_len(&self) -> usize {
+        5 + self.sub_len()
+    }
 }
 
 impl TlvEmitter for IsisTlvRouterCap {

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -36,6 +36,15 @@ impl ParseBe<IsisTlvExtIsReach> for IsisTlvExtIsReach {
     }
 }
 
+impl IsisTlvExtIsReach {
+    /// True value length in bytes, unsaturated. The u8 `len()`
+    /// saturates at 255 by design; this is the packer's source of
+    /// truth for probing a not-yet-split TLV without serializing it.
+    pub fn value_wire_len(&self) -> usize {
+        self.entries.iter().map(|e| e.len() as usize).sum()
+    }
+}
+
 impl TlvEmitter for IsisTlvExtIsReach {
     fn typ(&self) -> u8 {
         IsisTlvType::ExtIsReach.into()
@@ -76,6 +85,13 @@ impl ParseBe<IsisTlvMtIsReach> for IsisTlvMtIsReach {
                 entries,
             },
         ))
+    }
+}
+
+impl IsisTlvMtIsReach {
+    /// See `IsisTlvExtIsReach::value_wire_len` — plus the 2-byte MT ID.
+    pub fn value_wire_len(&self) -> usize {
+        2 + self.entries.iter().map(|e| e.len() as usize).sum::<usize>()
     }
 }
 

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -541,6 +541,15 @@ impl ParseBe<IsisTlvExtIpReach> for IsisTlvExtIpReach {
     }
 }
 
+impl IsisTlvExtIpReach {
+    /// True value length in bytes, unsaturated. The u8 `len()`
+    /// saturates at 255 by design; this is the packer's source of
+    /// truth for probing a not-yet-split TLV without serializing it.
+    pub fn value_wire_len(&self) -> usize {
+        self.entries.iter().map(|e| e.len() as usize).sum()
+    }
+}
+
 impl TlvEmitter for IsisTlvExtIpReach {
     fn typ(&self) -> u8 {
         IsisTlvType::ExtIpReach.into()
@@ -588,6 +597,13 @@ impl ParseBe<IsisTlvMtIpReach> for IsisTlvMtIpReach {
                 entries,
             },
         ))
+    }
+}
+
+impl IsisTlvMtIpReach {
+    /// See `IsisTlvExtIpReach::value_wire_len` — plus the 2-byte MT ID.
+    pub fn value_wire_len(&self) -> usize {
+        2 + self.entries.iter().map(|e| e.len() as usize).sum::<usize>()
     }
 }
 
@@ -689,6 +705,13 @@ impl ParseBe<IsisTlvIpv6Reach> for IsisTlvIpv6Reach {
             ipv6_reach_entry_span,
         )?;
         Ok((input, Self { entries }))
+    }
+}
+
+impl IsisTlvIpv6Reach {
+    /// See `IsisTlvExtIpReach::value_wire_len`.
+    pub fn value_wire_len(&self) -> usize {
+        self.entries.iter().map(|e| e.len() as usize).sum()
     }
 }
 
@@ -795,6 +818,13 @@ impl ParseBe<IsisTlvMtIpv6Reach> for IsisTlvMtIpv6Reach {
                 entries,
             },
         ))
+    }
+}
+
+impl IsisTlvMtIpv6Reach {
+    /// See `IsisTlvExtIpReach::value_wire_len` — plus the 2-byte MT ID.
+    pub fn value_wire_len(&self) -> usize {
+        2 + self.entries.iter().map(|e| e.len() as usize).sum::<usize>()
     }
 }
 
@@ -1359,6 +1389,18 @@ impl ParseBe<IsisTlvSrv6> for IsisTlvSrv6 {
                 locators,
             },
         ))
+    }
+}
+
+impl IsisTlvSrv6 {
+    /// See `IsisTlvExtIpReach::value_wire_len` — plus the 2-byte MT
+    /// header.
+    pub fn value_wire_len(&self) -> usize {
+        2 + self
+            .locators
+            .iter()
+            .map(|l| l.len() as usize)
+            .sum::<usize>()
     }
 }
 

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -492,13 +492,12 @@ backlog, ordered by risk and value.
 3. ~~**Parse-hardening pair**~~ — **done**: `IsisSub2SidStructure` rejects
    >128-bit sums (degrades to `Unknown`); SRGB/SRLB emit saturates the 24-bit
    range instead of wrapping.
-4. **O(n²) `wire_len()` packer probe** — the LSP packer measures a growing TLV
-   by cloning and fully serializing it after every entry pushed, so LSP
-   regeneration is quadratic in entries — exactly the production-sized-LSDB
-   regime where #1 used to hide. Fix: a `usize`-returning value-length summing
-   the per-entry math (already `usize` since #7), making it
-   `2 + value_len()` with zero allocation; the unsaturated sum must stay the
-   packer's source of truth.
+4. ~~**O(n²) `wire_len()` packer probe**~~ — **done**: the entry-bearing TLVs
+   (and RouterCap) expose an unsaturated `value_wire_len()`, `IsisTlv::wire_len`
+   is `2 + value` computed arithmetically, and the splitter probes the growing
+   TLV via the `SplittableTlv` trait with no clone and no serialization. A
+   unit test pins `wire_len == emitted bytes` across variants including an
+   over-full TLV 135.
 5. **Dedup the six sub-TLV dispatch registries** — the #10 fix made each copy
    bigger (the degrade-to-Unknown match is pasted six times); one generic
    helper removes ~250 lines and the risk that a seventh registry forgets the

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -126,6 +126,9 @@ trait SplittableTlv: Clone + Into<IsisTlv> {
     fn fresh(&self) -> Self;
     fn entries_mut(&mut self) -> &mut Vec<Self::Entry>;
     fn into_entries(self) -> Vec<Self::Entry>;
+    /// True (unsaturated) value length of the growing instance —
+    /// delegates to the codec so sizing has one source of truth.
+    fn value_wire_len(&self) -> usize;
 }
 
 impl SplittableTlv for IsisTlvExtIpReach {
@@ -139,6 +142,9 @@ impl SplittableTlv for IsisTlvExtIpReach {
     fn into_entries(self) -> Vec<Self::Entry> {
         self.entries
     }
+    fn value_wire_len(&self) -> usize {
+        IsisTlvExtIpReach::value_wire_len(self)
+    }
 }
 
 impl SplittableTlv for IsisTlvIpv6Reach {
@@ -151,6 +157,9 @@ impl SplittableTlv for IsisTlvIpv6Reach {
     }
     fn into_entries(self) -> Vec<Self::Entry> {
         self.entries
+    }
+    fn value_wire_len(&self) -> usize {
+        IsisTlvIpv6Reach::value_wire_len(self)
     }
 }
 
@@ -168,6 +177,9 @@ impl SplittableTlv for IsisTlvMtIsReach {
     fn into_entries(self) -> Vec<Self::Entry> {
         self.entries
     }
+    fn value_wire_len(&self) -> usize {
+        IsisTlvMtIsReach::value_wire_len(self)
+    }
 }
 
 impl SplittableTlv for IsisTlvMtIpv6Reach {
@@ -184,6 +196,9 @@ impl SplittableTlv for IsisTlvMtIpv6Reach {
     fn into_entries(self) -> Vec<Self::Entry> {
         self.entries
     }
+    fn value_wire_len(&self) -> usize {
+        IsisTlvMtIpv6Reach::value_wire_len(self)
+    }
 }
 
 /// Split a TLV whose serialized value would overflow the 8-bit
@@ -199,8 +214,11 @@ fn split_tlv_entries<T: SplittableTlv>(t: T) -> Vec<IsisTlv> {
     let mut current = template.clone();
     for entry in t.into_entries() {
         current.entries_mut().push(entry);
-        let probe: IsisTlv = current.clone().into();
-        if probe.wire_len() > TLV_WIRE_MAX {
+        // Arithmetic probe (2-byte TL header + unsaturated value
+        // length). The old probe cloned the growing TLV and fully
+        // serialized it after every entry pushed — O(n²)
+        // alloc+serialize per LSP regeneration.
+        if 2 + current.value_wire_len() > TLV_WIRE_MAX {
             let latest = current.entries_mut().pop().expect("just pushed");
             if !current.entries_mut().is_empty() {
                 out.push(current.into());


### PR DESCRIPTION
## Summary

Follow-up item 4 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

The LSP packer probed a growing TLV by cloning it into an `IsisTlv` and
fully serializing it into a fresh `BytesMut` after every entry pushed,
making LSP regeneration O(n²) in allocations and serialization work —
exactly the production-sized-LSDB regime where review finding #1 used
to hide.

- The entry-bearing TLVs (ExtIsReach/MtIsReach/ExtIpReach/MtIpReach/
  Ipv6Reach/MtIpv6Reach/Srv6) and RouterCap expose an unsaturated
  `pub value_wire_len()` computed from the per-entry math (`usize`
  since finding #7), keeping the codec the single source of truth for
  sizing.
- `IsisTlv::wire_len()` is now `2 + value` computed arithmetically with
  no allocation: entry-bearing variants use `value_wire_len()` so a
  not-yet-split TLV probes at its true size; LspEntries/MultiTopology/
  Unknown use exact fixed-stride math (their u8 `len()` wraps or
  clamps); every other variant's `len()` is exact by construction.
- The splitter's per-entry probe goes through a new
  `SplittableTlv::value_wire_len()` that delegates to the codec — no
  clone, no serialization.

Behavior is unchanged: `wire_len` still equals the emitted byte count
(emit writes all entries; only the length byte saturates).

## Test plan

- New unit test pins `wire_len == emitted bytes` across representative
  variants including an over-full 33-entry TLV 135 (266 bytes, over the
  257 split threshold).
- Existing packer tests (fragment packing, placement memory, shard-size
  asserts) pass unchanged; `cargo test --workspace --exclude bdd` green
  locally.

Generated with [Claude Code](https://claude.com/claude-code)