### PR TITLE
pim: codec groundwork for IPv6 (Phase 1)

### DIFF
--- a/crates/nd-packet/Cargo.toml
+++ b/crates/nd-packet/Cargo.toml
@@ -9,6 +9,7 @@ description = "Parser and encoder for IPv6 Neighbor Discovery (RFC 4861) Router 
 [dependencies]
 bitflags = "2.6.0"
 bytes = "1.9"
+packet-utils = { path = "../packet-utils" }
 
 [dev-dependencies]
 hex-literal = "1.0"

--- a/crates/nd-packet/src/checksum.rs
+++ b/crates/nd-packet/src/checksum.rs
@@ -1,9 +1,7 @@
 //! ICMPv6 checksum, RFC 4443 §2.3 (pseudo-header form per RFC 8200).
 //!
-//! The pseudo-header sums the IPv6 source + destination addresses,
-//! the upper-layer packet length, and a "next-header = 58" trailer.
-//! The ICMPv6 message itself contributes its full byte stream with
-//! the checksum field treated as zero.
+//! Thin ND-facing wrapper over the shared
+//! [`packet_utils::checksum_v6_pseudo`] with next-header 58 (ICMPv6).
 
 use std::net::Ipv6Addr;
 
@@ -12,47 +10,10 @@ use std::net::Ipv6Addr;
 /// checksum field set to zero — the caller is responsible for that.
 ///
 /// Returns the value to write into the on-wire checksum field
-/// (i.e., already one's-complemented). 0xFFFF is preferred over 0x0000
-/// because a transmitted zero indicates "no checksum" per RFC 768 for
-/// UDP — RFC 4443 §2.3 carries forward the convention.
+/// (already one's-complemented). `0xffff` is preferred over `0x0000`
+/// per RFC 4443 §2.3.
 pub fn compute_icmp6_checksum(src: Ipv6Addr, dst: Ipv6Addr, payload: &[u8]) -> u16 {
-    let mut sum: u32 = 0;
-
-    // Pseudo-header: src (16) + dst (16).
-    sum = sum_be_u16_slice(&src.octets(), sum);
-    sum = sum_be_u16_slice(&dst.octets(), sum);
-
-    // Upper-layer packet length (32-bit BE).
-    let len = payload.len() as u32;
-    sum = sum.wrapping_add(len >> 16);
-    sum = sum.wrapping_add(len & 0xffff);
-
-    // 3 zero bytes + next-header (58 = ICMPv6).
-    sum = sum.wrapping_add(58);
-
-    // Payload, treated as 16-bit BE words.
-    sum = sum_be_u16_slice(payload, sum);
-
-    // Fold 32-bit accumulator into 16 bits.
-    while (sum >> 16) != 0 {
-        sum = (sum & 0xffff) + (sum >> 16);
-    }
-    let folded = !(sum as u16);
-    if folded == 0 { 0xffff } else { folded }
-}
-
-fn sum_be_u16_slice(bytes: &[u8], mut sum: u32) -> u32 {
-    let mut i = 0;
-    while i + 1 < bytes.len() {
-        let word = ((bytes[i] as u32) << 8) | (bytes[i + 1] as u32);
-        sum = sum.wrapping_add(word);
-        i += 2;
-    }
-    if i < bytes.len() {
-        // Odd-byte tail: pad with zero per RFC 1071.
-        sum = sum.wrapping_add((bytes[i] as u32) << 8);
-    }
-    sum
+    packet_utils::checksum_v6_pseudo(src, dst, 58, payload)
 }
 
 #[cfg(test)]
@@ -62,44 +23,20 @@ mod tests {
 
     #[test]
     fn known_router_advert_checksum() {
-        // RA from fe80::1 to ff02::1, type=134 code=0 chksum=0
-        // CurHopLimit=64, M=O=0, RouterLifetime=1800, Reachable=0,
-        // Retrans=0. No options.
-        // ICMPv6 payload (16 bytes):
-        //   86 00 00 00  40 00 07 08  00 00 00 00  00 00 00 00
-        let payload = hex!(
-            "86 00 00 00 40 00 07 08 "
-            "00 00 00 00 00 00 00 00"
-        );
+        // RA from fe80::1 to ff02::1: the self-validation property
+        // (writing the checksum back in yields 0/0xffff) still holds
+        // through the delegated implementation.
+        let payload = hex!("86 00 00 00 40 00 07 08 00 00 00 00 00 00 00 00");
         let src = "fe80::1".parse::<Ipv6Addr>().unwrap();
         let dst = "ff02::1".parse::<Ipv6Addr>().unwrap();
         let cksum = compute_icmp6_checksum(src, dst, &payload);
-
-        // Verifying that recomputing with the checksum written back in
-        // yields zero (the standard self-validation property).
         let mut with_cksum = payload.to_vec();
         with_cksum[2..4].copy_from_slice(&cksum.to_be_bytes());
         let resum = compute_icmp6_checksum(src, dst, &with_cksum);
-        // The verified-checksum property is that summing in the
-        // already-written checksum field flips it to 0 (or 0xffff).
         assert!(
             resum == 0 || resum == 0xffff,
             "self-check failed: {:x}",
             resum
         );
-    }
-
-    #[test]
-    fn odd_length_payload() {
-        // Lengths that aren't a multiple of 2 must still produce a
-        // valid checksum (pad with zero on the last byte).
-        let src = "fe80::1".parse::<Ipv6Addr>().unwrap();
-        let dst = "fe80::2".parse::<Ipv6Addr>().unwrap();
-        // 5 bytes: not realistic ICMPv6 but exercises the odd-byte path.
-        let payload = hex!("86 00 00 00 40");
-        // We just ensure it doesn't panic and returns a non-zero
-        // value for a clearly-non-canonical zero checksum input.
-        let cksum = compute_icmp6_checksum(src, dst, &payload);
-        assert_ne!(cksum, 0);
     }
 }

