### PR TITLE
pim: IPv4 correctness floor for the IPv6 arc (Phase 0)

### DIFF
--- a/bdd/tests/configs/pim_assert/r3.yaml
+++ b/bdd/tests/configs/pim_assert/r3.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.6.2.1/24
+- if-name: eth2
+  ipv4:
+    address: 10.6.3.1/24
+router:
+  static:
+    ipv4:
+      route:
+      # RPF toward the source is pinned at r1 (10.6.2.2), so r3's
+      # (S,G) Join goes to r1 and makes r1 forward onto swB — the
+      # non-DR forwarder the assert election needs.
+      - prefix: 10.6.0.0/24
+        nexthop:
+        - address: 10.6.2.2
+  pim:
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth2
+      igmp:
+        enabled: true

--- a/bdd/tests/features/pim_assert.feature
+++ b/bdd/tests/features/pim_assert.feature
@@ -9,21 +9,30 @@ Feature: PIM assert election and LAN Join/Prune behaviors
   multi-access behaviors that keep exactly one copy of each packet
   on every LAN.
 
-  r1 and r2 both connect the upstream LAN (swA, toward r0 and the
-  source) and the receiver LAN (swB). Both track h2's IGMPv3 join
-  (no DR gating on local membership), so both join (S,G) toward r0 —
-  each must log the other's Join as suppressing — and both forward
-  onto swB, where the duplicate data triggers the assert election.
-  Metrics tie, so the higher address (r2, 10.6.2.3) must win; r1
-  must step down, and with its only outgoing interface assert-lost
-  its JoinDesired collapses — it prunes toward r0. r2 must overhear
-  that Prune and send the override Join, keeping r0 forwarding, and
-  h2 must keep receiving through r2.
+  r1 and r2 both connect the upstream LAN swA (toward r0 and the
+  source) and the contested LAN swB. They must forward the same
+  (S,G) onto swB by two independent mechanisms — so that DR gating
+  (only the DR turns local membership into forwarding state) cannot
+  collapse the test to a single forwarder:
+
+    * r2 is the DR on swB and forwards for h2, a receiver attached
+      directly to swB.
+    * r1 is NOT the DR on swB; it forwards because r3 (downstream,
+      with receiver h3) has its RPF toward the source pointed at r1
+      and sends r1 an (S,G) Join.
+
+  Both forward onto swB, the duplicate data triggers the assert, and
+  the higher address (r2, 10.6.2.3) wins. r1 steps down; with its
+  only outgoing interface assert-lost its JoinDesired collapses and
+  it prunes toward r0. r2 overhears that Prune and overrides it,
+  keeping r0 forwarding, and the assert winner then carries the LAN
+  for both receivers.
 
   Test Topology:
   ```
-    h1 --- r0 --- [swA LAN 10.6.1.0/24] --- r1 --- [swB LAN 10.6.2.0/24] --- h2
-   (src)           .1(r0) .2(r1) .3(r2)     r2          .2(r1) .3(r2)      (rcv)
+    h1(src) - r0 - [swA 10.6.1/24] - r1(.2) - [swB 10.6.2/24] - r2(.3, DR) - h2(.10 direct)
+                                        |             |
+                                     r0 also        r3(.1) - h3   (r3 RPFs to r1)
   ```
 
   Scenario: Assert election, join suppression and prune override on LANs
@@ -33,15 +42,19 @@ Feature: PIM assert election and LAN Join/Prune behaviors
     And I create namespace "r0"
     And I create namespace "r1"
     And I create namespace "r2"
+    And I create namespace "r3"
     And I create namespace "h1"
     And I create namespace "h2"
+    And I create namespace "h3"
     And I connect namespace "r0" interface "eth1" to namespace "swa" interface "pa0"
     And I connect namespace "r1" interface "eth1" to namespace "swa" interface "pa1"
     And I connect namespace "r2" interface "eth1" to namespace "swa" interface "pa2"
     And I connect namespace "r1" interface "eth2" to namespace "swb" interface "pb1"
     And I connect namespace "r2" interface "eth2" to namespace "swb" interface "pb2"
-    And I connect namespace "h2" interface "eth0" to namespace "swb" interface "pb3"
+    And I connect namespace "r3" interface "eth1" to namespace "swb" interface "pb3"
+    And I connect namespace "h2" interface "eth0" to namespace "swb" interface "pb4"
     And I connect namespace "r0" interface "eth2" to namespace "h1" interface "eth0"
