### PR TITLE
pim: pure address-family semantics on PimAf (Phase 2 slice 2b.1)

### DIFF
--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -558,11 +558,25 @@ consistent with the arc's smallest-safe-slice rule:
   `Neighbor<A>`, `AssertMetric/State<A>`, `RpSet<A>`, `BsrConfig/Run<A>`, `IgmpIf/Group<A>`,
   `PimLink<A>`. All logic stays concrete-IPv4 (methods on `impl Pim` / `impl PimLink<Ipv4>`),
   byte-identical. Verified: unit tests, `@pim_ssm`/`@pim_asm` live, identical binary md5.
-- **Slice 2b — logic + trait methods.** Add the behavioural methods to `PimAf`
-  (classification, prefix ops, checksum ctx, transports, membership codec) *together with*
-  the generic logic that calls them, flip `Pim` → `Pim<A>` and the `impl` blocks to
-  `impl<A: PimAf>`, extract the `Gm<A>` event engine + `Ipv4` codec, and put the forwarding
-  plane behind `PimForwardingPlane<A>`. Still IPv4-runtime-only.
+- **Slice 2b — logic + trait methods.** Measured, this is a ~5,600-LOC change (~15
+  `impl Pim` blocks flipping to `impl<A: PimAf> Pim<A>`, ~130 concrete `Ipv4Addr`/`Ipv4Net`
+  touchpoints) that cannot compile mid-way, so it lands as three compiler-verified,
+  byte-identical sub-slices, each its own PR:
+  - **2b.1 — pure semantics on `PimAf`.** Classification (`is_multicast`/`is_ssm`/
+    `is_reserved_group`), prefix ops (`prefix_new`/`prefix_contains`/`prefix_len`/
+    `prefix_addr`) and the `DEFAULT_SSM_RANGE`/`DEFAULT_RP_RANGE` consts, with every
+    existing concrete call site (`rp.rs`, `register.rs`, `igmp`, `tib.rs`, `bsr.rs`,
+    `config.rs`) routed through `Ipv4::…`. `Pim` stays concrete; unit-tested; byte-identical.
+    (`NAME`, `host_prefix`, wire conversion, etc. are deferred to the slice that first
+    needs them, so no trait method is ever dead under `-D warnings`.)
+  - **2b.2 — seam traits for the impure edges.** `PimForwardingPlane<A>` (rename
+    `ForwardingPlane`→`Mrt4`, `Upcall`→`Upcall<A>`) and the `Gm<A>` membership engine +
+    `GmCodec` (`Ipv4`/IGMP) adapter (rename `igmp/`→`gm/`). `Pim` still concrete, holding
+    `Mrt4` and `Gm<Ipv4>`.
+  - **2b.3 — the actor flip.** `Pim` → `Pim<A>`, `Message<A>`, `PimSend<A>`, all `impl`
+    blocks to `impl<A: PimAf>`, callbacks/show typed over `A`; add wire-conversion
+    (`from_ip`/`to_ip`) + transport-spawn methods to `PimAf` and route the `IpAddr::V4`
+    sites through them. Spawn `Pim::<Ipv4>::new` only — still IPv4-runtime-only.
 
 **Supervisor deferral.** The standalone `PimSupervisor` (§4.1) moves to the start of
 Phase 3: extracting it now — with only IPv4 at runtime and no `Pim<Ipv6>` to route to — is

--- a/zebra-rs/src/pim/af.rs
+++ b/zebra-rs/src/pim/af.rs
@@ -2,27 +2,61 @@
 //! generic over `A: PimAf`; one `Pim<A>` instance will be
 //! monomorphized per `(VRF, AF)`.
 //!
-//! This first slice carries only the associated address / prefix
-//! types — enough to parameterize every state type over the address
-//! family. The behavioural methods (classification, prefix ops,
-//! checksum context, transports, membership codec) arrive with the
-//! `Pim<A>` monomorphization slice, alongside the generic logic that
+//! This slice carries the associated address / prefix types plus the
+//! *pure* address-classification and prefix operations — the semantics
+//! that differ between IPv4 and IPv6 but touch neither the actor nor
+//! the sockets. The impure edges (wire conversion, checksum context,
+//! transports, forwarding plane, membership codec) arrive with the
+//! later monomorphization slices, alongside the generic logic that
 //! calls them, so no trait method is ever dead.
 //!
 //! `ipnet` has no trait unifying `Ipv4Net`/`Ipv6Net`, which is why
