### PR TITLE
bgp: propagate received EVPN withdraws to peers

### DIFF
--- a/bdd/tests/configs/bgp_evpn_rr_withdraw/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_rr_withdraw/z1-1.yaml
@@ -1,0 +1,29 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_evpn_rr_withdraw/z1-2.yaml
+++ b/bdd/tests/configs/bgp_evpn_rr_withdraw/z1-2.yaml
@@ -1,0 +1,25 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true

--- a/bdd/tests/configs/bgp_evpn_rr_withdraw/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_rr_withdraw/z2-1.yaml
@@ -1,0 +1,22 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      route-reflector:
+        client: true
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      route-reflector:
+        client: true

--- a/bdd/tests/configs/bgp_evpn_rr_withdraw/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_rr_withdraw/z3-1.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_evpn_rr_withdraw.feature
+++ b/bdd/tests/features/bgp_evpn_rr_withdraw.feature
@@ -1,0 +1,72 @@
+@serial
+@bgp_evpn_rr_withdraw
+Feature: EVPN route reflector propagates a client's withdraw
+  As a network operator
+  I want an EVPN route reflector to forward a client's withdraw to the
+  other clients, so nobody keeps forwarding to a departed host's VTEP.
+
+  Test Topology:
+  ```
+  ┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+  │     z1      │ EVPN │     z2      │ EVPN │     z3      │
+  │  AS 65001   │◀───▶│  AS 65001   │◀───▶│  AS 65001   │
+  │ vrf-blue    │ iBGP │   route     │ iBGP │  (client)   │
+  │ RD 65001:100│      │  reflector  │      │             │
+  │ Type-5 from │      │  (both are  │      │             │
+  │ 10.1.0.0/24 │      │   clients)  │      │             │
+  └─────────────┘      └─────────────┘      └─────────────┘
+   192.168.0.1          192.168.0.2          192.168.0.3
+  ```
+
+  z1 originates an EVPN Type-5 for 10.1.0.0/24 (`evpn advertise-ipv4`);
+  z2 reflects it to z3. Review finding #5: a received EVPN withdraw
+  removed the route from the reflector's Loc-RIB but was never fanned
+  to other peers — z3 kept the stale route (and its VTEP forwarding
+  state) until its session bounced.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+
+  Scenario: The reflector reflects z1's Type-5 to z3
+    Given the test topology exists
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "10.1.0.0"
+    And show command "show bgp evpn" in namespace "z3" should eventually contain "10.1.0.0"
+
+  Scenario: z1's withdraw reaches z3 through the reflector
+    Given the test topology exists
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then show command "show bgp evpn" in namespace "z2" should eventually not contain "10.1.0.0"
+    # The regression assertion: pre-fix the reflector removed the route
+    # locally but never sent MP_UNREACH onward, so z3 held it forever.
+    And show command "show bgp evpn" in namespace "z3" should eventually not contain "10.1.0.0"
+
+  Scenario: Re-advertising the network reaches z3 again
+    Given the test topology exists
+    When I apply config "z1-1.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then show command "show bgp evpn" in namespace "z3" should eventually contain "10.1.0.0"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7961,6 +7961,25 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
 
     route_evpn_export_selected(&rd, &prefix, &selected, removed.first(), bgp);
 
+    // Propagate the Loc-RIB change to peers — the withdraw twin of the
+    // announce path's `route_advertise_evpn_to_peers` fan-out, and the
+    // same shape as `route_mup_locrib_withdraw`. Without it a received
+    // EVPN withdraw (or a peer-down sweep) removed the route locally
+    // but every other peer — a route-reflector client, an eBGP transit
+    // neighbor — kept forwarding to the departed host's stale VTEP
+    // until its own session bounced. Only propagate when the Loc-RIB
+    // actually changed: re-flooding a withdraw for an already-absent
+    // route makes peers echo it back.
+    if selected.is_empty() {
+        if !removed.is_empty() {
+            route_withdraw_evpn_to_peers(rd, prefix.clone(), peers);
+        }
+    } else {
+        // Another path remains best for this key — re-advertise it so
+        // peers that held the withdrawn path converge on the survivor.
+        route_advertise_evpn_to_peers(rd, prefix.clone(), &selected, bgp, peers);
+    }
+
     // RFC 9574 selective AR: a withdrawn Replicator-AR route pulls the Leaf
     // A-D we may have originated toward it (no-op if we originated none).
     if bgp.local_rib.evpn_flood.role == AssistedReplicationRole::Leaf


### PR DESCRIPTION
## Summary
Fixes review finding #5 of `docs/design/bgp-code-review-findings.md` (EVPN received-withdraw never propagated to peers).

- `route_evpn_withdraw` — the handler for received EVPN MP_UNREACH, both peer-down cleanup arms, and the LLGR NO_LLGR sweep — recomputed best-path but never told any peer: `route_evpn_export_selected` is dataplane-only, `route_advertise_evpn_to_peers` early-returns on an empty selection, and `route_withdraw_evpn_to_peers` was only called from local-origination paths. An EVPN route reflector removed a client's withdrawn route locally while every other client kept forwarding to the departed host's stale VTEP until its own session bounced; eBGP EVPN transit leaked the same way. The v4 and MUP withdraw paths both propagate — EVPN never got the fan-out.
- Fix: mirror `route_mup_locrib_withdraw`'s shape at the end of `route_evpn_withdraw` — an emptied selection with a real removal fans `route_withdraw_evpn_to_peers` (gated on the Loc-RIB actually changing so an echoed withdraw of an absent route can't re-flood); a surviving candidate is re-advertised so peers converge on it. All withdraw entry points funnel through this one site, and the peer-down comment that previously claimed propagation is now true.

## Test plan
- New `bgp_evpn_rr_withdraw.feature` (z1 originates an EVPN Type-5 via `evpn advertise-ipv4`, z2 reflects to client z3), red/green-verified live: on the pre-fix binary z3 still held `10.1.0.0` after 60 poll attempts while the reflector had already dropped it — the exact finding; with the fix the withdraw reaches z3 and a re-advertise restores the route. Teardown clean.
- Full workspace suite (`--exclude bdd`) 39/39 green; 619 BGP unit tests; workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)