+    And I connect namespace "r3" interface "eth2" to namespace "h3" interface "eth0"
     And I execute "ip link add bra type bridge mcast_snooping 0" in namespace "swa"
     And I execute "ip link set pa0 master bra" in namespace "swa"
     And I execute "ip link set pa1 master bra" in namespace "swa"
@@ -51,32 +64,37 @@ Feature: PIM assert election and LAN Join/Prune behaviors
     And I execute "ip link set pb1 master brb" in namespace "swb"
     And I execute "ip link set pb2 master brb" in namespace "swb"
     And I execute "ip link set pb3 master brb" in namespace "swb"
+    And I execute "ip link set pb4 master brb" in namespace "swb"
     And I execute "ip link set brb up" in namespace "swb"
     And I start zebra-rs in namespace "r0"
     And I start zebra-rs in namespace "r1"
     And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
     And I apply config "r0.yaml" to namespace "r0"
     And I apply config "r1.yaml" to namespace "r1"
     And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
     And I add address "10.6.0.10/24" to interface "eth0" in namespace "h1"
     And I add address "10.6.2.10/24" to interface "eth0" in namespace "h2"
+    And I add address "10.6.3.10/24" to interface "eth0" in namespace "h3"
 
-    # Full neighborship on the upstream LAN.
-    Then show command "show pim neighbor" in namespace "r0" should eventually contain "10.6.1.2"
-    And show command "show pim neighbor" in namespace "r0" should eventually contain "10.6.1.3"
+    # Full neighborship on the contested LAN and r2 elected DR there.
+    Then show command "show pim neighbor" in namespace "r1" should eventually contain "10.6.2.3"
+    And show command "show pim interface" in namespace "r2" should eventually contain "10.6.2.3"
 
-    # h2 joins (10.6.0.10, 232.6.6.6): both r1 and r2 track the
-    # membership and join toward r0 — each overhears the other's Join
-    # on swA and suppresses its own refresh.
-    When I spawn "timeout 200 python3 tests/scripts/ssm_recv.py 232.6.6.6 10.6.0.10 10.6.2.10 5001 /tmp/pim_assert_rx" in namespace "h2"
+    # Both receivers join. r2 (DR on swB) serves h2 directly; r3 turns
+    # h3's membership into an (S,G) Join toward r1, so r1 forwards onto
+    # swB too. Each router overhears the other's Join on swA.
+    When I spawn "timeout 220 python3 tests/scripts/ssm_recv.py 232.6.6.6 10.6.0.10 10.6.2.10 5001 /tmp/pim_assert_h2" in namespace "h2"
+    And I spawn "timeout 220 python3 tests/scripts/ssm_recv.py 232.6.6.6 10.6.0.10 10.6.3.10 5001 /tmp/pim_assert_h3" in namespace "h3"
     Then show command "show pim upstream" in namespace "r1" should eventually contain "Joined"
     And show command "show pim upstream" in namespace "r2" should eventually contain "Joined"
     And daemon log in namespace "r1" should eventually contain "join suppressed"
     And daemon log in namespace "r2" should eventually contain "join suppressed"
 
-    # The sender starts: both forward onto swB, the duplicates
-    # trigger the assert election, and the higher address (r2) wins.
-    When I spawn "timeout 150 python3 tests/scripts/mcast_send.py 232.6.6.6 5001 10.6.0.10 120" in namespace "h1"
+    # The sender starts: both forward onto swB, the duplicates trigger
+    # the assert election, and the higher address (r2) wins.
+    When I spawn "timeout 180 python3 tests/scripts/mcast_send.py 232.6.6.6 5001 10.6.0.10 150" in namespace "h1"
     Then daemon log in namespace "r1" should eventually contain "assert loser"
     And show command "show pim assert" in namespace "r1" should eventually contain "Loser"
     And show command "show pim assert" in namespace "r1" should contain "10.6.2.3"
@@ -87,20 +105,26 @@ Feature: PIM assert election and LAN Join/Prune behaviors
     And daemon log in namespace "r1" should eventually contain "pruned toward"
     And daemon log in namespace "r2" should eventually contain "prune override"
 
