### PR TITLE
pim: genericize state model over PimAf (Phase 2 slice 2a)

### DIFF
--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -537,7 +537,7 @@ Each phase is one reviewable PR leaving the tree tested and useful.
 |---|---|---|
 | 0 | **DONE** — IPv4 correctness floor: DR gating **with `pim_assert` rework**, GenID re-sync, neighbor secondary-address storage/matching, ABI layout tests for existing structs | all seven IPv4 features green (assert feature redesigned, not deleted) |
 | 1 | **DONE** — Codec groundwork: checksum context API (all emit sites), MLD wire types, exponent encodings, mixed-family rejection, ICMPv6 checksum helper lifted to `packet-utils` | fixture + negative tests; IPv4 fixtures byte-identical |
-| 2 | Supervisor extraction + `Pim<A>`/`Gm<A>`/FP-trait genericization; **IPv4 runtime only** | all IPv4 unit + live BDD unchanged |
+| 2 | `Pim<A>`/`Gm<A>`/FP-trait genericization; **IPv4 runtime only**. Landed in compiling slices (see note). | all IPv4 unit + live BDD unchanged |
 | 3 | `Ipv6` transports: PIMv6 socket, Hello/neighbor/DR over LL | two-router adjacency BDD; invalid-transport negatives |
 | 4 | MLDv1/v2 engine via `Gm<Ipv6>` + TIB bridge | querier/compat/source-filter BDD |
 | 5 | `Mrt6` plane + generic RPF + SSM end-to-end | UDPv6 delivery + kernel MIF/MFC asserts (MVP gate) |
@@ -545,6 +545,29 @@ Each phase is one reviewable PR leaving the tree tested and useful.
 | 7 | IPv6 assert + per-VRF `Pim<Ipv6>` | LAN election + VRF isolation BDD |
 | 8 | IPv6 BSR (hash + fragmentation as acceptance criteria) | election/discovery BDD + FRR interop |
 | 9 | Embedded-RP | precedence tests + ASM datapath proof |
+
+### Phase 2 slicing note
+
+Genericizing `Pim` to `Pim<A>` is a big-bang at the module level (every method hangs off
+the god-object), so Phase 2 lands as compiler-verified slices, each keeping IPv4 green,
+consistent with the arc's smallest-safe-slice rule:
+
+- **Slice 2a — data model (DONE).** Introduce `PimAf` (associated `Addr`/`Prefix` only,
+  no methods yet, so nothing is dead) + the `Ipv4` marker impl, and parameterize every
+  state type over `A` with `A = Ipv4` defaults: `SgKey<A>`, `TibEntry<A>`, `RpfState<A>`,
+  `Neighbor<A>`, `AssertMetric/State<A>`, `RpSet<A>`, `BsrConfig/Run<A>`, `IgmpIf/Group<A>`,
+  `PimLink<A>`. All logic stays concrete-IPv4 (methods on `impl Pim` / `impl PimLink<Ipv4>`),
+  byte-identical. Verified: unit tests, `@pim_ssm`/`@pim_asm` live, identical binary md5.
+- **Slice 2b — logic + trait methods.** Add the behavioural methods to `PimAf`
+  (classification, prefix ops, checksum ctx, transports, membership codec) *together with*
+  the generic logic that calls them, flip `Pim` → `Pim<A>` and the `impl` blocks to
+  `impl<A: PimAf>`, extract the `Gm<A>` event engine + `Ipv4` codec, and put the forwarding
+  plane behind `PimForwardingPlane<A>`. Still IPv4-runtime-only.
+
+**Supervisor deferral.** The standalone `PimSupervisor` (§4.1) moves to the start of
+Phase 3: extracting it now — with only IPv4 at runtime and no `Pim<Ipv6>` to route to — is
+ownership churn with no payoff, and it belongs where the AF-split routing first matters.
+The config-manager integration keeps working unchanged through `Pim<Ipv4>` meanwhile.
 
 ### MVP gate — after Phase 5
 

