### PR TITLE
ospf-packet: cleanup — remove dead items, dedup SID/Label codec

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -1098,13 +1098,6 @@ impl From<u16> for RouterInfoTlvType {
     }
 }
 
-impl RouterInfoTlvType {
-    pub fn is_known(&self) -> bool {
-        use RouterInfoTlvType::*;
-        matches!(self, Algo | Fad)
-    }
-}
-
 #[derive(Debug, NomBE, Clone, PartialEq)]
 #[nom(Selector = "RouterInfoTlvType")]
 pub enum RouterInfoTlv {

--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -9,7 +9,7 @@ use ipnet::Ipv4Net;
 use nom::bytes::complete::take;
 use nom::error::{ErrorKind, make_error};
 use nom::number::complete::{be_u8, be_u16, be_u24, be_u32};
-use nom::{Err, IResult, Needed};
+use nom::{Err, IResult};
 use nom_derive::*;
 use packet_utils::{Algo, ExtAdminGroup, SidLabelTlv};
 
@@ -1159,29 +1159,13 @@ pub struct RouterInfoTlvSidLabelRange {
     pub sid_label: SidLabelTlv,
 }
 
-/// Parse OSPF SID/Label value after TlvTypeLen (2+2 byte header) has been consumed.
-/// Length 3 = Label (24-bit), Length 4 = Index (32-bit).
-fn parse_ospf_sid_label(input: &[u8], len: u16) -> IResult<&[u8], SidLabelTlv> {
-    match len {
-        3 => {
-            let (input, label) = be_u24(input)?;
-            Ok((input, SidLabelTlv::Label(label)))
-        }
-        4 => {
-            let (input, index) = be_u32(input)?;
-            Ok((input, SidLabelTlv::Index(index)))
-        }
-        _ => Err(Err::Incomplete(Needed::new(len as usize))),
-    }
-}
-
 impl RouterInfoTlvSidLabelRange {
     pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, range) = be_u24(input)?;
         let (input, _reserved) = be_u8(input)?;
         // OSPF Sub-TLV header: 2-byte type + 2-byte length.
         let (input, tl) = TlvTypeLen::parse_be(input)?;
-        let (input, sid_label) = parse_ospf_sid_label(input, tl.len)?;
+        let (input, sid_label) = SidLabelTlv::parse_by_len(input, tl.len as usize)?;
         Ok((input, Self { range, sid_label }))
     }
 }
@@ -1199,7 +1183,7 @@ impl RouterInfoTlvLocalBlock {
         let (input, _reserved) = be_u8(input)?;
         // OSPF Sub-TLV header: 2-byte type + 2-byte length.
         let (input, tl) = TlvTypeLen::parse_be(input)?;
-        let (input, sid_label) = parse_ospf_sid_label(input, tl.len)?;
+        let (input, sid_label) = SidLabelTlv::parse_by_len(input, tl.len as usize)?;
         Ok((input, Self { range, sid_label }))
     }
 }