--- a/crates/packet-utils/src/checksum6.rs
+++ b/crates/packet-utils/src/checksum6.rs
@@ -1,0 +1,96 @@
+//! IPv6 upper-layer checksum with the RFC 8200 §8.1 pseudo-header.
+//!
+//! Shared by every IPv6 upper-layer protocol codec (ICMPv6/ND, MLD,
+//! PIMv6): the pseudo-header sums the source and destination
+//! addresses, the upper-layer packet length, and the next-header
+//! value; the upper-layer message contributes its full byte stream
+//! with its own checksum field treated as zero.
+
+use std::net::Ipv6Addr;
+
+/// Compute the IPv6 upper-layer checksum for `payload` (which must
+/// include the upper-layer header with its checksum field zeroed)
+/// carried between `src` and `dst` with the given `next_header`
+/// (58 = ICMPv6/MLD, 103 = PIM).
+///
+/// Returns the value to write into the on-wire checksum field
+/// (already one's-complemented). `0xffff` is returned instead of
+/// `0x0000` — a transmitted zero means "no checksum" for UDP
+/// (RFC 768), a convention RFC 4443 §2.3 carries forward.
+pub fn checksum_v6_pseudo(src: Ipv6Addr, dst: Ipv6Addr, next_header: u8, payload: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+
+    // Pseudo-header: src (16) + dst (16).
+    sum = sum_be_u16_slice(&src.octets(), sum);
+    sum = sum_be_u16_slice(&dst.octets(), sum);
+
+    // Upper-layer packet length (32-bit BE).
+    let len = payload.len() as u32;
+    sum = sum.wrapping_add(len >> 16);
+    sum = sum.wrapping_add(len & 0xffff);
+
+    // 3 zero bytes + next-header.
+    sum = sum.wrapping_add(next_header as u32);
+
+    // Payload, treated as 16-bit BE words.
+    sum = sum_be_u16_slice(payload, sum);
+
+    // Fold the 32-bit accumulator into 16 bits.
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    let folded = !(sum as u16);
+    if folded == 0 { 0xffff } else { folded }
+}
+
+fn sum_be_u16_slice(bytes: &[u8], mut sum: u32) -> u32 {
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        let word = ((bytes[i] as u32) << 8) | (bytes[i + 1] as u32);
+        sum = sum.wrapping_add(word);
+        i += 2;
+    }
+    if i < bytes.len() {
+        // Odd-byte tail: pad with zero (RFC 1071).
+        sum = sum.wrapping_add((bytes[i] as u32) << 8);
+    }
+    sum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[test]
+    fn icmp6_self_validates() {
+        // RA fe80::1 → ff02::1 (next-header 58).
+        let payload = hex!("86 00 00 00 40 00 07 08 00 00 00 00 00 00 00 00");
+        let src = "fe80::1".parse::<Ipv6Addr>().unwrap();
+        let dst = "ff02::1".parse::<Ipv6Addr>().unwrap();
+        let cksum = checksum_v6_pseudo(src, dst, 58, &payload);
+        let mut with = payload.to_vec();
+        with[2..4].copy_from_slice(&cksum.to_be_bytes());
+        let resum = checksum_v6_pseudo(src, dst, 58, &with);
+        assert!(resum == 0 || resum == 0xffff, "self-check {:x}", resum);
+    }
+
+    #[test]
+    fn next_header_changes_the_sum() {
+        let src = "2001:db8::1".parse::<Ipv6Addr>().unwrap();
+        let dst = "2001:db8::2".parse::<Ipv6Addr>().unwrap();
+        let payload = hex!("20 00 00 00");
+        assert_ne!(
+            checksum_v6_pseudo(src, dst, 58, &payload),
+            checksum_v6_pseudo(src, dst, 103, &payload),
+        );
+    }
+
+    #[test]
+    fn odd_length_payload() {
+        let src = "fe80::1".parse::<Ipv6Addr>().unwrap();
+        let dst = "fe80::2".parse::<Ipv6Addr>().unwrap();
+        let payload = hex!("86 00 00 00 40");
+        assert_ne!(checksum_v6_pseudo(src, dst, 58, &payload), 0);
+    }
+}

--- a/crates/packet-utils/src/lib.rs
+++ b/crates/packet-utils/src/lib.rs
@@ -1,6 +1,7 @@
 mod admin_group;
 mod algo;
 mod bounded_capacity;
+mod checksum6;
 mod many0;
 mod safe_split_at;
 mod sid_label;
@@ -9,6 +10,7 @@ mod util;
 pub use admin_group::*;
 pub use algo::*;
 pub use bounded_capacity::*;
+pub use checksum6::*;
 pub use many0::*;
 pub use safe_split_at::*;
 pub use sid_label::*;

--- a/crates/pim-packet/src/addr.rs
+++ b/crates/pim-packet/src/addr.rs
@@ -60,6 +60,12 @@ fn host_masklen(addr: &IpAddr) -> u8 {
     }
 }
 
+/// The PIM address-family value (`PIM_AF_IPV4`/`PIM_AF_IPV6`) of an
+/// address — used to reject family mixing within a message.
+pub fn addr_family(addr: &IpAddr) -> u8 {
+    family_of(addr)
+}
+
 /// Encoded-Unicast address: family, encoding type, native address.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EncodedUnicast {

--- a/crates/pim-packet/src/checksum.rs
+++ b/crates/pim-packet/src/checksum.rs
@@ -1,44 +1,82 @@
-//! Internet checksum (RFC 1071) helpers for PIM and IGMP.
+//! Internet checksum for PIM and IGMP/MLD.
 //!
-//! IPv4 PIM checksums the whole PIM message, except Register, whose
-//! checksum covers only the first 8 octets (header + flags word) so
-//! the encapsulated data packet is excluded (RFC 7761 §4.9). IGMP
-//! checksums the whole IGMP message. IPv6 PIM adds a pseudo-header —
-//! out of scope until the pim6 arc.
+//! IPv4 PIM checksums the whole PIM message over a plain RFC 1071
+//! sum; IPv6 PIM adds the RFC 8200 pseudo-header (next-header 103).
+//! Register messages, in both families, checksum only the first eight
+//! octets (header + flags word) so the encapsulated data packet is
+//! excluded (RFC 7761 §4.9). IGMP checksums the whole message
+//! plainly; MLD (ICMPv6) uses the pseudo-header (next-header 58).
+
+use std::net::Ipv6Addr;
 
 use internet_checksum::Checksum;
+use packet_utils::checksum_v6_pseudo;
 
 use crate::PimType;
+
+/// PIM is IP protocol 103.
+pub const PIM_NEXT_HEADER: u8 = 103;
 
 /// Register checksum coverage: PIM header (4) + flags word (4).
 const REGISTER_CHECKSUM_LEN: usize = 8;
 
-/// Compute the internet checksum over `data` (checksum field must be
-/// zero in the input). Returns the big-endian bytes to write into the
-/// checksum field.
+/// The address-family context a PIM checksum is computed in. IPv4 is
+/// a plain RFC 1071 sum; IPv6 folds in the pseudo-header, so it needs
+/// the outer source and destination addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PimChecksumContext {
+    Ipv4,
+    Ipv6 { src: Ipv6Addr, dst: Ipv6Addr },
+}
+
+/// Compute the RFC 1071 internet checksum over `data` (checksum field
+/// must be zero in the input). Returns the big-endian bytes to write
+/// into the checksum field.
 pub fn in_checksum(data: &[u8]) -> [u8; 2] {
     let mut cksum = Checksum::new();
     cksum.add_bytes(data);
     cksum.checksum()
 }
 
