### PR TITLE
pim: Bootstrap Router — election, BSM flooding, candidate RPs

### DIFF
--- a/bdd/tests/configs/pim_bsr/r1.yaml
+++ b/bdd/tests/configs/pim_bsr/r1.yaml
@@ -1,0 +1,14 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.9.21.1/24
+- if-name: eth2
+  ipv4:
+    address: 10.9.22.1/24
+router:
+  pim:
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth2
+      dr-priority: 1

--- a/bdd/tests/configs/pim_bsr/r2.yaml
+++ b/bdd/tests/configs/pim_bsr/r2.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: eth3
+  ipv4:
+    address: 10.9.22.2/24
+- if-name: eth4
+  ipv4:
+    address: 10.9.23.1/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.9.21.0/24
+        nexthop:
+        - address: 10.9.22.1
+  pim:
+    bsr:
+      candidate-bsr:
+        address: 10.9.22.2
+        priority: 100
+      candidate-rp:
+        address: 10.9.22.2
+    interface:
+    - if-name: eth3
+      dr-priority: 1
+    - if-name: eth4
+      dr-priority: 1

--- a/bdd/tests/configs/pim_bsr/r3.yaml
+++ b/bdd/tests/configs/pim_bsr/r3.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: eth5
+  ipv4:
+    address: 10.9.23.2/24
+- if-name: eth6
+  ipv4:
+    address: 10.9.24.1/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.9.22.0/24
+        nexthop:
+        - address: 10.9.23.1
+      - prefix: 10.9.21.0/24
+        nexthop:
+        - address: 10.9.23.1
+  pim:
+    interface:
+    - if-name: eth5
+      dr-priority: 1
+    - if-name: eth6
+      igmp:
+        enabled: true

--- a/bdd/tests/features/pim_bsr.feature
+++ b/bdd/tests/features/pim_bsr.feature
@@ -1,0 +1,72 @@
+@serial
+@pim_bsr
+Feature: PIM Bootstrap Router elects itself and distributes the RP-set
+  As a network operator
+  I want a candidate BSR to win the election, collect candidate-RP
+  advertisements and flood the group-to-RP mapping in Bootstrap
+  Messages, so every router in the domain learns the RP without any
+  static configuration — and the full ASM control loop (shared tree,
+  register, SPT) runs on the learned mapping.
+
+  Same chain as the pim_asm feature, but NO router has a static RP:
+  r2 is candidate-BSR and candidate-RP (10.9.22.2). r1 and r3 must
+  learn both the elected BSR and the RP purely from flooded BSMs,
+  after which an any-source join at h2 and a sender at h1 must
+  converge exactly as the static-RP scenario did.
+
+  Test Topology:
+  ```
+    h1 (10.9.21.10, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(C-BSR,C-RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (10.9.24.10, receiver)
+                                  10.9.21.1    10.9.22.1/.2          10.9.23.1/.2               10.9.24.1
+  ```
+
+  Scenario: BSR election, RP-set distribution and ASM traffic
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "h1" interface "eth0" to namespace "r1" interface "eth1"
+    And I connect namespace "r1" interface "eth2" to namespace "r2" interface "eth3"
+    And I connect namespace "r2" interface "eth4" to namespace "r3" interface "eth5"
+    And I connect namespace "r3" interface "eth6" to namespace "h2" interface "eth7"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I add address "10.9.21.10/24" to interface "eth0" in namespace "h1"
+    And I add address "10.9.24.10/24" to interface "eth7" in namespace "h2"
+
+    # r2 claims the BSR role; r1 and r3 learn it from flooded BSMs.
+    Then show command "show pim bsr" in namespace "r2" should eventually contain "Elected"
+    And show command "show pim bsr" in namespace "r1" should eventually contain "10.9.22.2"
+    And show command "show pim bsr" in namespace "r3" should eventually contain "10.9.22.2"
+
+    # The RP mapping arrives via the BSM RP-set — no static config.
+    And show command "show pim rp-info" in namespace "r1" should eventually contain "bsr"
+    And show command "show pim rp-info" in namespace "r3" should eventually contain "10.9.22.2"
+
+    # The ASM control loop runs on the learned RP: shared tree from
+    # h2's join, register cycle from h1's traffic, payload delivered.
+    When I spawn "timeout 150 python3 tests/scripts/asm_recv.py 239.9.9.9 10.9.24.10 5001 /tmp/pim_bsr_rx" in namespace "h2"
+    Then show command "show pim upstream" in namespace "r3" should eventually contain "(*, 239.9.9.9)"
+    And show command "show mroute" in namespace "r2" should eventually contain "(*, 239.9.9.9)"
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send.py 239.9.9.9 5001 10.9.21.10 90" in namespace "h1"
+    Then show command "show mroute" in namespace "r2" should eventually contain "(10.9.21.10, 239.9.9.9)"
+    And show command "show pim upstream" in namespace "r1" should eventually contain "RegPrune"
+    And command "cat /tmp/pim_bsr_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim_bsr_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/crates/pim-packet/src/bsr.rs
+++ b/crates/pim-packet/src/bsr.rs
@@ -1,0 +1,183 @@
+//! Bootstrap Router messages (RFC 5059): the Bootstrap Message
+//! carrying the elected BSR's identity and the RP-set, and the
+//! Candidate-RP-Advertisement unicast to the BSR.
+
+use std::net::IpAddr;
+
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom::number::complete::{be_u8, be_u16};
+
+use crate::addr::{EncodedGroup, EncodedUnicast};
+
+/// One RP inside a BSM group set (RFC 5059 §4.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BsmRp {
+    pub addr: EncodedUnicast,
+    pub holdtime: u16,
+    pub priority: u8,
+}
+
+impl BsmRp {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, addr) = EncodedUnicast::parse_be(input)?;
+        let (input, holdtime) = be_u16(input)?;
+        let (input, priority) = be_u8(input)?;
+        let (input, _reserved) = be_u8(input)?;
+        Ok((
+            input,
+            Self {
+                addr,
+                holdtime,
+                priority,
+            },
+        ))
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        self.addr.emit(buf);
+        buf.put_u16(self.holdtime);
+        buf.put_u8(self.priority);
+        buf.put_u8(0);
+    }
+}
+
+/// One group range with its candidate RPs (RFC 5059 §4.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BsmGroup {
+    pub group: EncodedGroup,
+    /// Total RPs for the range across all fragments.
+    pub rp_count: u8,
+    pub rps: Vec<BsmRp>,
+}
+
+impl BsmGroup {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = EncodedGroup::parse_be(input)?;
+        let (input, rp_count) = be_u8(input)?;
+        let (mut input, frag_rp_count) = be_u8(input)?;
+        let (rest, _reserved) = be_u16(input)?;
+        input = rest;
+        let mut rps = Vec::with_capacity(frag_rp_count as usize);
+        for _ in 0..frag_rp_count {
+            let (rest, rp) = BsmRp::parse_be(input)?;
+            rps.push(rp);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                group,
+                rp_count,
+                rps,
+            },
+        ))
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        self.group.emit(buf);
+        buf.put_u8(self.rp_count);
+        buf.put_u8(self.rps.len() as u8);
+        buf.put_u16(0);
+        for rp in &self.rps {
+            rp.emit(buf);
+        }
+    }
+}
+
+/// Bootstrap Message (RFC 5059 §4.2), flooded hop-by-hop to
+/// ALL-PIM-ROUTERS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimBootstrap {
+    pub fragment_tag: u16,
+    pub hash_mask_len: u8,
+    pub bsr_priority: u8,
+    pub bsr_addr: EncodedUnicast,
+    pub groups: Vec<BsmGroup>,
+}
+
+impl PimBootstrap {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, fragment_tag) = be_u16(input)?;
+        let (input, hash_mask_len) = be_u8(input)?;
+        let (input, bsr_priority) = be_u8(input)?;
+        let (mut input, bsr_addr) = EncodedUnicast::parse_be(input)?;
+        let mut groups = Vec::new();
+        while !input.is_empty() {
+            let (rest, group) = BsmGroup::parse_be(input)?;
+            groups.push(group);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                fragment_tag,
+                hash_mask_len,
+                bsr_priority,
+                bsr_addr,
+                groups,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.fragment_tag);
+        buf.put_u8(self.hash_mask_len);
+        buf.put_u8(self.bsr_priority);
+        self.bsr_addr.emit(buf);
+        for group in &self.groups {
+            group.emit(buf);
+        }
+    }
+
+    pub fn bsr_v4(&self) -> Option<std::net::Ipv4Addr> {
+        match self.bsr_addr.addr {
+            IpAddr::V4(a) => Some(a),
+            IpAddr::V6(_) => None,
+        }
+    }
+}
+
+/// Candidate-RP-Advertisement (RFC 5059 §4.3), unicast to the
+/// elected BSR.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimCandRpAdv {
+    pub priority: u8,
+    pub holdtime: u16,
+    pub rp_addr: EncodedUnicast,
+    pub groups: Vec<EncodedGroup>,
+}
+
+impl PimCandRpAdv {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, prefix_count) = be_u8(input)?;
+        let (input, priority) = be_u8(input)?;
+        let (input, holdtime) = be_u16(input)?;
+        let (mut input, rp_addr) = EncodedUnicast::parse_be(input)?;
+        let mut groups = Vec::with_capacity(prefix_count as usize);
+        for _ in 0..prefix_count {
+            let (rest, group) = EncodedGroup::parse_be(input)?;
+            groups.push(group);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                priority,
+                holdtime,
+                rp_addr,
+                groups,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.groups.len() as u8);
+        buf.put_u8(self.priority);
+        buf.put_u16(self.holdtime);
+        self.rp_addr.emit(buf);
+        for group in &self.groups {
+            group.emit(buf);
+        }
+    }
+}

