### PR TITLE
bgp: pick the SRv6 service SID by destination family at FIB install

### DIFF
--- a/docs/design/bgp-code-review-findings.md
+++ b/docs/design/bgp-code-review-findings.md
@@ -5,7 +5,10 @@ effort. Ten independent finder angles produced 68 candidates; each surviving
 candidate was checked by an independent adversarial verifier that had to name a
 concrete trigger and quote the decisive lines, then a fresh gap sweep added more.
 
-**Result: 34 confirmed correctness bugs + 15 confirmed cleanup items.** Three
+**Result: 34 confirmed correctness bugs + 15 confirmed cleanup items.**
+**Status 2026-07-18: top-9 fixed and merged** (PRs #1962, #1972, #1981,
+#1984, #1987, #1991, #1997, and the finding-#9 branch); fixes below the
+cap remain open. Three
 candidates were refuted (two vty-disconnect "panics" are guarded by detached
 forwarding tasks; the N>1 BSID resync is covered by a mirrored winners replica).
 
@@ -30,7 +33,7 @@ deepest fix.
 
 ## Top 15 (ranked most severe first)
 
-### 1. Daemon crash: `fsm()` unwrap on a removed peer slot — `peer.rs:1801`
+### 1. Daemon crash: `fsm()` unwrap on a removed peer slot — `peer.rs:1801` — FIXED (PR #1962)
 
 `fsm()` does `peer_map.get_mut_by_idx(id).unwrap()` with no guard, and
 `process_msg` (`inst.rs:2148`) dispatches `Message::Event(ident, event)` to it
@@ -45,7 +48,7 @@ the next dispatch hits `get_mut_by_idx(ident).unwrap()` on `None` → **panic
 crashes the whole daemon, killing every session.** Second path: dynamic-peer reap
 (`inst.rs:2385`) plus a queued timer/dial event.
 
-### 2. 4-byte-ASN peers can never establish — `peer.rs:2086`
+### 2. 4-byte-ASN peers can never establish — `peer.rs:2086` — FIXED (PR #1972, full RFC 6793)
 
 After the AS4-aware ASN check passes (`2055-2058`, folds the AS4 capability), the
 code re-compares the raw 2-octet field `packet.asn as u32 != peer.remote_as` and
@@ -57,7 +60,7 @@ attempt, no NOTIFICATION. **Any 4-byte-ASN peer is permanently rejected.**
 Outbound is also broken: `peer.rs:2947` truncates local-as to `u16` instead of
 sending AS_TRANS. Fix: delete the redundant `2086` comparison.
 
-### 3. VRF delete → cross-VRF traffic leak — `inst.rs:2440`
+### 3. VRF delete → cross-VRF traffic leak — `inst.rs:2440` — FIXED (PR #1981)
 
 `apply_vrf_commit_diff`'s despawn arm frees and immediately reclaims the VRF's
 MPLS label (`2464-2468`) but never purges the VRF's exported rows
@@ -72,7 +75,7 @@ advertised to remote PEs; the freed label is handed to the next VRF, whose
 `DecapVrf` ILM binds it → **remote PEs still forwarding to the old advertisement
 decap into the wrong VRF.**
 
-### 4. Dual-homed L3VPN withdraw blackholes the survivor — `vrf/inst.rs:1444`
+### 4. Dual-homed L3VPN withdraw blackholes the survivor — `vrf/inst.rs:1444` — FIXED (PR #1984)
 
 `handle_import_v4` stores every import under `(prefix, id 0, ORIGINATED_PEER)`
 ignoring the origin RD (`1310-1351`), and `handle_withdraw_import` also ignores
@@ -86,7 +89,7 @@ second replaces the first row; PE1 withdraws → the VRF removes the row now hol
 **PE2's still-valid route → CE-side blackhole**, and nothing re-imports RD 2:2's
 winner until an unrelated event.
 
-### 5. EVPN received-withdraw never propagated to peers — `route.rs:7955`
+### 5. EVPN received-withdraw never propagated to peers — `route.rs:7955` — FIXED (PR #1987)
 
 `route_evpn_withdraw` (handler for received EVPN MP_UNREACH, also used by
 peer-down cleanup) recomputes best-path but its only peer-facing action is
@@ -101,7 +104,7 @@ reflects to B; A withdraws it → RR removes it locally but **B never receives t
 withdraw and keeps forwarding to the departed host's stale VTEP** until the B
 session bounces. Also affects eBGP EVPN transit and both peer-down cleanup arms.
 
-### 6. IPv6 empty-selection never withdraws from peers — `route.rs:6331`
+### 6. IPv6 empty-selection never withdraws from peers — `route.rs:6331` — FIXED (PR #1991)
 
 `route_ipv6_update` gates the peer fan-out on `if !selected.is_empty()`
 (also VPNv6 at `6359`), so an UPDATE whose best-path delta empties the selection
@@ -114,7 +117,7 @@ deny of the last candidate (`dispatch.rs:627-634`) or the NHT reachability gate
 FIB entry deleted but **no MP_UNREACH sent → other peers hold and forward on the
 stale v6/VPNv6 route indefinitely.**
 
-### 7. ipv6 encapsulation-type missing from UpdateGroupSig — `update_group.rs:350`
+### 7. ipv6 encapsulation-type missing from UpdateGroupSig — `update_group.rs:350` — FIXED (PR #1997)
 
 `signature_of` omits per-peer `afi-safi ipv6 encapsulation-type`
 (`ipv6_srv6_encap`/`ipv6_srv6_strict`), but `route_update_ipv6` uses it to strip
@@ -129,7 +132,7 @@ own comment (`11313`) calls this fatal: the CE tracks an unresolvable provider
 locator and blackholes.** Order-dependent; incremental (post-sync) advertisements
 only.
 
-### 8. vpnv4 next-hop-self/unchanged shared through the group memo — `route.rs:11110`
+### 8. vpnv4 next-hop-self/unchanged shared through the group memo — `route.rs:11110` — FIXED (PR #1997)
 
 Per-peer `afi-safi vpnv4 next-hop-self`/`next-hop-unchanged` select the egress
 NEXT_HOP (`11110-11115`, via per-peer `sync_ctx`) but are not `UpdateGroupSig`
@@ -140,7 +143,7 @@ warns explicitly against adding per-peer state to the memoized path.
 **Trigger:** an Inter-AS Option-B ASBR with `next-hop-self` toward PE1 but not PE2
 (both same group) → one PE is sent the **wrong NEXT_HOP → VPN traffic blackholes.**
 
-### 9. Family-blind SRv6 service-SID selection at FIB install — `route.rs:701`
+### 9. Family-blind SRv6 service-SID selection at FIB install — `route.rs:701` — FIXED (fib-install + show sites; nht_target keeps first-SID by design, see its doc)
 
 `select_fib_entry_v4` (`701`) and `select_fib_entry_v6` (`972`, `980`) use
 first-SID `srv6_l3_sid()`, whose own doc (`bgp_attr.rs:166`) warns consumers to

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -199,6 +199,14 @@ pub fn bgp_nexthop_ip(attr: &BgpAttr) -> Option<IpAddr> {
 /// retains. Everything else (SR-MPLS VPN, plain unicast) keeps tracking
 /// the BGP next-hop. All of a route's NHT sites — register, transport
 /// lookup, re-eval, untrack — must agree, so they all call this.
+///
+/// Known limitation: for a split End.DT4 + End.DT6 pair this tracks the
+/// FIRST SID regardless of the destination family the FIB steers into
+/// (`srv6_l3_sid_for_dest` there). Both SIDs of one route come from the
+/// same PE's locator in practice, so reachability is equivalent; making
+/// this family-aware would require threading the family through every
+/// register/untrack site in lockstep (a mismatch desyncs the NHT
+/// refcounts), which is not worth it for a same-locator distinction.
 pub fn nht_target(attr: &BgpAttr) -> Option<IpAddr> {
     if let Some((sid, _behavior)) = attr.srv6_l3_sid() {
         return Some(IpAddr::V6(sid));

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -701,13 +701,18 @@ fn select_fib_entry_v4(
     // installs an H.Encap entry toward that SID instead of an MPLS
     // label stack — gated on the underlay next-hop resolving, like the
     // MPLS path. CE-learned routes carry no Prefix-SID, so this never
-    // fires for them.
-    if best.typ == BgpRibType::Originated
-        && let Some((sid, _behavior)) = best.attr.srv6_l3_sid()
-    {
-        return transport
-            .filter(|t| !t.is_empty())
-            .and_then(|t| build_srv6_vpn_fib_entry(sid, t));
+    // fires for them. The SID is picked family-aware: an originator may
+    // advertise a split End.DT4 + End.DT6 pair, and steering v4 traffic
+    // at the End.DT6 SID blackholes it at the egress decap (review
+    // finding #9). No family-compatible decap SID ⇒ install nothing
+    // rather than a wrong-family H.Encap.
+    if best.typ == BgpRibType::Originated && best.attr.srv6_l3_sid().is_some() {
+        let sids: Vec<_> = best.attr.srv6_l3_sids().collect();
+        return bgp_packet::srv6_l3_sid_for_dest(&sids, true).and_then(|(sid, _behavior)| {
+            transport
+                .filter(|t| !t.is_empty())
+                .and_then(|t| build_srv6_vpn_fib_entry(sid, t))
+        });
     }
     if is_vpn_fib_winner(best, transport) {
         build_vpn_fib_entry(best.label.map(|l| l.label).unwrap_or(0), transport.unwrap())
@@ -972,17 +977,24 @@ fn select_fib_entry_v6(
     if let Some(entry) = vxlan_vpn_entry(best, transport) {
         return Some(entry);
     }
-    // SRv6 L3VPN (VPNv6 over an SRv6 underlay) — see `select_fib_entry_v4`.
-    if best.typ == BgpRibType::Originated
-        && let Some((sid, _behavior)) = best.attr.srv6_l3_sid()
-    {
-        return transport
-            .filter(|t| !t.is_empty())
-            .and_then(|t| build_srv6_vpn_fib_entry(sid, t));
+    // SRv6 L3VPN (VPNv6 over an SRv6 underlay) — see `select_fib_entry_v4`,
+    // including the family-aware SID pick (a v6 destination must not be
+    // steered at an End.DT4 SID).
+    if best.typ == BgpRibType::Originated && best.attr.srv6_l3_sid().is_some() {
+        let sids: Vec<_> = best.attr.srv6_l3_sids().collect();
+        return bgp_packet::srv6_l3_sid_for_dest(&sids, false).and_then(|(sid, _behavior)| {
+            transport
+                .filter(|t| !t.is_empty())
+                .and_then(|t| build_srv6_vpn_fib_entry(sid, t))
+        });
     }
+    let received_sid = {
+        let sids: Vec<_> = best.attr.srv6_l3_sids().collect();
+        bgp_packet::srv6_l3_sid_for_dest(&sids, false)
+    };
     if is_vpn_fib_winner(best, transport) {
         build_vpn_fib_entry(best.label.map(|l| l.label).unwrap_or(0), transport.unwrap())
-    } else if let Some((sid, _behavior)) = best.attr.srv6_l3_sid() {
+    } else if let Some((sid, _behavior)) = received_sid {
         // A *received* plain IPv6 unicast route carrying an SRv6 L3
         // service SID installs an H.Encaps entry toward the SID instead
         // of a plain next-hop entry, so matched traffic is SRv6-
@@ -21157,5 +21169,96 @@ mod v6_empty_selection_tests {
                 .contains_key(&nlri.prefix),
             "peer B's Adj-RIB-Out must be pruned by the withdraw"
         );
+    }
+}
+
+#[cfg(test)]
+mod srv6_sid_family_tests {
+    use super::*;
+    use bgp_packet::{
+        PrefixSid, PrefixSidTlv, SRV6_BEHAVIOR_END_DT4, SRV6_BEHAVIOR_END_DT6, Srv6ServiceTlv,
+        Srv6SidInfo,
+    };
+
+    /// An imported (Originated) row whose attr carries the given SRv6 L3
+    /// service SIDs — the shape a split-pair VPN route takes.
+    fn split_pair_rib(sids: Vec<(std::net::Ipv6Addr, u16)>) -> BgpRib {
+        let attr = BgpAttr {
+            prefix_sid: Some(PrefixSid {
+                tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                    sids: sids
+                        .into_iter()
+                        .map(|(sid, behavior)| Srv6SidInfo::new(sid, 0, behavior, None))
+                        .collect(),
+                    ..Default::default()
+                })],
+            }),
+            ..Default::default()
+        };
+        BgpRib::new_arc(
+            ORIGINATED_PEER,
+            Ipv4Addr::new(10, 0, 0, 9),
+            BgpRibType::Originated,
+            0,
+            0,
+            Arc::new(attr),
+            None,
+            None,
+            false,
+        )
+    }
+
+    fn transport() -> Vec<rib::nht::ResolvedNexthop> {
+        vec![rib::nht::ResolvedNexthop {
+            addr: "2001:db8::fe".parse().unwrap(),
+            ifindex: 1,
+            labels: Vec::new(),
+            segs: Vec::new(),
+            seg_encap: None,
+        }]
+    }
+
+    fn entry_segs(entry: &rib::entry::RibEntry) -> Vec<std::net::Ipv6Addr> {
+        match &entry.nexthop {
+            rib::Nexthop::Uni(uni) => uni.segs.clone(),
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
+    /// Review finding #9 regression: a split `[End.DT6, End.DT4]` pair
+    /// (DT6 first — the order that broke) must steer v4 traffic at the
+    /// End.DT4 SID and v6 traffic at the End.DT6 SID. The old code took
+    /// the first SID for both, H.Encapping v4 toward a decap that only
+    /// serves IPv6 — a blackhole.
+    #[test]
+    fn split_pair_steers_each_family_at_its_own_sid() {
+        let dt6: std::net::Ipv6Addr = "fcbb:1::6".parse().unwrap();
+        let dt4: std::net::Ipv6Addr = "fcbb:1::4".parse().unwrap();
+        let rib = split_pair_rib(vec![
+            (dt6, SRV6_BEHAVIOR_END_DT6),
+            (dt4, SRV6_BEHAVIOR_END_DT4),
+        ]);
+        let t = transport();
+
+        let v4 = select_fib_entry_v4(&rib, Some(&t), None).expect("v4 entry");
+        assert_eq!(entry_segs(&v4), vec![dt4], "v4 must pick the End.DT4 SID");
+
+        let v6 = select_fib_entry_v6(&rib, Some(&t), None).expect("v6 entry");
+        assert_eq!(entry_segs(&v6), vec![dt6], "v6 must pick the End.DT6 SID");
+    }
+
+    /// No family-compatible decap SID ⇒ install nothing, not a
+    /// wrong-family H.Encap.
+    #[test]
+    fn family_incompatible_sid_installs_nothing() {
+        let dt6: std::net::Ipv6Addr = "fcbb:1::6".parse().unwrap();
+        let rib = split_pair_rib(vec![(dt6, SRV6_BEHAVIOR_END_DT6)]);
+        let t = transport();
+        assert!(
+            select_fib_entry_v4(&rib, Some(&t), None).is_none(),
+            "a v4 destination cannot be served by an End.DT6-only route"
+        );
+        let v6 = select_fib_entry_v6(&rib, Some(&t), None).expect("v6 entry");
+        assert_eq!(entry_segs(&v6), vec![dt6]);
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1844,7 +1844,10 @@ fn write_bgp_entry_detail<V: BgpShowView>(
         if let Some(li) = rib.attr.prefix_sid_label_index() {
             writeln!(out, "    Prefix-SID Label-Index: {}", li)?;
         }
-        if let Some((sid, behavior)) = rib.attr.srv6_l3_sid() {
+        // Every SRv6 L3 service SID, not just the first: an originator
+        // may advertise a split End.DT4 + End.DT6 pair, and the FIB
+        // picks per destination family — show what is actually carried.
+        for (sid, behavior) in rib.attr.srv6_l3_sids() {
             let kind = if rib.is_originated() {
                 "Local SID"
             } else {


### PR DESCRIPTION
## Summary
Fixes review finding #9 of `docs/design/bgp-code-review-findings.md` (family-blind SRv6 service-SID selection).

- `select_fib_entry_v4`/`_v6` took the FIRST SRv6 L3 service SID via `srv6_l3_sid()` — whose own doc warns consumers off it — so a VPN route advertising a legal split `End.DT4` + `End.DT6` pair H.Encapped v4 traffic toward the End.DT6 SID, whose decap only serves IPv6: a blackhole at the egress PE (mirror-image for v6). An earlier commit fixed only the MUP sites.
- Fix: both VPN install arms and the received-plain-v6 H.Encaps arm now pick via `srv6_l3_sid_for_dest` (exact family behavior, then End.DT46); a route whose SIDs carry known L3-decap behaviors with none family-compatible installs **nothing** for that family rather than a wrong-family encap. `show ip bgp <prefix>` detail renders every carried service SID instead of the first. `nht_target` deliberately keeps the first-SID rule (register/untrack must stay in lockstep or NHT refcounts desync; a split pair shares one locator in practice) — now documented on the function.
- Also marks findings #1–#9 as fixed (with PR numbers) in the review-findings doc.

## Test plan
- New unit tests drive `select_fib_entry_v4`/`_v6` with a `[End.DT6, End.DT4]` pair (DT6 first — the order that broke), red/green-verified: on first-SID code v4 is steered at the DT6 SID and a DT6-only route still installs a v4 entry; with the fix each family gets its own SID and the incompatible case installs nothing.
- Full workspace suite (`--exclude bdd`) 39/39 green; workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)