-/// Verify a received PIM message's checksum. `packet` is the whole
-/// PIM message (IP payload) including the on-wire checksum field.
-/// Register messages are verified over the first 8 octets only.
-pub fn pim_verify_checksum(packet: &[u8]) -> bool {
-    if packet.len() < 4 {
-        return false;
-    }
+/// Checksum coverage of a PIM message: whole message, except Register
+/// which covers only the first eight octets.
+fn pim_region(packet: &[u8]) -> &[u8] {
     let typ = PimType::from(packet[0] & 0x0f);
-    let region = if typ == PimType::Register && packet.len() >= REGISTER_CHECKSUM_LEN {
+    if typ == PimType::Register && packet.len() >= REGISTER_CHECKSUM_LEN {
         &packet[..REGISTER_CHECKSUM_LEN]
     } else {
         packet
-    };
-    in_checksum(region) == [0, 0]
+    }
 }
 
-/// Verify a received IGMP message's checksum over the whole message.
+/// Verify a received PIM message's checksum in its address-family
+/// context. `packet` is the whole PIM message (transport payload)
+/// including the on-wire checksum field.
+///
+/// For IPv6, RFC 7761 §4.9 allows a peer to checksum the entire
+/// Register message (not just the first eight octets); the receive
+/// path accepts either coverage for compatibility.
+pub fn pim_verify_checksum(packet: &[u8], ctx: PimChecksumContext) -> bool {
+    if packet.len() < 4 {
+        return false;
+    }
+    match ctx {
+        PimChecksumContext::Ipv4 => in_checksum(pim_region(packet)) == [0, 0],
+        PimChecksumContext::Ipv6 { src, dst } => {
+            let region = pim_region(packet);
+            // A zero result over the covered region means valid.
+            if checksum_v6_pseudo(src, dst, PIM_NEXT_HEADER, region) == 0xffff {
+                return true;
+            }
+            // Compatibility: a peer that checksummed the whole
+            // Register message.
+            region.len() != packet.len()
+                && checksum_v6_pseudo(src, dst, PIM_NEXT_HEADER, packet) == 0xffff
+        }
+    }
+}
+
+/// Verify a received IGMP message's checksum (plain, whole message).
 pub fn igmp_verify_checksum(packet: &[u8]) -> bool {
     if packet.len() < 4 {
         return false;
@@ -46,16 +84,29 @@ pub fn igmp_verify_checksum(packet: &[u8]) -> bool {
     in_checksum(packet) == [0, 0]
 }
 
+/// Verify a received MLD message's checksum (ICMPv6 pseudo-header,
+/// next-header 58, whole message).
+pub fn mld_verify_checksum(packet: &[u8], src: Ipv6Addr, dst: Ipv6Addr) -> bool {
+    if packet.len() < 4 {
+        return false;
+    }
+    checksum_v6_pseudo(src, dst, 58, packet) == 0xffff
+}
+
 /// Fill the PIM checksum field (bytes 2..4) of an emitted message
-/// sitting at offset 0 of `buf`.
-pub(crate) fn pim_fill_checksum(typ: PimType, buf: &mut [u8]) {
-    let region_end = if typ == PimType::Register && buf.len() >= REGISTER_CHECKSUM_LEN {
-        REGISTER_CHECKSUM_LEN
-    } else {
-        buf.len()
-    };
-    let cksum = in_checksum(&buf[..region_end]);
-    buf[2..4].copy_from_slice(&cksum);
+/// sitting at offset 0 of `buf`, in its address-family context.
+pub(crate) fn pim_fill_checksum(buf: &mut [u8], ctx: PimChecksumContext) {
+    let region_len = pim_region(buf).len();
+    match ctx {
+        PimChecksumContext::Ipv4 => {
+            let cksum = in_checksum(&buf[..region_len]);
+            buf[2..4].copy_from_slice(&cksum);
+        }
+        PimChecksumContext::Ipv6 { src, dst } => {
+            let cksum = checksum_v6_pseudo(src, dst, PIM_NEXT_HEADER, &buf[..region_len]);
+            buf[2..4].copy_from_slice(&cksum.to_be_bytes());
+        }
+    }
 }
 
 /// Fill the IGMP checksum field (bytes 2..4) of an emitted message
@@ -63,4 +114,10 @@ pub(crate) fn pim_fill_checksum(typ: PimType, buf: &mut [u8]) {
 pub(crate) fn igmp_fill_checksum(buf: &mut [u8]) {
     let cksum = in_checksum(buf);
     buf[2..4].copy_from_slice(&cksum);
+}
+
+/// Fill the MLD (ICMPv6) checksum field (bytes 2..4).
+pub(crate) fn mld_fill_checksum(buf: &mut [u8], src: Ipv6Addr, dst: Ipv6Addr) {
+    let cksum = checksum_v6_pseudo(src, dst, 58, buf);
+    buf[2..4].copy_from_slice(&cksum.to_be_bytes());
 }

--- a/crates/pim-packet/src/lib.rs
+++ b/crates/pim-packet/src/lib.rs
@@ -5,12 +5,18 @@ mod disp;
 mod hello;
 mod igmp;
 mod joinprune;
+mod mld;
 mod parser;
+mod timers;
 mod typ;
 
-pub use addr::{EncodedGroup, EncodedSource, EncodedUnicast, PIM_AF_IPV4, PIM_AF_IPV6};
+pub use addr::{
+    EncodedGroup, EncodedSource, EncodedUnicast, PIM_AF_IPV4, PIM_AF_IPV6, addr_family,
+};
 pub use bsr::{BsmGroup, BsmRp, PimBootstrap, PimCandRpAdv};
-pub use checksum::{igmp_verify_checksum, in_checksum, pim_verify_checksum};
+pub use checksum::{
+    PimChecksumContext, igmp_verify_checksum, in_checksum, mld_verify_checksum, pim_verify_checksum,
+};
 pub use hello::{
     HelloTlv, PIM_HELLO_TLV_ADDRESS_LIST, PIM_HELLO_TLV_DR_PRIORITY, PIM_HELLO_TLV_GENERATION_ID,
     PIM_HELLO_TLV_HOLDTIME, PIM_HELLO_TLV_LAN_PRUNE_DELAY, PimHello,
@@ -20,5 +26,10 @@ pub use igmp::{
     IgmpGroupMessage, IgmpGroupRecord, IgmpPacket, IgmpRecordType, IgmpV3Query, IgmpV3Report,
 };
 pub use joinprune::{JpGroup, PimJoinPrune};
+pub use mld::{
+    MLD_QUERY, MLD_V1_DONE, MLD_V1_REPORT, MLD_V2_REPORT, MldGroupMessage, MldGroupRecord,
+    MldPacket, MldV2Query, MldV2Report,
+};
 pub use parser::{PIM_VERSION, PimAssert, PimPacket, PimPayload, PimRegister, PimRegisterStop};
+pub use timers::{code_to_value, code16_to_value, value_to_code};
 pub use typ::PimType;

--- a/crates/pim-packet/src/mld.rs
+++ b/crates/pim-packet/src/mld.rs
@@ -1,0 +1,367 @@
+//! MLD wire formats: MLDv1 (RFC 2710) and MLDv2 (RFC 3810), carried
+//! over ICMPv6. The MLDv2 group-record model is numerically
+//! identical to IGMPv3's, so [`IgmpRecordType`] is reused; only the
+//! addresses widen to `Ipv6Addr` and the on-wire framing differs
+//! (ICMPv6 type/code header, 16-byte addresses, ICMPv6 checksum).
+
+use std::net::Ipv6Addr;
+
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::number::complete::{be_u8, be_u16};
+use packet_utils::ParseBe;
+
+use crate::checksum::mld_fill_checksum;
+use crate::igmp::IgmpRecordType;
+
+/// ICMPv6 type numbers used by MLD.
+pub const MLD_QUERY: u8 = 130;
+pub const MLD_V1_REPORT: u8 = 131;
+pub const MLD_V1_DONE: u8 = 132;
+pub const MLD_V2_REPORT: u8 = 143;
+
+/// An MLDv1 query is exactly 24 octets; a longer query is MLDv2.
+const MLD_V1_QUERY_LEN: usize = 24;
+
+// MLDv2 query S/QRV octet: Resv(4) | S | QRV(3).
+const V2_QUERY_S_FLAG: u8 = 0x08;
+const V2_QUERY_QRV_MASK: u8 = 0x07;
+
+/// The common 24-octet MLD message body (after the ICMPv6
+/// type/code/checksum): MLDv1 query/report/done. `max_resp_code` is
+/// meaningful only for queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MldGroupMessage {
+    pub max_resp_code: u16,
+    pub group: Ipv6Addr,
+}
+
+impl MldGroupMessage {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, max_resp_code) = be_u16(input)?;
+        let (input, _reserved) = be_u16(input)?;
+        let (input, group) = Ipv6Addr::parse_be(input)?;
+        Ok((
+            input,
+            Self {
+                max_resp_code,
+                group,
+            },
+        ))
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.max_resp_code);
+        buf.put_u16(0);
+        buf.put(&self.group.octets()[..]);
+    }
+}
+
+/// MLDv2 membership query (RFC 3810 §5.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MldV2Query {
+    pub max_resp_code: u16,
+    pub group: Ipv6Addr,
+    pub suppress: bool,
+    pub qrv: u8,
+    pub qqic: u8,
+    pub sources: Vec<Ipv6Addr>,
+}
+
+impl MldV2Query {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, max_resp_code) = be_u16(input)?;
+        let (input, _reserved) = be_u16(input)?;
+        let (input, group) = Ipv6Addr::parse_be(input)?;
+        let (input, s_qrv) = be_u8(input)?;
+        let (input, qqic) = be_u8(input)?;
+        let (mut input, num_sources) = be_u16(input)?;
+        let mut sources = Vec::with_capacity(num_sources as usize);
+        for _ in 0..num_sources {
+            let (rest, s) = Ipv6Addr::parse_be(input)?;
+            sources.push(s);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                max_resp_code,
+                group,
+                suppress: s_qrv & V2_QUERY_S_FLAG != 0,
+                qrv: s_qrv & V2_QUERY_QRV_MASK,
+                qqic,
+                sources,
+            },
+        ))
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.max_resp_code);
+        buf.put_u16(0);
+        buf.put(&self.group.octets()[..]);
+        let mut s_qrv = self.qrv & V2_QUERY_QRV_MASK;
+        if self.suppress {
+            s_qrv |= V2_QUERY_S_FLAG;
+        }
+        buf.put_u8(s_qrv);
+        buf.put_u8(self.qqic);
+        buf.put_u16(self.sources.len() as u16);
+        for s in &self.sources {
+            buf.put(&s.octets()[..]);
+        }
+    }
+}
+
+/// MLDv2 multicast address record (RFC 3810 §5.2.4) — the IPv6 twin
+/// of `IgmpGroupRecord`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MldGroupRecord {
+    pub rec_type: IgmpRecordType,
+    pub group: Ipv6Addr,
+    pub sources: Vec<Ipv6Addr>,
+    /// Auxiliary data (multiple of 4 octets), preserved round-trip.
+    pub aux: Vec<u8>,
+}
+
+impl MldGroupRecord {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, rec_type) = be_u8(input)?;
+        let (input, aux_len) = be_u8(input)?;
+        let (input, num_sources) = be_u16(input)?;
+        let (mut input, group) = Ipv6Addr::parse_be(input)?;
+        let mut sources = Vec::with_capacity(num_sources as usize);
+        for _ in 0..num_sources {
+            let (rest, s) = Ipv6Addr::parse_be(input)?;
+            sources.push(s);
+            input = rest;
+        }
+        let (input, aux) = take(aux_len as usize * 4)(input)?;
+        Ok((
+            input,
+            Self {
+                rec_type: rec_type.into(),
+                group,
+                sources,
+                aux: aux.to_vec(),
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.rec_type.into());
+        buf.put_u8((self.aux.len() / 4) as u8);
+        buf.put_u16(self.sources.len() as u16);
+        buf.put(&self.group.octets()[..]);
+        for s in &self.sources {
+            buf.put(&s.octets()[..]);
+        }
+        buf.put(&self.aux[..]);
+    }
+}
+
+/// MLDv2 membership report (RFC 3810 §5.2).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MldV2Report {
+    pub records: Vec<MldGroupRecord>,
+}
+
+impl MldV2Report {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, _reserved) = be_u16(input)?;
+        let (mut input, num_records) = be_u16(input)?;
+        let mut records = Vec::with_capacity(num_records as usize);
+        for _ in 0..num_records {
+            let (rest, r) = MldGroupRecord::parse_be(input)?;
+            records.push(r);
+            input = rest;
+        }
+        Ok((input, Self { records }))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MldPacket {
+    QueryV1(MldGroupMessage),
+    QueryV2(MldV2Query),
+    ReportV1(MldGroupMessage),
+    DoneV1(MldGroupMessage),
+    ReportV2(MldV2Report),
+    Unknown { typ: u8, data: Vec<u8> },
+}
+
+impl MldPacket {
+    pub fn typ(&self) -> u8 {
+        use MldPacket::*;
+        match self {
+            QueryV1(_) | QueryV2(_) => MLD_QUERY,
+            ReportV1(_) => MLD_V1_REPORT,
+            DoneV1(_) => MLD_V1_DONE,
+            ReportV2(_) => MLD_V2_REPORT,
+            Unknown { typ, .. } => *typ,
+        }
+    }
+
+    /// Parse a whole MLD message (the ICMPv6 payload). Checksum
+    /// verification is a separate step (`mld_verify_checksum`).
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let total = input.len();
+        let (rest, typ) = be_u8(input)?;
+        let (rest, _code) = be_u8(rest)?;
+        let (rest, _checksum) = be_u16(rest)?;
+        let (rest, packet) = match typ {
+            MLD_QUERY if total == MLD_V1_QUERY_LEN => {
+                let (rest, m) = MldGroupMessage::parse_be(rest)?;
+                (rest, Self::QueryV1(m))
+            }
+            MLD_QUERY if total > MLD_V1_QUERY_LEN => {
+                let (rest, q) = MldV2Query::parse_be(rest)?;
+                (rest, Self::QueryV2(q))
+            }
+            MLD_V1_REPORT => {
+                let (rest, m) = MldGroupMessage::parse_be(rest)?;
+                (rest, Self::ReportV1(m))
+            }
+            MLD_V1_DONE => {
+                let (rest, m) = MldGroupMessage::parse_be(rest)?;
+                (rest, Self::DoneV1(m))
+            }
+            MLD_V2_REPORT => {
+                let (rest, r) = MldV2Report::parse_be(rest)?;
+                (rest, Self::ReportV2(r))
+            }
+            typ => (
+                &rest[rest.len()..],
+                Self::Unknown {
+                    typ,
+                    data: rest.to_vec(),
+                },
+            ),
+        };
+        Ok((rest, packet))
+    }
+
+    /// Emit the message and fill the ICMPv6 checksum from the outer
+    /// (src, dst). The message must start at offset 0 of `buf`.
+    pub fn emit(&self, buf: &mut BytesMut, src: Ipv6Addr, dst: Ipv6Addr) {
+        use MldPacket::*;
+        buf.put_u8(self.typ());
+        buf.put_u8(0);
+        buf.put_u16(0);
+        match self {
+            QueryV1(m) | ReportV1(m) | DoneV1(m) => m.emit(buf),
+            QueryV2(q) => q.emit(buf),
+            ReportV2(r) => {
+                buf.put_u16(0);
+                buf.put_u16(r.records.len() as u16);
+                for rec in &r.records {
+                    rec.emit(buf);
+                }
+            }
+            Unknown { data, .. } => buf.put(&data[..]),
+        }
+        mld_fill_checksum(buf, src, dst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checksum::mld_verify_checksum;
+
+    const SRC: &str = "fe80::1";
+    const DST: &str = "ff02::16";
+
+    fn round_trip(p: &MldPacket) -> MldPacket {
+        let src: Ipv6Addr = SRC.parse().unwrap();
+        let dst: Ipv6Addr = DST.parse().unwrap();
+        let mut buf = BytesMut::new();
+        p.emit(&mut buf, src, dst);
+        assert!(mld_verify_checksum(&buf, src, dst), "bad checksum");
+        let (rest, parsed) = MldPacket::parse_be(&buf).expect("parse");
+        assert!(rest.is_empty(), "trailing bytes");
+        assert_eq!(&parsed, p);
+        parsed
+    }
+
+    #[test]
+    fn v1_query_report_done() {
+        let g: Ipv6Addr = "ff3e::1234".parse().unwrap();
+        // General query: group unspecified, 24 octets.
+        round_trip(&MldPacket::QueryV1(MldGroupMessage {
+            max_resp_code: 10000,
+            group: Ipv6Addr::UNSPECIFIED,
+        }));
+        round_trip(&MldPacket::ReportV1(MldGroupMessage {
+            max_resp_code: 0,
+            group: g,
+        }));
+        round_trip(&MldPacket::DoneV1(MldGroupMessage {
+            max_resp_code: 0,
+            group: g,
+        }));
+    }
+
+    #[test]
+    fn v2_query_with_sources() {
+        let q = MldV2Query {
+            max_resp_code: 10000,
+            group: "ff3e::1".parse().unwrap(),
+            suppress: false,
+            qrv: 2,
+            qqic: 125,
+            sources: vec![
+                "2001:db8::1".parse().unwrap(),
+                "2001:db8::2".parse().unwrap(),
+            ],
+        };
+        let out = round_trip(&MldPacket::QueryV2(q));
+        let MldPacket::QueryV2(q) = out else {
+            panic!("not v2 query");
+        };
+        assert_eq!(q.qrv, 2);
+        assert_eq!(q.sources.len(), 2);
+    }
+
+    #[test]
+    fn v2_report_all_record_types() {
+        let g: Ipv6Addr = "ff3e::5".parse().unwrap();
+        let s: Ipv6Addr = "2001:db8::9".parse().unwrap();
+        let records = [
+            IgmpRecordType::ModeIsInclude,
+            IgmpRecordType::ModeIsExclude,
+            IgmpRecordType::ChangeToInclude,
+            IgmpRecordType::ChangeToExclude,
+            IgmpRecordType::AllowNewSources,
+            IgmpRecordType::BlockOldSources,
+        ]
+        .into_iter()
+        .map(|rec_type| MldGroupRecord {
+            rec_type,
+            group: g,
+            sources: vec![s],
+            aux: vec![],
+        })
+        .collect();
+        let out = round_trip(&MldPacket::ReportV2(MldV2Report { records }));
+        let MldPacket::ReportV2(r) = out else {
+            panic!("not v2 report");
+        };
+        assert_eq!(r.records.len(), 6);
+        assert_eq!(r.records[0].rec_type, IgmpRecordType::ModeIsInclude);
+    }
+
+    #[test]
+    fn bad_checksum_detected() {
+        let src: Ipv6Addr = SRC.parse().unwrap();
+        let dst: Ipv6Addr = DST.parse().unwrap();
+        let mut buf = BytesMut::new();
+        MldPacket::ReportV1(MldGroupMessage {
+            max_resp_code: 0,
+            group: "ff3e::1".parse().unwrap(),
+        })
+        .emit(&mut buf, src, dst);
+        // A different destination invalidates the pseudo-header sum.
+        assert!(!mld_verify_checksum(&buf, src, "ff02::1".parse().unwrap()));
+    }
+}

--- a/crates/pim-packet/src/parser.rs
+++ b/crates/pim-packet/src/parser.rs
@@ -5,9 +5,9 @@ use nom::error::{ErrorKind, make_error};
 use nom::number::complete::{be_u8, be_u16, be_u32};
 use nom::{Err, IResult};
 
-use crate::addr::{EncodedGroup, EncodedUnicast};
+use crate::addr::{EncodedGroup, EncodedUnicast, addr_family};
 use crate::bsr::{PimBootstrap, PimCandRpAdv};
-use crate::checksum::pim_fill_checksum;
+use crate::checksum::{PimChecksumContext, pim_fill_checksum};
 use crate::hello::PimHello;
 use crate::joinprune::PimJoinPrune;
 use crate::typ::PimType;
@@ -147,6 +147,53 @@ impl PimPayload {
         }
     }
 
