### PR TITLE
isis-packet: dedup sub-TLV registries and sub-block parses

### DIFF
--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use crate::util::{ParseBe, TlvEmitter, u32_u8_3};
 use crate::{IsisTlv, IsisTlvType, many0_complete};
 
-use super::{IsisCapCode, IsisCodeLen, IsisSubTlvUnknown};
+use super::{IsisCapCode, IsisSubTlvUnknown};
+
+impl_parse_subs!(IsisSubTlv, FadSubTlv);
 
 #[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -34,27 +36,6 @@ pub enum IsisSubTlv {
 }
 
 impl IsisSubTlv {
-    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, cl) = IsisCodeLen::parse_be(input)?;
-        let (input, sub) = packet_utils::safe_split_at(input, cl.len as usize)?;
-        // A malformed *known* sub-TLV must not truncate the list —
-        // degrade it to Unknown with its bytes preserved (mirroring the
-        // top-level TLV loop) so the sub-TLVs after it still parse.
-        let mut val = match Self::parse_be(sub, cl.code.into()) {
-            Ok((_, val)) => val,
-            Err(_) => IsisSubTlv::Unknown(IsisSubTlvUnknown {
-                code: cl.code,
-                len: cl.len,
-                data: sub.to_vec(),
-            }),
-        };
-        if let IsisSubTlv::Unknown(ref mut v) = val {
-            v.code = cl.code;
-            v.len = cl.len;
-        }
-        Ok((input, val))
-    }
-
     pub fn len(&self) -> u8 {
         use IsisSubTlv::*;
         match self {
@@ -567,25 +548,6 @@ pub enum FadSubTlv {
 }
 
 impl FadSubTlv {
-    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, cl) = IsisCodeLen::parse_be(input)?;
-        let (input, sub) = packet_utils::safe_split_at(input, cl.len as usize)?;
-        // Malformed known sub-TLV → Unknown, so followers still parse.
-        let mut val = match Self::parse_be(sub, cl.code.into()) {
-            Ok((_, val)) => val,
-            Err(_) => FadSubTlv::Unknown(IsisSubTlvUnknown {
-                code: cl.code,
-                len: cl.len,
-                data: sub.to_vec(),
-            }),
-        };
-        if let FadSubTlv::Unknown(ref mut v) = val {
-            v.code = cl.code;
-            v.len = cl.len;
-        }
-        Ok((input, val))
-    }
-
     pub fn len(&self) -> u8 {
         use FadSubTlv::*;
         match self {

--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -6,6 +6,37 @@ pub struct IsisCodeLen {
     pub len: u8,
 }
 
+/// Implements the shared sub-TLV registry walk for a `#[nom(Selector)]`
+/// enum with an `Unknown(IsisSubTlvUnknown)` variant: read {code, len},
+/// slice the value, dispatch on the code, and degrade a malformed
+/// *known* sub-TLV to Unknown with its bytes preserved — mirroring the
+/// top-level TLV loop — so the sub-TLVs after it still parse. One
+/// definition instead of six hand-kept copies; a new registry gets the
+/// degrade and the Unknown code/len patch for free.
+macro_rules! impl_parse_subs {
+    ($($ty:ty),+ $(,)?) => {$(
+        impl $ty {
+            pub fn parse_subs(input: &[u8]) -> nom::IResult<&[u8], Self> {
+                let (input, cl) = crate::sub::IsisCodeLen::parse_be(input)?;
+                let (input, sub) = packet_utils::safe_split_at(input, cl.len as usize)?;
+                let mut val = match Self::parse_be(sub, cl.code.into()) {
+                    Ok((_, val)) => val,
+                    Err(_) => Self::Unknown(crate::sub::IsisSubTlvUnknown {
+                        code: cl.code,
+                        len: cl.len,
+                        data: sub.to_vec(),
+                    }),
+                };
+                if let Self::Unknown(ref mut v) = val {
+                    v.code = cl.code;
+                    v.len = cl.len;
+                }
+                Ok((input, val))
+            }
+        }
+    )+};
+}
+
 pub mod cap;
 pub use cap::{
     ExtAdminGroup, FadSubCode, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg,

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -7,16 +7,18 @@ use nom::IResult;
 use nom::bytes::complete::take;
 use nom::number::complete::{be_u8, be_u16, be_u24, be_u32};
 use nom_derive::*;
-use packet_utils::{Algo, safe_split_at};
+use packet_utils::Algo;
 use serde::{Deserialize, Serialize};
 
-use crate::util::{ParseBe, TlvEmitter, emit_sub_tlvs, u32_u8_3};
+use crate::util::{ParseBe, TlvEmitter, emit_sub_tlvs, parse_sub_block, u32_u8_3};
+
+impl_parse_subs!(IsisSubTlv);
 use crate::{
     IPV4_ADDR_LEN, IPV6_ADDR_LEN, IsisNeighborId, IsisSysId, IsisTlv, IsisTlvType, SidLabelValue,
     many0_complete,
 };
 
-use super::{Behavior, IsisCodeLen, IsisNeighCode, IsisSub2Tlv, IsisSubTlvUnknown};
+use super::{Behavior, IsisNeighCode, IsisSub2Tlv, IsisSubTlvUnknown};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvExtIsReach {
@@ -221,9 +223,7 @@ impl ParseBe<IsisTlvExtIsReachEntry> for IsisTlvExtIsReachEntry {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, neighbor_id) = take(7usize)(input)?;
         let (input, metric) = be_u24(input)?;
-        let (input, sublen) = be_u8(input)?;
-        let (input, sub) = safe_split_at(input, sublen as usize)?;
-        let (_, subs) = many0_complete(IsisSubTlv::parse_subs).parse(sub)?;
+        let (input, subs) = parse_sub_block(input, IsisSubTlv::parse_subs)?;
 
         let mut tlv = Self::default();
         tlv.neighbor_id.id.copy_from_slice(neighbor_id);
@@ -281,27 +281,6 @@ pub enum IsisSubTlv {
 }
 
 impl IsisSubTlv {
-    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, cl) = IsisCodeLen::parse_be(input)?;
-        let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        // A malformed *known* sub-TLV must not truncate the list —
-        // degrade it to Unknown with its bytes preserved (mirroring the
-        // top-level TLV loop) so the sub-TLVs after it still parse.
-        let mut val = match Self::parse_be(sub, cl.code.into()) {
-            Ok((_, val)) => val,
-            Err(_) => IsisSubTlv::Unknown(IsisSubTlvUnknown {
-                code: cl.code,
-                len: cl.len,
-                data: sub.to_vec(),
-            }),
-        };
-        if let IsisSubTlv::Unknown(ref mut v) = val {
-            v.code = cl.code;
-            v.len = cl.len;
-        }
-        Ok((input, val))
-    }
-
     pub fn len(&self) -> u8 {
         use IsisSubTlv::*;
         match self {
@@ -1061,22 +1040,18 @@ impl ParseBe<IsisSubSrv6EndXSid> for IsisSubSrv6EndXSid {
         let (input, weight) = be_u8(input)?;
         let (input, behavior) = be_u16(input)?;
         let (input, sid) = Ipv6Addr::parse_be(input)?;
-        let (input, sub2_len) = be_u8(input)?;
-        let mut sub = Self {
-            flags,
-            algo: algo.into(),
-            weight,
-            behavior: behavior.into(),
-            sid,
-            sub2s: vec![],
-        };
-        if sub2_len == 0 {
-            return Ok((input, sub));
-        }
-        let (input, sub2_data) = safe_split_at(input, sub2_len as usize)?;
-        let (_, sub2s) = many0_complete(IsisSub2Tlv::parse_subs).parse(sub2_data)?;
-        sub.sub2s = sub2s;
-        Ok((input, sub))
+        let (input, sub2s) = parse_sub_block(input, IsisSub2Tlv::parse_subs)?;
+        Ok((
+            input,
+            Self {
+                flags,
+                algo: algo.into(),
+                weight,
+                behavior: behavior.into(),
+                sid,
+                sub2s,
+            },
+        ))
     }
 }
 
@@ -1125,23 +1100,19 @@ impl ParseBe<IsisSubSrv6LanEndXSid> for IsisSubSrv6LanEndXSid {
         let (input, weight) = be_u8(input)?;
         let (input, behavior) = be_u16(input)?;
         let (input, sid) = Ipv6Addr::parse_be(input)?;
-        let (input, sub2_len) = be_u8(input)?;
-        let mut sub = Self {
-            system_id,
-            flags,
-            algo: algo.into(),
-            weight,
-            behavior: behavior.into(),
-            sid,
-            sub2s: vec![],
-        };
-        if sub2_len == 0 {
-            return Ok((input, sub));
-        }
-        let (input, sub2_data) = safe_split_at(input, sub2_len as usize)?;
-        let (_, sub2s) = many0_complete(IsisSub2Tlv::parse_subs).parse(sub2_data)?;
-        sub.sub2s = sub2s;
-        Ok((input, sub))
+        let (input, sub2s) = parse_sub_block(input, IsisSub2Tlv::parse_subs)?;
+        Ok((
+            input,
+            Self {
+                system_id,
+                flags,
+                algo: algo.into(),
+                weight,
+                behavior: behavior.into(),
+                sid,
+                sub2s,
+            },
+        ))
     }
 }
 

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -10,13 +10,14 @@ use nom_derive::*;
 use packet_utils::{Algo, safe_split_at};
 use serde::{Deserialize, Serialize};
 
-use crate::util::{ParseBe, TlvEmitter, emit_sub_tlvs};
+use crate::util::{ParseBe, TlvEmitter, emit_sub_tlvs, parse_sub_block};
 use crate::{IsisTlv, IsisTlvType, SidLabelValue, many0_complete};
 
 use super::{
-    Behavior, IsisCodeLen, IsisPrefixCode, IsisSrv6MirrorSub2Code, IsisSrv6SidSub2Code,
-    IsisSubTlvUnknown,
+    Behavior, IsisPrefixCode, IsisSrv6MirrorSub2Code, IsisSrv6SidSub2Code, IsisSubTlvUnknown,
 };
+
+impl_parse_subs!(IsisSubTlv, IsisSub2Tlv, IsisMirrorSub2Tlv);
 
 #[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -111,20 +112,16 @@ impl ParseBe<IsisSubSrv6EndSid> for IsisSubSrv6EndSid {
         let (input, flags) = be_u8(input)?;
         let (input, behavior) = be_u16(input)?;
         let (input, sid) = Ipv6Addr::parse_be(input)?;
-        let (input, sub2_len) = be_u8(input)?;
-        let mut sub = Self {
-            flags,
-            behavior: behavior.into(),
-            sid,
-            sub2s: vec![],
-        };
-        if sub2_len == 0 {
-            return Ok((input, sub));
-        }
-        let (input, sub2_data) = safe_split_at(input, sub2_len as usize)?;
-        let (_, sub2s) = many0_complete(IsisSub2Tlv::parse_subs).parse(sub2_data)?;
-        sub.sub2s = sub2s;
-        Ok((input, sub))
+        let (input, sub2s) = parse_sub_block(input, IsisSub2Tlv::parse_subs)?;
+        Ok((
+            input,
+            Self {
+                flags,
+                behavior: behavior.into(),
+                sid,
+                sub2s,
+            },
+        ))
     }
 }
 
@@ -171,20 +168,16 @@ impl ParseBe<IsisSubSrv6MirrorSid> for IsisSubSrv6MirrorSid {
         let (input, flags) = be_u8(input)?;
         let (input, behavior) = be_u16(input)?;
         let (input, sid) = Ipv6Addr::parse_be(input)?;
-        let (input, sub2_len) = be_u8(input)?;
-        let mut sub = Self {
-            flags,
-            behavior: behavior.into(),
-            sid,
-            sub2s: vec![],
-        };
-        if sub2_len == 0 {
-            return Ok((input, sub));
-        }
-        let (input, sub2_data) = safe_split_at(input, sub2_len as usize)?;
-        let (_, sub2s) = many0_complete(IsisMirrorSub2Tlv::parse_subs).parse(sub2_data)?;
-        sub.sub2s = sub2s;
-        Ok((input, sub))
+        let (input, sub2s) = parse_sub_block(input, IsisMirrorSub2Tlv::parse_subs)?;
+        Ok((
+            input,
+            Self {
+                flags,
+                behavior: behavior.into(),
+                sid,
+                sub2s,
+            },
+        ))
     }
 }
 
@@ -257,25 +250,6 @@ pub enum IsisMirrorSub2Tlv {
 }
 
 impl IsisMirrorSub2Tlv {
-    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, cl) = IsisCodeLen::parse_be(input)?;
-        let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        // Malformed known sub-TLV → Unknown, so followers still parse.
-        let mut val = match Self::parse_be(sub, cl.code.into()) {
-            Ok((_, val)) => val,
-            Err(_) => IsisMirrorSub2Tlv::Unknown(IsisSubTlvUnknown {
-                code: cl.code,
-                len: cl.len,
-                data: sub.to_vec(),
-            }),
-        };
-        if let IsisMirrorSub2Tlv::Unknown(ref mut v) = val {
-            v.code = cl.code;
-            v.len = cl.len;
-        }
-        Ok((input, val))
-    }
-
     pub fn len(&self) -> u8 {
         use IsisMirrorSub2Tlv::*;
         match self {
@@ -361,25 +335,6 @@ pub enum IsisSub2Tlv {
 }
 
 impl IsisSub2Tlv {
-    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, cl) = IsisCodeLen::parse_be(input)?;
-        let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        // Malformed known sub-TLV → Unknown, so followers still parse.
-        let mut val = match Self::parse_be(sub, cl.code.into()) {
-            Ok((_, val)) => val,
-            Err(_) => IsisSub2Tlv::Unknown(IsisSubTlvUnknown {
-                code: cl.code,
-                len: cl.len,
-                data: sub.to_vec(),
-            }),
-        };
-        if let IsisSub2Tlv::Unknown(ref mut v) = val {
-            v.code = cl.code;
-            v.len = cl.len;
-        }
-        Ok((input, val))
-    }
-
     pub fn len(&self) -> u8 {
         use IsisSub2Tlv::*;
         match self {
@@ -402,27 +357,6 @@ impl IsisSub2Tlv {
 }
 
 impl IsisSubTlv {
-    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, cl) = IsisCodeLen::parse_be(input)?;
-        let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        // A malformed *known* sub-TLV must not truncate the list —
-        // degrade it to Unknown with its bytes preserved (mirroring the
-        // top-level TLV loop) so the sub-TLVs after it still parse.
-        let mut val = match Self::parse_be(sub, cl.code.into()) {
-            Ok((_, val)) => val,
-            Err(_) => IsisSubTlv::Unknown(IsisSubTlvUnknown {
-                code: cl.code,
-                len: cl.len,
-                data: sub.to_vec(),
-            }),
-        };
-        if let IsisSubTlv::Unknown(ref mut v) = val {
-            v.code = cl.code;
-            v.len = cl.len;
-        }
-        Ok((input, val))
-    }
-
     pub fn len(&self) -> u8 {
         use IsisSubTlv::*;
         match self {
@@ -1258,9 +1192,7 @@ impl ParseBe<IsisTlvExtIpReachEntry> for IsisTlvExtIpReachEntry {
         if !flags.sub_tlv() {
             return Ok((input, tlv));
         }
-        let (input, sublen) = be_u8(input)?;
-        let (input, sub) = safe_split_at(input, sublen as usize)?;
-        let (_, subs) = many0_complete(IsisSubTlv::parse_subs).parse(sub)?;
+        let (input, subs) = parse_sub_block(input, IsisSubTlv::parse_subs)?;
         tlv.subs = subs;
         Ok((input, tlv))
     }
@@ -1282,9 +1214,7 @@ impl ParseBe<IsisTlvIpv6ReachEntry> for IsisTlvIpv6ReachEntry {
         if !flags.sub_tlv() {
             return Ok((input, tlv));
         }
-        let (input, sublen) = be_u8(input)?;
-        let (input, sub) = safe_split_at(input, sublen as usize)?;
-        let (_, subs) = many0_complete(IsisSubTlv::parse_subs).parse(sub)?;
+        let (input, subs) = parse_sub_block(input, IsisSubTlv::parse_subs)?;
         tlv.subs = subs;
         Ok((input, tlv))
     }
@@ -1361,12 +1291,7 @@ impl ParseBe<Srv6Locator> for Srv6Locator {
             locator,
             subs: Vec::new(),
         };
-        let (input, sublen) = be_u8(input)?;
-        if sublen == 0 {
-            return Ok((input, tlv));
-        }
-        let (input, sub) = safe_split_at(input, sublen as usize)?;
-        let (_, subs) = many0_complete(IsisSubTlv::parse_subs).parse(sub)?;
+        let (input, subs) = parse_sub_block(input, IsisSubTlv::parse_subs)?;
         tlv.subs = subs;
         Ok((input, tlv))
     }

--- a/crates/isis-packet/src/util.rs
+++ b/crates/isis-packet/src/util.rs
@@ -1,6 +1,26 @@
 use bytes::{BufMut, BytesMut};
+use nom::{IResult, Parser};
+use packet_utils::{many0_complete, safe_split_at};
 
 pub use packet_utils::{ParseBe, TlvEmitter, u32_u8_3, write_hold_time};
+
+/// Parse a length-prefixed sub-TLV block: read the one-octet block
+/// length, slice exactly that many bytes, and run `parse_one` to
+/// exhaustion inside the slice. This is the shared shape behind every
+/// reach-entry and SRv6-SID sub-TLV block (previously re-implemented
+/// verbatim at eight sites).
+pub fn parse_sub_block<T>(
+    input: &[u8],
+    parse_one: impl Fn(&[u8]) -> IResult<&[u8], T>,
+) -> IResult<&[u8], Vec<T>> {
+    let (input, sublen) = nom::number::complete::be_u8(input)?;
+    if sublen == 0 {
+        return Ok((input, Vec::new()));
+    }
+    let (input, sub) = safe_split_at(input, sublen as usize)?;
+    let (_, subs) = many0_complete(parse_one).parse(sub)?;
+    Ok((input, subs))
+}
 
 /// Emit sub-TLVs with a back-patched length byte.
 ///

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -498,10 +498,13 @@ backlog, ordered by risk and value.
    TLV via the `SplittableTlv` trait with no clone and no serialization. A
    unit test pins `wire_len == emitted bytes` across variants including an
    over-full TLV 135.
-5. **Dedup the six sub-TLV dispatch registries** — the #10 fix made each copy
-   bigger (the degrade-to-Unknown match is pasted six times); one generic
-   helper removes ~250 lines and the risk that a seventh registry forgets the
-   Unknown patch or the degrade.
+5. ~~**Dedup the six sub-TLV dispatch registries**~~ — **done**: a single
+   `impl_parse_subs!` macro in `sub/mod.rs` generates all six `parse_subs`
+   registries (dispatch + degrade-to-Unknown + code/len patch), and a shared
+   `util::parse_sub_block` helper replaces the eight hand-rolled
+   length-prefixed sub-block parses. A seventh registry now gets the degrade
+   machinery for free. Behavior pinned by the existing degrade/round-trip
+   tests, which were written against the hand-rolled copies.
 6. **BGP-LS Extended Admin Group (TLV 1173) producer** — enabled by #13:
    `ext_admin_group()` exists, but there is no `BGPLS_ATTR_EXT_ADMIN_GROUP`
    constant, so links advertising only the RFC 7308 group export no color at


### PR DESCRIPTION
## Summary

Follow-up item 5 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

The sub-TLV registry walk (read `{code, len}` → `safe_split_at` →
dispatch → degrade-to-Unknown → patch Unknown code/len) was hand-copied
across six enums, and the length-prefixed sub-block parse (read u8 len →
`safe_split_at` → `many0_complete`) was re-implemented at eight sites.
The finding-#10 fix made every registry copy bigger, so a seventh
registry risked forgetting the Unknown patch or the degrade.

- New `impl_parse_subs!` macro in `sub/mod.rs` generates `parse_subs`
  for a `#[nom(Selector)]` enum with an `Unknown(IsisSubTlvUnknown)`
  variant; the six registries (neigh `IsisSubTlv`, prefix
  `IsisSubTlv`/`IsisSub2Tlv`/`IsisMirrorSub2Tlv`, cap
  `IsisSubTlv`/`FadSubTlv`) are one invocation each.
- New `util::parse_sub_block` reads the one-octet block length, slices,
  and runs the given `parse_subs` to exhaustion; the eight call sites
  (ExtIsReach/ExtIpReach/Ipv6Reach entries, `Srv6Locator`, and the four
  SRv6 End/Mirror/EndX/LanEndX SID sub2 blocks) now use it, and the SID
  parsers collapse to straight-line field parsing.

Net −88 lines; no behavior change.

## Test plan

- The degrade-to-Unknown, sub-block round-trip, and follower-survival
  tests from findings #10/#14 and the SRv6 series were all written
  against the hand-rolled copies and pass unchanged.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)