-//! prefix behaviour will live on this trait rather than on bounds of
-//! the prefix type. `A` defaults to [`super::ipv4::Ipv4`] everywhere
-//! so the concrete IPv4 engine reads unchanged.
+//! prefix behaviour lives on this trait rather than on bounds of the
+//! prefix type. `A` defaults to [`super::ipv4::Ipv4`] everywhere so
+//! the concrete IPv4 engine reads unchanged.
 
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 use serde::Serialize;
 
-/// Marker + associated types for one PIM address family.
+/// Marker, associated types and pure address-family semantics for one
+/// PIM address family.
 pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static {
     /// A router-wide protocol address (source, group, RP, neighbor).
     type Addr: Copy + Ord + Eq + Hash + Display + Debug + Send + Sync + Serialize + 'static;
     /// A multicast / RP group range.
     type Prefix: Copy + Eq + Ord + Display + Debug + Send + Sync + 'static;
+
+    /// Default SSM range: `232.0.0.0/8` (RFC 4607) / `ff3x::/32`.
+    const DEFAULT_SSM_RANGE: Self::Prefix;
+    /// Default RP-eligible group range: `224.0.0.0/4` / `ff00::/8`.
+    const DEFAULT_RP_RANGE: Self::Prefix;
+
+    /// Whether `a` is a multicast address.
+    fn is_multicast(a: Self::Addr) -> bool;
+
+    /// Whether `a` falls in the Source-Specific Multicast range. For
+    /// IPv6 this honours any scope nibble rather than a single literal
+    /// prefix, so it is a required method rather than a
+    /// `DEFAULT_SSM_RANGE` containment test.
+    fn is_ssm(a: Self::Addr) -> bool;
+
+    /// Whether `a` is a link-scope / control group that must never be
+    /// forwarded (`224.0.0.0/24` for IPv4; interface- and link-local
+    /// scopes for IPv6).
+    fn is_reserved_group(a: Self::Addr) -> bool;
+
+    /// Build a prefix from a network address and length; `None` if the
+    /// length is invalid for the family.
+    fn prefix_new(addr: Self::Addr, len: u8) -> Option<Self::Prefix>;
+
+    /// Whether the prefix covers the address.
+    fn prefix_contains(p: &Self::Prefix, a: &Self::Addr) -> bool;
+
+    /// The prefix length in bits.
+    fn prefix_len(p: &Self::Prefix) -> u8;
+
+    /// The prefix's network address.
+    fn prefix_addr(p: &Self::Prefix) -> Self::Addr;
 }

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -77,8 +77,7 @@ impl BsrConfig {
         }
         Some((
             self.crp_addr?,
-            self.crp_group
-                .unwrap_or_else(|| "224.0.0.0/4".parse().unwrap()),
+            self.crp_group.unwrap_or(Ipv4::DEFAULT_RP_RANGE),
             self.crp_priority.unwrap_or(192),
         ))
     }
@@ -158,8 +157,10 @@ impl Pim {
         self.bsr
             .rp_set
             .iter()
-            .filter(|((range, _), e)| range.contains(&grp) && e.expires > now)
-            .max_by_key(|((range, rp), e)| (range.prefix_len(), std::cmp::Reverse(e.priority), *rp))
+            .filter(|((range, _), e)| Ipv4::prefix_contains(range, &grp) && e.expires > now)
+            .max_by_key(|((range, rp), e)| {
+                (Ipv4::prefix_len(range), std::cmp::Reverse(e.priority), *rp)
+            })
             .map(|((_, rp), _)| *rp)
     }
 
