### PR TITLE
bgp: out-policy delete re-advertises via a clearing PolicyRx on Unregister

### DIFF
--- a/bdd/tests/configs/bgp_out_policy_delete/z1-deny.yaml
+++ b/bdd/tests/configs/bgp_out_policy_delete/z1-deny.yaml
@@ -1,0 +1,27 @@
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          out: DENY-ALL
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_out_policy_delete/z1-nopolicy.yaml
+++ b/bdd/tests/configs/bgp_out_policy_delete/z1-nopolicy.yaml
@@ -1,0 +1,25 @@
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_out_policy_delete/z2.yaml
+++ b/bdd/tests/configs/bgp_out_policy_delete/z2.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_out_policy_delete.feature
+++ b/bdd/tests/features/bgp_out_policy_delete.feature
@@ -1,0 +1,62 @@
+@serial
+@bgp_out_policy_delete
+Feature: Deleting an outbound route-policy re-advertises the suppressed routes
+  As a network operator
+  I want removing a neighbor's `afi-safi ipv4 policy out` binding to
+  re-advertise the routes that policy was suppressing.
+
+  Test Topology:
+  ```
+  z1 (AS65001) ──eBGP── z2 (AS65002)
+  192.168.0.1/24        192.168.0.2/24
+  ```
+  z1 originates 10.0.0.1/32 and 10.0.0.2/32. With `policy out DENY-ALL`
+  bound toward z2, neither reaches z2. Review finding #12: deleting that
+  binding left z1's cached out-policy snapshot still denying everything
+  and never re-advertised — z2 stayed route-less until a new policy name
+  was bound.
+
+  Config files:
+  - z1-deny.yaml: z1 with `afi-safi ipv4 policy out DENY-ALL`.
+  - z1-nopolicy.yaml: same, minus the policy binding (the delete diff).
+  - z2.yaml: plain AS65002 peer.
+
+  Scenario: Setup; the out-policy denies both routes to z2
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-deny.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: Deleting the out-policy re-advertises both routes
+    Given the test topology exists
+    When I apply config "z1-nopolicy.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    # The regression assertion: pre-fix z1's cached snapshot kept
+    # denying, so z2 never saw these; with the fix the unbind pushes a
+    # clearing resolve and soft-out re-advertises.
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: Re-binding the out-policy denies them again
+    Given the test topology exists
+    When I apply config "z1-deny.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-code-review-findings.md
+++ b/docs/design/bgp-code-review-findings.md
@@ -6,7 +6,7 @@ candidate was checked by an independent adversarial verifier that had to name a
 concrete trigger and quote the decisive lines, then a fresh gap sweep added more.
 
 **Result: 34 confirmed correctness bugs + 15 confirmed cleanup items.**
-**Status 2026-07-18: top-11 fixed and merged** (PRs #1962, #1972, #1981,
+**Status 2026-07-18: top-12 fixed and merged** (PRs #1962, #1972, #1981,
 #1984, #1987, #1991, #1997, and the finding-#9 branch); fixes below the
 cap remain open. Three
 candidates were refuted (two vty-disconnect "panics" are guarded by detached
@@ -187,7 +187,7 @@ while the Loc-RIB keeps both paths.** Amplifier: peer-down cleanup
 rows survive even session teardown, stuck in the FIB. Trigger is a
 nonconformant/malicious (attacker-controlled) peer.
 
-### 12. Deleting an out-policy leaves the stale snapshot denying everything — `config.rs:713`
+### 12. Deleting an out-policy leaves the stale snapshot denying everything — `config.rs:713` — FIXED (Unregister now emits a clearing PolicyRx)
 
 `config_afi_safi_policy_out` on Delete only sends `Unregister`, and the policy
 actor emits no `PolicyRx` on `Unregister` (`policy/inst.rs:379`), so neither

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -397,6 +397,42 @@ impl Policy {
                         map.remove(&name);
                     }
                 }
+                // Tell the subscriber it is no longer bound to `name`:
+                // push a resolve reply carrying `None` so it clears any
+                // stale resolved object and soft-reconfigures, exactly
+                // like a `Register` to an undefined name (which already
+                // "always answers, even with None" above). Previously
+                // `Unregister` only dropped the watch, so an out-policy
+                // *delete* left the peer's cached snapshot denying every
+                // prefix and never re-advertised the routes the removed
+                // policy had suppressed (review finding #12). Key-chain
+                // unbinds ride `apply_ao_refresh_all`, not this path, and
+                // the chain is shared config — a `None` here would wrongly
+                // evict it — so they are skipped.
+                let reply = match policy_type {
+                    PolicyType::PrefixSetIn | PolicyType::PrefixSetOut => {
+                        Some(PolicyRx::PrefixSet {
+                            name,
+                            ident,
+                            policy_type,
+                            prefix_set: None,
+                        })
+                    }
+                    PolicyType::PolicyListIn | PolicyType::PolicyListOut | PolicyType::TableMap => {
+                        Some(PolicyRx::PolicyList {
+                            name,
+                            ident,
+                            policy_type,
+                            policy_list: None,
+                        })
+                    }
+                    PolicyType::KeyChain(_) => None,
+                };
+                if let Some(reply) = reply
+                    && let Some(tx) = self.clients.get(&proto)
+                {
+                    let _ = tx.send(reply);
+                }
             }
         }
     }
