### PR TITLE
pim: per-VRF instances and VRF-aware next-hop tracking

### DIFF
--- a/bdd/tests/configs/pim_vrf/r1.yaml
+++ b/bdd/tests/configs/pim_vrf/r1.yaml
@@ -1,0 +1,20 @@
+vrf:
+- name: mvrf
+interface:
+- if-name: eth1
+  vrf: mvrf
+  ipv4:
+    address: 10.8.13.1/24
+- if-name: eth3
+  vrf: mvrf
+  ipv4:
+    address: 10.8.14.1/24
+router:
+  pim:
+    vrf:
+    - name: mvrf
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth3
+        dr-priority: 1

--- a/bdd/tests/configs/pim_vrf/r2.yaml
+++ b/bdd/tests/configs/pim_vrf/r2.yaml
@@ -1,0 +1,29 @@
+vrf:
+- name: mvrf
+interface:
+- if-name: eth2
+  vrf: mvrf
+  ipv4:
+    address: 10.8.13.2/24
+- if-name: eth5
+  vrf: mvrf
+  ipv4:
+    address: 10.8.15.1/24
+router:
+  static:
+    vrf:
+    - name: mvrf
+      ipv4:
+        route:
+        - prefix: 10.8.14.0/24
+          nexthop:
+          - address: 10.8.13.1
+  pim:
+    vrf:
+    - name: mvrf
+      interface:
+      - if-name: eth2
+        dr-priority: 1
+      - if-name: eth5
+        igmp:
+          enabled: true

--- a/bdd/tests/features/pim_vrf.feature
+++ b/bdd/tests/features/pim_vrf.feature
@@ -1,0 +1,69 @@
+@serial
+@pim_vrf
+Feature: PIM SSM forwarding inside a VRF
+  As a network operator
+  I want `router pim vrf <name>` to run a full per-VRF PIM instance —
+  sockets bound into the VRF, the kernel multicast table selected
+  with MRT_TABLE, IGMP and Join/Prune state scoped to the VRF — so
+  multicast in one VRF neither sees nor disturbs the default table.
+
+  Same shape as the pim_ssm feature, but every router interface is
+  enslaved to VRF mvrf and all PIM/IGMP config lives under
+  `router pim vrf mvrf`. The default PIM instance runs with no
+  interfaces and must stay empty while the mvrf child converges.
+
+  Test Topology (all router interfaces in VRF mvrf):
+  ```
+    h1 (10.8.14.10, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (10.8.15.10, receiver)
+                                    10.8.14.1     10.8.13.1/.2       10.8.15.1
+  ```
+
+  Scenario: SSM join builds the (S,G) tree in the VRF and traffic flows
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "r1" interface "eth1" to namespace "r2" interface "eth2"
+    And I connect namespace "r1" interface "eth3" to namespace "h1" interface "eth4"
+    And I connect namespace "r2" interface "eth5" to namespace "h2" interface "eth6"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "10.8.14.10/24" to interface "eth4" in namespace "h1"
+    And I add address "10.8.15.10/24" to interface "eth6" in namespace "h2"
+
+    # The per-VRF child spawned and registered its show channel;
+    # neighborship forms inside the VRF while the default instance
+    # stays empty.
+    Then show command "show task" in namespace "r2" should eventually contain "mvrf"
+    And show command "show pim vrf mvrf neighbor" in namespace "r2" should eventually contain "10.8.13.1"
+    And show command "show pim neighbor" in namespace "r2" should not contain "10.8.13.1"
+
+    # h2 source-specifically joins (10.8.14.10, 232.8.8.8) — IGMP,
+    # upstream join and TIB all inside the VRF.
+    When I spawn "timeout 150 python3 tests/scripts/ssm_recv.py 232.8.8.8 10.8.14.10 10.8.15.10 5001 /tmp/pim_vrf_rx" in namespace "h2"
+    Then show command "show igmp vrf mvrf groups" in namespace "r2" should eventually contain "232.8.8.8"
+    And show command "show pim vrf mvrf upstream" in namespace "r2" should eventually contain "Joined"
+    And show command "show mroute vrf mvrf" in namespace "r2" should eventually contain "232.8.8.8"
+    And show command "show mroute vrf mvrf" in namespace "r1" should eventually contain "232.8.8.8"
+
+    # Kernel MFCs live in the VRF's multicast table.
+    And command "ip mroute show table all" in namespace "r1" should eventually contain "Iif: eth3"
+    And command "ip mroute show table all" in namespace "r2" should eventually contain "Iif: eth2"
+
+    # The datapath proof: h1's datagrams reach h2 through both VRF
+    # forwarding caches.
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send.py 232.8.8.8 5001 10.8.14.10 90" in namespace "h1"
+    Then command "cat /tmp/pim_vrf_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim_vrf_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3142,6 +3142,7 @@ fn nht_track_received(bgp: &mut BgpTop, rib: &mut BgpRib, dep: super::nht::NhtDe
         let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
             nh,
+            vrf_id: 0,
         });
     }
 }
@@ -3165,6 +3166,7 @@ fn nht_track_received_attr(bgp: &mut BgpTop, attr: &BgpAttr, dep: super::nht::Nh
         let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
             nh,
+            vrf_id: 0,
         });
     }
     reachable
@@ -3200,6 +3202,7 @@ fn mup_segment_track(
         let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
             nh,
+            vrf_id: 0,
         });
     }
     cache.transport_for(nh).to_vec()
