### PR TITLE
isis: export extended admin groups to BGP-LS

### DIFF
--- a/crates/bgp-packet/src/attrs/bgpls_attr.rs
+++ b/crates/bgp-packet/src/attrs/bgpls_attr.rs
@@ -53,6 +53,8 @@ pub const BGPLS_ATTR_OPAQUE_LINK: u16 = 1097;
 pub const BGPLS_ATTR_LINK_NAME: u16 = 1098;
 pub const BGPLS_ATTR_ADJACENCY_SID: u16 = 1099;
 pub const BGPLS_ATTR_LAN_ADJACENCY_SID: u16 = 1100;
+/// RFC 9104 — Extended Administrative Group (link attribute), distinct
+/// from the classic Administrative Group (1088).
 pub const BGPLS_ATTR_EXT_ADMIN_GROUP: u16 = 1173;
 
 // ===== Prefix Attribute TLVs (RFC 9552 Section 4.3, RFC 9085) =====
@@ -227,8 +229,6 @@ mod tests {
 
     #[test]
     fn link_attrs_round_trip() {
-        assert_eq!(BGPLS_ATTR_EXT_ADMIN_GROUP, 1173);
-
         let mut attr = BgpLsAttr::new();
         attr.push(BGPLS_ATTR_ADMIN_GROUP, vec![0, 0, 0, 0x0f]);
         attr.push(

--- a/crates/bgp-packet/src/attrs/bgpls_attr.rs
+++ b/crates/bgp-packet/src/attrs/bgpls_attr.rs
@@ -53,6 +53,7 @@ pub const BGPLS_ATTR_OPAQUE_LINK: u16 = 1097;
 pub const BGPLS_ATTR_LINK_NAME: u16 = 1098;
 pub const BGPLS_ATTR_ADJACENCY_SID: u16 = 1099;
 pub const BGPLS_ATTR_LAN_ADJACENCY_SID: u16 = 1100;
+pub const BGPLS_ATTR_EXT_ADMIN_GROUP: u16 = 1173;
 
 // ===== Prefix Attribute TLVs (RFC 9552 Section 4.3, RFC 9085) =====
 pub const BGPLS_ATTR_IGP_FLAGS: u16 = 1152;
@@ -226,8 +227,14 @@ mod tests {
 
     #[test]
     fn link_attrs_round_trip() {
+        assert_eq!(BGPLS_ATTR_EXT_ADMIN_GROUP, 1173);
+
         let mut attr = BgpLsAttr::new();
         attr.push(BGPLS_ATTR_ADMIN_GROUP, vec![0, 0, 0, 0x0f]);
+        attr.push(
+            BGPLS_ATTR_EXT_ADMIN_GROUP,
+            vec![0x01, 0x02, 0x03, 0x04, 0xaa, 0xbb, 0xcc, 0xdd],
+        );
         // Maximum link bandwidth: IEEE 754 f32 (1 Gbit/s).
         attr.push(
             BGPLS_ATTR_MAX_LINK_BANDWIDTH,

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -505,10 +505,10 @@ backlog, ordered by risk and value.
    length-prefixed sub-block parses. A seventh registry now gets the degrade
    machinery for free. Behavior pinned by the existing degrade/round-trip
    tests, which were written against the hand-rolled copies.
-6. **BGP-LS Extended Admin Group (TLV 1173) producer** — enabled by #13:
-   `ext_admin_group()` exists, but there is no `BGPLS_ATTR_EXT_ADMIN_GROUP`
-   constant, so links advertising only the RFC 7308 group export no color at
-   all (the old, wrong 1088 mapping was removed deliberately).
+6. ~~**BGP-LS Extended Admin Group (TLV 1173) producer**~~ — **done**:
+   `BGPLS_ATTR_EXT_ADMIN_GROUP` is defined by `bgp-packet`, and the IS-IS
+   producer serializes every RFC 7308 group word in network byte order while
+   keeping it distinct from the classic Administrative Group TLV 1088.
 7. **Small-cleanup sweep (one PR)** — the duplicated ~55-line padding function
    (`IsisHello`/`IsisP2pHello`), the three identical RFC 8570 bandwidth
    wrappers, and the seven dead `is_empty()` methods.

--- a/zebra-rs/src/isis/bgp_ls.rs
+++ b/zebra-rs/src/isis/bgp_ls.rs
@@ -23,9 +23,10 @@
 use std::collections::BTreeMap;
 
 use bgp_packet::{
-    BGPLS_ATTR_ADMIN_GROUP, BGPLS_ATTR_IGP_METRIC, BGPLS_ATTR_PREFIX_METRIC,
-    BGPLS_ATTR_TE_DEFAULT_METRIC, BgpLsAttr, BgpLsNlri, LsLinkDescriptor, LsLinkNlri,
-    LsNodeDescSub, LsNodeDescriptor, LsNodeNlri, LsPrefixDescriptor, LsPrefixNlri, LsProtocolId,
+    BGPLS_ATTR_ADMIN_GROUP, BGPLS_ATTR_EXT_ADMIN_GROUP, BGPLS_ATTR_IGP_METRIC,
+    BGPLS_ATTR_PREFIX_METRIC, BGPLS_ATTR_TE_DEFAULT_METRIC, BgpLsAttr, BgpLsNlri, LsLinkDescriptor,
+    LsLinkNlri, LsNodeDescSub, LsNodeDescriptor, LsNodeNlri, LsPrefixDescriptor, LsPrefixNlri,
+    LsProtocolId,
 };
 use ipnet::IpNet;
 use isis_packet::{IsisLsp, IsisSysId, IsisTlv, IsisTlvExtIsReachEntry};
@@ -67,10 +68,10 @@ type Object = (BgpLsNlri, BgpLsAttr);
 
 /// Build the Link Attribute TLVs (RFC 9552 §4.2) for one IS-IS adjacency:
 /// IGP metric (1095, the base TLV-22 metric), and — when the entry carries
-/// the corresponding sub-TLVs — admin-group (1088) and TE default metric
-/// (1092). Max-link-bandwidth (1089) is omitted: the IS-IS link sub-TLV set
-/// parsed here has no max-bandwidth variant (only residual/available/
-/// utilized), so there is nothing to translate yet.
+/// the corresponding sub-TLVs — admin-group (1088), extended admin-group
+/// (1173), and TE default metric (1092). Max-link-bandwidth (1089) is omitted:
+/// the IS-IS link sub-TLV set parsed here has no max-bandwidth variant (only
+/// residual/available/utilized), so there is nothing to translate yet.
 fn link_attr(e: &IsisTlvExtIsReachEntry) -> BgpLsAttr {
     let mut attr = BgpLsAttr::new();
     // IGP metric is a 3-octet value in BGP-LS (RFC 9552 §4.2; 1, 2, or 3
@@ -78,6 +79,10 @@ fn link_attr(e: &IsisTlvExtIsReachEntry) -> BgpLsAttr {
     attr.push(BGPLS_ATTR_IGP_METRIC, e.metric.to_be_bytes()[1..].to_vec());
     if let Some(ag) = e.admin_group() {
         attr.push(BGPLS_ATTR_ADMIN_GROUP, ag.to_be_bytes().to_vec());
+    }
+    if let Some(ag) = e.ext_admin_group() {
+        let value = ag.iter().flat_map(|word| word.to_be_bytes()).collect();
+        attr.push(BGPLS_ATTR_EXT_ADMIN_GROUP, value);
     }
     if let Some(te) = e.te_metric() {
         attr.push(BGPLS_ATTR_TE_DEFAULT_METRIC, te.to_be_bytes().to_vec());
@@ -378,8 +383,8 @@ mod tests {
         assert!(advertised.is_empty());
     }
     use isis_packet::{
-        IsisLspId, IsisNeighborId, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvExtIsReach,
-        IsisTlvExtIsReachEntry,
+        IsisLspId, IsisNeighborId, IsisSubAdminGrp, IsisTlvExtIpReach, IsisTlvExtIpReachEntry,
+        IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
     };
 
     fn sysid(last: u8) -> IsisSysId {
@@ -449,6 +454,27 @@ mod tests {
             link.remote_node.subs,
             vec![LsNodeDescSub::IgpRouterId(vec![0, 0, 0, 0, 0, 2])]
         );
+    }
+
+    #[test]
+    fn link_attr_maps_extended_admin_group_to_1173() {
+        let entry = IsisTlvExtIsReachEntry {
+            neighbor_id: IsisNeighborId::from_sys_id(&sysid(2), 0),
+            metric: 10,
+            subs: vec![
+                IsisSubAdminGrp {
+                    groups: vec![0x0102_0304, 0xaabb_ccdd],
+                }
+                .into(),
+            ],
+        };
+
+        let attr = link_attr(&entry);
+        assert_eq!(
+            attr.get(BGPLS_ATTR_EXT_ADMIN_GROUP),
+            Some(&[0x01, 0x02, 0x03, 0x04, 0xaa, 0xbb, 0xcc, 0xdd][..])
+        );
+        assert_eq!(attr.get(BGPLS_ATTR_ADMIN_GROUP), None);
     }
 
     #[test]

--- a/zebra-rs/src/isis/bgp_ls.rs
+++ b/zebra-rs/src/isis/bgp_ls.rs
@@ -80,7 +80,12 @@ fn link_attr(e: &IsisTlvExtIsReachEntry) -> BgpLsAttr {
     if let Some(ag) = e.admin_group() {
         attr.push(BGPLS_ATTR_ADMIN_GROUP, ag.to_be_bytes().to_vec());
     }
-    if let Some(ag) = e.ext_admin_group() {
+    // A peer's zero-length EAG sub-TLV parses to an empty word list;
+    // RFC 9104's value mirrors the IGP's 32-bit blocks, so an empty
+    // TLV 1173 is meaningless — skip it rather than emit it.
+    if let Some(ag) = e.ext_admin_group()
+        && !ag.is_empty()
+    {
         let value = ag.iter().flat_map(|word| word.to_be_bytes()).collect();
         attr.push(BGPLS_ATTR_EXT_ADMIN_GROUP, value);
     }
@@ -475,6 +480,20 @@ mod tests {
             Some(&[0x01, 0x02, 0x03, 0x04, 0xaa, 0xbb, 0xcc, 0xdd][..])
         );
         assert_eq!(attr.get(BGPLS_ATTR_ADMIN_GROUP), None);
+    }
+
+    /// A peer's zero-length EAG sub-TLV (parseable from the wire) must
+    /// not become a zero-length TLV 1173.
+    #[test]
+    fn link_attr_skips_empty_extended_admin_group() {
+        let entry = IsisTlvExtIsReachEntry {
+            neighbor_id: IsisNeighborId::from_sys_id(&sysid(2), 0),
+            metric: 10,
+            subs: vec![IsisSubAdminGrp { groups: vec![] }.into()],
+        };
+
+        let attr = link_attr(&entry);
+        assert_eq!(attr.get(BGPLS_ATTR_EXT_ADMIN_GROUP), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add the BGP-LS Extended Administrative Group TLV 1173 constant
- export IS-IS RFC 7308 extended administrative-group words in network byte order
- keep extended groups distinct from classic Administrative Group TLV 1088
- mark follow-up item 6 complete in the IS-IS packet review

## Testing

- `cargo test -p bgp-packet attrs::bgpls_attr::tests`
- `cargo test -p zebra-rs isis::bgp_ls::tests`
- `cargo fmt --all -- --check`
- `git diff --check`