@@ -633,4 +669,106 @@ pub fn serve(mut policy: Policy) {
     tokio::spawn(async move {
         policy.event_loop().await;
     });
+}
+
+#[cfg(test)]
+mod unregister_reply_tests {
+    use super::*;
+
+    /// Review finding #12: an out-policy *delete* must push a resolve
+    /// reply carrying `None` so the subscriber clears its cached
+    /// snapshot and re-advertises the routes the removed policy had
+    /// suppressed. Previously `Unregister` only dropped the watch, so
+    /// the peer kept denying every prefix forever.
+    #[tokio::test]
+    async fn unregister_policy_list_emits_clearing_reply() {
+        let mut policy = Policy::new();
+        let (tx, mut rx) = mpsc::unbounded_channel::<PolicyRx>();
+        policy
+            .process_msg(Message::Subscribe {
+                proto: "bgp".to_string(),
+                tx,
+            })
+            .await;
+
+        policy
+            .process_msg(Message::Unregister {
+                proto: "bgp".to_string(),
+                name: "DENY-ALL".to_string(),
+                ident: 42,
+                policy_type: PolicyType::PolicyListOut,
+            })
+            .await;
+
+        match rx.try_recv() {
+            Ok(PolicyRx::PolicyList {
+                name,
+                ident,
+                policy_type,
+                policy_list,
+            }) => {
+                assert_eq!(name, "DENY-ALL");
+                assert_eq!(ident, 42);
+                assert_eq!(policy_type, PolicyType::PolicyListOut);
+                assert!(policy_list.is_none(), "unbind resolves to no policy");
+            }
+            other => panic!("expected a clearing PolicyList reply, got {other:?}"),
+        }
+    }
+
+    /// The prefix-set unbind pushes the same clearing reply.
+    #[tokio::test]
+    async fn unregister_prefix_set_emits_clearing_reply() {
+        let mut policy = Policy::new();
+        let (tx, mut rx) = mpsc::unbounded_channel::<PolicyRx>();
+        policy
+            .process_msg(Message::Subscribe {
+                proto: "bgp".to_string(),
+                tx,
+            })
+            .await;
+        policy
+            .process_msg(Message::Unregister {
+                proto: "bgp".to_string(),
+                name: "PS-OUT".to_string(),
+                ident: 7,
+                policy_type: PolicyType::PrefixSetOut,
+            })
+            .await;
+        assert!(
+            matches!(
+                rx.try_recv(),
+                Ok(PolicyRx::PrefixSet {
+                    prefix_set: None,
+                    ..
+                })
+            ),
+            "prefix-set unbind must push a None reply"
+        );
+    }
+
+    /// A key-chain unbind must NOT push a reply — the chain is shared
+    /// config; a `None` here would wrongly evict it, and key-chain
+    /// unbinds ride `apply_ao_refresh_all` instead.
+    #[tokio::test]
+    async fn unregister_key_chain_emits_no_reply() {
+        use crate::policy::KeyChainScope;
+        let mut policy = Policy::new();
+        let (tx, mut rx) = mpsc::unbounded_channel::<PolicyRx>();
+        policy
+            .process_msg(Message::Subscribe {
+                proto: "bgp".to_string(),
+                tx,
+            })
+            .await;
+        policy
+            .process_msg(Message::Unregister {
+                proto: "bgp".to_string(),
+                name: "KC".to_string(),
+                ident: 1,
+                policy_type: PolicyType::KeyChain(KeyChainScope::BgpNeighbor),
+            })
+            .await;
+        assert!(rx.try_recv().is_err(), "key-chain unbind pushes nothing");
+    }
 }


### PR DESCRIPTION
## Summary
Fixes review finding #12 of `docs/design/bgp-code-review-findings.md` (deleting an out-policy leaves the stale snapshot denying everything).

- Deleting a neighbor's `afi-safi <af> policy out <name>` binding sent only `Unregister` to the policy actor, which emitted no `PolicyRx` — so neither `rebuild_out_policy` nor `apply_soft_out_peer` ran on unbind. The peer's cached out-policy snapshot (carried by every `SyncCtx`) kept the resolved DENY-ALL, so v4-unicast egress kept denying every prefix; it survived an FSM bounce, and with the watch gone even editing the policy no longer reached the peer. The neighbor stayed route-less until a new out-policy name was bound.
- Fix: the `Register` path already "always answers, even with None" so a subscriber clears stale state and soft-reconfigures. `Unregister` now does the same — after dropping the watch it pushes a `PolicyRx` carrying `None` for prefix-set / policy-list / table-map types, routing the unbind through the identical `process_policy_msg` path (clear the resolved object, rebuild the snapshot, soft-out re-advertise / soft-in replay). Key-chain unbinds are skipped (shared config; they ride `apply_ao_refresh_all`). Shared with ISIS, which only unregisters KeyChain types and ignores PrefixSet/PolicyList replies — no behavior change there.

## Test plan
- Unit (policy actor): `Unregister` of a policy-list / prefix-set emits a `None`-carrying reply; a key-chain unregister emits nothing.
- BDD `bgp_out_policy_delete` (z1 binds `policy out DENY-ALL`, both routes vanish from z2; deleting the binding must return them), red/green-verified live: on the pre-fix binary z2 stayed route-less (`got: []`) — the exact finding; with the fix the routes return, and re-binding denies them again.
- Full workspace suite (`--exclude bdd`) 39/39 green; workspace clippy (`--all-targets`) clean.

Generated with [Claude Code](https://claude.com/claude-code)