+    /// Every encoded address in the payload has family `family`. The
+    /// Register inner packet's IP version (first nibble) is also
+    /// checked against `family`, so an IPv6 Register carrying an
+    /// IPv4 packet is rejected. Hello (which may legitimately carry a
+    /// mix in its Address List only if a router is dual-stacked on a
+    /// link — out of scope) and Unknown are not constrained here.
+    fn family_consistent(&self, family: u8) -> bool {
+        use PimPayload::*;
+        let ip_ver = |data: &[u8]| data.first().map(|b| b >> 4);
+        match self {
+            RegisterStop(m) => {
+                addr_family(&m.group.addr) == family && addr_family(&m.source.addr) == family
+            }
+            JoinPrune(m) => {
+                addr_family(&m.upstream_neighbor.addr) == family
+                    && m.groups.iter().all(|g| {
+                        addr_family(&g.group.addr) == family
+                            && g.joins.iter().all(|s| addr_family(&s.addr) == family)
+                            && g.prunes.iter().all(|s| addr_family(&s.addr) == family)
+                    })
+            }
+            Assert(m) => {
+                addr_family(&m.group.addr) == family && addr_family(&m.source.addr) == family
+            }
+            Register(m) => match ip_ver(&m.data) {
+                // Null-Registers may be empty; a data-carrying
+                // Register's inner IP version must match the family.
+                None => true,
+                Some(4) => family == crate::PIM_AF_IPV4,
+                Some(6) => family == crate::PIM_AF_IPV6,
+                Some(_) => false,
+            },
+            Bootstrap(m) => {
+                addr_family(&m.bsr_addr.addr) == family
+                    && m.groups.iter().all(|g| {
+                        addr_family(&g.group.addr) == family
+                            && g.rps.iter().all(|rp| addr_family(&rp.addr.addr) == family)
+                    })
+            }
+            CandRpAdv(m) => {
+                addr_family(&m.rp_addr.addr) == family
+                    && m.groups.iter().all(|g| addr_family(&g.addr) == family)
+            }
+            Hello(_) | Unknown { .. } => true,
+        }
+    }
+
     fn parse_be(input: &[u8], typ: PimType) -> IResult<&[u8], Self> {
         match typ {
             PimType::Hello => {
@@ -245,34 +292,55 @@ impl PimPacket {
         ))
     }
 
-    /// Emit the message into an empty buffer and fill in the
-    /// checksum. The message must start at offset 0 of `buf`.
-    pub fn emit(&self, buf: &mut BytesMut) {
+    /// Emit the message into an empty buffer and fill in the checksum
+    /// in its address-family context. The message must start at
+    /// offset 0 of `buf`. For IPv4 the context is
+    /// [`PimChecksumContext::Ipv4`]; IPv6 supplies the outer
+    /// (src, dst) for the pseudo-header, so the caller must have
+    /// selected the on-wire source before calling.
+    pub fn emit(&self, buf: &mut BytesMut, ctx: PimChecksumContext) {
         buf.put_u8((self.version << 4) | u8::from(self.typ));
         buf.put_u8(0);
         buf.put_u16(0);
         self.payload.emit(buf);
-        pim_fill_checksum(self.typ, buf);
+        pim_fill_checksum(buf, ctx);
+    }
+
+    /// Every encoded address carried by the message resolves to
+    /// `family` (`PIM_AF_IPV4` / `PIM_AF_IPV6`). A message must not
+    /// mix families: an IPv6 Register may not carry an IPv4 inner
+    /// packet, a BSM may not mix RP families, etc. Callers reject
+    /// a message whose encoded family disagrees with the outer
+    /// transport before applying it to protocol state.
+    pub fn family_consistent(&self, family: u8) -> bool {
+        self.payload.family_consistent(family)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     use hex_literal::hex;
 
     use super::*;
+    use crate::PIM_AF_IPV4;
     use crate::addr::EncodedSource;
     use crate::checksum::pim_verify_checksum;
     use crate::hello::HelloTlv;
 
+    const V4: PimChecksumContext = PimChecksumContext::Ipv4;
+
     fn round_trip(wire: &[u8]) -> PimPacket {
-        assert!(pim_verify_checksum(wire), "fixture checksum invalid");
+        assert!(pim_verify_checksum(wire, V4), "fixture checksum invalid");
         let (rest, packet) = PimPacket::parse_be(wire).expect("parse");
         assert!(rest.is_empty(), "trailing bytes after parse");
+        assert!(
+            packet.family_consistent(PIM_AF_IPV4),
+            "encoded family mismatch"
+        );
         let mut buf = BytesMut::new();
-        packet.emit(&mut buf);
+        packet.emit(&mut buf, V4);
         assert_eq!(&buf[..], wire, "emit does not round-trip");
         packet
     }
@@ -313,8 +381,8 @@ mod tests {
         };
         let packet = PimPacket::new(PimPayload::Hello(hello));
         let mut buf = BytesMut::new();
-        packet.emit(&mut buf);
-        assert!(pim_verify_checksum(&buf));
+        packet.emit(&mut buf, V4);
+        assert!(pim_verify_checksum(&buf, V4));
         let (_, reparsed) = PimPacket::parse_be(&buf).expect("parse");
         assert_eq!(reparsed.payload, packet.payload);
     }
@@ -356,12 +424,13 @@ mod tests {
 
     #[test]
     fn register_checksum_covers_first_8_bytes_only() {
-        // Null bit set, 4 bytes of encapsulated data excluded from
-        // the checksum.
+        // Null bit set; the encapsulated data (a minimal IPv4 inner
+        // header, version nibble 4) is excluded from the checksum,
+        // which therefore stays 0x9eff regardless of the inner bytes.
         let wire = hex!(
             "21 00 9e ff"  // v2 Register, checksum over first 8 bytes
             "40 00 00 00"  // B=0 N=1
-            "de ad be ef"  // encapsulated data (not checksummed)
+            "45 00 00 14"  // inner IPv4 header start (not checksummed)
         );
         let packet = round_trip(&wire);
         let PimPayload::Register(register) = &packet.payload else {
@@ -369,7 +438,7 @@ mod tests {
         };
         assert!(!register.border);
         assert!(register.null_register);
-        assert_eq!(register.data, vec![0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(register.data, vec![0x45, 0x00, 0x00, 0x14]);
     }
 
     #[test]
@@ -468,6 +537,62 @@ mod tests {
         )
         .to_vec();
         wire[5] ^= 0x01;
-        assert!(!pim_verify_checksum(&wire));
+        assert!(!pim_verify_checksum(&wire, V4));
+    }
+
+    #[test]
+    fn ipv6_checksum_round_trip() {
+        // A PIMv6 Hello: emit with the IPv6 context, verify with the
+        // same (src, dst), and confirm a different dst fails.
+        let src: Ipv6Addr = "fe80::1".parse().unwrap();
+        let dst: Ipv6Addr = "ff02::d".parse().unwrap();
+        let ctx = PimChecksumContext::Ipv6 { src, dst };
+        let hello = PimHello {
+            tlvs: vec![HelloTlv::Holdtime(105), HelloTlv::DrPriority(1)],
+        };
+        let packet = PimPacket::new(PimPayload::Hello(hello));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf, ctx);
+        assert!(pim_verify_checksum(&buf, ctx));
+        let bad = PimChecksumContext::Ipv6 {
+            src,
+            dst: "ff02::16".parse().unwrap(),
+        };
+        assert!(!pim_verify_checksum(&buf, bad));
+    }
+
+    #[test]
+    fn mixed_family_rejected() {
+        // An IPv6 Register carrying an IPv4 inner packet must be
+        // rejected against the IPv6 family.
+        use crate::PIM_AF_IPV6;
+        let register = PimRegister {
+            border: false,
+            null_register: false,
+            data: vec![0x45, 0, 0, 20], // IPv4 header (version nibble 4)
+        };
+        let packet = PimPacket::new(PimPayload::Register(register));
+        assert!(!packet.family_consistent(PIM_AF_IPV6));
+        assert!(packet.family_consistent(PIM_AF_IPV4));
+
+        // A Join/Prune whose group is IPv6 but source IPv4 is
+        // internally inconsistent against either family.
+        use crate::JpGroup;
+        use crate::addr::{EncodedGroup, EncodedSource, EncodedUnicast};
+        let jp = {
+            let mut jp = PimJoinPrune::new(
+                EncodedUnicast::new(IpAddr::V6("fe80::1".parse().unwrap())),
+                210,
+            );
+            jp.groups = vec![JpGroup {
+                group: EncodedGroup::new(IpAddr::V6("ff3e::1".parse().unwrap())),
+                joins: vec![EncodedSource::sg(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)))],
+                prunes: vec![],
+            }];
+            jp
+        };
+        let packet = PimPacket::new(PimPayload::JoinPrune(jp));
+        assert!(!packet.family_consistent(PIM_AF_IPV6));
+        assert!(!packet.family_consistent(PIM_AF_IPV4));
     }
 }

--- a/crates/pim-packet/src/timers.rs
+++ b/crates/pim-packet/src/timers.rs
@@ -1,0 +1,102 @@
+//! Exponent-coded time fields shared by IGMPv3 (RFC 3376 §4.1.1,
+//! §4.1.7) and MLDv2 (RFC 3810 §5.1.3, §5.1.9): the Max Response
+//! Code / Max Response Delay and the Querier's Query Interval Code.
+//!
+//! A value below 128 is carried verbatim. From 128 up, the octet is
+//! `0b1EEE_MMMM` and the represented value is
+//! `(0x10 | mant) << (exp + 3)`, extending the range far past the
+//! 8-bit maximum. IGMP times are in units of 1/10 s; MLD Max Resp is
+//! in ms and QQIC in s — the unit is the caller's concern, this is
+//! the raw code↔value transform. MLDv2 Max Resp is 16-bit but uses
+//! the same rule; expose both widths.
+
+/// Decode an 8-bit exponent-coded field (Max Resp / QQIC).
+pub fn code_to_value(code: u8) -> u16 {
+    if code < 128 {
+        code as u16
+    } else {
+        let mant = (code & 0x0f) as u16;
+        let exp = ((code >> 4) & 0x07) as u32;
+        (0x10 | mant) << (exp + 3)
+    }
+}
+
+/// Encode a value into an 8-bit exponent-coded field. Values < 128
+/// pass through; larger values pick the smallest exponent whose
+/// mantissa fits, saturating at the maximum representable code
+/// (`0xff` ≈ 31744).
+pub fn value_to_code(value: u16) -> u8 {
+    if value < 128 {
+        return value as u8;
+    }
+    for exp in 0u32..8 {
+        // value = (0x10 | mant) << (exp + 3), mant in 0..=15.
+        let base = 0x10u32 << (exp + 3);
+        let step = 1u32 << (exp + 3);
+        let v = value as u32;
+        if v < base + 16 * step {
+            let mant = ((v - base) / step).min(15) as u8;
+            return 0x80 | ((exp as u8) << 4) | mant;
+        }
+    }
+    0xff
+}
+
+/// Decode a 16-bit MLDv2 Max Response Code (RFC 3810 §5.1.3): the
+/// same rule with a 12-bit mantissa/exponent split above `0x8000`.
+pub fn code16_to_value(code: u16) -> u32 {
+    if code < 0x8000 {
+        code as u32
+    } else {
+        let mant = (code & 0x0fff) as u32;
+        let exp = ((code >> 12) & 0x07) as u32;
+        (0x1000 | mant) << (exp + 3)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_values_pass_through() {
+        for v in [0u16, 1, 10, 100, 127] {
+            assert_eq!(code_to_value(v as u8), v);
+            assert_eq!(value_to_code(v), v as u8);
+        }
+    }
+
+    #[test]
+    fn exponent_form_round_trips_representable_values() {
+        // Every code >= 128 decodes; re-encoding the decoded value
+        // reproduces the same code (canonical representables).
+        for code in 128u16..=255 {
+            let v = code_to_value(code as u8);
+            assert_eq!(value_to_code(v), code as u8, "code {code:#x} -> {v}");
+        }
+    }
+
+    #[test]
+    fn known_igmp_values() {
+        // RFC 3376: Max Resp Code 0x80 → 128 base? decode check.
+        assert_eq!(code_to_value(0x80), (0x10) << 3); // mant 0, exp 0
+        assert_eq!(code_to_value(0xff), (0x1f) << 10); // mant 15, exp 7
+    }
+
+    #[test]
+    fn large_value_encodes_above_255() {
+        // A 400-decisecond max-resp (40 s) exceeds 8 bits and must
+        // round-trip through the exponent form, not clamp to 255.
+        let code = value_to_code(400);
+        assert!(code >= 128);
+        // Decodes back to a value near 400 (canonical granularity).
+        let v = code_to_value(code);
+        assert!((384..=416).contains(&v), "decoded {v}");
+    }
+
+    #[test]
+    fn code16_matches_8bit_below_threshold() {
+        assert_eq!(code16_to_value(100), 100);
+        assert_eq!(code16_to_value(0x8000), 0x1000 << 3);
+    }
+}

--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -536,7 +536,7 @@ Each phase is one reviewable PR leaving the tree tested and useful.
 | Phase | Deliverable | Required proof |
 |---|---|---|
 | 0 | **DONE** — IPv4 correctness floor: DR gating **with `pim_assert` rework**, GenID re-sync, neighbor secondary-address storage/matching, ABI layout tests for existing structs | all seven IPv4 features green (assert feature redesigned, not deleted) |
-| 1 | Codec groundwork: checksum context API (all emit sites), MLD wire types, exponent encodings, mixed-family rejection, ICMPv6 checksum helper lifted to `packet-utils` | fixture + negative tests; IPv4 fixtures byte-identical |
+| 1 | **DONE** — Codec groundwork: checksum context API (all emit sites), MLD wire types, exponent encodings, mixed-family rejection, ICMPv6 checksum helper lifted to `packet-utils` | fixture + negative tests; IPv4 fixtures byte-identical |
 | 2 | Supervisor extraction + `Pim<A>`/`Gm<A>`/FP-trait genericization; **IPv4 runtime only** | all IPv4 unit + live BDD unchanged |
 | 3 | `Ipv6` transports: PIMv6 socket, Hello/neighbor/DR over LL | two-router adjacency BDD; invalid-transport negatives |
 | 4 | MLDv1/v2 engine via `Gm<Ipv6>` + TIB bridge | querier/compat/source-filter BDD |

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -150,10 +150,14 @@ fn send_query(
     ifindex: u32,
     group: Option<Ipv4Addr>,
 ) {
-    // Max Resp is in units of 1/10 s in both v2 and v3; group-specific
-    // queries use the Last Member Query Interval (1 s).
+    // Max Resp is in units of 1/10 s; group-specific queries use the
+    // Last Member Query Interval (1 s). The exponent-coded form
+    // (pim_packet::value_to_code) represents values past 8 bits
+    // instead of clamping.
     let max_resp = match group {
-        None => (cfg.igmp.query_max_resp() as u32 * 10).min(250) as u8,
+        None => pim_packet::value_to_code(
+            (cfg.igmp.query_max_resp() as u32 * 10).min(u16::MAX as u32) as u16,
+        ),
         Some(_) => 10,
     };
     let dst = group.unwrap_or(IGMP_ALL_HOSTS);
@@ -168,9 +172,8 @@ fn send_query(
             group: group.unwrap_or(Ipv4Addr::UNSPECIFIED),
             suppress: false,
             qrv: IGMP_ROBUSTNESS as u8,
-            // QQIC values >= 128 use exponential encoding; clamp
-            // instead until large intervals are needed.
-            qqic: cfg.igmp.query_interval().min(127) as u8,
+            // QQIC in seconds, exponent-coded above 127.
+            qqic: pim_packet::value_to_code(cfg.igmp.query_interval()),
             sources: vec![],
         })
     };

--- a/zebra-rs/src/pim/network.rs
+++ b/zebra-rs/src/pim/network.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use bytes::BytesMut;
 use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn};