--- a/zebra-rs/src/pim/af.rs
+++ b/zebra-rs/src/pim/af.rs
@@ -1,0 +1,28 @@
+//! The PIM address-family abstraction. The protocol data model is
+//! generic over `A: PimAf`; one `Pim<A>` instance will be
+//! monomorphized per `(VRF, AF)`.
+//!
+//! This first slice carries only the associated address / prefix
+//! types — enough to parameterize every state type over the address
+//! family. The behavioural methods (classification, prefix ops,
+//! checksum context, transports, membership codec) arrive with the
+//! `Pim<A>` monomorphization slice, alongside the generic logic that
+//! calls them, so no trait method is ever dead.
+//!
+//! `ipnet` has no trait unifying `Ipv4Net`/`Ipv6Net`, which is why
+//! prefix behaviour will live on this trait rather than on bounds of
+//! the prefix type. `A` defaults to [`super::ipv4::Ipv4`] everywhere
+//! so the concrete IPv4 engine reads unchanged.
+
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+
+use serde::Serialize;
+
+/// Marker + associated types for one PIM address family.
+pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static {
+    /// A router-wide protocol address (source, group, RP, neighbor).
+    type Addr: Copy + Ord + Eq + Hash + Display + Debug + Send + Sync + Serialize + 'static;
+    /// A multicast / RP group range.
+    type Prefix: Copy + Eq + Ord + Display + Debug + Send + Sync + 'static;
+}

--- a/zebra-rs/src/pim/assert_fsm.rs
+++ b/zebra-rs/src/pim/assert_fsm.rs
@@ -16,7 +16,9 @@ use std::time::{Duration, Instant};
 
 use pim_packet::{EncodedGroup, EncodedUnicast, PimAssert, PimPacket, PimPayload};
 
+use super::af::PimAf;
 use super::inst::{Pim, PimSend};
+use super::ipv4::Ipv4;
 use super::macros::inherited_olist;
 use super::socket::ALL_PIM_ROUTERS;
 use super::tib::SgKey;