-    # Steady state: r0 still forwards, r2 carries the LAN, h2 receives.
+    # Steady state: r0 still forwards and the assert winner carries
+    # swB for both receivers.
     And command "ip mroute show" in namespace "r0" should eventually contain "Iif: eth2"
-    And command "cat /tmp/pim_assert_rx" in namespace "h2" should eventually contain "ssm-hello"
+    And command "cat /tmp/pim_assert_h2" in namespace "h2" should eventually contain "ssm-hello"
+    And command "cat /tmp/pim_assert_h3" in namespace "h3" should eventually contain "ssm-hello"
 
   Scenario: Teardown topology
-    When I execute "rm -f /tmp/pim_assert_rx" in namespace "h2"
+    When I execute "rm -f /tmp/pim_assert_h2" in namespace "h2"
+    And I execute "rm -f /tmp/pim_assert_h3" in namespace "h3"
     And I stop zebra-rs in namespace "r0"
     And I stop zebra-rs in namespace "r1"
     And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
     And I delete namespace "r0"
     And I delete namespace "r1"
     And I delete namespace "r2"
+    And I delete namespace "r3"
     And I delete namespace "swa"
     And I delete namespace "swb"
     And I delete namespace "h1"
     And I delete namespace "h2"
+    And I delete namespace "h3"
     Then the test environment should be clean

--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -535,7 +535,7 @@ Each phase is one reviewable PR leaving the tree tested and useful.
 
 | Phase | Deliverable | Required proof |
 |---|---|---|