@@ -1245,24 +1229,13 @@ impl RouterInfoTlv {
 /// Emit an OSPF-style SID/Label sub-TLV (2-byte type + 2-byte length).
 fn emit_ospf_sid_label(buf: &mut BytesMut, sid_label: &SidLabelTlv) {
     buf.put_u16(1); // SID/Label sub-TLV type.
-    match sid_label {
-        SidLabelTlv::Label(v) => {
-            buf.put_u16(3);
-            buf.put(&packet_utils::u32_u8_3(*v)[..]);
-        }
-        SidLabelTlv::Index(v) => {
-            buf.put_u16(4);
-            buf.put_u32(*v);
-        }
-    }
+    buf.put_u16(sid_label.len() as u16);
+    sid_label.emit_value(buf);
 }
 
 /// Return wire length of OSPF SID/Label sub-TLV (4 byte header + value).
 fn ospf_sid_label_len(sid_label: &SidLabelTlv) -> u16 {
-    4 + match sid_label {
-        SidLabelTlv::Label(_) => 3,
-        SidLabelTlv::Index(_) => 4,
-    }
+    4 + sid_label.len() as u16
 }
 
 impl RouterInfoLsa {
@@ -1756,18 +1729,7 @@ impl ExtPrefixSidSubTlv {
         let (input, mt_id) = be_u8(input)?;
         let (input, algo) = Algo::parse_be(input)?;
         // Remaining bytes determine Label (3) vs Index (4).
-        let sid_len = input.len();
-        let (input, sid) = match sid_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => return Err(Err::Incomplete(Needed::new(sid_len))),
-        };
+        let (input, sid) = SidLabelTlv::parse_by_len(input, input.len())?;
         Ok((
             input,
             Self {
@@ -1871,10 +1833,7 @@ impl ExtPrefixSubTlv {
 impl ExtPrefixSidSubTlv {
     fn value_len(&self) -> u16 {
         // flags(1) + reserved(1) + mt_id(1) + algo(1) + sid(3 or 4)
-        4 + match &self.sid {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        4 + self.sid.len() as u16
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -1882,10 +1841,7 @@ impl ExtPrefixSidSubTlv {
         buf.put_u8(0); // reserved
         buf.put_u8(self.mt_id);
         buf.put_u8(self.algo.into());
-        match &self.sid {
-            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
-            SidLabelTlv::Index(v) => buf.put_u32(*v),
-        }
+        self.sid.emit_value(buf);
     }
 }
 
@@ -1992,10 +1948,7 @@ impl ExtLinkSubTlv {
 impl AdjSidSubTlv {
     fn value_len(&self) -> u16 {
         // flags(1) + reserved(1) + mt_id(1) + weight(1) + sid(3 or 4)
-        4 + match &self.sid {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        4 + self.sid.len() as u16
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -2003,20 +1956,14 @@ impl AdjSidSubTlv {
         buf.put_u8(0); // reserved
         buf.put_u8(self.mt_id);
         buf.put_u8(self.weight);
-        match &self.sid {
-            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
-            SidLabelTlv::Index(v) => buf.put_u32(*v),
-        }
+        self.sid.emit_value(buf);
     }
 }
 
 impl LanAdjSidSubTlv {
     fn value_len(&self) -> u16 {
         // flags(1) + reserved(1) + mt_id(1) + weight(1) + neighbor_id(4) + sid(3 or 4)
-        8 + match &self.sid {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        8 + self.sid.len() as u16
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -2025,10 +1972,7 @@ impl LanAdjSidSubTlv {
         buf.put_u8(self.mt_id);
         buf.put_u8(self.weight);
         buf.put(&self.neighbor_id.octets()[..]);
-        match &self.sid {
-            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
-            SidLabelTlv::Index(v) => buf.put_u32(*v),
-        }
+        self.sid.emit_value(buf);
     }
 }
 
@@ -2554,18 +2498,7 @@ impl AdjSidSubTlv {
         let (input, mt_id) = be_u8(input)?;
         let (input, weight) = be_u8(input)?;
         // Remaining bytes determine Label (3) vs Index (4).
-        let sid_len = input.len();
-        let (input, sid) = match sid_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => return Err(Err::Incomplete(Needed::new(sid_len))),
-        };
+        let (input, sid) = SidLabelTlv::parse_by_len(input, input.len())?;
         Ok((
             input,
             Self {
@@ -2596,18 +2529,7 @@ impl LanAdjSidSubTlv {
         let (input, weight) = be_u8(input)?;
         let (input, neighbor_id) = Ipv4Addr::parse_be(input)?;
         // Remaining bytes determine Label (3) vs Index (4).
-        let sid_len = input.len();
-        let (input, sid) = match sid_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => return Err(Err::Incomplete(Needed::new(sid_len))),
-        };
+        let (input, sid) = SidLabelTlv::parse_by_len(input, input.len())?;
         Ok((
             input,
             Self {

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -1651,40 +1651,21 @@ pub struct Ospfv3PrefixSidSubTlv {
 impl Ospfv3PrefixSidSubTlv {
     fn value_len(&self) -> u16 {
         // flags(1) + algo(1) + reserved(2) + sid(3 or 4)
-        4 + match &self.sid {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        4 + self.sid.len() as u16
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags.into());
         buf.put_u8(self.algo.into());
         buf.put_u16(0); // reserved
-        match &self.sid {
-            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
-            SidLabelTlv::Index(v) => buf.put_u32(*v),
-        }
+        self.sid.emit_value(buf);
     }
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, flags) = be_u8(input)?;
         let (input, algo) = be_u8(input)?;
         let (input, _reserved) = be_u16(input)?;
-        let sid_len = input.len();
-        let (input, sid) = match sid_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => {
-                return Err(nom::Err::Incomplete(nom::Needed::new(sid_len)));
-            }
-        };
+        let (input, sid) = SidLabelTlv::parse_by_len(input, input.len())?;
         Ok((
             input,
             Self {
@@ -1713,40 +1694,21 @@ pub struct Ospfv3AdjSidSubTlv {
 impl Ospfv3AdjSidSubTlv {
     fn value_len(&self) -> u16 {
         // flags(1) + weight(1) + reserved(2) + sid(3 or 4)
-        4 + match &self.sid {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        4 + self.sid.len() as u16
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags.into());
         buf.put_u8(self.weight);
         buf.put_u16(0); // reserved
-        match &self.sid {
-            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
-            SidLabelTlv::Index(v) => buf.put_u32(*v),
-        }
+        self.sid.emit_value(buf);
     }
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, flags) = be_u8(input)?;
         let (input, weight) = be_u8(input)?;
         let (input, _reserved) = be_u16(input)?;
-        let sid_len = input.len();
-        let (input, sid) = match sid_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => {
-                return Err(nom::Err::Incomplete(nom::Needed::new(sid_len)));
-            }
-        };
+        let (input, sid) = SidLabelTlv::parse_by_len(input, input.len())?;
         Ok((
             input,
             Self {
@@ -1774,10 +1736,7 @@ pub struct Ospfv3LanAdjSidSubTlv {
 impl Ospfv3LanAdjSidSubTlv {
     fn value_len(&self) -> u16 {
         // flags(1) + weight(1) + reserved(2) + neighbor_router_id(4) + sid(3 or 4)
-        8 + match &self.sid {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        8 + self.sid.len() as u16
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -1785,10 +1744,7 @@ impl Ospfv3LanAdjSidSubTlv {
         buf.put_u8(self.weight);
         buf.put_u16(0); // reserved
         buf.put(&self.neighbor_router_id.octets()[..]);
-        match &self.sid {
-            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
-            SidLabelTlv::Index(v) => buf.put_u32(*v),
-        }
+        self.sid.emit_value(buf);
     }
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
@@ -1796,20 +1752,7 @@ impl Ospfv3LanAdjSidSubTlv {
         let (input, weight) = be_u8(input)?;
         let (input, _reserved) = be_u16(input)?;
         let (input, neighbor_router_id) = Ipv4Addr::parse_be(input)?;
-        let sid_len = input.len();
-        let (input, sid) = match sid_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => {
-                return Err(nom::Err::Incomplete(nom::Needed::new(sid_len)));
-            }
-        };
+        let (input, sid) = SidLabelTlv::parse_by_len(input, input.len())?;
         Ok((
             input,
             Self {
@@ -2145,26 +2088,15 @@ impl Ospfv3SidLabelRangeTlv {
         // range(3) + reserved(1) + sub-TLV header(4) + sub-TLV value
         // (3 or 4 octets, no padding -- callers parse Label vs Index
         // by the sub-TLV's length field exactly).
-        8 + match &self.sid_label {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        8 + self.sid_label.len() as usize
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put(&packet_utils::u32_u8_3(self.range)[..]);
         buf.put_u8(0); // reserved
         buf.put_u16(OSPFV3_SUB_TLV_SID_LABEL);
-        match &self.sid_label {
-            SidLabelTlv::Label(v) => {
-                buf.put_u16(3);
-                buf.put(&packet_utils::u32_u8_3(*v)[..]);
-            }
-            SidLabelTlv::Index(v) => {
-                buf.put_u16(4);
-                buf.put_u32(*v);
-            }
-        }
+        buf.put_u16(self.sid_label.len() as u16);
+        self.sid_label.emit_value(buf);
     }
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
@@ -2172,19 +2104,7 @@ impl Ospfv3SidLabelRangeTlv {
         let (input, _reserved) = be_u8(input)?;
         let (input, _sub_typ) = be_u16(input)?;
         let (input, sub_len) = be_u16(input)?;
-        let (input, sid_label) = match sub_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => {
-                return Err(nom::Err::Incomplete(nom::Needed::new(sub_len as usize)));
-            }
-        };
+        let (input, sid_label) = SidLabelTlv::parse_by_len(input, sub_len as usize)?;
         Ok((input, Self { range, sid_label }))
     }
 }
@@ -2201,26 +2121,15 @@ pub struct Ospfv3SrLocalBlockTlv {
 
 impl Ospfv3SrLocalBlockTlv {
     fn value_len(&self) -> usize {
-        8 + match &self.sid_label {
-            SidLabelTlv::Label(_) => 3,
-            SidLabelTlv::Index(_) => 4,
-        }
+        8 + self.sid_label.len() as usize
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put(&packet_utils::u32_u8_3(self.range)[..]);
         buf.put_u8(0);
         buf.put_u16(OSPFV3_SUB_TLV_SID_LABEL);
-        match &self.sid_label {
-            SidLabelTlv::Label(v) => {
-                buf.put_u16(3);
-                buf.put(&packet_utils::u32_u8_3(*v)[..]);
-            }
-            SidLabelTlv::Index(v) => {
-                buf.put_u16(4);
-                buf.put_u32(*v);
-            }
-        }
+        buf.put_u16(self.sid_label.len() as u16);
+        self.sid_label.emit_value(buf);
     }
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
@@ -2228,19 +2137,7 @@ impl Ospfv3SrLocalBlockTlv {
         let (input, _reserved) = be_u8(input)?;
         let (input, _sub_typ) = be_u16(input)?;
         let (input, sub_len) = be_u16(input)?;
-        let (input, sid_label) = match sub_len {
-            3 => {
-                let (input, label) = be_u24(input)?;
-                (input, SidLabelTlv::Label(label))
-            }
-            4 => {
-                let (input, index) = be_u32(input)?;
-                (input, SidLabelTlv::Index(index))
-            }
-            _ => {
-                return Err(nom::Err::Incomplete(nom::Needed::new(sub_len as usize)));
-            }
-        };
+        let (input, sid_label) = SidLabelTlv::parse_by_len(input, sub_len as usize)?;
         Ok((input, Self { range, sid_label }))
     }
 }

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -2586,23 +2586,6 @@ pub enum Ospfv3ExtTlv {
 }
 
 impl Ospfv3ExtTlv {
-    /// Wire length including the 4-byte TLV header, padded to the
-    /// next 4-byte boundary per RFC 8362 §3.
-    #[allow(dead_code)] // consumed by typed TLV decoders (PR-D2+).
-    fn wire_len(&self) -> usize {
-        let value_len = match self {
-            Ospfv3ExtTlv::RouterLink(t) => t.value_len(),
-            Ospfv3ExtTlv::IntraAreaPrefix(t) => t.value_len(),
-            Ospfv3ExtTlv::SrAlgorithm(t) => t.value_len(),
-            Ospfv3ExtTlv::SidLabelRange(t) => t.value_len(),
-            Ospfv3ExtTlv::SrLocalBlock(t) => t.value_len(),
-            Ospfv3ExtTlv::Fad(t) => t.value_len(),
-            Ospfv3ExtTlv::Srv6Capabilities(t) => t.value_len() as usize,
-            Ospfv3ExtTlv::Unknown { value, .. } => value.len(),
-        };
-        4 + ((value_len + 3) & !3)
-    }
-
     fn emit(&self, buf: &mut BytesMut) {
         let (typ, value_len) = match self {
             Ospfv3ExtTlv::RouterLink(t) => (OSPFV3_EXT_TLV_ROUTER_LINK, t.value_len()),

--- a/crates/packet-utils/src/sid_label.rs
+++ b/crates/packet-utils/src/sid_label.rs
@@ -26,9 +26,33 @@ impl SidLabelTlv {
     pub fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(1); // SID/Label sub-TLV type is always 1.
         buf.put_u8(self.len());
+        self.emit_value(buf);
+    }
+
+    /// Emit just the 3-byte Label / 4-byte Index value, without any TLV header.
+    /// OSPF (RFC 8665/8666) frames the SID/Label with its own 2-byte type +
+    /// 2-byte length header and emits the value via this method.
+    pub fn emit_value(&self, buf: &mut BytesMut) {
         match self {
             SidLabelTlv::Label(v) => buf.put(&u32_u8_3(*v)[..]),
             SidLabelTlv::Index(v) => buf.put_u32(*v),
+        }
+    }
+
+    /// Parse a SID/Label *value* whose length was read from a preceding header
+    /// (3 = 24-bit Label, 4 = 32-bit Index). Used by the OSPF codecs, whose
+    /// sub-TLV framing differs from IS-IS's `parse_sid_label`.
+    pub fn parse_by_len(input: &[u8], len: usize) -> IResult<&[u8], SidLabelTlv> {
+        match len {
+            3 => {
+                let (input, label) = be_u24(input)?;
+                Ok((input, SidLabelTlv::Label(label)))
+            }
+            4 => {
+                let (input, index) = be_u32(input)?;
+                Ok((input, SidLabelTlv::Index(index)))
+            }
+            _ => Err(Err::Incomplete(Needed::new(len))),
         }
     }
 }

--- a/docs/design/ospf-packet-code-review.md
+++ b/docs/design/ospf-packet-code-review.md
@@ -30,8 +30,8 @@ most-severe first.
 | 11 | **Robustness** | `parser.rs:693` | `parse_lsa_with_length` swallows all errors into `Unknown` | ✅ #1990 |
 | 12 | **Correctness** | `parser.rs:422` (+`816`) | v2 emit writes stored `num_adv`/`num_links`, not derived | ✅ #1986 |
 | 13 | **Correctness** | `parser.rs:82` (+`227`) | Unknown v2 payload emit drops body; `typ()` → Hello | ✅ #1998 |
-| 14 | **Cleanup (reuse)** | `parser.rs:618` | Fletcher checksum + FAD/SID codecs duplicated | ⬜ open |
-| 15 | **Cleanup (dead code)** | `parser.rs:1197` (+`1077`, `v3.rs`) | Dead `pub` items add confusing API surface | ⬜ open |
+| 14 | **Cleanup (reuse)** | `parser.rs:618` | Fletcher checksum + FAD/SID codecs duplicated | 🟡 #2005 (SID) |
+| 15 | **Cleanup (dead code)** | `parser.rs:1197` (+`1077`, `v3.rs`) | Dead `pub` items add confusing API surface | ✅ #2005 |
 
 ---
 
@@ -55,6 +55,7 @@ are fixed and merged to `main`. The review document itself landed in #1955.
 | [#1990](https://github.com/zebra-rs/zebra-rs/pull/1990) | 11 | `parse_lsa_with_length` propagates a known-type body-parse error instead of masking it as `Unknown`; unknown types stay tolerant; **validated by `ospfv2_tilfa` BDD** |
 | [#1993](https://github.com/zebra-rs/zebra-rs/pull/1993) | 10 | `verify_checksum` checks received LSAs against their cached wire bytes (`raw`); typed re-emit kept only as the self-originated fallback |
 | [#1998](https://github.com/zebra-rs/zebra-rs/pull/1998) | 13 | `Ospfv2Packet::emit` writes the Unknown payload body; `Ospfv2Payload::typ()` returns the stored type (emit match now exhaustive) |
+| [#2005](https://github.com/zebra-rs/zebra-rs/pull/2005) | 15, 14 (SID) | Removed dead `is_known` / `Ospfv3ExtTlv::wire_len`; deduped ~25 SID/Label dispatch sites onto `packet_utils::SidLabelTlv`; **validated by `ospfv2_tilfa` + `ospfv3_tilfa` BDDs**. Fletcher/FAD hoists deferred. |
 
 Each fix carries a regression test: byte-offset unit tests where a `show`-based
 check could not discriminate the bug, plus live BDD features for the Prefix-SID
@@ -81,13 +82,18 @@ silent interop break in a shipped datapath). Suggested order:
 > Finding 13 (Unknown v2 payload emit) was fixed in
 > [#1998](https://github.com/zebra-rs/zebra-rs/pull/1998).
 
-**Cleanup — low-severity, opportunistic**
-1. **Finding 15 (remainder) — delete dead `pub` items** (`is_known`,
-   `Ospfv3ExtTlv::wire_len`; `RouterInfoTlvUnknown::parse_tlv` was already removed
-   with finding 8). Trivial deletions.
-2. **Finding 14 — hoist duplicated codecs into `packet-utils`** (Fletcher
-   checksum shared with `isis-packet`; FAD and SID/Label dispatch shared v2/v3).
-   Larger refactor; best done the next time those codecs are touched.
+> Finding 15 and the SID/Label-dispatch part of finding 14 were done in
+> [#2005](https://github.com/zebra-rs/zebra-rs/pull/2005).
+
+**Remaining — deferred, opportunistic**
+1. **Finding 14 (remainder) — hoist the Fletcher checksum and FAD codec into
+   `packet-utils`.** The Fletcher `lsa_checksum_calc` is provably the offset-14
+   generalization of `isis-packet`'s offset-12 `checksum_calc`; the FAD Flags /
+   ExcludeSrlg payload codecs are duplicated v2/v3 (admin-group is already
+   shared). Both are cross-crate and touch on-wire checksums / codecs used by
+   OSPFv2, OSPFv3, and IS-IS — best done the next time those codecs are touched,
+   with known-answer tests at both checksum offsets. The SID/Label dispatch part
+   is already done (#2005).
 
 **Additional notes (below the top 15)** — opportunistic:
 - `parser.rs` / `v3.rs` emit: stamp packet length via `try_into`/`checked` so a
@@ -399,6 +405,8 @@ from `typ()`.
 ## Cleanup findings
 
 ### 14. Fletcher checksum + FAD/SID codecs duplicated
+> 🟡 **Partly fixed in [#2005](https://github.com/zebra-rs/zebra-rs/pull/2005)** — the SID/Label dispatch (~25 sites) is deduped onto `packet_utils::SidLabelTlv`. The Fletcher-checksum and FAD-codec hoists remain deferred (cross-crate, checksum-touching).
+
 **`crates/ospf-packet/src/parser.rs:612`**
 
 - `lsa_checksum_calc` re-implements the RFC 1008 Fletcher-with-offset math that
@@ -419,6 +427,8 @@ A fix or hardening applied to one copy silently misses the others, letting v2/v3
 ---
 
 ### 15. Dead `pub` items add confusing API surface
+> ✅ **Fixed in [#2005](https://github.com/zebra-rs/zebra-rs/pull/2005)** — `is_known` and `Ospfv3ExtTlv::wire_len` removed (`parse_tlv` was cleared with #8).
+
 **`crates/ospf-packet/src/parser.rs:1190`** (and `parser.rs:1070`, `v3.rs:2577`)
 
 - `RouterInfoTlvUnknown::parse_tlv` — never wired in (it's the correct fix for


### PR DESCRIPTION
## Summary

Two low-severity cleanup findings from the ospf-packet crate code review (`docs/design/ospf-packet-code-review.md`), one commit each. (Supersedes #2003, which was auto-closed by a branch-delete race during merge.)

**Finding #15 (remainder) — remove dead `pub` items.** Delete `RouterInfoTlvType::is_known` and `Ospfv3ExtTlv::wire_len`, both callerless workspace-wide (the latter kept alive only by a stale `#[allow(dead_code)]`).

**Finding #14 (SID-dispatch part) — dedup SID/Label dispatch.** The SID/Label Label-vs-Index dispatch was re-inlined at ~25 sites across the OSPFv2 and OSPFv3 codecs. Centralize on `packet_utils::SidLabelTlv`: add `parse_by_len` and `emit_value` (both additive), route the crate's own `emit()` through `emit_value`, and replace every inlined parse/value-length/emit site in `parser.rs` and `v3.rs`.

Net −181 lines. Wire behavior unchanged (inlined logic was byte-identical). The Fletcher-checksum and FAD-codec cross-crate hoists in #14 are deferred (review's "when next touched" guidance).

## Test plan

- `cargo test -p ospf-packet -p packet-utils`: all pass (SR sub-TLV round-trip tests are byte-exact).
- `cargo clippy --workspace`: clean (including `isis-packet`, which shares `SidLabelTlv`).
- End-to-end: `ospfv2_tilfa` + `ospfv3_tilfa` BDDs — 20 scenarios / 127 steps, 0 failed.

Generated with [Claude Code](https://claude.com/claude-code)