@@ -3217,6 +3220,7 @@ fn mup_segment_untrack(bgp: &mut BgpTop, rd: RouteDistinguisher, prefix: &MupPre
         let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh,
+            vrf_id: 0,
         });
     }
 }
@@ -3263,6 +3267,7 @@ pub(super) fn mup_endpoint_track_cache(
         let _ = rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
             nh: endpoint,
+            vrf_id: 0,
         });
     }
     cache.transport_for(endpoint).to_vec()
@@ -3302,6 +3307,7 @@ pub(super) fn mup_endpoint_untrack_cache(
         let _ = rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh: endpoint,
+            vrf_id: 0,
         });
     }
 }
@@ -3348,6 +3354,7 @@ fn nht_untrack_withdrawn(
         let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh,
+            vrf_id: 0,
         });
     }
 }
@@ -9261,6 +9268,7 @@ fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
             let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
                 proto: "bgp".to_string(),
                 nh: endpoint,
+                vrf_id: 0,
             });
         }
     }
@@ -9288,6 +9296,7 @@ fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
         let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh: endpoint,
+            vrf_id: 0,
         });
     }
 }

--- a/zebra-rs/src/config/pim.rs
+++ b/zebra-rs/src/config/pim.rs
@@ -38,7 +38,7 @@ pub fn spawn_pim(config: &ConfigManager) {
     // The mroute socket claims the kernel's multicast-routing
     // instance (MRT_INIT) — EADDRINUSE means another multicast
     // daemon owns it on this host.
-    let fp = match ForwardingPlane::new(&probe) {
+    let fp = match ForwardingPlane::new(&probe, 0) {
         Ok(fp) => fp,
         Err(e) => {
             tracing::warn!("pim: not started (mroute socket: {e}); PIM disabled");
@@ -47,7 +47,20 @@ pub fn spawn_pim(config: &ConfigManager) {
     };
     let (rib_client, rib_rx) = config.subscribe_to_rib("pim");
     let ctx = ProtoContext::default_table(rib_client);
-    let pim = inst::Pim::new(ctx, sock, igmp_sock, fp, rib_rx);
+    // `"pim"` is the default-instance proto label; per-VRF children
+    // get `"pim:vrf:<name>"`. The subscriber + config.tx let the
+    // default task mint per-VRF RIB subscriptions and (de)register
+    // `show pim vrf <name>` channels.
+    let pim = inst::Pim::new(
+        ctx,
+        sock,
+        igmp_sock,
+        fp,
+        rib_rx,
+        "pim".to_string(),
+        config.rib_subscriber(),
+        config.tx.clone(),
+    );
     config.subscribe("pim", pim.cm.tx.clone());
     config.subscribe_show("pim", pim.show.tx.clone());
     let task = inst::serve(pim);

--- a/zebra-rs/src/context/proto.rs
+++ b/zebra-rs/src/context/proto.rs
@@ -82,6 +82,23 @@ impl ProtoContext {
         }
     }
 
+    /// Same as [`Self::for_vrf`] but with a parked `RibClient` — for
+    /// probe contexts whose only job is opening VRF-bound sockets
+    /// before the real RIB subscription exists (PIM's per-VRF spawn
+    /// opens its sockets first so a failure doesn't leave a dead
+    /// `RibRx` receiver queued in RIB's inbox). Same leak rationale
+    /// as [`Self::default_table_no_rib`].
+    pub fn for_vrf_no_rib(vrf_id: u32, vrf_ifname: String) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        Box::leak(Box::new(rx));
+        let rib = RibClient::new(tx, crate::rib::client::ProtoId::from_raw(u32::MAX));
+        Self {
+            vrf_id,
+            vrf_ifname: Some(vrf_ifname),
+            rib,
+        }
+    }
+
     /// Context for a protocol instance attached to a non-default
     /// VRF. The socket factories will `SO_BINDTODEVICE` to
     /// `vrf_ifname` so the resulting socket lands in the matching

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -20,7 +20,8 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::sleep_until;
 
 use crate::config::{
-    Args, ConfigChannel, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
+    Args, CommandPath, ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, RibSubscriber,
+    ShowChannel, path_from_command, vrf_config_split,
 };
 use crate::context::{ProtoContext, Task};
 use crate::rib::api::RibRx;
@@ -105,6 +106,24 @@ pub struct Pim {
     pub(crate) igmp_sock: Arc<AsyncFd<Socket>>,
     /// RIB client context — carries the NHT registrations for RPF.
     pub(crate) ctx: ProtoContext,
+    /// `"pim"` for the default instance, `"pim:vrf:<name>"` for a
+    /// per-VRF child — namespaces name-keyed RIB registrations.
+    pub proto_label: String,
+    /// RIB-subscription factory, used by the parent to mint per-VRF
+    /// clients; cloned into children.
+    pub(crate) rib_subscriber: RibSubscriber,
+    /// Sender into the config manager, for (de)registering a child's
+    /// `show pim vrf <name>` channel.
+    pub(crate) config_tx: mpsc::Sender<crate::config::Message>,
+    /// Per-VRF buffered config (parent only), rewritten with the
+    /// `vrf <name>` selector stripped; replayed into a child at spawn
+    /// and kept so a VrfDel→VrfAdd flap respawns from intent.
+    pub(crate) vrf_log: BTreeMap<String, Vec<(Vec<CommandPath>, ConfigOp)>>,
+    /// Running per-VRF children (parent only), keyed by VRF name.
+    pub(crate) vrf_registry: BTreeMap<String, super::vrf::PimVrfHandle>,
+    /// Kernel VRF masters from `RibRx::VrfAdd` (parent only):
+    /// name → (table_id, ifindex).
+    pub(crate) rib_known_vrfs: BTreeMap<String, (u32, u32)>,
     _read_task: Task<()>,
     _write_task: Task<()>,
     _igmp_read_task: Task<()>,
@@ -113,12 +132,16 @@ pub struct Pim {
 }
 
 impl Pim {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: ProtoContext,
         sock: AsyncFd<Socket>,
         igmp_sock: AsyncFd<Socket>,
         fp: ForwardingPlane,
         rib_rx: UnboundedReceiver<RibRx>,
+        proto_label: String,
+        rib_subscriber: RibSubscriber,
+        config_tx: mpsc::Sender<crate::config::Message>,
     ) -> Self {
         let sock = Arc::new(sock);
         let igmp_sock = Arc::new(igmp_sock);
@@ -170,6 +193,12 @@ impl Pim {
             sock,
             igmp_sock,
             ctx,
+            proto_label,
+            rib_subscriber,
+            config_tx,
+            vrf_log: BTreeMap::new(),
+            vrf_registry: BTreeMap::new(),
+            rib_known_vrfs: BTreeMap::new(),
             _read_task: read_task,
             _write_task: write_task,
             _igmp_read_task: igmp_read_task,
@@ -248,6 +277,18 @@ impl Pim {
                 self.rpf_nexthop_update(nh, resolution);
                 return;
             }
+            RibRx::VrfAdd {
+                name,
+                table_id,
+                ifindex,
+            } => {
+                self.vrf_add(name, table_id, ifindex);
+                return;
+            }
+            RibRx::VrfDel { name } => {
+                self.vrf_del(name);
+                return;
+            }
             _ => return,
         }
         // Any link/address change can flip on-link-ness of tracked
@@ -256,9 +297,105 @@ impl Pim {
     }
 
     fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        if msg.op == ConfigOp::CommitEnd {
+            self.vrf_commit_end();
+            return;
+        }
+        if msg.op == ConfigOp::CommitStart {
+            return;
+        }
+        // `/router/pim/vrf/<name>/…` belongs to a per-VRF child, not
+        // this instance: strip the selector, buffer for replay,
+        // forward live when the child runs. A child's paths never
+        // carry a `vrf` segment, so this is a no-op there.
+        if let Some((name, rewritten)) = vrf_config_split("pim", &msg.paths) {
+            self.vrf_config_record(name, rewritten, msg.op);
+            return;
+        }
         let (path, args) = path_from_command(&msg.paths);
         if let Some(f) = self.callbacks.get(&path).copied() {
             f(self, args, msg.op);
+        }
+    }
+
+    // ---- per-VRF child management (default instance only) ----
+
+    fn vrf_config_record(&mut self, name: String, rewritten: Vec<CommandPath>, op: ConfigOp) {
+        if let Some(handle) = self.vrf_registry.get(&name) {
+            let _ = handle.cm_tx.send(ConfigRequest::new(rewritten.clone(), op));
+        }
+        self.vrf_log
+            .entry(name.clone())
+            .or_default()
+            .push((rewritten, op));
+        // The kernel VrfAdd may already have arrived before this
+        // intent line — spawn from whichever half lands second.
+        self.vrf_spawn_if_ready(&name);
+    }
+
+    fn vrf_spawn_if_ready(&mut self, name: &str) {
+        if self.vrf_registry.contains_key(name) {
+            return;
+        }
+        let Some(&(table_id, _)) = self.rib_known_vrfs.get(name) else {
+            return;
+        };
+        let has_intent = self
+            .vrf_log
+            .get(name)
+            .is_some_and(|log| super::vrf::vrf_log_active(log));
+        if !has_intent {
+            return;
+        }
+        let log = self.vrf_log.get(name).cloned().unwrap_or_default();
+        if let Some(handle) =
+            super::vrf::spawn_pim_vrf(name, table_id, &self.rib_subscriber, &self.config_tx, &log)
+        {
+            self.vrf_registry.insert(name.to_string(), handle);
+        }
+    }
+
+    fn vrf_add(&mut self, name: String, table_id: u32, ifindex: u32) {
+        if self.proto_label != "pim" {
+            return;
+        }
+        self.rib_known_vrfs
+            .insert(name.clone(), (table_id, ifindex));
+        self.vrf_spawn_if_ready(&name);
+    }
+
+    /// Kernel VRF master removed: despawn the child but KEEP its
+    /// config log so a later VrfAdd respawns from intent.
+    fn vrf_del(&mut self, name: String) {
+        if self.proto_label != "pim" {
+            return;
+        }
+        self.rib_known_vrfs.remove(&name);
+        if self.vrf_registry.remove(&name).is_some() {
+            super::vrf::despawn_pim_vrf(&name, &self.config_tx, &self.rib_subscriber);
+        }
+    }
+
+    /// CommitEnd fan-out: tear down children whose `router pim vrf
+    /// <name>` block was fully deleted this commit, then forward
+    /// CommitEnd to the survivors.
+    fn vrf_commit_end(&mut self) {
+        let emptied: Vec<String> = self
+            .vrf_log
+            .iter()
+            .filter(|(_, log)| !super::vrf::vrf_log_active(log))
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in emptied {
+            self.vrf_log.remove(&name);
+            if self.vrf_registry.remove(&name).is_some() {
+                super::vrf::despawn_pim_vrf(&name, &self.config_tx, &self.rib_subscriber);
+            }
+        }
+        for handle in self.vrf_registry.values() {
+            let _ = handle
+                .cm_tx
+                .send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
         }
     }
 

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -17,3 +17,4 @@ pub mod rpf;
 pub mod show;
 pub mod socket;
 pub mod tib;
+pub mod vrf;

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -29,6 +29,7 @@ const MRT_DEL_VIF: c_int = 203;
 const MRT_ADD_MFC: c_int = 204;
 const MRT_DEL_MFC: c_int = 205;
 const MRT_PIM: c_int = 208;
+const MRT_TABLE: c_int = 209;
 
 const VIFF_USE_IFINDEX: u8 = 0x8;
 const VIFF_REGISTER: u8 = 0x4;
@@ -155,7 +156,10 @@ pub struct ForwardingPlane {
 }
 
 impl ForwardingPlane {
-    pub fn new(ctx: &ProtoContext) -> std::io::Result<Self> {
+    /// `table_id != 0` selects a non-default kernel multicast routing
+    /// table (`MRT_TABLE`, must precede `MRT_INIT`) — the per-VRF
+    /// instance path. Requires `CONFIG_IP_MROUTE_MULTIPLE_TABLES`.
+    pub fn new(ctx: &ProtoContext, table_id: u32) -> std::io::Result<Self> {
         // The mroute socket must be a raw IGMP socket. MRT_INIT
         // claims the (per-table) multicast-routing instance — EADDRINUSE
         // means another daemon owns it.
@@ -163,6 +167,9 @@ impl ForwardingPlane {
         sock.set_nonblocking(true)?;
         // Upcalls burst with traffic; keep a deep receive buffer.
         let _ = sock.set_recv_buffer_size(1024 * 1024);
+        if table_id != 0 {
+            mrt_setsockopt(&sock, MRT_TABLE, &table_id)?;
+        }
         let one: c_int = 1;
         mrt_setsockopt(&sock, MRT_INIT, &one)?;
         // PIM mode: enables register decapsulation and the

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -53,8 +53,9 @@ impl Pim {
         }
         let state = compute_rpf(&self.links, src, None);
         let _ = self.ctx.rib.send(rib::Message::NexthopRegister {
-            proto: "pim".to_string(),
+            proto: self.proto_label.clone(),
             nh: IpAddr::V4(src),
+            vrf_id: self.ctx.vrf_id(),
         });
         self.rpf.insert(
             src,
@@ -75,8 +76,9 @@ impl Pim {
         if entry.refs == 0 {
             self.rpf.remove(&src);
             let _ = self.ctx.rib.send(rib::Message::NexthopUnregister {
-                proto: "pim".to_string(),
+                proto: self.proto_label.clone(),
                 nh: IpAddr::V4(src),
+                vrf_id: self.ctx.vrf_id(),
             });
         }
     }

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -324,9 +324,11 @@ fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::
             sg: key.to_string(),
             iif,
             rpf_neighbor,
+            // "None", not "NotJoined": BDD substring assertions on
+            // "Joined" must not match the negative state.
             state: match entry.join_state {
                 JoinState::Joined => "Joined".to_string(),
-                JoinState::NotJoined => "NotJoined".to_string(),
+                JoinState::NotJoined => "None".to_string(),
             },
             reg: match entry.reg_state {
                 RegState::NoInfo => "-".to_string(),

--- a/zebra-rs/src/pim/vrf.rs
+++ b/zebra-rs/src/pim/vrf.rs
@@ -1,0 +1,156 @@
+//! Per-VRF PIM instance spawn / despawn, mirroring `crate::isis::vrf`.
+//!
+//! The default `router pim` task acts as a thin parent: it forwards
+//! every `/router/pim/vrf/<name>/…` config line — rewritten to strip
+//! the `vrf <name>` selector (see `crate::config::vrf_config_split`)
+//! — into a full per-VRF [`Pim`] whose callbacks / TIB / show paths
+//! run unchanged.
+//!
+//! Unlike IS-IS (L2 PDUs, RIB binding only), PIM's isolation needs
+//! all three sockets rebuilt inside the VRF: the protocol-103 and
+//! IGMP sockets get `SO_BINDTODEVICE` via
+//! [`ProtoContext::for_vrf`]'s socket factory, and the mroute socket
+//! selects the VRF's kernel multicast table with `MRT_TABLE` before
+//! `MRT_INIT`.
+//!
+//! A child is spawned only once **both** config intent exists (the
+//! parent's `vrf_log`) **and** the kernel VRF master has been created
+//! (`RibRx::VrfAdd` delivered the `table_id`). The buffered config is
+//! replayed into the fresh child, followed by one synthetic
+//! `CommitEnd`.
+
+use tokio::sync::mpsc::{Sender, UnboundedSender};
+
+use crate::config::{CommandPath, ConfigOp, ConfigRequest, Message, RibSubscriber};
+use crate::context::{ProtoContext, Task};
+
+use super::inst::{self, Pim};
+use super::mroute::ForwardingPlane;
+use super::socket::{igmp_socket, pim_socket};
+
+/// Handle to one running per-VRF PIM task, stashed on the parent's
+/// `vrf_registry`. Dropping it aborts the child's event loop.
+pub struct PimVrfHandle {
+    pub cm_tx: UnboundedSender<ConfigRequest>,
+    #[allow(dead_code)]
+    pub task: Task<()>,
+}
+
+/// Per-VRF instance proto label — namespaces the child's name-keyed
+/// RIB registrations away from the parent's.
+pub fn vrf_proto_label(name: &str) -> String {
+    format!("pim:vrf:{name}")
+}
+
+/// Manager show-channel registry key — must match what the manager's
+/// `DisplayTx` handler computes from `show pim vrf <name> …`.
+pub fn vrf_show_key(name: &str) -> String {
+    format!("pim:vrf:{name}")
+}
+
+/// True if the buffered config log still has at least one net-effect
+/// `Set` item (a `Set` cancelled by a matching `Delete` drops out).
+pub fn vrf_log_active(log: &[(Vec<CommandPath>, ConfigOp)]) -> bool {
+    let mut active: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for (paths, op) in log {
+        let key = paths
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+            .join("/");
+        match op {
+            ConfigOp::Set => {
+                active.insert(key);
+            }
+            ConfigOp::Delete => {
+                active.remove(&key);
+            }
+            _ => {}
+        }
+    }
+    !active.is_empty()
+}
+
+/// Build + spawn a per-VRF PIM task. Returns `None` when the VRF's
+/// sockets cannot be opened (missing kernel support, another
+/// multicast daemon owning the table) — the caller leaves the
+/// registry empty so a later event retries.
+pub fn spawn_pim_vrf(
+    name: &str,
+    table_id: u32,
+    rib_subscriber: &RibSubscriber,
+    config_tx: &Sender<Message>,
+    buffered: &[(Vec<CommandPath>, ConfigOp)],
+) -> Option<PimVrfHandle> {
+    let proto = vrf_proto_label(name);
+
+    // All three sockets live inside the VRF. Open them BEFORE the RIB
+    // subscription so a failure doesn't leave a dead RibRx receiver
+    // queued in RIB's inbox (same contract as the default spawn).
+    let probe = ProtoContext::for_vrf_no_rib(table_id, name.to_string());
+    let sock = match pim_socket(&probe) {
+        Ok(sock) => sock,
+        Err(e) => {
+            tracing::warn!(vrf = %name, "pim: vrf instance not started ({e})");
+            return None;
+        }
+    };
+    let igmp_sock = match igmp_socket(&probe) {
+        Ok(sock) => sock,
+        Err(e) => {
+            tracing::warn!(vrf = %name, "pim: vrf instance not started (igmp socket: {e})");
+            return None;
+        }
+    };
+    let fp = match ForwardingPlane::new(&probe, table_id) {
+        Ok(fp) => fp,
+        Err(e) => {
+            tracing::warn!(vrf = %name, "pim: vrf instance not started (mroute socket: {e})");
+            return None;
+        }
+    };
+
+    let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, table_id);
+    let ctx = ProtoContext::for_vrf(rib_client, table_id, name.to_string());
+
+    let pim = Pim::new(
+        ctx,
+        sock,
+        igmp_sock,
+        fp,
+        rib_rx,
+        proto.clone(),
+        rib_subscriber.clone(),
+        config_tx.clone(),
+    );
+    let cm_tx = pim.cm.tx.clone();
+
+    let _ = config_tx.try_send(Message::SubscribeShowVrf {
+        key: vrf_show_key(name),
+        tx: pim.show.tx.clone(),
+    });
+
+    // Replay buffered config in commit order, then one synthetic
+    // CommitEnd so the child reconciles.
+    for (paths, op) in buffered {
+        let _ = cm_tx.send(ConfigRequest::new(paths.clone(), *op));
+    }
+    let _ = cm_tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
+
+    let task = inst::serve(pim);
+    tracing::info!(vrf = %name, table_id, "pim: spawned per-VRF instance");
+
+    Some(PimVrfHandle { cm_tx, task })
+}
+
+/// Tear down a per-VRF instance's manager + RIB registrations. The
+/// caller removes the handle from `vrf_registry`, which drops the
+/// `Task` and aborts the event loop — closing the sockets runs the
+/// kernel's implicit MRT_DONE cleanup for the VRF table.
+pub fn despawn_pim_vrf(name: &str, config_tx: &Sender<Message>, rib_subscriber: &RibSubscriber) {
+    let _ = config_tx.try_send(Message::UnsubscribeShowVrf {
+        key: vrf_show_key(name),
+    });
+    rib_subscriber.send_proto_cleanup(&vrf_proto_label(name));
+    tracing::info!(vrf = %name, "pim: despawned per-VRF instance");
+}

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -170,13 +170,15 @@ pub enum Message {
         name: String,
     },
     /// Next-Hop Tracking: register interest in resolving `nh` against
-    /// the global table. Triggers an immediate `RibRx::NexthopUpdate`
-    /// back to `proto` and subsequent updates whenever the covering
-    /// route changes. Registrations are deduplicated + refcounted per
-    /// nexthop in `Rib::nht`.
+    /// the table selected by `vrf_id` (0 = the global table, else a
+    /// VRF's kernel table id). Triggers an immediate
+    /// `RibRx::NexthopUpdate` back to `proto` and subsequent updates
+    /// whenever the covering route changes. Registrations are
+    /// deduplicated + refcounted per (vrf, nexthop) in `Rib::nht`.
     NexthopRegister {
         proto: String,
         nh: std::net::IpAddr,
+        vrf_id: u32,
     },
     /// Fast-reroute switchover trigger (see
     /// `docs/design/nexthop-protect-kernel-failover.md`): the sender
@@ -197,6 +199,7 @@ pub enum Message {
     NexthopUnregister {
         proto: String,
         nh: std::net::IpAddr,
+        vrf_id: u32,
     },
     /// Reserve a dynamic MPLS label block of `size` labels for `proto`
     /// from the central [`super::label_manager::LabelManager`]. The RIB
@@ -1115,11 +1118,22 @@ impl Rib {
 
     /// Push the current value of `blocks[name]` (Some / None) to every
     /// protocol that has registered a watch on this name.
-    /// Resolve `nh` against the appropriate global (default-VRF) table.
-    fn nht_resolve(&self, nh: IpAddr) -> super::nht::NexthopResolution {
+    /// Resolve `nh` against the table selected by `vrf_id` (0 = the
+    /// global table). A VRF whose table doesn't exist yet resolves as
+    /// unreachable — the next VRF route event re-resolves.
+    fn nht_resolve(&self, vrf_id: u32, nh: IpAddr) -> super::nht::NexthopResolution {
+        if vrf_id == 0 {
+            return match nh {
+                IpAddr::V4(a) => super::nht::resolve_v4(&self.table, a),
+                IpAddr::V6(a) => super::nht::resolve_v6(&self.table_v6, a),
+            };
+        }
+        let Some(tables) = self.vrf_tables.get(&vrf_id) else {
+            return super::nht::NexthopResolution::default();
+        };
         match nh {
-            IpAddr::V4(a) => super::nht::resolve_v4(&self.table, a),
-            IpAddr::V6(a) => super::nht::resolve_v6(&self.table_v6, a),
+            IpAddr::V4(a) => super::nht::resolve_v4(&tables.table, a),
+            IpAddr::V6(a) => super::nht::resolve_v6(&tables.table_v6, a),
         }
     }
 
@@ -1127,10 +1141,10 @@ impl Rib {
     /// cache, and push the current resolution to the registering
     /// client immediately (the "synchronous-first" reply — even on a
     /// non-fresh register, so a late joiner gets the state).
-    fn nht_register(&mut self, proto: String, nh: IpAddr) {
-        self.nht.register(proto.clone(), nh);
-        let resolution = self.nht_resolve(nh);
-        if let Some(entry) = self.nht.entries.get_mut(&nh) {
+    fn nht_register(&mut self, proto: String, vrf_id: u32, nh: IpAddr) {
+        self.nht.register(proto.clone(), vrf_id, nh);
+        let resolution = self.nht_resolve(vrf_id, nh);
+        if let Some(entry) = self.nht.entries.get_mut(&(vrf_id, nh)) {
             entry.resolution = resolution.clone();
         }
         if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
@@ -1160,14 +1174,14 @@ impl Rib {
     /// global-table route change. (Recompute-all for now; narrowing to
     /// only the affected nexthops is a follow-up, as is firing on
     /// link/addr changes.)
-    fn nht_recompute_and_notify(&mut self) {
+    pub(crate) fn nht_recompute_and_notify(&mut self) {
         if self.nht.entries.is_empty() {
             return;
         }
         let mut updates: Vec<(IpAddr, super::nht::NexthopResolution, Vec<String>)> = Vec::new();
-        for nh in self.nht.tracked() {
-            let resolution = self.nht_resolve(nh);
-            if let Some(entry) = self.nht.entries.get_mut(&nh)
+        for (vrf_id, nh) in self.nht.tracked() {
+            let resolution = self.nht_resolve(vrf_id, nh);
+            if let Some(entry) = self.nht.entries.get_mut(&(vrf_id, nh))
                 && entry.resolution != resolution
             {
                 entry.resolution = resolution.clone();
@@ -2622,8 +2636,8 @@ impl Rib {
                     self.ipv6_route_del_vrf(table_id, &prefix, rib).await;
                 }
             }
-            Message::NexthopRegister { proto, nh } => {
-                self.nht_register(proto, nh);
+            Message::NexthopRegister { proto, nh, vrf_id } => {
+                self.nht_register(proto, vrf_id, nh);
             }
             Message::ProtectSwitch { addr } => {
                 let (rewired, evicted) =
@@ -2646,8 +2660,8 @@ impl Rib {
                     tracing::debug!("ProtectSwitch {addr} table {table_id}: no eligible groups");
                 }
             }
-            Message::NexthopUnregister { proto, nh } => {
-                self.nht.unregister(&proto, nh);
+            Message::NexthopUnregister { proto, nh, vrf_id } => {
+                self.nht.unregister(&proto, vrf_id, nh);
             }
             Message::LabelBlockRequest { proto, size } => {
                 self.label_block_request(proto, size);

--- a/zebra-rs/src/rib/nht.rs
+++ b/zebra-rs/src/rib/nht.rs
@@ -309,39 +309,41 @@ pub struct NhtEntry {
     pub watchers: BTreeSet<String>,
 }
 
-/// Registry of tracked nexthops, keyed by address. One entry per
-/// distinct nexthop regardless of how many clients/routes depend on
-/// it; an entry is dropped when its last watcher unregisters.
+/// Registry of tracked nexthops, keyed by (vrf table id, address) —
+/// `vrf_id == 0` is the global table. One entry per distinct key
+/// regardless of how many clients/routes depend on it; an entry is
+/// dropped when its last watcher unregisters.
 #[derive(Debug, Default)]
 pub struct NhtRegistry {
-    pub entries: HashMap<IpAddr, NhtEntry>,
+    pub entries: HashMap<(u32, IpAddr), NhtEntry>,
 }
 
 impl NhtRegistry {
-    /// Add `client` as a watcher of `nh`. Returns `true` when this is
-    /// the first registration for `nh` (the caller should resolve it).
-    pub fn register(&mut self, client: String, nh: IpAddr) -> bool {
-        let entry = self.entries.entry(nh).or_default();
+    /// Add `client` as a watcher of `nh` in `vrf_id`. Returns `true`
+    /// when this is the first registration (the caller should resolve
+    /// it).
+    pub fn register(&mut self, client: String, vrf_id: u32, nh: IpAddr) -> bool {
+        let entry = self.entries.entry((vrf_id, nh)).or_default();
         let fresh = entry.watchers.is_empty();
         entry.watchers.insert(client);
         fresh
     }
 
-    /// Remove `client` from `nh`'s watchers. Returns `true` when the
+    /// Remove `client` from the watchers. Returns `true` when the
     /// entry has no watchers left and was dropped.
-    pub fn unregister(&mut self, client: &str, nh: IpAddr) -> bool {
-        if let Some(entry) = self.entries.get_mut(&nh) {
+    pub fn unregister(&mut self, client: &str, vrf_id: u32, nh: IpAddr) -> bool {
+        if let Some(entry) = self.entries.get_mut(&(vrf_id, nh)) {
             entry.watchers.remove(client);
             if entry.watchers.is_empty() {
-                self.entries.remove(&nh);
+                self.entries.remove(&(vrf_id, nh));
                 return true;
             }
         }
         false
     }
 
-    /// Tracked nexthop addresses (for re-resolution on a RIB change).
-    pub fn tracked(&self) -> Vec<IpAddr> {
+    /// Tracked (vrf, nexthop) pairs (for re-resolution on a RIB change).
+    pub fn tracked(&self) -> Vec<(u32, IpAddr)> {
         self.entries.keys().copied().collect()
     }
 }
@@ -718,10 +720,13 @@ mod tests {
     fn registry_dedup_and_refcount() {
         let mut reg = NhtRegistry::default();
         let nh: IpAddr = "10.0.0.8".parse().unwrap();
-        assert!(reg.register("bgp".into(), nh)); // first → fresh
-        assert!(!reg.register("static".into(), nh)); // second watcher → not fresh
-        assert!(!reg.unregister("bgp", nh)); // still has "static"
-        assert!(reg.unregister("static", nh)); // last watcher → dropped
+        assert!(reg.register("bgp".into(), 0, nh)); // first → fresh
+        assert!(!reg.register("static".into(), 0, nh)); // second watcher → not fresh
+        // Same address in a VRF is a distinct entry.
+        assert!(reg.register("pim:vrf:red".into(), 7, nh));
+        assert!(!reg.unregister("bgp", 0, nh)); // still has "static"
+        assert!(reg.unregister("static", 0, nh)); // last global watcher → dropped
+        assert!(reg.unregister("pim:vrf:red", 7, nh));
         assert!(reg.entries.is_empty());
     }
 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -597,6 +597,9 @@ impl Rib {
             after.as_ref(),
             table_id,
         );
+        // VRF-aware NHT: a VRF route change can move tracked
+        // resolutions (PIM RPF in a VRF etc.).
+        self.nht_recompute_and_notify();
     }
 
     pub async fn ipv4_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv4Net, entry: RibEntry) {
@@ -630,6 +633,9 @@ impl Rib {
             after.as_ref(),
             table_id,
         );
+        // VRF-aware NHT: a VRF route change can move tracked
+        // resolutions (PIM RPF in a VRF etc.).
+        self.nht_recompute_and_notify();
     }
 
     pub async fn ipv6_route_add_vrf(
@@ -677,6 +683,9 @@ impl Rib {
             after.as_ref(),
             table_id,
         );
+        // VRF-aware NHT: a VRF route change can move tracked
+        // resolutions (PIM RPF in a VRF etc.).
+        self.nht_recompute_and_notify();
     }
 
     pub async fn ipv6_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv6Net, entry: RibEntry) {
@@ -710,6 +719,9 @@ impl Rib {
             after.as_ref(),
             table_id,
         );
+        // VRF-aware NHT: a VRF route change can move tracked
+        // resolutions (PIM RPF in a VRF etc.).
+        self.nht_recompute_and_notify();
     }
 
     /// Best-path selection + FIB reconcile for one VRF prefix. Mirrors

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4072,6 +4072,105 @@ module config {
             }
           }
         }
+        list vrf {
+          ext:help "Per-VRF PIM instance";
+          // Mirrors the default PIM tree for each named VRF: the
+          // default `router pim` task forwards every `vrf <name> ...`
+          // line — with the `vrf <name>` prefix stripped — to a full
+          // per-VRF PIM instance whose sockets and kernel MFC live in
+          // the VRF (SO_BINDTODEVICE + MRT_TABLE). Hand-declared
+          // subset, like `router isis`'s vrf list.
+          key "name";
+          leaf name {
+            ext:help "VRF name";
+            ext:dynamic "rib:vrf";
+            type string;
+          }
+          container rp {
+            ext:help "Rendezvous Point configuration";
+            list static {
+              ext:help "Static RP address for a group range";
+              key "address";
+              leaf address {
+                ext:help "RP address";
+                type inet:ipv4-address;
+              }
+              leaf group {
+                ext:help "Multicast group prefix served by this RP";
+                type inet:ipv4-prefix;
+                default "224.0.0.0/4";
+              }
+            }
+          }
+          list interface {
+            ext:help "Per-interface PIM configuration";
+            key "if-name";
+            leaf if-name {
+              ext:help "Interface name";
+              ext:dynamic "rib:interface";
+              type string;
+            }
+            leaf dr-priority {
+              ext:help "Designated Router election priority";
+              type uint32;
+              default 1;
+            }
+            container hello {
+              ext:help "PIM Hello parameters";
+              leaf interval {
+                ext:help "Hello transmit interval (seconds)";
+                type uint16 {
+                  range "1..18000";
+                }
+                units "seconds";
+                default 30;
+              }
+              leaf holdtime {
+                ext:help "Neighbor holdtime advertised in Hellos (seconds)";
+                type uint16 {
+                  range "1..65535";
+                }
+                units "seconds";
+              }
+            }
+            leaf passive {
+              ext:help "Do not send or process PIM packets on this interface";
+              type boolean;
+              default false;
+            }
+            container igmp {
+              ext:help "IGMP on this interface";
+              leaf enabled {
+                ext:help "Enable IGMP membership tracking";
+                type boolean;
+                default false;
+              }
+              leaf version {
+                ext:help "IGMP version to run";
+                type uint8 {
+                  range "2..3";
+                }
+                default 3;
+              }
+              leaf query-interval {
+                ext:help "General query transmit interval (seconds)";
+                type uint16 {
+                  range "1..1800";
+                }
+                units "seconds";
+                default 125;
+              }
+              leaf query-max-response-time {
+                ext:help "Max response time advertised in queries (seconds)";
+                type uint16 {
+                  range "1..25";
+                }
+                units "seconds";
+                default 10;
+              }
+            }
+          }
+        }
       }
       container static {
         ext:help "Static route configuration";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -996,6 +996,23 @@ module exec {
         ext:help "IGMP group membership";
         presence "IGMP groups";
       }
+      list vrf {
+        ext:help "Per-VRF IGMP state";
+        key name;
+        leaf name {
+          ext:help "VRF name";
+          ext:dynamic "rib:vrf";
+          type string;
+        }
+        leaf interface {
+          ext:help "IGMP interfaces in this VRF";
+          type empty;
+        }
+        leaf groups {
+          ext:help "IGMP groups in this VRF";
+          type empty;
+        }
+      }
     }
 
     container pim {
@@ -1021,11 +1038,52 @@ module exec {
         ext:help "PIM assert election state";
         presence "PIM assert";
       }
+      list vrf {
+        // Per-VRF PIM show: the manager strips the `vrf <name>`
+        // selector (vrf_redirect_split) and redirects into the child
+        // registered as "pim:vrf:<name>".
+        ext:help "Per-VRF PIM instance";
+        key name;
+        leaf name {
+          ext:help "VRF name";
+          ext:dynamic "rib:vrf";
+          type string;
+        }
+        leaf interface {
+          ext:help "PIM interfaces in this VRF";
+          type empty;
+        }
+        leaf neighbor {
+          ext:help "PIM neighbors in this VRF";
+          type empty;
+        }
+        leaf upstream {
+          ext:help "PIM upstream state in this VRF";
+          type empty;
+        }
+        leaf rp-info {
+          ext:help "Group-to-RP mappings in this VRF";
+          type empty;
+        }
+        leaf assert {
+          ext:help "Assert state in this VRF";
+          type empty;
+        }
+      }
     }
 
     container mroute {
       ext:help "IP multicast routing table";
       presence "Multicast routes";
+      list vrf {
+        ext:help "Multicast routes in a VRF";
+        key name;
+        leaf name {
+          ext:help "VRF name";
+          ext:dynamic "rib:vrf";
+          type string;
+        }
+      }
     }
 
     container ospfv3 {


### PR DESCRIPTION
## Summary

Phase 7 of the PIM-SM/SSM arc (architecture: `docs/design/pim-sm-ssm-architecture.md`; Phases 1–6: #1951 / #1956 / #1960 / #1965 / #1973 / #1980):

- **Per-VRF PIM instances** (`pim/vrf.rs`, the `isis/vrf.rs` pattern): the default task is a thin parent — `router pim vrf <name> …` lines are stripped/buffered/forwarded into a full per-VRF child, spawned once both config intent and the kernel `VrfAdd` exist; despawned on `VrfDel` (intent kept for respawn) or config deletion at CommitEnd. Children open **all three sockets inside the VRF** before touching RIB: protocol-103 + IGMP via `SO_BINDTODEVICE` (new `ProtoContext::for_vrf_no_rib` probe helper), mroute with `MRT_TABLE` before `MRT_INIT`.
- **RIB NHT becomes VRF-aware** — the substantive find of this phase: NHT previously resolved only against the global table (and routed updates by bare proto name), so a VRF child's RPF could never resolve — caught live with the LHR stuck unjoined. Now `NexthopRegister/Unregister` carry `vrf_id`, the registry keys by (vrf, nexthop), resolution walks the VRF's tables, and all four VRF route mutators trigger recompute+notify. BGP's nine call sites pass `vrf_id: 0` unchanged in behavior.
- **Show/YANG**: `show pim|igmp|mroute vrf <name> …` via the generic manager redirect; `router pim { list vrf }` mirroring the full PIM subtree.
- **Assertion-hardening fix**: upstream state displays `None` instead of `NotJoined` — the old string contained "Joined" as a substring and silently weakened every prior BDD assertion.

## Test plan

- Live BDD under sudo: `@pim_vrf` — two routers fully inside VRF `mvrf`: child registration visible in `show task`, neighbors/IGMP/upstream/mroute all VRF-scoped while the **default instance provably stays empty**, kernel MFCs in the VRF table (`ip mroute show table all`), UDP payload delivered end-to-end through both VRF forwarding caches. All 34 steps ✔.
- All six PIM features re-run green in one batch, with installed binary+YANG integrity md5/grep-checked before and after (a mid-session stomp by another session was caught and corrected this way).
- `cargo test --workspace --exclude bdd`: green (incl. updated VRF-keyed NHT registry test). Forced-fresh `clippy -D warnings`: exit 0. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)