### PR TITLE
ospf-packet: derive OSPFv2 LSA counts at emit

### DIFF
--- a/crates/ospf-packet/src/disp.rs
+++ b/crates/ospf-packet/src/disp.rs
@@ -188,7 +188,7 @@ impl Display for OspfLsUpdate {
             f,
             r#"== Link State Update ==
  Num advertisement: {}"#,
-            self.num_adv
+            self.lsas.len()
         )?;
         for req in self.lsas.iter() {
             write!(f, "\n{}", req)?;
@@ -218,7 +218,8 @@ impl Display for RouterLsa {
             r#"== Router LSA ==
   Flags: {}
   Num links: {}"#,
-            self.flags, self.num_links
+            self.flags,
+            self.links.len()
         )?;
         for link in self.links.iter() {
             write!(f, "\n{}", link)?;

--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -378,11 +378,19 @@ impl OspfLsRequestEntry {
     }
 }
 
-#[derive(Debug, NomBE)]
+#[derive(Debug)]
 pub struct OspfLsUpdate {
-    pub num_adv: u32,
-    #[nom(Parse = "{ |x| parse_lsas_with_raw(x, num_adv as usize) }")]
     pub lsas: Vec<OspfLsa>,
+}
+
+impl ParseBe<OspfLsUpdate> for OspfLsUpdate {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], OspfLsUpdate> {
+        // The wire `# advertisements` count only drives the parse loop; the
+        // authoritative count on emit is `lsas.len()`, so it is not stored.
+        let (input, num_adv) = be_u32(input)?;
+        let (input, lsas) = parse_lsas_with_raw(input, num_adv as usize)?;
+        Ok((input, OspfLsUpdate { lsas }))
+    }
 }
 
 /// Parse `n` LSAs, stamping each one's `raw` field with the slice of