-use pim_packet::{IgmpPacket, PimPacket, igmp_verify_checksum, pim_verify_checksum};
+use pim_packet::{
+    IgmpPacket, PimChecksumContext, PimPacket, igmp_verify_checksum, pim_verify_checksum,
+};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
@@ -62,7 +64,9 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                 }
                 let pim_input = &input[ihl..];
 
-                if !pim_verify_checksum(pim_input) {
+                // This instance is IPv4; the IPv6 read task will pass
+                // the pseudo-header context (Phase 3).
+                if !pim_verify_checksum(pim_input, PimChecksumContext::Ipv4) {
                     tracing::debug!("pim: bad checksum from {} on ifindex {ifindex}", src.ip());
                     return Err(ErrorKind::InvalidData.into());
                 }
@@ -225,7 +229,7 @@ pub async fn igmp_write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedRece
 pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<PimSend>) {
     while let Some(send) = rx.recv().await {
         let mut buf = BytesMut::new();
-        send.packet.emit(&mut buf);
+        send.packet.emit(&mut buf, PimChecksumContext::Ipv4);
 
         let iov = [IoSlice::new(&buf)];
         let sockaddr: SockaddrIn = SocketAddrV4::new(send.dst, 0).into();


### PR DESCRIPTION
## Summary

Phase 1 of the IPv6 PIM/MLD arc (plan: `docs/design/pim-ipv6-architecture.md`; Phase 0 was #2000). Pure `pim-packet`/`packet-utils` codec work — **no IPv6 runtime**. Five plan deliverables:

- **`PimChecksumContext` threaded through every emit/verify site**: `PimPacket::emit(buf, ctx)` and `pim_verify_checksum(packet, ctx)` take `Ipv4` (plain RFC 1071, byte-identical to before) or `Ipv6 { src, dst }` (RFC 8200 pseudo-header, next-header 103). Register 8-octet coverage and the RFC 7761 whole-message compatibility acceptance are both handled. The two daemon call sites pass `Ipv4`.
- **Shared `checksum_v6_pseudo` lifted into `packet-utils`**: `nd-packet`'s `compute_icmp6_checksum` now delegates to it (one implementation, not three); PIM (103) and MLD (58) both reuse it.
- **MLD wire types** (`mld.rs`): MLDv1 query/report/done (RFC 2710) + MLDv2 query/report (RFC 3810) over ICMPv6; MLDv2 records **reuse** the numerically-identical `IgmpRecordType` rather than duplicating it.
- **Mixed outer/encoded family rejection**: `PimPacket::family_consistent` walks every encoded address and the Register inner IP version, so an IPv6 Register carrying an IPv4 inner packet (or a family-mixed BSM) is rejected before touching protocol state.
- **Exponent-coded Max-Resp/QQIC** (`timers.rs`): the RFC 3376 §4.1.1/§4.1.7 (== MLDv2) code↔value transform, shared by both families, replacing the daemon's `.min(127)`/`.min(250)` clamps. Defaults still encode verbatim, so no wire change.

## Test plan

- `cargo test -p pim-packet`: 15 → 26 tests (IPv6 checksum round-trip + wrong-dst rejection, mixed-family rejection, MLD v1/v2 all-record-type round-trips, exponent codec incl. large-value-doesn't-clamp). `packet-utils`/`nd-packet` green.
- IPv4 fixtures byte-identical; `pim_igmp` + `pim_ssm` pass live on the rebuilt binary (md5-checked before/after — the query-code path is exercised).
- `cargo test --workspace --exclude bdd`: green. Forced-fresh `clippy -D warnings`: exit 0. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)