@@ -29,17 +31,17 @@ pub const ASSERT_TIME: Duration = Duration::from_secs(180);
 pub const ASSERT_REFRESH: Duration = Duration::from_secs(177);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AssertMetric {
+pub struct AssertMetric<A: PimAf = Ipv4> {
     pub rpt_bit: bool,
     pub pref: u32,
     pub metric: u32,
-    pub addr: Ipv4Addr,
+    pub addr: A::Addr,
 }
 
-impl AssertMetric {
+impl<A: PimAf> AssertMetric<A> {
     /// RFC 7761 §4.6.3: lower (rpt, pref, metric) wins; the higher
     /// address breaks ties.
-    pub fn better_than(&self, other: &AssertMetric) -> bool {
+    pub fn better_than(&self, other: &AssertMetric<A>) -> bool {
         if self.rpt_bit != other.rpt_bit {
             return !self.rpt_bit;
         }
@@ -54,16 +56,16 @@ impl AssertMetric {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AssertRole {
+pub enum AssertRole<A: PimAf = Ipv4> {
     Winner,
-    Loser { winner: Ipv4Addr },
+    Loser { winner: A::Addr },
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct AssertState {
-    pub role: AssertRole,
+pub struct AssertState<A: PimAf = Ipv4> {
+    pub role: AssertRole<A>,
     /// The winning metric (ours as winner, the winner's as loser).
-    pub winner_metric: AssertMetric,
+    pub winner_metric: AssertMetric<A>,
     pub expires: Instant,
 }
 

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -19,7 +19,9 @@ use pim_packet::{
     PimPayload,
 };
 
+use super::af::PimAf;
 use super::inst::{Pim, PimSend};
+use super::ipv4::Ipv4;
 use super::socket::ALL_PIM_ROUTERS;
 
 /// BSM origination period at the elected BSR (RFC 5059 §5).
@@ -34,17 +36,31 @@ const CRP_HOLDTIME: u16 = 150;
 
 const HASH_MASK_LEN: u8 = 10;
 
-#[derive(Debug, Clone, Default)]
-pub struct BsrConfig {
+#[derive(Debug, Clone)]
+pub struct BsrConfig<A: PimAf = Ipv4> {
     /// Candidate-BSR: (advertised address, priority).
-    pub cbsr_addr: Option<Ipv4Addr>,
+    pub cbsr_addr: Option<A::Addr>,
     pub cbsr_priority: Option<u8>,
     pub cbsr_enabled: bool,
     /// Candidate-RP: advertised address + served range + priority.
-    pub crp_addr: Option<Ipv4Addr>,
-    pub crp_group: Option<Ipv4Net>,
+    pub crp_addr: Option<A::Addr>,
+    pub crp_group: Option<A::Prefix>,
     pub crp_priority: Option<u8>,
     pub crp_enabled: bool,
+}
+
+impl<A: PimAf> Default for BsrConfig<A> {
+    fn default() -> Self {
+        Self {
+            cbsr_addr: None,
+            cbsr_priority: None,
+            cbsr_enabled: false,
+            crp_addr: None,
+            crp_group: None,
+            crp_priority: None,
+            crp_enabled: false,
+        }
+    }
 }
 
 impl BsrConfig {
@@ -88,11 +104,11 @@ pub struct BsrRpEntry {
     pub expires: Instant,
 }
 
-#[derive(Debug, Default)]
-pub struct BsrRun {
+#[derive(Debug)]
+pub struct BsrRun<A: PimAf = Ipv4> {
     pub role: Option<BsrRole>,
     /// The domain's current BSR: (priority, address).
-    pub elected: Option<(u8, Ipv4Addr)>,
+    pub elected: Option<(u8, A::Addr)>,
     /// Non-elected: discard the BSR + learned set when this passes.
     pub bsm_expires: Option<Instant>,
     /// Elected only: next scheduled BSM.
@@ -102,9 +118,24 @@ pub struct BsrRun {
     pub fragment_tag: u16,
     /// Learned candidate RPs: (group range, RP address) → entry.
     /// Fed by C-RP advs at the BSR and by BSMs everywhere else.
-    pub rp_set: BTreeMap<(Ipv4Net, Ipv4Addr), BsrRpEntry>,
+    pub rp_set: BTreeMap<(A::Prefix, A::Addr), BsrRpEntry>,
     /// RPF-tracked BSR address (released on BSR change/loss).
-    pub rpf_target: Option<Ipv4Addr>,
+    pub rpf_target: Option<A::Addr>,
+}
+
+impl<A: PimAf> Default for BsrRun<A> {
+    fn default() -> Self {
+        Self {
+            role: None,
+            elected: None,
+            bsm_expires: None,
+            originate_next: None,
+            crp_next: None,
+            fragment_tag: 0,
+            rp_set: BTreeMap::new(),
+            rpf_target: None,
+        }
+    }
 }
 
 impl BsrRun {

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -13,7 +13,9 @@ use std::time::{Duration, Instant};
 use pim_packet::{IgmpGroupMessage, IgmpGroupRecord, IgmpPacket, IgmpRecordType, IgmpV3Query};
 use tokio::sync::mpsc::UnboundedSender;
 
+use super::af::PimAf;
 use super::inst::{IgmpSend, Pim};
+use super::ipv4::Ipv4;
 use super::link::LinkConfig;
 use super::socket::IGMP_ALL_HOSTS;
 use super::tib::SgKey;
@@ -81,26 +83,26 @@ pub enum FilterMode {
     Exclude,
 }
 
-pub struct IgmpGroup {
+pub struct IgmpGroup<A: PimAf = Ipv4> {
     pub filter_mode: FilterMode,
     /// Group timer — EXCLUDE mode only (RFC 3376 §6.5).
     pub expires: Option<Instant>,
     /// INCLUDE sources with their source timers.
-    pub sources: BTreeMap<Ipv4Addr, Instant>,
+    pub sources: BTreeMap<A::Addr, Instant>,
     /// Older-version-host-present: a v1/v2 report was heard; while
     /// running, v3 source semantics are suspended for the group.
     pub v2_host_until: Option<Instant>,
-    pub last_reporter: Option<Ipv4Addr>,
+    pub last_reporter: Option<A::Addr>,
     pub uptime: Instant,
     /// Sources currently reflected into the TIB as local (S,G)
     /// membership — the diff base for [`Pim::igmp_tib_sync`].
-    pub synced: BTreeSet<Ipv4Addr>,
+    pub synced: BTreeSet<A::Addr>,
     /// Any-source (EXCLUDE) membership currently reflected into the
     /// TIB as local (*,G) state.
     pub asm_synced: bool,
 }
 
-impl IgmpGroup {
+impl<A: PimAf> IgmpGroup<A> {
     fn new(now: Instant, filter_mode: FilterMode) -> Self {
         Self {
             filter_mode,
@@ -116,23 +118,23 @@ impl IgmpGroup {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QuerierState {
+pub enum QuerierState<A: PimAf = Ipv4> {
     Querier,
-    NonQuerier { querier: Ipv4Addr, until: Instant },
+    NonQuerier { querier: A::Addr, until: Instant },
 }
 
 /// Runtime IGMP state for one interface, present while IGMP is
 /// enabled and the interface is usable.
-pub struct IgmpIf {
-    pub querier: QuerierState,
+pub struct IgmpIf<A: PimAf = Ipv4> {
+    pub querier: QuerierState<A>,
     /// Startup general queries left to send at the startup interval.
     startup_remaining: u8,
     /// Next general-query transmission (meaningful as Querier only).
     next_query: Instant,
-    pub groups: BTreeMap<Ipv4Addr, IgmpGroup>,
+    pub groups: BTreeMap<A::Addr, IgmpGroup<A>>,
 }
 
-impl IgmpIf {
+impl<A: PimAf> IgmpIf<A> {
     pub fn new(now: Instant) -> Self {
         Self {
             querier: QuerierState::Querier,

--- a/zebra-rs/src/pim/ipv4.rs
+++ b/zebra-rs/src/pim/ipv4.rs
@@ -1,0 +1,20 @@
+//! The IPv4 [`PimAf`] marker. This slice sets only the associated
+//! address / prefix types; the behavioural methods land with the
+//! `Pim<A>` monomorphization.
+
+use std::net::Ipv4Addr;
+
+use ipnet::Ipv4Net;
+
+use super::af::PimAf;
+
+/// IPv4 address-family marker. The ordering / hash / default derives
+/// are what let `#[derive(Ord, Hash, Default)]` on the generic data
+/// types (which add an `A: …` bound) resolve for `A = Ipv4`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Ipv4;
+
+impl PimAf for Ipv4 {
+    type Addr = Ipv4Addr;
+    type Prefix = Ipv4Net;
+}

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -4,15 +4,17 @@
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
-use ipnet::{IpNet, Ipv4Net};
+use ipnet::IpNet;
 use rand::RngExt;
 
 use crate::context::Timer;
 use crate::rib::Link;
 use crate::rib::link::LinkAddr;
 
+use super::af::PimAf;
 use super::igmp::{IgmpConfig, IgmpIf};
 use super::inst::{Message, Pim};
+use super::ipv4::Ipv4;
 use super::neighbor::Neighbor;
 use super::socket::{igmp_join_if, igmp_leave_if, pim_join_if, pim_leave_if};
 
@@ -54,25 +56,25 @@ impl LinkConfig {
 }
 
 /// Runtime per-interface state, keyed by ifindex in [`Pim::links`].
-pub struct PimLink {
+pub struct PimLink<A: PimAf = Ipv4> {
     pub ifindex: u32,
     pub name: String,
     pub link_up: bool,
-    /// IPv4 addresses on the link; the first is the primary address
+    /// Family addresses on the link; the first is the primary address
     /// used as our Hello source identity and DR candidate.
-    pub addrs: Vec<Ipv4Net>,
+    pub addrs: Vec<A::Prefix>,
     /// PIM is running on this interface (group joined, hello timer
     /// armed). Derived state — see [`Pim::reconcile`].
     pub enabled: bool,
     pub gen_id: u32,
-    pub dr: Option<Ipv4Addr>,
-    pub nbrs: BTreeMap<Ipv4Addr, Neighbor>,
+    pub dr: Option<A::Addr>,
+    pub nbrs: BTreeMap<A::Addr, Neighbor<A>>,
     pub hello_timer: Option<Timer>,
     /// IGMP runtime state — `Some` while IGMP runs on this interface.
-    pub igmp: Option<IgmpIf>,
+    pub igmp: Option<IgmpIf<A>>,
 }
 
-impl PimLink {
+impl PimLink<Ipv4> {
     pub fn from_link(link: &Link) -> Self {
         let addrs = link
             .addr4

--- a/zebra-rs/src/pim/macros.rs
+++ b/zebra-rs/src/pim/macros.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn olist_combines_local_and_downstream() {
-        let mut tib = BTreeMap::new();
+        let mut tib: BTreeMap<SgKey, TibEntry> = BTreeMap::new();
         let mut e = TibEntry::new();
         e.local.insert(3);
         e.downstream.insert(5, ds_join());
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn prune_pending_still_forwards() {
-        let mut tib = BTreeMap::new();
+        let mut tib: BTreeMap<SgKey, TibEntry> = BTreeMap::new();
         let mut e = TibEntry::new();
         e.downstream.insert(
             5,
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn inherited_folds_shared_tree_minus_rpt_prunes() {
-        let mut tib = BTreeMap::new();
+        let mut tib: BTreeMap<SgKey, TibEntry> = BTreeMap::new();
         // (S,G): downstream on 5.
         let mut e = TibEntry::new();
         e.downstream.insert(5, ds_join());
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn lost_assert_excluded_from_forwarding_and_jd() {
         use crate::pim::assert_fsm::{AssertMetric, AssertRole, AssertState};
-        let mut tib = BTreeMap::new();
+        let mut tib: BTreeMap<SgKey, TibEntry> = BTreeMap::new();
         let mut e = TibEntry::new();
         e.local.insert(5);
         e.asserts.insert(
@@ -214,7 +214,8 @@ mod tests {
     #[test]
     fn assert_metric_ordering() {
         use crate::pim::assert_fsm::AssertMetric;
-        let base = AssertMetric {
+        use crate::pim::ipv4::Ipv4;
+        let base = AssertMetric::<Ipv4> {
             rpt_bit: false,
             pref: 100,
             metric: 10,
@@ -241,7 +242,7 @@ mod tests {
 
     #[test]
     fn mfc_excludes_iif() {
-        let mut tib = BTreeMap::new();
+        let mut tib: BTreeMap<SgKey, TibEntry> = BTreeMap::new();
         let mut e = TibEntry::new();
         e.local.insert(3);
         e.local.insert(7);

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -1,11 +1,19 @@
-//! PIM-SM (RFC 7761). Phase 2: instance skeleton — Hello, neighbors,
-//! DR election. Architecture: docs/design/pim-sm-ssm-architecture.md.
+//! PIM-SM (RFC 7761). Architecture:
+//! docs/design/pim-sm-ssm-architecture.md and (IPv6 arc)
+//! docs/design/pim-ipv6-architecture.md.
+//!
+//! The protocol data model is generic over the address family
+//! ([`af::PimAf`]); the type parameter defaults to [`ipv4::Ipv4`] so
+//! the concrete IPv4 engine reads unchanged while the IPv6 arc
+//! monomorphizes a second instance.
 
+pub mod af;
 pub mod assert_fsm;
 pub mod bsr;
 pub mod config;
 pub mod igmp;
 pub mod inst;
+pub mod ipv4;
 pub mod jp;
 pub mod link;
 pub mod macros;

--- a/zebra-rs/src/pim/neighbor.rs
+++ b/zebra-rs/src/pim/neighbor.rs
@@ -9,7 +9,9 @@ use pim_packet::PimHello;
 
 use crate::context::Timer;
 
+use super::af::PimAf;
 use super::inst::{Message, Pim};
+use super::ipv4::Ipv4;
 
 /// RFC 7761: a holdtime of 0xffff means "never time out".
 const HOLDTIME_INFINITE: u16 = 0xffff;
@@ -18,8 +20,8 @@ const HOLDTIME_INFINITE: u16 = 0xffff;
 /// 3.5 × the default 30 s hello period.
 const HOLDTIME_DEFAULT: u16 = 105;
 
-pub struct Neighbor {
-    pub addr: Ipv4Addr,
+pub struct Neighbor<A: PimAf = Ipv4> {
+    pub addr: A::Addr,
     pub holdtime: u16,
     pub dr_priority: Option<u32>,
     pub gen_id: Option<u32>,
@@ -30,7 +32,7 @@ pub struct Neighbor {
     /// resolved nexthop may be any of the neighbor's addresses, not
     /// just the hello source (mandatory for IPv6, where hellos come
     /// from link-locals but routes may carry globals).
-    pub secondary: Vec<Ipv4Addr>,
+    pub secondary: Vec<A::Addr>,
     pub uptime: Instant,
     pub expiry: Option<Timer>,
 }

--- a/zebra-rs/src/pim/rp.rs
+++ b/zebra-rs/src/pim/rp.rs
@@ -7,7 +7,9 @@ use std::net::Ipv4Addr;
 
 use ipnet::Ipv4Net;
 
+use super::af::PimAf;
 use super::inst::Pim;
+use super::ipv4::Ipv4;
 use super::tib::SgKey;
 
 /// Default SSM range (RFC 4607): no RP, no register, (S,G) only.
@@ -20,9 +22,17 @@ pub fn is_ssm(grp: Ipv4Addr) -> bool {
 }
 
 /// Static RP table: RP address → served group range.
-#[derive(Debug, Clone, Default)]
-pub struct RpSet {
-    pub statics: BTreeMap<Ipv4Addr, Ipv4Net>,
+#[derive(Debug, Clone)]
+pub struct RpSet<A: PimAf = Ipv4> {
+    pub statics: BTreeMap<A::Addr, A::Prefix>,
+}
+
+impl<A: PimAf> Default for RpSet<A> {
+    fn default() -> Self {
+        Self {
+            statics: BTreeMap::new(),
+        }
+    }
 }
 
 impl Pim {

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -9,11 +9,13 @@ use std::net::{IpAddr, Ipv4Addr};
 use crate::rib;
 use crate::rib::nht::NexthopResolution;
 
+use super::af::PimAf;
 use super::inst::Pim;
+use super::ipv4::Ipv4;
 use super::tib::SgKey;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RpfState {
+pub enum RpfState<A: PimAf = Ipv4> {
     Unresolved,
     /// The source is on-link: no upstream neighbor, no Join to send.
     Connected {
@@ -23,11 +25,11 @@ pub enum RpfState {
     /// address is a live PIM neighbor there.
     Gateway {
         ifindex: u32,
-        nexthop: Ipv4Addr,
+        nexthop: A::Addr,
     },
 }
 
-impl RpfState {
+impl<A: PimAf> RpfState<A> {
     pub fn ifindex(&self) -> Option<u32> {
         match self {
             RpfState::Unresolved => None,
@@ -36,8 +38,8 @@ impl RpfState {
     }
 }
 
-pub struct RpfEntry {
-    pub state: RpfState,
+pub struct RpfEntry<A: PimAf = Ipv4> {
+    pub state: RpfState<A>,
     refs: usize,
     resolution: Option<NexthopResolution>,
 }

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -18,8 +18,10 @@ use std::fmt;
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
+use super::af::PimAf;
 use super::assert_fsm::AssertState;
 use super::inst::Pim;
+use super::ipv4::Ipv4;
 use super::macros::{inherited_effective, inherited_olist, join_desired_effective, mfc_oifs};
 use super::mroute::{REG_VIF, Upcall, UpcallKind};
 use super::rpf::RpfState;
@@ -36,25 +38,25 @@ pub const KEEPALIVE_PERIOD: Duration = Duration::from_secs(210);
 pub const PRUNE_PENDING_DELAY: Duration = Duration::from_millis(3000);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SgKey {
+pub enum SgKey<A: PimAf = Ipv4> {
     /// Shared-tree state rooted at RP(G).
-    StarG { grp: Ipv4Addr },
+    StarG { grp: A::Addr },
     /// Source-tree state.
-    Sg { src: Ipv4Addr, grp: Ipv4Addr },
+    Sg { src: A::Addr, grp: A::Addr },
     /// Source pruned off the shared tree (downstream prune records;
     /// the upstream side rides the (*,G) refresh).
-    SgRpt { src: Ipv4Addr, grp: Ipv4Addr },
+    SgRpt { src: A::Addr, grp: A::Addr },
 }
 
-impl SgKey {
-    pub fn grp(&self) -> Ipv4Addr {
+impl<A: PimAf> SgKey<A> {
+    pub fn grp(&self) -> A::Addr {
         match self {
             SgKey::StarG { grp } | SgKey::Sg { grp, .. } | SgKey::SgRpt { grp, .. } => *grp,
         }
     }
 }
 
-impl fmt::Display for SgKey {
+impl<A: PimAf> fmt::Display for SgKey<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SgKey::StarG { grp } => write!(f, "(*, {})", grp),
@@ -108,15 +110,15 @@ pub struct InstalledMfc {
     pub oifs: Vec<u16>,
 }
 
-pub struct TibEntry {
+pub struct TibEntry<A: PimAf = Ipv4> {
     pub join_state: JoinState,
     /// RPF snapshot this entry currently operates on; refreshed by
     /// `tib_rpf_change` so a change can prune the old upstream first.
-    pub rpf: RpfState,
+    pub rpf: RpfState<A>,
     /// Address the RPF tracking follows: the source for (S,G), RP(G)
     /// for (*,G). `None` for (S,G,rpt) (no upstream of its own) and
     /// for (*,G) without a known RP.
-    pub rpf_target: Option<Ipv4Addr>,
+    pub rpf_target: Option<A::Addr>,
     /// Interfaces with local IGMP membership ((S,G) INCLUDE sources
     /// on Sg entries; EXCLUDE/any-source membership on StarG).
     pub local: BTreeSet<u32>,
@@ -124,7 +126,7 @@ pub struct TibEntry {
     /// entries presence means "rpt-pruned on this interface".
     pub downstream: BTreeMap<u32, Downstream>,
     /// Assert election state per contested interface (Sg entries).
-    pub asserts: BTreeMap<u32, AssertState>,
+    pub asserts: BTreeMap<u32, AssertState<A>>,
     /// Kernel MFC shadow — `Some` while installed (Sg entries only).
     pub installed: Option<InstalledMfc>,
     /// Keepalive deadline for traffic-created state (NOCACHE at any
@@ -138,7 +140,7 @@ pub struct TibEntry {
     pub uptime: Instant,
 }
 
-impl TibEntry {
+impl<A: PimAf> TibEntry<A> {
     pub fn new() -> Self {
         Self {
             join_state: JoinState::NotJoined,
@@ -156,7 +158,7 @@ impl TibEntry {
     }
 }
 
-impl Default for TibEntry {
+impl<A: PimAf> Default for TibEntry<A> {
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
## Summary

First slice of IPv6 Phase 2: introduce the `PimAf` address-family trait and make the PIM **state model** generic over it, while keeping IPv4 the only runtime address family. Genericizing the `Pim` god-object is an inherently module-wide change, so — consistent with this arc's smallest-safe-slice discipline — Phase 2 lands in slices, each keeping IPv4 green:

- **Slice 2a (this PR)** — data model only.
- **Slice 2b (next)** — the trait's behavioural methods + the `Pim<A>` flip + generic logic (`Gm<A>` engine, `PimForwardingPlane<A>`).

### What changed
- New `PimAf` trait (`af.rs`) carrying only associated `Addr`/`Prefix` types — **no methods yet**, so nothing is dead-code under `-D warnings`.
- New `Ipv4` marker impl (`ipv4.rs`).
- Every state type parameterized over `A` with an `A = Ipv4` default: `SgKey<A>`, `TibEntry<A>`, `RpfState/RpfEntry<A>`, `Neighbor<A>`, `AssertMetric/Role/State<A>`, `RpSet<A>`, `BsrConfig/Run<A>`, `IgmpIf/Group<A>/QuerierState<A>`, `PimLink<A>`.

The `A = Ipv4` defaults let all concrete IPv4 logic (`impl Pim`, `impl PimLink<Ipv4>`) read unchanged — this is a **types-only refactor with byte-identical runtime behavior**.

### Notes
- `ipnet` exposes no common prefix trait over `Ipv4Net`/`Ipv6Net`, so `Prefix` is an associated type.
- `RpSet`/`BsrConfig`/`BsrRun` get hand-written `impl<A: PimAf> Default` because the derive spuriously demands `Addr: Default`.
- The standalone `PimSupervisor` extraction is deferred to the start of Phase 3, where AF-split routing first has something to route to.

## Test plan
- `cargo test -p zebra-rs pim::` → 11 passed.
- `cargo fmt --check` clean.
- Forced-clean workspace `cargo clippy --all-targets -D warnings` → exit 0.
- `@pim_ssm` + `@pim_asm` live BDD pass with the daemon binary md5 **identical before and after** this change.

Generated with [Claude Code](https://claude.com/claude-code)