-| 0 | IPv4 correctness floor: DR gating **with `pim_assert` rework**, GenID re-sync, neighbor secondary-address storage/matching, ABI layout tests for existing structs | all seven IPv4 features green (assert feature redesigned, not deleted) |
+| 0 | **DONE** — IPv4 correctness floor: DR gating **with `pim_assert` rework**, GenID re-sync, neighbor secondary-address storage/matching, ABI layout tests for existing structs | all seven IPv4 features green (assert feature redesigned, not deleted) |
 | 1 | Codec groundwork: checksum context API (all emit sites), MLD wire types, exponent encodings, mixed-family rejection, ICMPv6 checksum helper lifted to `packet-utils` | fixture + negative tests; IPv4 fixtures byte-identical |
 | 2 | Supervisor extraction + `Pim<A>`/`Gm<A>`/FP-trait genericization; **IPv4 runtime only** | all IPv4 unit + live BDD unchanged |
 | 3 | `Ipv6` transports: PIMv6 socket, Hello/neighbor/DR over LL | two-router adjacency BDD; invalid-transport negatives |

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -310,7 +310,14 @@ impl Pim {
     /// what was previously synced: INCLUDE source sets become local
     /// (S,G) state; EXCLUDE (any-source) membership becomes local
     /// (*,G) state (SSM-range groups never get (*,G)).
+    ///
+    /// Only the elected DR reflects membership into the TIB (RFC 7761
+    /// §4.3.2). A non-DR keeps full `IgmpIf` state so failover is
+    /// immediate, but presents an empty view here — so a DR→non-DR
+    /// transition withdraws everything and non-DR→DR re-adds it, both
+    /// through the same diff.
     pub(crate) fn igmp_tib_sync(&mut self, ifindex: u32, grp: Ipv4Addr) {
+        let is_dr = self.i_am_dr(ifindex);
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
@@ -320,7 +327,7 @@ impl Pim {
         let Some(group) = igmp.groups.get_mut(&grp) else {
             return;
         };
-        let current: BTreeSet<Ipv4Addr> = if group.filter_mode == FilterMode::Include {
+        let current: BTreeSet<Ipv4Addr> = if is_dr && group.filter_mode == FilterMode::Include {
             group.sources.keys().copied().collect()
         } else {
             BTreeSet::new()
@@ -328,7 +335,8 @@ impl Pim {
         let added: Vec<Ipv4Addr> = current.difference(&group.synced).copied().collect();
         let removed: Vec<Ipv4Addr> = group.synced.difference(&current).copied().collect();
         group.synced = current;
-        let asm_desired = group.filter_mode == FilterMode::Exclude && !super::rp::is_ssm(grp);
+        let asm_desired =
+            is_dr && group.filter_mode == FilterMode::Exclude && !super::rp::is_ssm(grp);
         let asm_was = group.asm_synced;
         group.asm_synced = asm_desired;
         for src in added {

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -443,19 +443,30 @@ impl Pim {
     }
 
     fn hello_packet(&self, link: &PimLink, config: &LinkConfig, holdtime: u16) -> PimPacket {
-        let hello = PimHello {
-            tlvs: vec![
-                HelloTlv::Holdtime(holdtime),
-                HelloTlv::LanPruneDelay {
-                    t_bit: false,
-                    propagation_delay: PIM_PROPAGATION_DELAY_MSEC,
-                    override_interval: PIM_OVERRIDE_INTERVAL_MSEC,
-                },
-                HelloTlv::DrPriority(config.dr_priority()),
-                HelloTlv::GenerationId(link.gen_id),
-            ],
-        };
-        PimPacket::new(PimPayload::Hello(hello))
+        let mut tlvs = vec![
+            HelloTlv::Holdtime(holdtime),
+            HelloTlv::LanPruneDelay {
+                t_bit: false,
+                propagation_delay: PIM_PROPAGATION_DELAY_MSEC,
+                override_interval: PIM_OVERRIDE_INTERVAL_MSEC,
+            },
+            HelloTlv::DrPriority(config.dr_priority()),
+            HelloTlv::GenerationId(link.gen_id),
+        ];
+        // Address List (RFC 7761 §4.3.4): advertise our non-primary
+        // addresses on the link so a neighbor can match an RPF
+        // nexthop that resolves to one of them. The primary (hello
+        // source) is implicit and omitted.
+        let secondary: Vec<pim_packet::EncodedUnicast> = link
+            .addrs
+            .iter()
+            .skip(1)
+            .map(|p| pim_packet::EncodedUnicast::new(std::net::IpAddr::V4(p.addr())))
+            .collect();
+        if !secondary.is_empty() {
+            tlvs.push(HelloTlv::AddressList(secondary));
+        }
+        PimPacket::new(PimPayload::Hello(PimHello { tlvs }))
     }
 
     pub(crate) fn hello_send(&mut self, ifindex: u32) {

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -103,6 +103,15 @@ impl PimLink {
     pub fn is_my_addr(&self, addr: &Ipv4Addr) -> bool {
         self.addrs.iter().any(|p| p.addr() == *addr)
     }
+
+    /// Is `addr` a live PIM neighbor on this link — matching either a
+    /// neighbor's hello source or one of its advertised secondary
+    /// addresses (RFC 7761 §4.3.4)? The RIB's resolved RPF nexthop
+    /// may be any address the neighbor owns, not just its hello
+    /// source.
+    pub fn neighbor_covers(&self, addr: &Ipv4Addr) -> bool {
+        self.nbrs.contains_key(addr) || self.nbrs.values().any(|n| n.secondary.contains(addr))
+    }
 }
 
 fn hello_timer(tx: &tokio::sync::mpsc::UnboundedSender<Message>, ifindex: u32, sec: u16) -> Timer {
@@ -311,6 +320,24 @@ impl Pim {
                 dr
             );
             link.dr = dr;
+            // Only the DR turns local (IGMP) membership into upstream
+            // PIM/OIF state, so a DR change must re-evaluate every
+            // group on this interface (RFC 7761 §4.3.2).
+            self.dr_membership_reeval(ifindex);
+        }
+    }
+
+    /// Push (as DR) or withdraw (as non-DR) the TIB reflection of
+    /// every group learned on this interface, after a DR transition.
+    /// Membership tracking in `IgmpIf` is kept warm regardless, so
+    /// failover is immediate.
+    pub(crate) fn dr_membership_reeval(&mut self, ifindex: u32) {
+        let groups: Vec<Ipv4Addr> = match self.links.get(&ifindex).and_then(|l| l.igmp.as_ref()) {
+            Some(igmp) => igmp.groups.keys().copied().collect(),
+            None => return,
+        };
+        for grp in groups {
+            self.igmp_tib_sync(ifindex, grp);
         }
     }
 

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -299,3 +299,73 @@ impl ForwardingPlane {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Layout of the hand-declared `linux/mroute.h` structs. If the
+    // kernel ABI or our declaration drifts, `MRT_ADD_VIF`/`MRT_ADD_MFC`
+    // would silently corrupt kernel state — assert the wire layout
+    // instead. `vifi_t` is u16 and `MAXVIFS` is 32 on Linux.
+    #[test]
+    fn vifctl_layout() {
+        assert_eq!(std::mem::size_of::<Vifctl>(), 16);
+        assert_eq!(std::mem::offset_of!(Vifctl, vifc_vifi), 0);
+        assert_eq!(std::mem::offset_of!(Vifctl, vifc_flags), 2);
+        assert_eq!(std::mem::offset_of!(Vifctl, vifc_threshold), 3);
+        assert_eq!(std::mem::offset_of!(Vifctl, vifc_rate_limit), 4);
+        assert_eq!(std::mem::offset_of!(Vifctl, vifc_lcl), 8);
+        assert_eq!(std::mem::offset_of!(Vifctl, vifc_rmt_addr), 12);
+    }
+
+    #[test]
+    fn mfcctl_layout() {
+        assert_eq!(std::mem::size_of::<Mfcctl>(), 60);
+        assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_origin), 0);
+        assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_mcastgrp), 4);
+        assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_parent), 8);
+        assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_ttls), 10);
+        // The counters follow the 32-byte TTL array with u32 padding.
+        assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_pkt_cnt), 44);
+        assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_expire), 56);
+        assert_eq!(MAXVIFS, 32);
+    }
+
+    fn upcall_buf(kind: u8, mbz: u8, vif: u16, src: [u8; 4], grp: [u8; 4]) -> [u8; 20] {
+        let mut b = [0u8; 20];
+        b[8] = kind;
+        b[9] = mbz; // im_mbz alias of ip->protocol
+        b[10] = vif as u8;
+        b[11] = (vif >> 8) as u8;
+        b[12..16].copy_from_slice(&src);
+        b[16..20].copy_from_slice(&grp);
+        b
+    }
+
+    #[test]
+    fn parse_upcall_accepts_igmpmsg() {
+        let b = upcall_buf(IGMPMSG_NOCACHE, 0, 3, [10, 0, 0, 2], [232, 1, 1, 1]);
+        let u = parse_upcall(&b).expect("nocache upcall");
+        assert!(matches!(u.kind, UpcallKind::Nocache));
+        assert_eq!(u.vif, 3);
+        assert_eq!(u.src, Ipv4Addr::new(10, 0, 0, 2));
+        assert_eq!(u.grp, Ipv4Addr::new(232, 1, 1, 1));
+    }
+
+    #[test]
+    fn parse_upcall_rejects_real_igmp() {
+        // A genuine IGMP packet has a nonzero protocol byte at [9].
+        let b = upcall_buf(0x16, 2, 0, [0; 4], [0; 4]);
+        assert!(parse_upcall(&b).is_none());
+    }
+
+    #[test]
+    fn parse_upcall_carries_wholepkt_payload() {
+        let mut v = upcall_buf(IGMPMSG_WHOLEPKT, 0, 0, [10, 0, 0, 2], [239, 1, 1, 1]).to_vec();
+        v.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let u = parse_upcall(&v).expect("wholepkt upcall");
+        assert!(matches!(u.kind, UpcallKind::WholePkt));
+        assert_eq!(u.payload, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+}

--- a/zebra-rs/src/pim/neighbor.rs
+++ b/zebra-rs/src/pim/neighbor.rs
@@ -25,6 +25,12 @@ pub struct Neighbor {
     pub gen_id: Option<u32>,
     /// (T bit, propagation delay ms, override interval ms).
     pub lan_prune_delay: Option<(bool, u16, u16)>,
+    /// Secondary addresses from the Hello Address List option
+    /// (RFC 7761 §4.3.4). RPF′ matching must consult these: the RIB's
+    /// resolved nexthop may be any of the neighbor's addresses, not
+    /// just the hello source (mandatory for IPv6, where hellos come
+    /// from link-locals but routes may carry globals).
+    pub secondary: Vec<Ipv4Addr>,
     pub uptime: Instant,
     pub expiry: Option<Timer>,
 }
@@ -68,6 +74,15 @@ impl Pim {
         }
 
         let gen_id = hello.generation_id();
+        let secondary: Vec<Ipv4Addr> = hello
+            .address_list()
+            .unwrap_or(&[])
+            .iter()
+            .filter_map(|a| match a.addr {
+                std::net::IpAddr::V4(v4) => Some(v4),
+                std::net::IpAddr::V6(_) => None,
+            })
+            .collect();
         let timer = expiry_timer(&self.tx, ifindex, src, holdtime);
         let link = self.links.get_mut(&ifindex).unwrap();
         let mut is_new = false;
@@ -78,7 +93,7 @@ impl Pim {
                 if nbr.gen_id != gen_id {
                     // Generation-ID change without an expiry: the
                     // neighbor restarted. Treat as a bounce so its
-                    // uptime and (in later phases) tree state reset.
+                    // uptime resets and the joined state re-syncs.
                     bounced = true;
                     nbr.uptime = Instant::now();
                 }
@@ -86,6 +101,7 @@ impl Pim {
                 nbr.dr_priority = hello.dr_priority();
                 nbr.gen_id = gen_id;
                 nbr.lan_prune_delay = hello.lan_prune_delay();
+                nbr.secondary = secondary.clone();
             })
             .or_insert_with(|| {
                 is_new = true;
@@ -95,6 +111,7 @@ impl Pim {
                     dr_priority: hello.dr_priority(),
                     gen_id,
                     lan_prune_delay: hello.lan_prune_delay(),
+                    secondary,
                     uptime: Instant::now(),
                     expiry: None,
                 }
@@ -115,6 +132,11 @@ impl Pim {
                 src,
                 link.name
             );
+            // RFC 7761 §4.3.1: a GenID change means the neighbor lost
+            // its state — re-introduce ourselves and re-send every
+            // Join that runs through it.
+            self.hello_send(ifindex);
+            self.tib_genid_resync(ifindex, src);
         }
         self.dr_election(ifindex);
     }

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -367,47 +367,65 @@ impl Pim {
 
     // ---- neighbor hooks ----
 
-    /// A new PIM neighbor appeared: entries parked for lack of an
-    /// upstream neighbor on that (interface, address) can join now.
-    pub(crate) fn tib_neighbor_up(&mut self, ifindex: u32, addr: Ipv4Addr) {
-        let keys: Vec<SgKey> = self
-            .tib
+    /// Every gateway entry whose RPF interface is `ifindex`. A
+    /// neighbor change may make or break coverage of a gateway
+    /// nexthop (which can be the neighbor's hello source *or* a
+    /// secondary address), so re-evaluate the whole set and let
+    /// `tib_update`'s coverage check decide join/prune.
+    fn gateway_keys_on(&self, ifindex: u32) -> Vec<SgKey> {
+        self.tib
             .iter()
-            .filter(|(_, e)| {
-                e.join_state == JoinState::NotJoined
-                    && e.rpf
-                        == RpfState::Gateway {
-                            ifindex,
-                            nexthop: addr,
-                        }
-            })
+            .filter(|(_, e)| matches!(e.rpf, RpfState::Gateway { ifindex: i, .. } if i == ifindex))
             .map(|(key, _)| *key)
-            .collect();
-        for key in keys {
+            .collect()
+    }
+
+    /// A new PIM neighbor appeared: entries parked for lack of an
+    /// upstream neighbor on this interface may now join.
+    pub(crate) fn tib_neighbor_up(&mut self, ifindex: u32, _addr: Ipv4Addr) {
+        for key in self.gateway_keys_on(ifindex) {
             self.tib_update(key);
         }
     }
 
-    /// A PIM neighbor vanished: entries joined through it fall back
-    /// to NotJoined (no prune TX — the peer is gone).
-    pub(crate) fn tib_neighbor_down(&mut self, ifindex: u32, addr: Ipv4Addr) {
-        let keys: Vec<SgKey> = self
+    /// A PIM neighbor vanished (already removed from the link's
+    /// table): entries joined through it lose coverage in
+    /// `tib_update` and fall back to NotJoined with no prune TX.
+    pub(crate) fn tib_neighbor_down(&mut self, ifindex: u32, _addr: Ipv4Addr) {
+        for key in self.gateway_keys_on(ifindex) {
+            self.tib_update(key);
+        }
+    }
+
+    /// RFC 7761 §4.3.1: a neighbor's Generation-ID changed, so it
+    /// restarted and lost its downstream Join state. Re-send a Join
+    /// (toward the entry's actual RPF nexthop, which the restarted
+    /// neighbor owns) for every entry joined through that neighbor,
+    /// so its tree is rebuilt without waiting a full refresh period.
+    pub(crate) fn tib_genid_resync(&mut self, ifindex: u32, addr: Ipv4Addr) {
+        let targets: Vec<(SgKey, Ipv4Addr)> = self
             .tib
             .iter()
-            .filter(|(_, e)| {
-                e.rpf
-                    == RpfState::Gateway {
-                        ifindex,
-                        nexthop: addr,
-                    }
+            .filter_map(|(key, e)| match e.rpf {
+                RpfState::Gateway {
+                    ifindex: i,
+                    nexthop,
+                } if i == ifindex
+                    && e.join_state == JoinState::Joined
+                    && (nexthop == addr
+                        || self
+                            .links
+                            .get(&ifindex)
+                            .map(|l| l.neighbor_covers(&nexthop))
+                            .unwrap_or(false)) =>
+                {
+                    Some((*key, nexthop))
+                }
+                _ => None,
             })
-            .map(|(key, _)| *key)
             .collect();
-        for key in keys {
-            if let Some(entry) = self.tib.get_mut(&key) {
-                entry.join_state = JoinState::NotJoined;
-            }
-            self.tib_update(key);
+        for (key, nexthop) in targets {
+            self.jp_send_entry(ifindex, nexthop, key, true);
         }
     }
 
@@ -497,7 +515,7 @@ impl Pim {
             RpfState::Gateway { ifindex, nexthop } => self
                 .links
                 .get(&ifindex)
-                .filter(|l| l.enabled && l.nbrs.contains_key(&nexthop))
+                .filter(|l| l.enabled && l.neighbor_covers(&nexthop))
                 .map(|_| (ifindex, nexthop)),
             _ => None,
         };


### PR DESCRIPTION
## Summary

Phase 0 of the IPv6 PIM/MLD arc (plan: `docs/design/pim-ipv6-architecture.md`). All-IPv4 code — the shared foundation both families will stand on, with **no IPv6 runtime**. Four items from the reviewed plan:

- **DR gating**: only the elected DR reflects IGMP membership into the TIB (`igmp_tib_sync` gates on `i_am_dr`; a DR transition re-evaluates every group via `dr_membership_reeval`). Non-DR routers keep `IgmpIf` state warm for immediate failover; both transition directions flow through the existing `synced`-set diff.
- **`pim_assert` rework**: DR gating collapses the old assert topology to a single forwarder (confirmed live — r1 went unjoined). The new topology gives r1 its OIF from a downstream PIM join (new r3 whose RPF is pinned at r1) while r2 forwards as DR for a direct receiver h2; both forward, the election fires, r2 (higher address) wins, r1 loses/prunes/is overridden exactly as before. **Stronger than the original**: it also asserts the receiver behind the loser's downstream router keeps receiving via the winner. 75 steps.
- **Secondary Address List** (RFC 7761 §4.3.4): `Neighbor` stores the Hello Address-List, we advertise our non-primary addresses, and upstream-neighbor liveness (`neighbor_covers`) + GenID re-sync consult primary **and** secondary. Without this, IPv6 joins never transmit (link-local hello source vs global RIB nexthop) — the blocking IPv6 finding, backported to IPv4 now.
- **GenID re-sync**: a Generation-ID bounce re-sends a Join toward the entry's RPF nexthop for every entry using that neighbor.
- **ABI layout tests**: `Vifctl`/`Mfcctl` size + field offsets pinned to `linux/mroute.h` (16 / 60 bytes) plus `parse_upcall` accept/reject/payload tests — the template for the MRT6 structs. Pim unit tests 6 → 11.

## Test plan

- Live BDD under sudo (fresh binary, md5-checked before and after): all seven PIM features (`adjacency`/`igmp`/`ssm`/`asm`/`assert`/`vrf`/`bsr`) pass in one batch on the DR-gated binary. The six single-forwarder features are unaffected (each router is sole DR on its receiver LAN); `pim_assert` was reworked and is now stronger.
- `cargo test --workspace --exclude bdd`: green. Forced-fresh `clippy -D warnings`: exit 0. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)