@@ -419,7 +427,7 @@ fn parse_lsas_with_raw(input: &[u8], n: usize) -> IResult<&[u8], Vec<OspfLsa>> {
 
 impl OspfLsUpdate {
     pub fn emit(&self, buf: &mut BytesMut) {
-        buf.put_u32(self.num_adv);
+        buf.put_u32(self.lsas.len().min(u32::MAX as usize) as u32);
         for lsa in self.lsas.iter() {
             lsa.emit(buf);
         }
@@ -797,23 +805,33 @@ impl OspfRouterTOS {
     }
 }
 
-#[derive(Debug, Clone, NomBE, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct RouterLsa {
     pub flags: u16,
-    pub num_links: u16,
-    #[nom(Parse = "parse_router_links")]
     pub links: Vec<RouterLsaLink>,
+}
+
+impl ParseBe<RouterLsa> for RouterLsa {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], RouterLsa> {
+        // The wire `# links` count is informational; the link records are
+        // parsed by consuming the rest of the LSA, and the authoritative count
+        // on emit is `links.len()`, so it is not stored.
+        let (input, flags) = be_u16(input)?;
+        let (input, _num_links) = be_u16(input)?;
+        let (input, links) = parse_router_links(input)?;
+        Ok((input, RouterLsa { flags, links }))
+    }
 }
 
 impl RouterLsa {
     pub fn lsa_len(&self) -> u16 {
-        // flags (2) + num_links (2) + sum of link lengths
+        // flags (2) + # links (2) + sum of link lengths
         4 + self.links.iter().map(|l| l.lsa_len()).sum::<u16>()
     }
 
     pub fn emit(&self, buf: &mut BytesMut) {
         buf.put_u16(self.flags);
-        buf.put_u16(self.num_links);
+        buf.put_u16(self.links.len().min(u16::MAX as usize) as u16);
         for link in &self.links {
             link.emit(buf);
         }
@@ -2950,6 +2968,29 @@ mod tests {
         let mut buf = BytesMut::new();
         tlv.emit(&mut buf);
         assert_eq!(&buf[..], &bytes[..]);
+    }
+
+    #[test]
+    fn router_lsa_num_links_derived_from_contents_on_emit() {
+        // Router-LSA body with a LYING "# links" (99) but a single link record.
+        // Parse ignores the wire count; emit writes the real count (1).
+        let bytes = [
+            0x00, 0x00, // flags
+            0x00, 0x63, // # links = 99 (bogus)
+            0x01, 0x01, 0x01, 0x01, // link id
+            0x0a, 0x00, 0x00, 0x00, // link data
+            0x03, 0x00, 0x00, 0x0a, // type=stub, #tos=0, metric=10
+        ];
+        let (rest, lsa) = RouterLsa::parse_be(&bytes).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(lsa.links.len(), 1);
+        let mut buf = BytesMut::new();
+        lsa.emit(&mut buf);
+        // Emitted "# links" is the actual count (1), not the wire's bogus 99.
+        assert_eq!(&buf[2..4], &[0x00, 0x01]);
+        // Flags and the link record round-trip byte-for-byte.
+        assert_eq!(&buf[0..2], &[0x00, 0x00]);
+        assert_eq!(&buf[4..], &bytes[4..]);
     }
 
     /// RFC 2328 §D.4.1-D.4.2: the checksum excludes the 64-bit

--- a/crates/ospf-packet/tests/ospfv2.rs
+++ b/crates/ospf-packet/tests/ospfv2.rs
@@ -172,6 +172,21 @@ pub fn parse_ls_upd_multi() {
     assert_eq!(rem.len(), 0);
     println!("{}", packet);
     println!("rem len: {:?}", rem.len());
+
+    // The `# advertisements` count is derived from the LSA vector on emit, so
+    // it survives a parse -> emit -> parse round-trip.
+    let n = match &packet.payload {
+        Ospfv2Payload::LsUpdate(u) => u.lsas.len(),
+        _ => panic!("expected LsUpdate"),
+    };
+    assert_eq!(n, 7);
+    let mut buf = BytesMut::new();
+    packet.emit(&mut buf);
+    let (_, packet2) = parse(&buf).unwrap();
+    match &packet2.payload {
+        Ospfv2Payload::LsUpdate(u) => assert_eq!(u.lsas.len(), n),
+        _ => panic!("expected LsUpdate"),
+    }
 }
 
 #[test]

--- a/docs/design/ospf-packet-code-review.md
+++ b/docs/design/ospf-packet-code-review.md
@@ -28,7 +28,7 @@ most-severe first.
 | 9 | **Security** | `zebra-rs/.../network_v6.rs:124` | v3 checksum skipped when any trailing bytes present | ✅ #1979 |
 | 10 | **Correctness** | `parser.rs:557` | `verify_checksum` re-emits typed form, ignores `raw` | ⬜ open |
 | 11 | **Robustness** | `parser.rs:693` | `parse_lsa_with_length` swallows all errors into `Unknown` | ⬜ open |
-| 12 | **Correctness** | `parser.rs:422` (+`816`) | v2 emit writes stored `num_adv`/`num_links`, not derived | ⬜ open |
+| 12 | **Correctness** | `parser.rs:422` (+`816`) | v2 emit writes stored `num_adv`/`num_links`, not derived | ✅ #1986 |
 | 13 | **Correctness** | `parser.rs:82` (+`227`) | Unknown v2 payload emit drops body; `typ()` → Hello | ⬜ open |
 | 14 | **Cleanup (reuse)** | `parser.rs:618` | Fletcher checksum + FAD/SID codecs duplicated | ⬜ open |
 | 15 | **Cleanup (dead code)** | `parser.rs:1197` (+`1077`, `v3.rs`) | Dead `pub` items add confusing API surface | ⬜ open |
@@ -38,9 +38,9 @@ most-severe first.
 ## Status (2026-07-18)
 
 All seven top findings — the three remote-DoS parse bugs and all four silent
-interop wire-format bugs — plus the security finding #9 and the round-trip
-finding #8 are fixed and merged to `main`. The review document itself landed in
-#1955.
+interop wire-format bugs — plus the security finding #9, the round-trip finding
+#8, and the correctness finding #12 are fixed and merged to `main`. The review
+document itself landed in #1955.
 
 | PR | Findings | Summary |
 |----|----------|---------|
@@ -51,6 +51,7 @@ finding #8 are fixed and merged to `main`. The review document itself landed in
 | [#1974](https://github.com/zebra-rs/zebra-rs/pull/1974) | 7 | End.X / LAN-End.X SID head → 6 bytes (RFC 9513 §9.1/§9.2) |
 | [#1979](https://github.com/zebra-rs/zebra-rs/pull/1979) | 9 | v3 receive checksum verified over `input[..pkt_len]` unconditionally, closing the trailing-bytes bypass; **validated by `ospfv3_auth` BDD** |
 | [#1982](https://github.com/zebra-rs/zebra-rs/pull/1982) | 8 (part of 15) | Unknown Router-Information TLV built from the header, not the value bytes; dead `RouterInfoTlvUnknown::parse_tlv` removed |
+| [#1986](https://github.com/zebra-rs/zebra-rs/pull/1986) | 12 | `num_adv`/`num_links` derived from `.len()` at emit (fields removed, custom `ParseBe`); **validated by `ospfv2_multi_area` BDD** |
 
 Each fix carries a regression test: byte-offset unit tests where a `show`-based
 check could not discriminate the bug, plus live BDD features for the Prefix-SID
@@ -66,19 +67,17 @@ meaningful lock.
 The remaining findings are all lower-severity than the merged set (no DoS, no
 silent interop break in a shipped datapath). Suggested order:
 
-> Findings 8 and 9 — the previous Tier-1 items — are fixed: #9 (v3 checksum-skip
-> bypass) in [#1979](https://github.com/zebra-rs/zebra-rs/pull/1979), #8 (Unknown
-> RouterInfo TLV round-trip) in [#1982](https://github.com/zebra-rs/zebra-rs/pull/1982).
+> Findings 8, 9, and 12 — the previous Tier-1 items — are fixed: #9 (v3
+> checksum-skip bypass) in [#1979](https://github.com/zebra-rs/zebra-rs/pull/1979),
+> #8 (Unknown RouterInfo TLV round-trip) in [#1982](https://github.com/zebra-rs/zebra-rs/pull/1982),
+> #12 (derive LSA counts at emit) in [#1986](https://github.com/zebra-rs/zebra-rs/pull/1986).
 
 **Tier 1 — correctness / robustness, moderate effort**
-1. **Finding 12 — derive `num_adv` / `num_links` at emit.** Mirror the v3 codec
-   (`Ospfv3LsUpdate::emit`), then delete the manual sync lines in the daemon
-   (`inst.rs:1983`, `inst.rs:5404/5502/5571`). Touches daemon call sites.
-2. **Finding 11 — `parse_lsa_with_length` should not swallow parse failures.**
+1. **Finding 11 — `parse_lsa_with_length` should not swallow parse failures.**
    Distinguish "unknown LS type" (→ `Unknown`, keep tolerant flooding) from
    "known type, body failed to parse" (→ propagate `Err`). Needs care to avoid
    regressing the intentional unmodeled-sub-TLV tolerance.
-3. **Finding 10 — `verify_checksum` should use `self.raw`.** Low effort; latent
+2. **Finding 10 — `verify_checksum` should use `self.raw`.** Low effort; latent
    today (only the crate's tests call it), so low urgency until it is wired into
    an ingress path. Pairs with the non-bijective `From<u8>` note below.
 
@@ -363,6 +362,8 @@ failed to parse" (→ propagate `Err`).
 ---
 
 ### 12. v2 emit writes stored `num_adv` / `num_links` instead of deriving them
+> ✅ **Fixed in [#1986](https://github.com/zebra-rs/zebra-rs/pull/1986)** — fields removed; counts derived from `.len()` at emit; validated by `ospfv2_multi_area` BDD.
+
 **`crates/ospf-packet/src/parser.rs:416`** (and `RouterLsa::emit`, `parser.rs:810`)
 
 `OspfLsUpdate::emit` writes `self.num_adv` verbatim; `RouterLsa::emit` writes

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1980,7 +1980,6 @@ impl Ospf<Ospfv2> {
             }
         }
 
-        router_lsa.num_links = router_lsa.links.len() as u16;
         router_lsa
     }
 
@@ -5401,7 +5400,6 @@ impl Ospf<Ospfv2> {
                 continue;
             }
             let ls_upd = OspfLsUpdate {
-                num_adv: 1,
                 lsas: vec![lsa.clone()],
             };
             let mut packet =
@@ -5499,7 +5497,6 @@ impl Ospf<Ospfv2> {
                 super::flood::ospf_ls_retransmit_add(nbr, lsa, retransmit_interval);
 
                 let ls_upd = OspfLsUpdate {
-                    num_adv: 1,
                     lsas: vec![lsa.clone()],
                 };
                 let mut packet =
@@ -5567,10 +5564,7 @@ impl Ospf<Ospfv2> {
         }
         let lsas: Vec<OspfLsa> = nbr.ls_rxmt.values().cloned().collect();
         tracing::info!("[Retransmit] Sending {} LSAs to {}", lsas.len(), addr);
-        let ls_upd = OspfLsUpdate {
-            num_adv: lsas.len() as u32,
-            lsas,
-        };
+        let ls_upd = OspfLsUpdate { lsas };
         let mut packet =
             Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
         apply_link_auth(

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -854,10 +854,7 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
         nbr.ident.prefix.addr(),
         lsas.len()
     );
-    let ls_upd = OspfLsUpdate {
-        num_adv: lsas.len() as u32,
-        lsas,
-    };
+    let ls_upd = OspfLsUpdate { lsas };
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsUpdate(ls_upd));
     apply_link_auth(&mut packet, &oi.auth_send_ctx());
     nbr.ptx


### PR DESCRIPTION
## Summary

`OspfLsUpdate::emit` wrote the stored `num_adv` and `RouterLsa::emit` the stored `num_links` verbatim, so any originate/mutate path that appended to the vector but forgot to re-sync the counter would emit a header count disagreeing with the payload — a divergence the v3 codec structurally cannot have because it derives the counts from `.len()` at emit.

Mirror v3: remove the `num_adv` / `num_links` fields, parse the wire count into a discarded local (custom `ParseBe`), and emit `lsas.len()` / `links.len()`. Update the two `Display` impls and delete the now-unnecessary manual sync — the `router_lsa.num_links = …` line and the `num_adv:` entries at four LS-Update construction sites.

Found in the ospf-packet crate code review (`docs/design/ospf-packet-code-review.md`, finding #12). Also marks that finding fixed in the doc.

## Test plan

- New RouterLsa unit test: a bogus on-wire `# links` of 99 with one link record emits count 1 (proving emit derives from contents, not the wire/stored value).
- LS-Update parse→emit→parse round-trip preserves the 7-LSA count.
- `cargo test -p ospf-packet`: 77 + 17 pass. `cargo test -p zebra-rs ospf::`: 84 pass. `cargo clippy --workspace`: clean.
- End-to-end: `ospfv2_multi_area` BDD (6-node ABR topology) passes — Router/Network/Summary LSAs flood and inter-area SPF converges with the field-less codec.

Generated with [Claude Code](https://claude.com/claude-code)