--- a/crates/pim-packet/src/disp.rs
+++ b/crates/pim-packet/src/disp.rs
@@ -107,8 +107,25 @@ impl Display for PimPacket {
                     assert.metric
                 )?;
             }
-            PimPayload::Bootstrap(data) | PimPayload::CandRpAdv(data) => {
-                writeln!(f, " {} bytes", data.len())?;
+            PimPayload::Bootstrap(bsm) => {
+                writeln!(
+                    f,
+                    " BSR: {} priority {} tag {} ({} group range(s))",
+                    bsm.bsr_addr,
+                    bsm.bsr_priority,
+                    bsm.fragment_tag,
+                    bsm.groups.len()
+                )?;
+            }
+            PimPayload::CandRpAdv(adv) => {
+                writeln!(
+                    f,
+                    " C-RP: {} priority {} holdtime {} ({} group range(s))",
+                    adv.rp_addr,
+                    adv.priority,
+                    adv.holdtime,
+                    adv.groups.len()
+                )?;
             }
             PimPayload::Unknown { data, .. } => {
                 writeln!(f, " {} bytes", data.len())?;

--- a/crates/pim-packet/src/lib.rs
+++ b/crates/pim-packet/src/lib.rs
@@ -1,4 +1,5 @@
 mod addr;
+mod bsr;
 mod checksum;
 mod disp;
 mod hello;
@@ -8,6 +9,7 @@ mod parser;
 mod typ;
 
 pub use addr::{EncodedGroup, EncodedSource, EncodedUnicast, PIM_AF_IPV4, PIM_AF_IPV6};
+pub use bsr::{BsmGroup, BsmRp, PimBootstrap, PimCandRpAdv};
 pub use checksum::{igmp_verify_checksum, in_checksum, pim_verify_checksum};
 pub use hello::{
     HelloTlv, PIM_HELLO_TLV_ADDRESS_LIST, PIM_HELLO_TLV_DR_PRIORITY, PIM_HELLO_TLV_GENERATION_ID,

--- a/crates/pim-packet/src/parser.rs
+++ b/crates/pim-packet/src/parser.rs
@@ -6,6 +6,7 @@ use nom::number::complete::{be_u8, be_u16, be_u32};
 use nom::{Err, IResult};
 
 use crate::addr::{EncodedGroup, EncodedUnicast};
+use crate::bsr::{PimBootstrap, PimCandRpAdv};
 use crate::checksum::pim_fill_checksum;
 use crate::hello::PimHello;
 use crate::joinprune::PimJoinPrune;
@@ -126,14 +127,9 @@ pub enum PimPayload {
     RegisterStop(PimRegisterStop),
     JoinPrune(PimJoinPrune),
     Assert(PimAssert),
-    /// Kept as raw bytes until the BSR phase adds structured parsing.
-    Bootstrap(Vec<u8>),
-    /// Kept as raw bytes until the BSR phase adds structured parsing.
-    CandRpAdv(Vec<u8>),
-    Unknown {
-        typ: PimType,
-        data: Vec<u8>,
-    },
+    Bootstrap(PimBootstrap),
+    CandRpAdv(PimCandRpAdv),
+    Unknown { typ: PimType, data: Vec<u8> },
 }
 
 impl PimPayload {
@@ -173,8 +169,14 @@ impl PimPayload {
                 let (input, assert) = PimAssert::parse_be(input)?;
                 Ok((input, Self::Assert(assert)))
             }
-            PimType::Bootstrap => Ok((&input[input.len()..], Self::Bootstrap(input.to_vec()))),
-            PimType::CandRpAdv => Ok((&input[input.len()..], Self::CandRpAdv(input.to_vec()))),
+            PimType::Bootstrap => {
+                let (input, bsm) = PimBootstrap::parse_be(input)?;
+                Ok((input, Self::Bootstrap(bsm)))
+            }
+            PimType::CandRpAdv => {
+                let (input, adv) = PimCandRpAdv::parse_be(input)?;
+                Ok((input, Self::CandRpAdv(adv)))
+            }
             typ => Ok((
                 &input[input.len()..],
                 Self::Unknown {
@@ -193,7 +195,9 @@ impl PimPayload {
             RegisterStop(v) => v.emit(buf),
             JoinPrune(v) => v.emit(buf),
             Assert(v) => v.emit(buf),
-            Bootstrap(data) | CandRpAdv(data) | Unknown { data, .. } => buf.put(&data[..]),
+            Bootstrap(v) => v.emit(buf),
+            CandRpAdv(v) => v.emit(buf),
+            Unknown { data, .. } => buf.put(&data[..]),
         }
     }
 }
@@ -399,6 +403,51 @@ mod tests {
         assert!(!assert_msg.rpt_bit);
         assert_eq!(assert_msg.metric_preference, 100);
         assert_eq!(assert_msg.metric, 20);
+    }
+
+    #[test]
+    fn bootstrap_round_trip() {
+        // BSR 10.1.22.2 prio 100, tag 1, hash-mask 10; one range
+        // 224.0.0.0/4 with one C-RP (10.1.22.2, holdtime 150).
+        let wire = hex!(
+            "24 00 ac f8"             // v2 Bootstrap, checksum
+            "00 01 0a 64"             // tag 1, hash 10, prio 100
+            "01 00 0a 01 16 02"       // BSR 10.1.22.2
+            "01 00 00 04 e0 00 00 00" // group 224.0.0.0/4
+            "01 01 00 00"             // rp count 1, frag rp count 1
+            "01 00 0a 01 16 02"       // RP 10.1.22.2
+            "00 96 00 00"             // holdtime 150, prio 0
+        );
+        let packet = round_trip(&wire);
+        let PimPayload::Bootstrap(bsm) = &packet.payload else {
+            panic!("not a bootstrap");
+        };
+        assert_eq!(bsm.fragment_tag, 1);
+        assert_eq!(bsm.hash_mask_len, 10);
+        assert_eq!(bsm.bsr_priority, 100);
+        assert_eq!(bsm.bsr_v4(), Some(Ipv4Addr::new(10, 1, 22, 2)));
+        assert_eq!(bsm.groups.len(), 1);
+        assert_eq!(bsm.groups[0].group.masklen, 4);
+        assert_eq!(bsm.groups[0].rps.len(), 1);
+        assert_eq!(bsm.groups[0].rps[0].holdtime, 150);
+    }
+
+    #[test]
+    fn cand_rp_adv_round_trip() {
+        let wire = hex!(
+            "28 00 d4 61"             // v2 Candidate-RP-Adv, checksum
+            "01 00 00 96"             // 1 prefix, prio 0, holdtime 150
+            "01 00 0a 01 16 02"       // RP 10.1.22.2
+            "01 00 00 04 e0 00 00 00" // group 224.0.0.0/4
+        );
+        let packet = round_trip(&wire);
+        let PimPayload::CandRpAdv(adv) = &packet.payload else {
+            panic!("not a cand-rp-adv");
+        };
+        assert_eq!(adv.priority, 0);
+        assert_eq!(adv.holdtime, 150);
+        assert_eq!(adv.rp_addr.addr, IpAddr::V4(Ipv4Addr::new(10, 1, 22, 2)));
+        assert_eq!(adv.groups.len(), 1);
     }
 
     #[test]

--- a/docs/design/pim-sm-ssm-architecture.md
+++ b/docs/design/pim-sm-ssm-architecture.md
@@ -1,9 +1,14 @@
 # PIM-SM/SSM — Overall Architecture & Phasing Plan
 
-Status: **proposal — no code yet** (branch `pim`). This document defines the architecture for
-a new PIM-SM/SSM protocol module in zebra-rs, based on a survey of two prior-art
-implementations (FRR `pimd`, ZebOS `pimd`/`mribd`) and of zebra-rs's own protocol-module
-conventions. It is written so a contributor can resume without the conversation history.
+Status: **implemented — all 8 phases merged** (PRs #1951 codec, #1956 skeleton, #1960 IGMP,
+#1965 dataplane+SSM, #1973 ASM/static-RP, #1980 assert+LAN, #1988 VRF, and the BSR phase).
+Each phase is proven by a live BDD feature (`bdd/tests/features/pim_*.feature`). This
+document defines the architecture, based on a survey of two prior-art implementations
+(FRR `pimd`, ZebOS `pimd`/`mribd`) and of zebra-rs's own protocol-module conventions.
+Notable deltas from the original plan, decided during implementation: show commands are
+top-level (`show pim`, not `show ip pim`); no kernel (\*,G) MFC (per-source NOCACHE entries
+with inherited OILs); no kernel register decap at the RP (switch-to-SPT-immediately); the
+tracing subtree is still a pending follow-up; deferred items in §15 remain deferred.
 
 PIM is genuinely greenfield in this tree: there is no mroute socket, no VIF/MFC handling,
 no IGMP host-side code, and no `RouteType::Multicast` path anywhere today. The only

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -1,0 +1,524 @@
+//! Bootstrap Router machinery (RFC 5059): candidate-BSR election,
+//! hop-by-hop RPF-checked BSM flooding, Candidate-RP advertisement,
+//! and the BSR-learned RP-set that `rp_lookup` falls back to when no
+//! static mapping covers a group.
+//!
+//! Simplifications, documented: RP selection inside the learned set
+//! is longest-prefix → lowest priority → highest address (the RFC
+//! 2362 hash for same-priority load-splitting is not implemented),
+//! and BSM fragments are treated as whole-set replacements per group
+//! range.
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{Duration, Instant};
+
+use ipnet::Ipv4Net;
+use pim_packet::{
+    BsmGroup, BsmRp, EncodedGroup, EncodedUnicast, PimBootstrap, PimCandRpAdv, PimPacket,
+    PimPayload,
+};
+
+use super::inst::{Pim, PimSend};
+use super::socket::ALL_PIM_ROUTERS;
+
+/// BSM origination period at the elected BSR (RFC 5059 §5).
+const BS_PERIOD: Duration = Duration::from_secs(60);
+
+/// Bootstrap timeout at non-elected routers: 2 × period + 10.
+const BS_TIMEOUT: Duration = Duration::from_secs(130);
+
+/// C-RP advertisement period and advertised holdtime (2.5 × period).
+const CRP_ADV_PERIOD: Duration = Duration::from_secs(60);
+const CRP_HOLDTIME: u16 = 150;
+
+const HASH_MASK_LEN: u8 = 10;
+
+#[derive(Debug, Clone, Default)]
+pub struct BsrConfig {
+    /// Candidate-BSR: (advertised address, priority).
+    pub cbsr_addr: Option<Ipv4Addr>,
+    pub cbsr_priority: Option<u8>,
+    pub cbsr_enabled: bool,
+    /// Candidate-RP: advertised address + served range + priority.
+    pub crp_addr: Option<Ipv4Addr>,
+    pub crp_group: Option<Ipv4Net>,
+    pub crp_priority: Option<u8>,
+    pub crp_enabled: bool,
+}
+
+impl BsrConfig {
+    fn cbsr(&self) -> Option<(Ipv4Addr, u8)> {
+        if !self.cbsr_enabled {
+            return None;
+        }
+        Some((self.cbsr_addr?, self.cbsr_priority.unwrap_or(64)))
+    }
+
+    fn crp(&self) -> Option<(Ipv4Addr, Ipv4Net, u8)> {
+        if !self.crp_enabled {
+            return None;
+        }
+        Some((
+            self.crp_addr?,
+            self.crp_group
+                .unwrap_or_else(|| "224.0.0.0/4".parse().unwrap()),
+            self.crp_priority.unwrap_or(192),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BsrRole {
+    /// Not a candidate; tracking whatever BSR the domain elects.
+    None,
+    /// Candidate waiting out the bootstrap timeout before claiming
+    /// the role.
+    Pending { until: Instant },
+    /// Candidate that lost to a preferred BSR.
+    Candidate,
+    /// The elected BSR: originates BSMs, collects C-RP advs.
+    Elected,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BsrRpEntry {
+    pub priority: u8,
+    pub holdtime: u16,
+    pub expires: Instant,
+}
+
+#[derive(Debug, Default)]
+pub struct BsrRun {
+    pub role: Option<BsrRole>,
+    /// The domain's current BSR: (priority, address).
+    pub elected: Option<(u8, Ipv4Addr)>,
+    /// Non-elected: discard the BSR + learned set when this passes.
+    pub bsm_expires: Option<Instant>,
+    /// Elected only: next scheduled BSM.
+    pub originate_next: Option<Instant>,
+    /// Candidate-RP: next advertisement.
+    pub crp_next: Option<Instant>,
+    pub fragment_tag: u16,
+    /// Learned candidate RPs: (group range, RP address) → entry.
+    /// Fed by C-RP advs at the BSR and by BSMs everywhere else.
+    pub rp_set: BTreeMap<(Ipv4Net, Ipv4Addr), BsrRpEntry>,
+    /// RPF-tracked BSR address (released on BSR change/loss).
+    pub rpf_target: Option<Ipv4Addr>,
+}
+
+impl BsrRun {
+    fn role(&self) -> BsrRole {
+        self.role.unwrap_or(BsrRole::None)
+    }
+}
+
+/// Higher (priority, address) wins the BSR election (RFC 5059 §3.1).
+fn preferred(a: (u8, Ipv4Addr), b: (u8, Ipv4Addr)) -> bool {
+    a > b
+}
+
+impl Pim {
+    /// The BSR-learned RP for `grp`: longest matching range, then
+    /// lowest priority, then highest address; expired entries are
+    /// skipped (swept by the tick).
+    pub(crate) fn bsr_rp_lookup(&self, grp: Ipv4Addr) -> Option<Ipv4Addr> {
+        let now = Instant::now();
+        self.bsr
+            .rp_set
+            .iter()
+            .filter(|((range, _), e)| range.contains(&grp) && e.expires > now)
+            .max_by_key(|((range, rp), e)| (range.prefix_len(), std::cmp::Reverse(e.priority), *rp))
+            .map(|((_, rp), _)| *rp)
+    }
+
+    /// Config changed: (re)enter or leave the candidate roles.
+    pub(crate) fn bsr_config_changed(&mut self) {
+        let now = Instant::now();
+        match (self.bsr_config.cbsr(), self.bsr.role()) {
+            (Some((_, priority)), BsrRole::None) => {
+                // Stagger by priority so the strongest candidate
+                // claims first when several start together.
+                let delay = Duration::from_millis(3000 + (255 - priority) as u64 * 20);
+                self.bsr.role = Some(BsrRole::Pending { until: now + delay });
+                tracing::info!("pim: candidate-BSR pending election");
+            }
+            (None, role) if role != BsrRole::None => {
+                if role == BsrRole::Elected {
+                    self.bsr.elected = None;
+                    self.bsr.originate_next = None;
+                    self.bsr_rp_set_flush();
+                }
+                self.bsr.role = Some(BsrRole::None);
+                tracing::info!("pim: candidate-BSR disabled");
+            }
+            _ => {}
+        }
+        if self.bsr_config.crp().is_some() {
+            // Advertise promptly once a BSR is known.
+            self.bsr.crp_next = Some(now);
+        } else {
+            self.bsr.crp_next = None;
+        }
+    }
+
+    fn bsr_rp_set_flush(&mut self) {
+        if !self.bsr.rp_set.is_empty() {
+            self.bsr.rp_set.clear();
+            self.rp_reevaluate();
+        }
+    }
+
+    /// Track the RPF toward the adopted BSR so the flooding check
+    /// has a reverse path to compare against.
+    fn bsr_track(&mut self, bsr: Ipv4Addr) {
+        if self.bsr.rpf_target == Some(bsr) {
+            return;
+        }
+        if let Some(old) = self.bsr.rpf_target.take() {
+            self.rpf_release(old);
+        }
+        self.rpf_acquire(bsr);
+        self.bsr.rpf_target = Some(bsr);
+    }
+
+    /// BSM RX (RFC 5059 §3.1): adopt preferred BSRs, absorb the
+    /// RP-set, re-flood hop-by-hop on the other PIM interfaces.
+    pub(crate) fn bootstrap_recv(&mut self, ifindex: u32, src: Ipv4Addr, bsm: &PimBootstrap) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        if !link.enabled || link.is_my_addr(&src) {
+            return;
+        }
+        let Some(bsr) = bsm.bsr_v4() else {
+            return;
+        };
+        // Our own BSM flooded back: ignore.
+        if self.links.values().any(|l| l.is_my_addr(&bsr)) {
+            return;
+        }
+        let candidate = (bsm.bsr_priority, bsr);
+
+        // RPF check: once we track this BSR, the BSM must arrive on
+        // the reverse-path interface (loop guard for the re-flood).
+        if self.bsr.rpf_target == Some(bsr)
+            && let Some(expected) = self.rpf_state_ifindex(bsr)
+            && expected != ifindex
+        {
+            tracing::debug!(
+                "pim: BSM for {} on {} fails RPF (expect ifindex {})",
+                bsr,
+                self.ifname(ifindex),
+                expected
+            );
+            return;
+        }
+
+        match self.bsr.elected {
+            Some(current) if preferred(current, candidate) => {
+                // Inferior BSM. An elected BSR answers with its own.
+                if self.bsr.role() == BsrRole::Elected {
+                    self.bsr_originate();
+                }
+                return;
+            }
+            _ => {}
+        }
+
+        // Preferred (or refreshing) BSR: adopt.
+        let new_bsr = self.bsr.elected != Some(candidate);
+        if new_bsr {
+            tracing::info!(
+                "pim: elected BSR is {} (priority {})",
+                bsr,
+                bsm.bsr_priority
+            );
+            if self.bsr.role() == BsrRole::Elected
+                || matches!(self.bsr.role(), BsrRole::Pending { .. })
+            {
+                self.bsr.role = Some(BsrRole::Candidate);
+                self.bsr.originate_next = None;
+            }
+        }
+        self.bsr.elected = Some(candidate);
+        self.bsr.bsm_expires = Some(Instant::now() + BS_TIMEOUT);
+        self.bsr_track(bsr);
+
+        // Absorb the RP-set: whole-range replacement per fragment.
+        let now = Instant::now();
+        let mut changed = false;
+        for group in &bsm.groups {
+            let IpAddr::V4(range_addr) = group.group.addr else {
+                continue;
+            };
+            let Ok(range) = Ipv4Net::new(range_addr, group.group.masklen) else {
+                continue;
+            };
+            self.bsr.rp_set.retain(|(r, _), _| *r != range);
+            for rp in &group.rps {
+                let IpAddr::V4(rp_addr) = rp.addr.addr else {
+                    continue;
+                };
+                if rp.holdtime == 0 {
+                    continue;
+                }
+                self.bsr.rp_set.insert(
+                    (range, rp_addr),
+                    BsrRpEntry {
+                        priority: rp.priority,
+                        holdtime: rp.holdtime,
+                        expires: now + Duration::from_secs(rp.holdtime as u64),
+                    },
+                );
+            }
+            changed = true;
+        }
+        if changed {
+            self.rp_reevaluate();
+        }
+
+        // Hop-by-hop re-flood to every other PIM interface.
+        let out: Vec<u32> = self
+            .links
+            .values()
+            .filter(|l| l.enabled && l.ifindex != ifindex)
+            .map(|l| l.ifindex)
+            .collect();
+        let packet = PimPacket::new(PimPayload::Bootstrap(bsm.clone()));
+        for oif in out {
+            let _ = self.send_tx.send(PimSend {
+                packet: packet.clone(),
+                ifindex: oif,
+                dst: ALL_PIM_ROUTERS,
+            });
+        }
+
+        // A candidate RP hearing a new BSR advertises right away.
+        if new_bsr && self.bsr_config.crp().is_some() {
+            self.bsr.crp_next = Some(Instant::now());
+        }
+    }
+
+    fn rpf_state_ifindex(&self, addr: Ipv4Addr) -> Option<u32> {
+        self.rpf.get(&addr).and_then(|e| e.state.ifindex())
+    }
+
+    /// C-RP advertisement RX — meaningful at the elected BSR only.
+    pub(crate) fn cand_rp_adv_recv(&mut self, src: Ipv4Addr, adv: &PimCandRpAdv) {
+        if self.bsr.role() != BsrRole::Elected {
+            return;
+        }
+        let IpAddr::V4(rp) = adv.rp_addr.addr else {
+            return;
+        };
+        let now = Instant::now();
+        let mut changed = false;
+        for group in &adv.groups {
+            let IpAddr::V4(range_addr) = group.addr else {
+                continue;
+            };
+            let Ok(range) = Ipv4Net::new(range_addr, group.masklen) else {
+                continue;
+            };
+            if adv.holdtime == 0 {
+                changed |= self.bsr.rp_set.remove(&(range, rp)).is_some();
+                continue;
+            }
+            self.bsr.rp_set.insert(
+                (range, rp),
+                BsrRpEntry {
+                    priority: adv.priority,
+                    holdtime: adv.holdtime,
+                    expires: now + Duration::from_secs(adv.holdtime as u64),
+                },
+            );
+            changed = true;
+        }
+        if changed {
+            tracing::info!("pim: C-RP {} registered by {} at the BSR", rp, src);
+            self.rp_reevaluate();
+            // Push the updated RP-set out promptly instead of waiting
+            // for the periodic BSM.
+            self.bsr.originate_next = Some(Instant::now());
+        }
+    }
+
+    /// Originate a BSM (elected BSR): the whole RP-set to every PIM
+    /// interface.
+    fn bsr_originate(&mut self) {
+        let Some((addr, priority)) = self.bsr_config.cbsr() else {
+            return;
+        };
+        self.bsr.fragment_tag = self.bsr.fragment_tag.wrapping_add(1);
+        let now = Instant::now();
+        let mut by_range: BTreeMap<Ipv4Net, Vec<BsmRp>> = BTreeMap::new();
+        for ((range, rp), entry) in self.bsr.rp_set.iter() {
+            if entry.expires <= now {
+                continue;
+            }
+            by_range.entry(*range).or_default().push(BsmRp {
+                addr: EncodedUnicast::new(IpAddr::V4(*rp)),
+                holdtime: entry.holdtime,
+                priority: entry.priority,
+            });
+        }
+        let groups: Vec<BsmGroup> = by_range
+            .into_iter()
+            .map(|(range, rps)| BsmGroup {
+                group: EncodedGroup {
+                    bidir: false,
+                    zone: false,
+                    masklen: range.prefix_len(),
+                    addr: IpAddr::V4(range.addr()),
+                },
+                rp_count: rps.len() as u8,
+                rps,
+            })
+            .collect();
+        let bsm = PimBootstrap {
+            fragment_tag: self.bsr.fragment_tag,
+            hash_mask_len: HASH_MASK_LEN,
+            bsr_priority: priority,
+            bsr_addr: EncodedUnicast::new(IpAddr::V4(addr)),
+            groups,
+        };
+        let packet = PimPacket::new(PimPayload::Bootstrap(bsm));
+        let out: Vec<u32> = self
+            .links
+            .values()
+            .filter(|l| l.enabled)
+            .map(|l| l.ifindex)
+            .collect();
+        for oif in out {
+            let _ = self.send_tx.send(PimSend {
+                packet: packet.clone(),
+                ifindex: oif,
+                dst: ALL_PIM_ROUTERS,
+            });
+        }
+    }
+
+    /// Send our C-RP advertisement to the elected BSR (or absorb it
+    /// locally when we are the BSR ourselves).
+    fn crp_advertise(&mut self) {
+        let Some((rp, range, priority)) = self.bsr_config.crp() else {
+            return;
+        };
+        let Some((_, bsr)) = self.bsr.elected else {
+            return;
+        };
+        if self.bsr.role() == BsrRole::Elected {
+            let now = Instant::now();
+            self.bsr.rp_set.insert(
+                (range, rp),
+                BsrRpEntry {
+                    priority,
+                    holdtime: CRP_HOLDTIME,
+                    expires: now + Duration::from_secs(CRP_HOLDTIME as u64),
+                },
+            );
+            self.rp_reevaluate();
+            return;
+        }
+        let adv = PimCandRpAdv {
+            priority,
+            holdtime: CRP_HOLDTIME,
+            rp_addr: EncodedUnicast::new(IpAddr::V4(rp)),
+            groups: vec![EncodedGroup {
+                bidir: false,
+                zone: false,
+                masklen: range.prefix_len(),
+                addr: IpAddr::V4(range.addr()),
+            }],
+        };
+        let packet = PimPacket::new(PimPayload::CandRpAdv(adv));
+        let _ = self.send_tx.send(PimSend {
+            packet,
+            ifindex: 0,
+            dst: bsr,
+        });
+    }
+
+    pub(crate) fn bsr_next_wakeup(&self) -> Option<Instant> {
+        let mut earliest: Option<Instant> = None;
+        let mut consider = |t: Instant| {
+            earliest = Some(earliest.map_or(t, |e| e.min(t)));
+        };
+        if let Some(BsrRole::Pending { until }) = self.bsr.role {
+            consider(until);
+        }
+        if let Some(t) = self.bsr.bsm_expires {
+            consider(t);
+        }
+        if let Some(t) = self.bsr.originate_next {
+            consider(t);
+        }
+        if let Some(t) = self.bsr.crp_next {
+            consider(t);
+        }
+        for entry in self.bsr.rp_set.values() {
+            consider(entry.expires);
+        }
+        earliest
+    }
+
+    pub(crate) fn bsr_tick(&mut self, now: Instant) {
+        // Candidate claims the role when nothing preferred spoke up.
+        if let Some(BsrRole::Pending { until }) = self.bsr.role
+            && until <= now
+            && let Some((addr, priority)) = self.bsr_config.cbsr()
+        {
+            self.bsr.role = Some(BsrRole::Elected);
+            self.bsr.elected = Some((priority, addr));
+            self.bsr.bsm_expires = None;
+            tracing::info!("pim: elected BSR (self, {} priority {})", addr, priority);
+            // Absorb our own candidate-RP first so the very first BSM
+            // already carries it.
+            if self.bsr_config.crp().is_some() {
+                self.crp_advertise();
+                self.bsr.crp_next = Some(now + CRP_ADV_PERIOD);
+            }
+            self.bsr_originate();
+            self.bsr.originate_next = Some(now + BS_PERIOD);
+        }
+
+        if let Some(t) = self.bsr.originate_next
+            && t <= now
+        {
+            self.bsr_originate();
+            self.bsr.originate_next = Some(now + BS_PERIOD);
+        }
+
+        // BSR timed out at a non-elected router.
+        if let Some(t) = self.bsr.bsm_expires
+            && t <= now
+        {
+            tracing::info!("pim: elected BSR timed out");
+            self.bsr.bsm_expires = None;
+            self.bsr.elected = None;
+            if let Some(old) = self.bsr.rpf_target.take() {
+                self.rpf_release(old);
+            }
+            self.bsr_rp_set_flush();
+            if self.bsr_config.cbsr().is_some() {
+                self.bsr.role = None;
+                self.bsr_config_changed();
+            }
+        }
+
+        if let Some(t) = self.bsr.crp_next
+            && t <= now
+        {
+            self.crp_advertise();
+            self.bsr.crp_next = Some(now + CRP_ADV_PERIOD);
+        }
+
+        // Sweep expired learned RPs.
+        let before = self.bsr.rp_set.len();
+        self.bsr.rp_set.retain(|_, e| e.expires > now);
+        if self.bsr.rp_set.len() != before {
+            self.rp_reevaluate();
+        }
+    }
+}

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -34,6 +34,16 @@ impl Pim {
         );
         self.callback_add("/router/pim/rp/static", config_rp_static);
         self.callback_add("/router/pim/rp/static/group", config_rp_static_group);
+        self.callback_add("/router/pim/bsr/candidate-bsr", config_cbsr);
+        self.callback_add("/router/pim/bsr/candidate-bsr/address", config_cbsr_address);
+        self.callback_add(
+            "/router/pim/bsr/candidate-bsr/priority",
+            config_cbsr_priority,
+        );
+        self.callback_add("/router/pim/bsr/candidate-rp", config_crp);
+        self.callback_add("/router/pim/bsr/candidate-rp/address", config_crp_address);
+        self.callback_add("/router/pim/bsr/candidate-rp/group", config_crp_group);
+        self.callback_add("/router/pim/bsr/candidate-rp/priority", config_crp_priority);
     }
 
     fn callback_add(&mut self, path: &str, cb: Callback) {
@@ -169,6 +179,60 @@ fn config_rp_static_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option
         *range = "224.0.0.0/4".parse().unwrap();
     }
     pim.rp_reevaluate();
+    Some(())
+}
+
+fn config_cbsr(pim: &mut Pim, _args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.cbsr_enabled = op.is_set();
+    pim.bsr_config_changed();
+    Some(())
+}
+
+fn config_cbsr_address(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.cbsr_addr = if op.is_set() {
+        Some(args.v4addr()?)
+    } else {
+        None
+    };
+    pim.bsr_config_changed();
+    Some(())
+}
+
+fn config_cbsr_priority(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.cbsr_priority = if op.is_set() { Some(args.u8()?) } else { None };
+    pim.bsr_config_changed();
+    Some(())
+}
+
+fn config_crp(pim: &mut Pim, _args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.crp_enabled = op.is_set();
+    pim.bsr_config_changed();
+    Some(())
+}
+
+fn config_crp_address(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.crp_addr = if op.is_set() {
+        Some(args.v4addr()?)
+    } else {
+        None
+    };
+    pim.bsr_config_changed();
+    Some(())
+}
+
+fn config_crp_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.crp_group = if op.is_set() {
+        Some(args.string()?.parse().ok()?)
+    } else {
+        None
+    };
+    pim.bsr_config_changed();
+    Some(())
+}
+
+fn config_crp_priority(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    pim.bsr_config.crp_priority = if op.is_set() { Some(args.u8()?) } else { None };
+    pim.bsr_config_changed();
     Some(())
 }
 

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -26,6 +26,7 @@ use crate::config::{
 use crate::context::{ProtoContext, Task};
 use crate::rib::api::RibRx;
 
+use super::bsr::{BsrConfig, BsrRun};
 use super::config::Callback;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
 use super::mroute::{ForwardingPlane, Upcall};
@@ -91,6 +92,9 @@ pub struct Pim {
     pub rpf: BTreeMap<Ipv4Addr, RpfEntry>,
     /// Static RP mappings.
     pub rp_set: RpSet,
+    /// Bootstrap-router config + runtime (RFC 5059).
+    pub bsr_config: BsrConfig,
+    pub bsr: BsrRun,
     /// Kernel dataplane: mroute socket, VIFs, MFC.
     pub(crate) fp: ForwardingPlane,
     /// Periodic J/P refresh deadlines per (ifindex, upstream nbr).
@@ -181,6 +185,8 @@ impl Pim {
             tib: BTreeMap::new(),
             rpf: BTreeMap::new(),
             rp_set: RpSet::default(),
+            bsr_config: BsrConfig::default(),
+            bsr: BsrRun::default(),
             fp,
             jp_refresh: BTreeMap::new(),
             send_tx,
@@ -221,10 +227,14 @@ impl Pim {
             self.process_rib_msg(msg);
         }
         loop {
-            let wakeup = match (self.igmp_next_wakeup(), self.tib_next_wakeup()) {
-                (Some(a), Some(b)) => Some(a.min(b)),
-                (a, b) => a.or(b),
-            };
+            let wakeup = [
+                self.igmp_next_wakeup(),
+                self.tib_next_wakeup(),
+                self.bsr_next_wakeup(),
+            ]
+            .into_iter()
+            .flatten()
+            .min();
             tokio::select! {
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);
@@ -242,6 +252,7 @@ impl Pim {
                     let now = Instant::now();
                     self.igmp_tick(now);
                     self.tib_tick(now);
+                    self.bsr_tick(now);
                 }
             }
         }
@@ -417,11 +428,11 @@ impl Pim {
             PimPayload::Register(register) => self.register_recv(src, register),
             PimPayload::RegisterStop(stop) => self.register_stop_recv(stop),
             PimPayload::Assert(assert) => self.assert_recv(ifindex, src, assert),
+            PimPayload::Bootstrap(bsm) => self.bootstrap_recv(ifindex, src, bsm),
+            PimPayload::CandRpAdv(adv) => self.cand_rp_adv_recv(src, adv),
             other => {
-                // Assert / Bootstrap handling arrives with later
-                // phases.
                 tracing::debug!(
-                    "pim: ignoring {} from {} on ifindex {} (not yet implemented)",
+                    "pim: ignoring {} from {} on ifindex {} (not implemented)",
                     packet.typ,
                     src,
                     ifindex

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -2,6 +2,7 @@
 //! DR election. Architecture: docs/design/pim-sm-ssm-architecture.md.
 
 pub mod assert_fsm;
+pub mod bsr;
 pub mod config;
 pub mod igmp;
 pub mod inst;

--- a/zebra-rs/src/pim/rp.rs
+++ b/zebra-rs/src/pim/rp.rs
@@ -26,8 +26,10 @@ pub struct RpSet {
 }
 
 impl Pim {
-    /// RP(G): longest-prefix match across the static entries. SSM
-    /// groups never map to an RP.
+    /// RP(G): longest-prefix match across the static entries; when
+    /// no static range covers the group, fall back to the
+    /// BSR-learned set (static beats BSR). SSM groups never map to
+    /// an RP.
     pub(crate) fn rp_lookup(&self, grp: Ipv4Addr) -> Option<Ipv4Addr> {
         if is_ssm(grp) || !grp.is_multicast() {
             return None;
@@ -38,6 +40,7 @@ impl Pim {
             .filter(|(_, range)| range.contains(&grp))
             .max_by_key(|(_, range)| range.prefix_len())
             .map(|(rp, _)| *rp)
+            .or_else(|| self.bsr_rp_lookup(grp))
     }
 
     /// I_am_RP(G): the mapped RP address is one of our interface

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -33,6 +33,8 @@ impl Pim {
             .set(show_pim_upstream)
             .path("/show/pim/rp-info")
             .set(show_pim_rp_info)
+            .path("/show/pim/bsr")
+            .set(show_pim_bsr)
             .path("/show/pim/assert")
             .set(show_pim_assert)
             .path("/show/mroute")
@@ -359,6 +361,47 @@ fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::
 }
 
 #[derive(Serialize)]
+struct BsrBrief {
+    role: String,
+    bsr: String,
+    priority: Option<u8>,
+    candidate_rps: usize,
+}
+
+fn show_pim_bsr(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    use super::bsr::BsrRole;
+    let role = match pim.bsr.role.unwrap_or(BsrRole::None) {
+        BsrRole::None => "Non-candidate",
+        BsrRole::Pending { .. } => "Pending",
+        BsrRole::Candidate => "Candidate",
+        BsrRole::Elected => "Elected",
+    };
+    let brief = BsrBrief {
+        role: role.to_string(),
+        bsr: pim
+            .bsr
+            .elected
+            .map_or_else(|| "none".to_string(), |(_, a)| a.to_string()),
+        priority: pim.bsr.elected.map(|(p, _)| p),
+        candidate_rps: pim.bsr.rp_set.len(),
+    };
+
+    if json {
+        return Ok(serde_json::to_string(&brief).unwrap());
+    }
+
+    let mut buf = String::new();
+    writeln!(buf, "PIM Bootstrap Router")?;
+    writeln!(buf, " Role:          {}", brief.role)?;
+    writeln!(buf, " Elected BSR:   {}", brief.bsr)?;
+    if let Some(priority) = brief.priority {
+        writeln!(buf, " BSR priority:  {}", priority)?;
+    }
+    writeln!(buf, " Candidate RPs: {}", brief.candidate_rps)?;
+    Ok(buf)
+}
+
+#[derive(Serialize)]
 struct AssertBrief {
     entry: String,
     interface: String,
@@ -413,12 +456,24 @@ struct RpInfoBrief {
 }
 
 fn show_pim_rp_info(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let now = Instant::now();
     let mut rows: Vec<RpInfoBrief> = vec![];
     for (rp, range) in pim.rp_set.statics.iter() {
         rows.push(RpInfoBrief {
             rp: rp.to_string(),
             group_range: range.to_string(),
             source: "static".to_string(),
+            is_self: pim.links.values().any(|l| l.is_my_addr(rp)),
+        });
+    }
+    for ((range, rp), entry) in pim.bsr.rp_set.iter() {
+        if entry.expires <= now {
+            continue;
+        }
+        rows.push(RpInfoBrief {
+            rp: rp.to_string(),
+            group_range: range.to_string(),
+            source: "bsr".to_string(),
             is_self: pim.links.values().any(|l| l.is_my_addr(rp)),
         });
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3988,6 +3988,40 @@ module config {
       container pim {
         ext:help "PIM-SM routing protocol configuration";
         presence "Enables configuration of PIM-SM";
+        container bsr {
+          ext:help "Bootstrap Router (RFC 5059)";
+          container candidate-bsr {
+            ext:help "Run as a candidate Bootstrap Router";
+            presence "Candidate BSR";
+            leaf address {
+              ext:help "Advertised BSR address (one of this router's addresses)";
+              type inet:ipv4-address;
+            }
+            leaf priority {
+              ext:help "BSR election priority (higher wins)";
+              type uint8;
+              default 64;
+            }
+          }
+          container candidate-rp {
+            ext:help "Advertise this router as a candidate RP";
+            presence "Candidate RP";
+            leaf address {
+              ext:help "Advertised RP address (one of this router's addresses)";
+              type inet:ipv4-address;
+            }
+            leaf group {
+              ext:help "Group prefix this RP serves";
+              type inet:ipv4-prefix;
+              default "224.0.0.0/4";
+            }
+            leaf priority {
+              ext:help "Candidate RP priority (lower preferred)";
+              type uint8;
+              default 192;
+            }
+          }
+        }
         container rp {
           ext:help "Rendezvous Point configuration";
           list static {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1034,6 +1034,10 @@ module exec {
         ext:help "PIM group-to-RP mappings";
         presence "PIM RP info";
       }
+      container bsr {
+        ext:help "Bootstrap Router state";
+        presence "PIM BSR";
+      }
       container assert {
         ext:help "PIM assert election state";
         presence "PIM assert";


### PR DESCRIPTION
## Summary

Phase 8 — the final phase of the PIM-SM/SSM arc (architecture: `docs/design/pim-sm-ssm-architecture.md`; Phases 1–7: #1951 / #1956 / #1960 / #1965 / #1973 / #1980 / #1988):

- **`pim-packet`**: structured RFC 5059 codecs replacing the raw-bytes placeholders — `PimBootstrap` (fragment tag, hash mask, BSR priority/address, group ranges with per-RP holdtime/priority) and `PimCandRpAdv` — with round-trip wire-fixture tests and hand-computed checksums.
- **`pim/bsr.rs`**: candidate-BSR election (priority-staggered Pending→Elected claim; preemption by preferred BSMs — higher priority, then address — demotes to Candidate; an elected BSR answers inferior BSMs with its own); hop-by-hop BSM re-flooding **loop-guarded by an RPF check** against the tracked BSR address (riding the Phase-7 VRF-aware NHT); 130 s bootstrap timeout; periodic **C-RP advertisements** unicast to the BSR (self-absorbed when we are it; 150 s holdtime; expiry sweep); a **triggered BSM on RP-set change** so mappings propagate in seconds rather than a full period.
- **RP-set consumption**: `rp_lookup` falls back to the BSR-learned set when no static range covers the group — static beats BSR; within BSR: longest prefix → lowest priority → highest address (the RFC 2362 same-priority hash is documented as not implemented).
- Management: `router pim bsr { candidate-bsr, candidate-rp }` YANG + callbacks, `show pim bsr`, `bsr`-sourced rows in `show pim rp-info`. The design doc's status header now records the completed 8-phase arc and its implementation-time deltas.

## Test plan

- Live BDD under sudo (fresh binary + YANG, integrity-checked before and after): `@pim_bsr` — the ASM chain with **zero static RP anywhere**: r2 elects itself (`Elected`), r1/r3 learn the BSR and the RP purely from flooded BSMs (`show pim bsr`, `bsr` rows in `rp-info`), then the complete ASM loop — shared tree, register cycle settling in `RegPrune`, payload delivered end-to-end — runs on the learned mapping. All 40 steps ✔.
- All seven PIM features (`adjacency`/`igmp`/`ssm`/`asm`/`assert`/`vrf`/`bsr`) pass in one batch.
- `cargo test --workspace --exclude bdd`: green (pim-packet now 15 tests). Forced-fresh `clippy -D warnings`: exit 0. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)