### PR TITLE
isis-packet: small-cleanup sweep (padding, bandwidth wrappers, is_empty)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,9 @@ result_large_err = "allow"
 large_enum_variant = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
+
+# Wire codecs — TLV `len()` is the protocol's one-octet length-field
+# value, not a container length; an `is_empty()` companion is
+# meaningless there (and for fixed-width SID values impossible), so
+# the no-op methods were removed rather than kept to satisfy the lint.
+len_without_is_empty = "allow"

--- a/crates/isis-packet/src/padding.rs
+++ b/crates/isis-packet/src/padding.rs
@@ -4,114 +4,72 @@ use crate::{
     IsisHello, IsisP2pHello, IsisPacket, IsisPdu, IsisTlv, IsisTlvPadding, IsisType, parse,
 };
 
+/// Pad a Hello out to the interface MTU with Padding TLVs (type 8):
+/// serialize the packet as-is to learn its current size, verify it
+/// re-parses, then append full 255-byte padding TLVs plus one smaller
+/// remainder TLV into `tlvs`. Shared by the LAN and P2P Hello
+/// wrappers below (previously duplicated verbatim in both).
+fn pad_to_mtu(packet: IsisPacket, tlvs: &mut Vec<IsisTlv>, mtu: usize) {
+    let mut buf = BytesMut::new();
+    packet.emit(&mut buf);
+
+    if parse(&buf).is_err() {
+        return;
+    }
+
+    // Make sure we don't underflow
+    let packet_len = buf.len();
+    let base_len = 3;
+    if packet_len + base_len > mtu {
+        // Not enough space for any padding
+        return;
+    }
+
+    let available_len = mtu - base_len - packet_len;
+    if available_len < 2 {
+        // Not enough space for even minimum padding TLV
+        return;
+    }
+
+    // 257 = 2 byte header + 255 byte padding
+    const TLV_MAX: usize = 255;
+    const TLV_OVERHEAD: usize = 2;
+    const TLV_SIZE: usize = TLV_OVERHEAD + TLV_MAX;
+
+    let full_padding_count = available_len / TLV_SIZE;
+    let remaining = available_len % TLV_SIZE;
+
+    // Helper to generate Padding TLV
+    fn padding_tlv(len: usize) -> IsisTlv {
+        IsisTlv::Padding(IsisTlvPadding {
+            padding: vec![0u8; len],
+        })
+    }
+
+    // Add full (255-byte) padding TLVs
+    for _ in 0..full_padding_count {
+        tlvs.push(padding_tlv(TLV_MAX));
+    }
+
+    // Add the remainder as one smaller padding TLV (if enough room for TLV header)
+    if remaining > TLV_OVERHEAD {
+        let pad_len = remaining - TLV_OVERHEAD;
+        if pad_len > 0 {
+            tlvs.push(padding_tlv(pad_len));
+        }
+    }
+}
+
 impl IsisHello {
     pub fn padding(&mut self, mtu: usize) {
-        let mut buf = BytesMut::new();
-
-        // Try to emit Hello packet.
         let packet = IsisPacket::from(IsisType::L1Hello, IsisPdu::L1Hello(self.clone()));
-        packet.emit(&mut buf);
-
-        if parse(&buf).is_err() {
-            return;
-        }
-
-        // Make sure we don't underflow
-        let packet_len = buf.len();
-        let base_len = 3;
-        if packet_len + base_len > mtu {
-            // Not enough space for any padding
-            return;
-        }
-
-        let available_len = mtu - base_len - packet_len;
-        if available_len < 2 {
-            // Not enough space for even minimum padding TLV
-            return;
-        }
-
-        // 257 = 2 byte header + 255 byte padding
-        const TLV_MAX: usize = 255;
-        const TLV_OVERHEAD: usize = 2;
-        const TLV_SIZE: usize = TLV_OVERHEAD + TLV_MAX;
-
-        let full_padding_count = available_len / TLV_SIZE;
-        let remaining = available_len % TLV_SIZE;
-
-        // Helper to generate Padding TLV
-        fn padding_tlv(len: usize) -> IsisTlv {
-            IsisTlv::Padding(IsisTlvPadding {
-                padding: vec![0u8; len],
-            })
-        }
-
-        // Add full (255-byte) padding TLVs
-        for _ in 0..full_padding_count {
-            self.tlvs.push(padding_tlv(TLV_MAX));
-        }
-
-        // Add the remainder as one smaller padding TLV (if enough room for TLV header)
-        if remaining > TLV_OVERHEAD {
-            let pad_len = remaining - TLV_OVERHEAD;
-            if pad_len > 0 {
-                self.tlvs.push(padding_tlv(pad_len));
-            }
-        }
+        pad_to_mtu(packet, &mut self.tlvs, mtu);
     }
 }
 
 impl IsisP2pHello {
     pub fn padding(&mut self, mtu: usize) {
-        let mut buf = BytesMut::new();
-
-        // Try to emit Hello packet.
         let packet = IsisPacket::from(IsisType::P2pHello, IsisPdu::P2pHello(self.clone()));
-        packet.emit(&mut buf);
-
-        if parse(&buf).is_err() {
-            return;
-        }
-
-        // Make sure we don't underflow
-        let packet_len = buf.len();
-        let base_len = 3;
-        if packet_len + base_len > mtu {
-            // Not enough space for any padding
-            return;
-        }
-
-        let available_len = mtu - base_len - packet_len;
-        if available_len < 2 {
-            // Not enough space for even minimum padding TLV
-            return;
-        }
-
-        // 257 = 2 byte header + 255 byte padding
-        const TLV_MAX: usize = 255;
-        const TLV_OVERHEAD: usize = 2;
-        const TLV_SIZE: usize = TLV_OVERHEAD + TLV_MAX;
-
-        let full_padding_count = available_len / TLV_SIZE;
-        let remaining = available_len % TLV_SIZE;
-
-        // Helper to generate Padding TLV
-        fn padding_tlv(len: usize) -> IsisTlv {
-            IsisTlv::Padding(IsisTlvPadding {
-                padding: vec![0u8; len],
-            })
-        }
-
-        // Add full (255-byte) padding TLVs
-        for _ in 0..full_padding_count {
-            self.tlvs.push(padding_tlv(TLV_MAX));
-        }
-
-        // Add the remainder as one smaller padding TLV (if enough room for TLV header)
-        if remaining > TLV_OVERHEAD {
-            let pad_len = remaining - TLV_OVERHEAD;
-            if pad_len > 0 {
-                self.tlvs.push(padding_tlv(pad_len));
-            }
-        }
+        pad_to_mtu(packet, &mut self.tlvs, mtu);
     }
 }

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1437,10 +1437,6 @@ impl SidLabelValue {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn emit(&self, buf: &mut BytesMut) {
         use SidLabelValue::*;
         match self {

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -49,10 +49,6 @@ impl IsisSubTlv {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn emit(&self, buf: &mut BytesMut) {
         use IsisSubTlv::*;
         match self {
@@ -558,10 +554,6 @@ impl FadSubTlv {
             ExcludeSrlg(v) => v.len(),
             Unknown(v) => v.len,
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     pub fn emit(&self, buf: &mut BytesMut) {

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -307,10 +307,6 @@ impl IsisSubTlv {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn emit(&self, buf: &mut BytesMut) {
         use IsisSubTlv::*;
         match self {
@@ -698,101 +694,63 @@ impl IsisSubBandwidthMetric {
     }
 }
 
-/// RFC 8570 §4.5 — Unidirectional Residual Bandwidth (sub-TLV 37).
-/// Maximum bandwidth minus bandwidth currently reserved by RSVP-TE.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
-pub struct IsisSubResidualBw {
-    pub bw: IsisSubBandwidthMetric,
+/// Generates one RFC 8570 bandwidth wrapper: a newtype over
+/// [`IsisSubBandwidthMetric`] whose codec differs only by sub-TLV
+/// code (the shared ident names both the `IsisNeighCode` and the
+/// `IsisSubTlv` variant). The three were previously identical
+/// hand-written copies.
+macro_rules! bandwidth_sub_tlv {
+    ($(#[$doc:meta])* $ty:ident => $variant:ident) => {
+        $(#[$doc])*
+        #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+        pub struct $ty {
+            pub bw: IsisSubBandwidthMetric,
+        }
+
+        impl ParseBe<$ty> for $ty {
+            fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+                let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
+                Ok((input, Self { bw }))
+            }
+        }
+
+        impl TlvEmitter for $ty {
+            fn typ(&self) -> u8 {
+                IsisNeighCode::$variant.into()
+            }
+            fn len(&self) -> u8 {
+                4
+            }
+            fn emit(&self, buf: &mut BytesMut) {
+                self.bw.emit(buf);
+            }
+        }
+
+        impl From<$ty> for IsisSubTlv {
+            fn from(v: $ty) -> Self {
+                IsisSubTlv::$variant(v)
+            }
+        }
+    };
 }
 
-impl ParseBe<IsisSubResidualBw> for IsisSubResidualBw {
-    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
-        Ok((input, Self { bw }))
-    }
-}
+bandwidth_sub_tlv!(
+    /// RFC 8570 §4.5 — Unidirectional Residual Bandwidth (sub-TLV 37).
+    /// Maximum bandwidth minus bandwidth currently reserved by RSVP-TE.
+    IsisSubResidualBw => ResidualBw
+);
 
-impl TlvEmitter for IsisSubResidualBw {
-    fn typ(&self) -> u8 {
-        IsisNeighCode::ResidualBw.into()
-    }
-    fn len(&self) -> u8 {
-        4
-    }
-    fn emit(&self, buf: &mut BytesMut) {
-        self.bw.emit(buf);
-    }
-}
+bandwidth_sub_tlv!(
+    /// RFC 8570 §4.6 — Unidirectional Available Bandwidth (sub-TLV 38).
+    /// Residual minus the measured non-RSVP-TE forwarding load.
+    IsisSubAvailableBw => AvailableBw
+);
 
-impl From<IsisSubResidualBw> for IsisSubTlv {
-    fn from(v: IsisSubResidualBw) -> Self {
-        IsisSubTlv::ResidualBw(v)
-    }
-}
-
-/// RFC 8570 §4.6 — Unidirectional Available Bandwidth (sub-TLV 38).
-/// Residual minus the measured non-RSVP-TE forwarding load.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
-pub struct IsisSubAvailableBw {
-    pub bw: IsisSubBandwidthMetric,
-}
-
-impl ParseBe<IsisSubAvailableBw> for IsisSubAvailableBw {
-    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
-        Ok((input, Self { bw }))
-    }
-}
-
-impl TlvEmitter for IsisSubAvailableBw {
-    fn typ(&self) -> u8 {
-        IsisNeighCode::AvailableBw.into()
-    }
-    fn len(&self) -> u8 {
-        4
-    }
-    fn emit(&self, buf: &mut BytesMut) {
-        self.bw.emit(buf);
-    }
-}
-
-impl From<IsisSubAvailableBw> for IsisSubTlv {
-    fn from(v: IsisSubAvailableBw) -> Self {
-        IsisSubTlv::AvailableBw(v)
-    }
-}
-
-/// RFC 8570 §4.7 — Unidirectional Utilized Bandwidth (sub-TLV 39).
-/// Actual link utilization as measured by the advertising node.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
-pub struct IsisSubUtilizedBw {
-    pub bw: IsisSubBandwidthMetric,
-}
-
-impl ParseBe<IsisSubUtilizedBw> for IsisSubUtilizedBw {
-    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
-        Ok((input, Self { bw }))
-    }
-}
-
-impl TlvEmitter for IsisSubUtilizedBw {
-    fn typ(&self) -> u8 {
-        IsisNeighCode::UtilizedBw.into()
-    }
-    fn len(&self) -> u8 {
-        4
-    }
-    fn emit(&self, buf: &mut BytesMut) {
-        self.bw.emit(buf);
-    }
-}
-
-impl From<IsisSubUtilizedBw> for IsisSubTlv {
-    fn from(v: IsisSubUtilizedBw) -> Self {
-        IsisSubTlv::UtilizedBw(v)
-    }
-}
+bandwidth_sub_tlv!(
+    /// RFC 8570 §4.7 — Unidirectional Utilized Bandwidth (sub-TLV 39).
+    /// Actual link utilization as measured by the advertising node.
+    IsisSubUtilizedBw => UtilizedBw
+);
 
 // RFC 9479 IS-IS Application-Specific Link Attributes
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -258,10 +258,6 @@ impl IsisMirrorSub2Tlv {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn emit(&self, buf: &mut BytesMut) {
         use IsisMirrorSub2Tlv::*;
         match self {
@@ -343,10 +339,6 @@ impl IsisSub2Tlv {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn emit(&self, buf: &mut BytesMut) {
         use IsisSub2Tlv::*;
         match self {
@@ -367,10 +359,6 @@ impl IsisSubTlv {
             Ipv6SourceRouterId(v) => v.len(),
             Unknown(v) => v.len,
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     pub fn emit(&self, buf: &mut BytesMut) {

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -509,9 +509,12 @@ backlog, ordered by risk and value.
    `BGPLS_ATTR_EXT_ADMIN_GROUP` is defined by `bgp-packet`, and the IS-IS
    producer serializes every RFC 7308 group word in network byte order while
    keeping it distinct from the classic Administrative Group TLV 1088.
-7. **Small-cleanup sweep (one PR)** — the duplicated ~55-line padding function
-   (`IsisHello`/`IsisP2pHello`), the three identical RFC 8570 bandwidth
-   wrappers, and the seven dead `is_empty()` methods.
+7. ~~**Small-cleanup sweep (one PR)**~~ — **done**: the two Hello padding
+   functions share one `pad_to_mtu`; a `bandwidth_sub_tlv!` macro generates the
+   three RFC 8570 wrappers; the seven no-op `is_empty()` methods are removed
+   (with `clippy::len_without_is_empty` allowed workspace-wide — TLV `len()` is
+   a wire length field, not a container length). The meaningful all-zero
+   `IsisSysId`/`IsisNeighborId::is_empty` checks are untouched.
 8. **Optional: live interop validation** — the flag/bit fixes (#2, #5, #13,
    #14) are unit-tested against FRR's *source*; a BDD or lab run against a
    real FRR/IOS neighbor exercising RouterCap S-flag, multi-area TLV 1, and


### PR DESCRIPTION
## Summary

Follow-up item 7 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`) — the non-blocking cleanup
backlog, net −99 lines with no behavior change.

- **Padding dedup:** `IsisHello::padding` and `IsisP2pHello::padding`
  were byte-identical ~55-line copies (including a nested `padding_tlv`
  defined twice); both are now thin wrappers over one `pad_to_mtu`.
- **Bandwidth wrappers:** the three RFC 8570 bandwidth sub-TLVs
  (Residual/Available/Utilized, codes 37/38/39) were identical
  hand-written newtype codecs differing only by code point; a
  `bandwidth_sub_tlv!` macro generates them, per-type RFC doc comments
  preserved.
- **Dead `is_empty()`s:** the seven no-op `self.len() == 0` methods
  (`SidLabelValue` and the six sub-TLV enums) had no callers and
  existed only to satisfy `clippy::len_without_is_empty`; removed, and
  the lint is allowed workspace-wide with a justifying comment — TLV
  `len()` is the protocol's one-octet length-field value, not a
  container length. The meaningful all-zero
  `IsisSysId`/`IsisNeighborId::is_empty` checks are untouched.

## Test plan

- No behavior change intended; the RFC 8570 round-trip tests pin the
  bandwidth codecs byte-for-byte and the padding path is exercised by
  the existing Hello/padding tests.
- `cargo clippy --workspace --exclude bdd --all-targets` and
  `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)