### PR TITLE
ospf-packet: emit Unknown OSPFv2 payload body and real type

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -79,7 +79,7 @@ impl Ospfv2Packet {
             LsRequest(v) => v.emit(buf),
             LsUpdate(v) => v.emit(buf),
             LsAck(v) => v.emit(buf),
-            _ => {}
+            Unknown(v) => buf.put(&v.payload[..]),
         }
         // OSPF packet length — header + body, RFC 2328 §A.3.1.
         // RFC 2328 §D.4: the cryptographic-auth digest follows the
@@ -224,7 +224,7 @@ impl Ospfv2Payload {
             LsRequest(_) => OspfType::LsRequest,
             LsUpdate(_) => OspfType::LsUpdate,
             LsAck(_) => OspfType::LsAck,
-            Unknown(_v) => OspfType::Hello,
+            Unknown(v) => v.typ,
         }
     }
 }
@@ -3061,6 +3061,38 @@ mod tests {
         assert!(rest.is_empty());
         match lsp {
             OspfLsp::Unknown(u) => assert_eq!(u.data, vec![0xDE, 0xAD, 0xBE, 0xEF]),
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_v2_payload_roundtrips() {
+        // A packet of an unrecognized OSPF type reports its real type and
+        // carries its body verbatim through emit — not a header-only Hello.
+        let payload = Ospfv2Payload::Unknown(OspfUnknown {
+            typ: OspfType::Unknown(6),
+            payload: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        });
+        assert_eq!(payload.typ(), OspfType::Unknown(6));
+
+        let pkt = Ospfv2Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::new(0, 0, 0, 0),
+            payload,
+        );
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+        // Header type byte is the unknown type (6), not Hello (1).
+        assert_eq!(buf[1], 6);
+        // Length covers the 24-byte header + 4-byte body (not header-only 24).
+        assert_eq!(u16::from_be_bytes([buf[2], buf[3]]), 28);
+        assert_eq!(&buf[24..28], &[0xDE, 0xAD, 0xBE, 0xEF]);
+
+        // Re-parses to the same Unknown payload and type.
+        let (_, parsed) = parse(&buf).expect("re-parse");
+        assert_eq!(parsed.typ, OspfType::Unknown(6));
+        match parsed.payload {
+            Ospfv2Payload::Unknown(u) => assert_eq!(u.payload, vec![0xDE, 0xAD, 0xBE, 0xEF]),
             other => panic!("expected Unknown, got {other:?}"),
         }
     }

--- a/docs/design/ospf-packet-code-review.md
+++ b/docs/design/ospf-packet-code-review.md
@@ -29,7 +29,7 @@ most-severe first.
 | 10 | **Correctness** | `parser.rs:557` | `verify_checksum` re-emits typed form, ignores `raw` | ✅ #1993 |
 | 11 | **Robustness** | `parser.rs:693` | `parse_lsa_with_length` swallows all errors into `Unknown` | ✅ #1990 |
 | 12 | **Correctness** | `parser.rs:422` (+`816`) | v2 emit writes stored `num_adv`/`num_links`, not derived | ✅ #1986 |
-| 13 | **Correctness** | `parser.rs:82` (+`227`) | Unknown v2 payload emit drops body; `typ()` → Hello | ⬜ open |
+| 13 | **Correctness** | `parser.rs:82` (+`227`) | Unknown v2 payload emit drops body; `typ()` → Hello | ✅ #1998 |
 | 14 | **Cleanup (reuse)** | `parser.rs:618` | Fletcher checksum + FAD/SID codecs duplicated | ⬜ open |
 | 15 | **Cleanup (dead code)** | `parser.rs:1197` (+`1077`, `v3.rs`) | Dead `pub` items add confusing API surface | ⬜ open |
 
@@ -39,8 +39,8 @@ most-severe first.
 
 All seven top findings — the three remote-DoS parse bugs and all four silent
 interop wire-format bugs — plus the security finding #9, the round-trip finding
-#8, the correctness findings #12 and #10, and the robustness finding #11 are
-fixed and merged to `main`. The review document itself landed in #1955.
+#8, the correctness findings #12, #10, and #13, and the robustness finding #11
+are fixed and merged to `main`. The review document itself landed in #1955.
 
 | PR | Findings | Summary |
 |----|----------|---------|
@@ -54,6 +54,7 @@ fixed and merged to `main`. The review document itself landed in #1955.
 | [#1986](https://github.com/zebra-rs/zebra-rs/pull/1986) | 12 | `num_adv`/`num_links` derived from `.len()` at emit (fields removed, custom `ParseBe`); **validated by `ospfv2_multi_area` BDD** |
 | [#1990](https://github.com/zebra-rs/zebra-rs/pull/1990) | 11 | `parse_lsa_with_length` propagates a known-type body-parse error instead of masking it as `Unknown`; unknown types stay tolerant; **validated by `ospfv2_tilfa` BDD** |
 | [#1993](https://github.com/zebra-rs/zebra-rs/pull/1993) | 10 | `verify_checksum` checks received LSAs against their cached wire bytes (`raw`); typed re-emit kept only as the self-originated fallback |
+| [#1996](https://github.com/zebra-rs/zebra-rs/pull/1998) | 13 | `Ospfv2Packet::emit` writes the Unknown payload body; `Ospfv2Payload::typ()` returns the stored type (emit match now exhaustive) |
 
 Each fix carries a regression test: byte-offset unit tests where a `show`-based
 check could not discriminate the bug, plus live BDD features for the Prefix-SID
@@ -77,14 +78,14 @@ silent interop break in a shipped datapath). Suggested order:
 > #10 (verify checksum over raw) [#1993](https://github.com/zebra-rs/zebra-rs/pull/1993).
 > Only low-severity cleanup remains.
 
+> Finding 13 (Unknown v2 payload emit) was fixed in
+> [#1996](https://github.com/zebra-rs/zebra-rs/pull/1998).
+
 **Cleanup — low-severity, opportunistic**
-1. **Finding 13 — Unknown v2 payload emit drops body / `typ()` → Hello.** Latent
-   (daemon never re-emits unknown-type packets); fix the public-API trap when
-   convenient.
-2. **Finding 15 (remainder) — delete dead `pub` items** (`is_known`,
+1. **Finding 15 (remainder) — delete dead `pub` items** (`is_known`,
    `Ospfv3ExtTlv::wire_len`; `RouterInfoTlvUnknown::parse_tlv` was already removed
    with finding 8). Trivial deletions.
-3. **Finding 14 — hoist duplicated codecs into `packet-utils`** (Fletcher
+2. **Finding 14 — hoist duplicated codecs into `packet-utils`** (Fletcher
    checksum shared with `isis-packet`; FAD and SID/Label dispatch shared v2/v3).
    Larger refactor; best done the next time those codecs are touched.
 
@@ -380,6 +381,8 @@ the manual sync lines.
 ---
 
 ### 13. Unknown v2 payload emit drops the body; `typ()` maps Unknown → Hello
+> ✅ **Fixed in [#1996](https://github.com/zebra-rs/zebra-rs/pull/1998)** — emit writes the stored payload; `typ()` returns the stored type; emit match now exhaustive.
+
 **`crates/ospf-packet/src/parser.rs:82`** (and `parser.rs:227`)
 
 `Ospfv2Packet::emit`'s `_ => {}` arm never writes an `Unknown` payload's bytes, so

--- a/docs/design/ospf-packet-code-review.md
+++ b/docs/design/ospf-packet-code-review.md
@@ -54,7 +54,7 @@ are fixed and merged to `main`. The review document itself landed in #1955.
 | [#1986](https://github.com/zebra-rs/zebra-rs/pull/1986) | 12 | `num_adv`/`num_links` derived from `.len()` at emit (fields removed, custom `ParseBe`); **validated by `ospfv2_multi_area` BDD** |
 | [#1990](https://github.com/zebra-rs/zebra-rs/pull/1990) | 11 | `parse_lsa_with_length` propagates a known-type body-parse error instead of masking it as `Unknown`; unknown types stay tolerant; **validated by `ospfv2_tilfa` BDD** |
 | [#1993](https://github.com/zebra-rs/zebra-rs/pull/1993) | 10 | `verify_checksum` checks received LSAs against their cached wire bytes (`raw`); typed re-emit kept only as the self-originated fallback |
-| [#1996](https://github.com/zebra-rs/zebra-rs/pull/1998) | 13 | `Ospfv2Packet::emit` writes the Unknown payload body; `Ospfv2Payload::typ()` returns the stored type (emit match now exhaustive) |
+| [#1998](https://github.com/zebra-rs/zebra-rs/pull/1998) | 13 | `Ospfv2Packet::emit` writes the Unknown payload body; `Ospfv2Payload::typ()` returns the stored type (emit match now exhaustive) |
 
 Each fix carries a regression test: byte-offset unit tests where a `show`-based
 check could not discriminate the bug, plus live BDD features for the Prefix-SID
@@ -79,7 +79,7 @@ silent interop break in a shipped datapath). Suggested order:
 > Only low-severity cleanup remains.
 
 > Finding 13 (Unknown v2 payload emit) was fixed in
-> [#1996](https://github.com/zebra-rs/zebra-rs/pull/1998).
+> [#1998](https://github.com/zebra-rs/zebra-rs/pull/1998).
 
 **Cleanup — low-severity, opportunistic**
 1. **Finding 15 (remainder) — delete dead `pub` items** (`is_known`,
@@ -381,7 +381,7 @@ the manual sync lines.
 ---
 
 ### 13. Unknown v2 payload emit drops the body; `typ()` maps Unknown → Hello
-> ✅ **Fixed in [#1996](https://github.com/zebra-rs/zebra-rs/pull/1998)** — emit writes the stored payload; `typ()` returns the stored type; emit match now exhaustive.
+> ✅ **Fixed in [#1998](https://github.com/zebra-rs/zebra-rs/pull/1998)** — emit writes the stored payload; `typ()` returns the stored type; emit match now exhaustive.
 
 **`crates/ospf-packet/src/parser.rs:82`** (and `parser.rs:227`)
 


### PR DESCRIPTION
## Summary

`Ospfv2Packet::emit`'s `_ => {}` arm dropped an `Unknown` payload's captured bytes, so re-emitting a parsed unknown-type packet produced a header-only frame with a truncated length and a checksum over the wrong bytes. `Ospfv2Payload::typ()` also returned `OspfType::Hello` for `Unknown`, so building a packet via `Ospfv2Packet::new` (which derives the header type from `payload.typ()`) stamped it as Hello.

Emit the stored `payload` bytes and return the stored `typ` (populated by `parse_enum`). The emit match is now exhaustive, so a future payload variant is a compile error rather than a silent drop.

Found in the ospf-packet crate code review (`docs/design/ospf-packet-code-review.md`, finding #13). Also marks that finding fixed in the doc. (The v3 emit already writes the Unknown body, so this is v2-only.)

## Test plan

- New round-trip test: an unknown-type packet keeps its type byte (6, not 1) and its body through emit, and re-parses to the same `Unknown` payload.
- `cargo test -p ospf-packet`: 81 + 17 pass. `cargo test -p zebra-rs ospf::`: 84 pass. `cargo clippy --workspace`: clean.

Generated with [Claude Code](https://claude.com/claude-code)