@@ -283,7 +284,7 @@ impl Pim {
             let IpAddr::V4(range_addr) = group.group.addr else {
                 continue;
             };
-            let Ok(range) = Ipv4Net::new(range_addr, group.group.masklen) else {
+            let Some(range) = Ipv4::prefix_new(range_addr, group.group.masklen) else {
                 continue;
             };
             self.bsr.rp_set.retain(|(r, _), _| *r != range);
@@ -349,7 +350,7 @@ impl Pim {
             let IpAddr::V4(range_addr) = group.addr else {
                 continue;
             };
-            let Ok(range) = Ipv4Net::new(range_addr, group.masklen) else {
+            let Some(range) = Ipv4::prefix_new(range_addr, group.masklen) else {
                 continue;
             };
             if adv.holdtime == 0 {
@@ -400,8 +401,8 @@ impl Pim {
                 group: EncodedGroup {
                     bidir: false,
                     zone: false,
-                    masklen: range.prefix_len(),
-                    addr: IpAddr::V4(range.addr()),
+                    masklen: Ipv4::prefix_len(&range),
+                    addr: IpAddr::V4(Ipv4::prefix_addr(&range)),
                 },
                 rp_count: rps.len() as u8,
                 rps,
@@ -459,8 +460,8 @@ impl Pim {
             groups: vec![EncodedGroup {
                 bidir: false,
                 zone: false,
-                masklen: range.prefix_len(),
-                addr: IpAddr::V4(range.addr()),
+                masklen: Ipv4::prefix_len(&range),
+                addr: IpAddr::V4(Ipv4::prefix_addr(&range)),
             }],
         };
         let packet = PimPacket::new(PimPayload::CandRpAdv(adv));

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -5,7 +5,9 @@
 
 use crate::config::{Args, ConfigOp};
 
+use super::af::PimAf;
 use super::inst::Pim;
+use super::ipv4::Ipv4;
 
 pub type Callback = fn(&mut Pim, Args, ConfigOp) -> Option<()>;
 
@@ -162,7 +164,7 @@ fn config_rp_static(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
         pim.rp_set
             .statics
             .entry(address)
-            .or_insert_with(|| "224.0.0.0/4".parse().unwrap());
+            .or_insert(Ipv4::DEFAULT_RP_RANGE);
     } else {
         pim.rp_set.statics.remove(&address);
     }
@@ -176,7 +178,7 @@ fn config_rp_static_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option
         let range = args.string()?.parse().ok()?;
         pim.rp_set.statics.insert(address, range);
     } else if let Some(range) = pim.rp_set.statics.get_mut(&address) {
-        *range = "224.0.0.0/4".parse().unwrap();
+        *range = Ipv4::DEFAULT_RP_RANGE;
     }
     pim.rp_reevaluate();
     Some(())

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -433,7 +433,7 @@ impl Pim {
         cfg: &LinkConfig,
         now: Instant,
     ) {
-        if !group_addr.is_multicast() {
+        if !Ipv4::is_multicast(group_addr) {
             return;
         }
         let Some(igmp) = self.link_igmp_mut(ifindex) else {
@@ -486,7 +486,7 @@ impl Pim {
         cfg: &LinkConfig,
         now: Instant,
     ) {
-        if !record.group.is_multicast() {
+        if !Ipv4::is_multicast(record.group) {
             return;
         }
         let gmi = cfg.igmp.gmi();

--- a/zebra-rs/src/pim/ipv4.rs
+++ b/zebra-rs/src/pim/ipv4.rs
@@ -1,6 +1,4 @@
-//! The IPv4 [`PimAf`] marker. This slice sets only the associated
-//! address / prefix types; the behavioural methods land with the
-//! `Pim<A>` monomorphization.
+//! The IPv4 [`PimAf`] marker and its pure address-family semantics.
 
 use std::net::Ipv4Addr;
 
@@ -17,4 +15,93 @@ pub struct Ipv4;
 impl PimAf for Ipv4 {
     type Addr = Ipv4Addr;
     type Prefix = Ipv4Net;
+
+    // `Ipv4Net::new_assert` is a const fn, so the canonical ranges are
+    // true associated consts. `232.0.0.0/8` is the RFC 4607 SSM range;
+    // `224.0.0.0/4` is the RFC 7761 RP-eligible group range.
+    const DEFAULT_SSM_RANGE: Ipv4Net = Ipv4Net::new_assert(Ipv4Addr::new(232, 0, 0, 0), 8);
+    const DEFAULT_RP_RANGE: Ipv4Net = Ipv4Net::new_assert(Ipv4Addr::new(224, 0, 0, 0), 4);
+
+    fn is_multicast(a: Ipv4Addr) -> bool {
+        a.is_multicast()
+    }
+
+    fn is_ssm(a: Ipv4Addr) -> bool {
+        Self::DEFAULT_SSM_RANGE.contains(&a)
+    }
+
+    fn is_reserved_group(a: Ipv4Addr) -> bool {
+        // 224.0.0.0/24 — the link-local control scope, never forwarded.
+        a.octets()[..3] == [224, 0, 0]
+    }
+
+    fn prefix_new(addr: Ipv4Addr, len: u8) -> Option<Ipv4Net> {
+        Ipv4Net::new(addr, len).ok()
+    }
+
+    fn prefix_contains(p: &Ipv4Net, a: &Ipv4Addr) -> bool {
+        p.contains(a)
+    }
+
+    fn prefix_len(p: &Ipv4Net) -> u8 {
+        p.prefix_len()
+    }
+
+    fn prefix_addr(p: &Ipv4Net) -> Ipv4Addr {
+        p.addr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multicast_classification() {
+        assert!(Ipv4::is_multicast(Ipv4Addr::new(239, 1, 1, 1)));
+        assert!(Ipv4::is_multicast(Ipv4Addr::new(232, 0, 0, 5)));
+        assert!(!Ipv4::is_multicast(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    #[test]
+    fn ssm_range_is_232_slash_8() {
+        assert!(Ipv4::is_ssm(Ipv4Addr::new(232, 0, 0, 1)));
+        assert!(Ipv4::is_ssm(Ipv4Addr::new(232, 255, 255, 255)));
+        // ASM groups and non-multicast are not SSM.
+        assert!(!Ipv4::is_ssm(Ipv4Addr::new(239, 1, 1, 1)));
+        assert!(!Ipv4::is_ssm(Ipv4Addr::new(233, 0, 0, 1)));
+        assert!(!Ipv4::is_ssm(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    #[test]
+    fn reserved_group_is_link_local_control_scope() {
+        assert!(Ipv4::is_reserved_group(Ipv4Addr::new(224, 0, 0, 1)));
+        assert!(Ipv4::is_reserved_group(Ipv4Addr::new(224, 0, 0, 13)));
+        assert!(!Ipv4::is_reserved_group(Ipv4Addr::new(224, 0, 1, 1)));
+        assert!(!Ipv4::is_reserved_group(Ipv4Addr::new(239, 1, 1, 1)));
+    }
+
+    #[test]
+    fn prefix_ops() {
+        let p = Ipv4::prefix_new(Ipv4Addr::new(10, 1, 0, 0), 16).unwrap();
+        assert!(Ipv4::prefix_contains(&p, &Ipv4Addr::new(10, 1, 2, 3)));
+        assert!(!Ipv4::prefix_contains(&p, &Ipv4Addr::new(10, 2, 0, 1)));
+        assert_eq!(Ipv4::prefix_len(&p), 16);
+        assert_eq!(Ipv4::prefix_addr(&p), Ipv4Addr::new(10, 1, 0, 0));
+        assert!(Ipv4::prefix_new(Ipv4Addr::new(10, 0, 0, 0), 33).is_none());
+    }
+
+    #[test]
+    fn default_ranges() {
+        assert_eq!(Ipv4::prefix_len(&Ipv4::DEFAULT_SSM_RANGE), 8);
+        assert_eq!(
+            Ipv4::prefix_addr(&Ipv4::DEFAULT_SSM_RANGE),
+            Ipv4Addr::new(232, 0, 0, 0)
+        );
+        assert_eq!(Ipv4::prefix_len(&Ipv4::DEFAULT_RP_RANGE), 4);
+        assert_eq!(
+            Ipv4::prefix_addr(&Ipv4::DEFAULT_RP_RANGE),
+            Ipv4Addr::new(224, 0, 0, 0)
+        );
+    }
 }

--- a/zebra-rs/src/pim/register.rs
+++ b/zebra-rs/src/pim/register.rs
@@ -17,7 +17,9 @@ use pim_packet::{
     EncodedGroup, EncodedUnicast, PimPacket, PimPayload, PimRegister, PimRegisterStop,
 };
 
+use super::af::PimAf;
 use super::inst::{Pim, PimSend};
+use super::ipv4::Ipv4;
 use super::mroute::Upcall;
 use super::rp::is_ssm;
 use super::tib::{JoinState, KEEPALIVE_PERIOD, RegState, SgKey};
@@ -120,7 +122,7 @@ impl Pim {
         }
         let src = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
         let grp = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
-        if !grp.is_multicast() || is_ssm(grp) {
+        if !Ipv4::is_multicast(grp) || is_ssm(grp) {
             return;
         }
         if !self.i_am_rp(grp) {

--- a/zebra-rs/src/pim/rp.rs
+++ b/zebra-rs/src/pim/rp.rs
@@ -5,20 +5,16 @@
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
-use ipnet::Ipv4Net;
-
 use super::af::PimAf;
 use super::inst::Pim;
 use super::ipv4::Ipv4;
 use super::tib::SgKey;
 
 /// Default SSM range (RFC 4607): no RP, no register, (S,G) only.
-fn ssm_range() -> Ipv4Net {
-    Ipv4Net::new(Ipv4Addr::new(232, 0, 0, 0), 8).unwrap()
-}
-
+/// Concrete-IPv4 wrapper over [`Ipv4::is_ssm`] kept for the existing
+/// call sites in `register.rs`/`igmp`.
 pub fn is_ssm(grp: Ipv4Addr) -> bool {
-    ssm_range().contains(&grp)
+    Ipv4::is_ssm(grp)
 }
 
 /// Static RP table: RP address → served group range.
@@ -41,14 +37,14 @@ impl Pim {
     /// BSR-learned set (static beats BSR). SSM groups never map to
     /// an RP.
     pub(crate) fn rp_lookup(&self, grp: Ipv4Addr) -> Option<Ipv4Addr> {
-        if is_ssm(grp) || !grp.is_multicast() {
+        if Ipv4::is_ssm(grp) || !Ipv4::is_multicast(grp) {
             return None;
         }
         self.rp_set
             .statics
             .iter()
-            .filter(|(_, range)| range.contains(&grp))
-            .max_by_key(|(_, range)| range.prefix_len())
+            .filter(|(_, range)| Ipv4::prefix_contains(range, &grp))
+            .max_by_key(|(_, range)| Ipv4::prefix_len(range))
             .map(|(rp, _)| *rp)
             .or_else(|| self.bsr_rp_lookup(grp))
     }

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -267,7 +267,7 @@ impl Pim {
     pub(crate) fn process_upcall(&mut self, upcall: Upcall) {
         match upcall.kind {
             UpcallKind::Nocache => {
-                if !upcall.grp.is_multicast() || upcall.grp.octets()[..3] == [224, 0, 0] {
+                if !Ipv4::is_multicast(upcall.grp) || Ipv4::is_reserved_group(upcall.grp) {
                     return;
                 }
                 let key = SgKey::Sg {


### PR DESCRIPTION
## Summary

First of **three** compiling sub-slices of Phase 2b (the `Pim` → `Pim<A>` genericization). Measured, 2b is a ~5,600-LOC big-bang that can't compile mid-way, so it lands as byte-identical sub-slices, each its own PR:

- **2b.1 (this PR)** — pure address-family *semantics* on `PimAf`. `Pim` stays concrete.
- **2b.2** — seam traits for the impure edges: `PimForwardingPlane<A>` + the `Gm<A>` membership engine.
- **2b.3** — the mechanical actor flip: `Pim` → `Pim<A>`, `Message<A>`, callbacks/show typed over `A`, wire conversion.

### What changed
Add the pure, socket-free semantics to `PimAf` and route every existing concrete call site through `Ipv4::…`, so the family-varying logic is isolated and unit-tested *before* the mechanical flip.

Trait surface (each method lands with a real caller — nothing dead under `-D warnings`):
- `DEFAULT_SSM_RANGE` (`232.0.0.0/8`) / `DEFAULT_RP_RANGE` (`224.0.0.0/4`) as true associated consts (`Ipv4Net::new_assert` is `const`).
- `is_multicast` / `is_ssm` / `is_reserved_group`.
- `prefix_new` / `prefix_contains` / `prefix_len` / `prefix_addr`.

Routed call sites, all byte-identical:
- `rp.rs`: `is_ssm` free fn delegates to `Ipv4::is_ssm`; `rp_lookup` LPM + multicast guard via the trait.
- `register.rs` / `igmp`: multicast guards.
- `tib.rs`: NOCACHE reserved-group guard (`224.0.0.0/24`) → `is_reserved_group`.
- `config.rs` / `bsr.rs`: `"224.0.0.0/4"` literals → `DEFAULT_RP_RANGE`; BSM/C-RP range construction → `prefix_new`; emit `masklen`/`addr` → `prefix_len`/`prefix_addr`.

`NAME`, `host_prefix`, wire conversion (`from_ip`/`to_ip`) and the impure edges are deferred to the sub-slices that first call them.

## Test plan
- 16 pim unit tests, incl. **5 new `PimAf` semantics tests** (multicast/SSM/reserved-group classification, prefix ops, default ranges).
- `cargo fmt --check` clean.
- Forced-clean workspace `cargo clippy --all-targets -D warnings` → exit 0.
- Full workspace suite (`--exclude bdd`) green.
- `@pim_ssm` + `@pim_asm` live BDD pass (4 scenarios) with the daemon binary md5 **identical before and after** (`a0c02434…`), no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)