### PR TITLE
pim: forwarding plane behind PimForwardingPlane<A> (Phase 2 slice 2b.2)

### DIFF
--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -539,7 +539,7 @@ Each phase is one reviewable PR leaving the tree tested and useful.
 | 1 | **DONE** — Codec groundwork: checksum context API (all emit sites), MLD wire types, exponent encodings, mixed-family rejection, ICMPv6 checksum helper lifted to `packet-utils` | fixture + negative tests; IPv4 fixtures byte-identical |
 | 2 | `Pim<A>`/`Gm<A>`/FP-trait genericization; **IPv4 runtime only**. Landed in compiling slices (see note). | all IPv4 unit + live BDD unchanged |
 | 3 | `Ipv6` transports: PIMv6 socket, Hello/neighbor/DR over LL | two-router adjacency BDD; invalid-transport negatives |
-| 4 | MLDv1/v2 engine via `Gm<Ipv6>` + TIB bridge | querier/compat/source-filter BDD |
+| 4 | Extract the shared `Gm<A>` engine + `GmCodec` (rename `igmp/`→`gm/`), then MLDv1/v2 via `Gm<Ipv6>` + TIB bridge (the second codec that validates the seam) | querier/compat/source-filter BDD |
 | 5 | `Mrt6` plane + generic RPF + SSM end-to-end | UDPv6 delivery + kernel MIF/MFC asserts (MVP gate) |
 | 6 | Static-RP ASM, IPv6 Register path, SPT | three-router ASM traffic proof |
 | 7 | IPv6 assert + per-VRF `Pim<Ipv6>` | LAN election + VRF isolation BDD |
@@ -569,14 +569,22 @@ consistent with the arc's smallest-safe-slice rule:
     `config.rs`) routed through `Ipv4::…`. `Pim` stays concrete; unit-tested; byte-identical.
     (`NAME`, `host_prefix`, wire conversion, etc. are deferred to the slice that first
     needs them, so no trait method is ever dead under `-D warnings`.)
-  - **2b.2 — seam traits for the impure edges.** `PimForwardingPlane<A>` (rename
-    `ForwardingPlane`→`Mrt4`, `Upcall`→`Upcall<A>`) and the `Gm<A>` membership engine +
-    `GmCodec` (`Ipv4`/IGMP) adapter (rename `igmp/`→`gm/`). `Pim` still concrete, holding
-    `Mrt4` and `Gm<Ipv4>`.
+  - **2b.2 — the forwarding-plane seam.** `PimForwardingPlane<A>` (rename
+    `ForwardingPlane`→`Mrt4`, `Upcall`→`Upcall<A>`), with `Mrt4: PimForwardingPlane<Ipv4>`.
+    This is the one seam the flip *requires* — the `Pim.fp` field type must be trait-bound
+    before `Pim` can be generic. `Pim` stays concrete, holding `Mrt4`.
   - **2b.3 — the actor flip.** `Pim` → `Pim<A>`, `Message<A>`, `PimSend<A>`, all `impl`
-    blocks to `impl<A: PimAf>`, callbacks/show typed over `A`; add wire-conversion
-    (`from_ip`/`to_ip`) + transport-spawn methods to `PimAf` and route the `IpAddr::V4`
-    sites through them. Spawn `Pim::<Ipv4>::new` only — still IPv4-runtime-only.
+    blocks to `impl<A: PimAf>` (the membership FSM in `igmp/` flips generically *in place* —
+    it becomes `A`-generic without being extracted); callbacks/show typed over `A`; add
+    wire-conversion (`from_ip`/`to_ip`) + transport-spawn methods to `PimAf` and route the
+    `IpAddr::V4` sites through them. Spawn `Pim::<Ipv4>::new` only — still IPv4-runtime-only.
+
+  **`Gm<A>` engine extraction deferred to Phase 4.** §6's standalone `Gm<A>` engine +
+  `GmCodec` adapter (rename `igmp/`→`gm/`) is *not* done in Phase 2. Extracting the shared
+  membership engine with only the IGMP codec present designs the engine/codec seam blind;
+  MLD is the second implementor that validates it, so the extraction lands in Phase 4
+  alongside `Gm<Ipv6>`/MLD. Through Phase 2/3 the membership FSM stays as `impl<A> Pim<A>`
+  methods (already `A`-generic after 2b.3), which is all the flip needs.
 
 **Supervisor deferral.** The standalone `PimSupervisor` (§4.1) moves to the start of
 Phase 3: extracting it now — with only IPv4 at runtime and no `Pim<Ipv6>` to route to — is

--- a/zebra-rs/src/config/pim.rs
+++ b/zebra-rs/src/config/pim.rs
@@ -1,6 +1,6 @@
 use crate::context::ProtoContext;
 use crate::pim::inst;
-use crate::pim::mroute::ForwardingPlane;
+use crate::pim::mroute::{Mrt4, PimForwardingPlane};
 use crate::pim::socket::{igmp_socket, pim_socket};
 use crate::rib;
 
@@ -38,7 +38,7 @@ pub fn spawn_pim(config: &ConfigManager) {
     // The mroute socket claims the kernel's multicast-routing
     // instance (MRT_INIT) — EADDRINUSE means another multicast
     // daemon owns it on this host.
-    let fp = match ForwardingPlane::new(&probe, 0) {
+    let fp = match Mrt4::new(&probe, 0) {
         Ok(fp) => fp,
         Err(e) => {
             tracing::warn!("pim: not started (mroute socket: {e}); PIM disabled");

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -29,7 +29,7 @@ use crate::rib::api::RibRx;
 use super::bsr::{BsrConfig, BsrRun};
 use super::config::Callback;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
-use super::mroute::{ForwardingPlane, Upcall};
+use super::mroute::{Mrt4, Upcall};
 use super::network::{igmp_read_packet, igmp_write_packet, mroute_read, read_packet, write_packet};
 use super::rp::RpSet;
 use super::rpf::RpfEntry;
@@ -96,7 +96,7 @@ pub struct Pim {
     pub bsr_config: BsrConfig,
     pub bsr: BsrRun,
     /// Kernel dataplane: mroute socket, VIFs, MFC.
-    pub(crate) fp: ForwardingPlane,
+    pub(crate) fp: Mrt4,
     /// Periodic J/P refresh deadlines per (ifindex, upstream nbr).
     pub(crate) jp_refresh: BTreeMap<(u32, Ipv4Addr), std::time::Instant>,
     pub(crate) send_tx: UnboundedSender<PimSend>,
@@ -141,7 +141,7 @@ impl Pim {
         ctx: ProtoContext,
         sock: AsyncFd<Socket>,
         igmp_sock: AsyncFd<Socket>,
-        fp: ForwardingPlane,
+        fp: Mrt4,
         rib_rx: UnboundedReceiver<RibRx>,
         proto_label: String,
         rib_subscriber: RibSubscriber,

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -15,6 +15,7 @@ use super::af::PimAf;
 use super::igmp::{IgmpConfig, IgmpIf};
 use super::inst::{Message, Pim};
 use super::ipv4::Ipv4;
+use super::mroute::PimForwardingPlane;
 use super::neighbor::Neighbor;
 use super::socket::{igmp_join_if, igmp_leave_if, pim_join_if, pim_leave_if};
 

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -2,8 +2,13 @@
 //! (`MRT_INIT`/`MRT_PIM`), VIF allocation and MFC programming, and
 //! upcall parsing. All `MRT_*` interaction is confined here — the
 //! protocol engine only sees typed [`Upcall`] messages and the
-//! [`ForwardingPlane`] methods, mirroring the ZebOS pimd/mribd
+//! [`PimForwardingPlane`] methods, mirroring the ZebOS pimd/mribd
 //! boundary inside one process.
+//!
+//! The plane is abstracted behind the [`PimForwardingPlane<A>`] trait
+//! so an IPv6 `Mrt6` (MRT6/MIF/MFC over `linux/mroute6.h`) can slot in
+//! per address family; [`Mrt4`] is the IPv4 implementor. Only the
+//! trait seam exists yet — the engine still runs IPv4-only.
 //!
 //! Linux delivers upcalls on the mroute socket disguised as IP
 //! packets whose protocol field is zero (`struct igmpmsg` overlays
@@ -21,6 +26,9 @@ use std::sync::Arc;
 use tokio::io::unix::AsyncFd;
 
 use crate::context::ProtoContext;
+
+use super::af::PimAf;
+use super::ipv4::Ipv4;
 
 // linux/mroute.h — not exposed by the libc crate.
 const MRT_INIT: c_int = 200;
@@ -87,19 +95,20 @@ pub enum UpcallKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct Upcall {
+pub struct Upcall<A: PimAf = Ipv4> {
     pub kind: UpcallKind,
     pub vif: u16,
-    pub src: Ipv4Addr,
-    pub grp: Ipv4Addr,
+    pub src: A::Addr,
+    pub grp: A::Addr,
     /// The punted original IP packet — populated for WHOLEPKT (the
     /// Register encapsulation payload), empty otherwise.
     pub payload: Vec<u8>,
 }
 
-/// Parse one datagram read from the mroute socket. `None` for
-/// anything that is not an upcall (real IGMP traffic, runts).
-pub fn parse_upcall(buf: &[u8]) -> Option<Upcall> {
+/// Parse one datagram read from the IPv4 mroute socket. `None` for
+/// anything that is not an upcall (real IGMP traffic, runts). The
+/// IPv6 read task will produce an `Upcall<Ipv6>` from `mrt6msg`.
+pub fn parse_upcall(buf: &[u8]) -> Option<Upcall<Ipv4>> {
     if buf.len() < 20 || buf[9] != 0 {
         // buf[9] is ip->protocol alias im_mbz: nonzero ⇒ a genuine
         // IGMP packet, handled on the IGMP socket.
@@ -145,21 +154,45 @@ fn mrt_setsockopt<T>(sock: &Socket, opt: c_int, val: &T) -> std::io::Result<()> 
     Ok(())
 }
 
-/// Owner of the mroute socket, the VIF table and the kernel MFC.
+/// The kernel multicast-forwarding plane, abstracted over the address
+/// family. All per-AF UAPI (`MRT_*`/`MRT6_*`, `Vifctl`/`mif6ctl`,
+/// `Mfcctl`/`mf6cctl`) lives behind a concrete implementor; upcall
+/// parsing stays in the concrete read task and produces the shared
+/// typed [`Upcall<A>`]. [`Mrt4`] is the IPv4 implementor.
+pub trait PimForwardingPlane<A: PimAf>: Sized {
+    /// Claim the (per-table) kernel multicast-routing instance.
+    /// `table_id != 0` selects a non-default table (must precede the
+    /// init sockopt) — the per-VRF path.
+    fn new(ctx: &ProtoContext, table_id: u32) -> std::io::Result<Self>;
+    /// Allocate and program a VIF/MIF for `ifindex` (idempotent).
+    fn vif_add(&mut self, ifindex: u32);
+    /// Remove the VIF/MIF for `ifindex`.
+    fn vif_del(&mut self, ifindex: u32);
+    /// The VIF/MIF index currently mapped to `ifindex`.
+    fn vif(&self, ifindex: u32) -> Option<u16>;
+    /// The ifindex mapped to a VIF/MIF index (upcall arrival lookup).
+    fn ifindex_of(&self, vif: u16) -> Option<u32>;
+    /// Install or replace the (S,G) MFC entry.
+    fn mfc_add(&self, src: A::Addr, grp: A::Addr, iif: u16, oifs: &[u16]);
+    /// Remove the (S,G) MFC entry.
+    fn mfc_del(&self, src: A::Addr, grp: A::Addr);
+}
+
+/// Owner of the IPv4 mroute socket, the VIF table and the kernel MFC.
 /// Dropping it closes the socket, which makes the kernel run the
 /// implicit `MRT_DONE` cleanup (VIFs and MFC entries flushed).
-pub struct ForwardingPlane {
+pub struct Mrt4 {
     pub sock: Arc<AsyncFd<Socket>>,
     /// ifindex → VIF. Index 0 stays reserved for the register VIF
     /// (ASM phase).
     vifs: BTreeMap<u32, u16>,
 }
 
-impl ForwardingPlane {
+impl PimForwardingPlane<Ipv4> for Mrt4 {
     /// `table_id != 0` selects a non-default kernel multicast routing
     /// table (`MRT_TABLE`, must precede `MRT_INIT`) — the per-VRF
     /// instance path. Requires `CONFIG_IP_MROUTE_MULTIPLE_TABLES`.
-    pub fn new(ctx: &ProtoContext, table_id: u32) -> std::io::Result<Self> {
+    fn new(ctx: &ProtoContext, table_id: u32) -> std::io::Result<Self> {
         // The mroute socket must be a raw IGMP socket. MRT_INIT
         // claims the (per-table) multicast-routing instance — EADDRINUSE
         // means another daemon owns it.
@@ -196,18 +229,18 @@ impl ForwardingPlane {
         })
     }
 
-    pub fn vif(&self, ifindex: u32) -> Option<u16> {
+    fn vif(&self, ifindex: u32) -> Option<u16> {
         self.vifs.get(&ifindex).copied()
     }
 
-    pub fn ifindex_of(&self, vif: u16) -> Option<u32> {
+    fn ifindex_of(&self, vif: u16) -> Option<u32> {
         self.vifs
             .iter()
             .find(|(_, v)| **v == vif)
             .map(|(ifindex, _)| *ifindex)
     }
 
-    pub fn vif_add(&mut self, ifindex: u32) {
+    fn vif_add(&mut self, ifindex: u32) {
         if self.vifs.contains_key(&ifindex) {
             return;
         }
@@ -237,7 +270,7 @@ impl ForwardingPlane {
         }
     }
 
-    pub fn vif_del(&mut self, ifindex: u32) {
+    fn vif_del(&mut self, ifindex: u32) {
         let Some(vif) = self.vifs.remove(&ifindex) else {
             return;
         };
@@ -258,7 +291,7 @@ impl ForwardingPlane {
 
     /// Install or replace the (S,G) MFC entry. `MRT_ADD_MFC` on an
     /// existing (origin, group) updates it in place.
-    pub fn mfc_add(&self, src: Ipv4Addr, grp: Ipv4Addr, iif: u16, oifs: &[u16]) {
+    fn mfc_add(&self, src: Ipv4Addr, grp: Ipv4Addr, iif: u16, oifs: &[u16]) {
         let mut mc = Mfcctl {
             mfcc_origin: u32::from_ne_bytes(src.octets()),
             mfcc_mcastgrp: u32::from_ne_bytes(grp.octets()),
@@ -281,7 +314,7 @@ impl ForwardingPlane {
         }
     }
 
-    pub fn mfc_del(&self, src: Ipv4Addr, grp: Ipv4Addr) {
+    fn mfc_del(&self, src: Ipv4Addr, grp: Ipv4Addr) {
         let mc = Mfcctl {
             mfcc_origin: u32::from_ne_bytes(src.octets()),
             mfcc_mcastgrp: u32::from_ne_bytes(grp.octets()),

--- a/zebra-rs/src/pim/register.rs
+++ b/zebra-rs/src/pim/register.rs
@@ -20,7 +20,7 @@ use pim_packet::{
 use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::ipv4::Ipv4;
-use super::mroute::Upcall;
+use super::mroute::{PimForwardingPlane, Upcall};
 use super::rp::is_ssm;
 use super::tib::{JoinState, KEEPALIVE_PERIOD, RegState, SgKey};
 

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -23,7 +23,7 @@ use super::assert_fsm::AssertState;
 use super::inst::Pim;
 use super::ipv4::Ipv4;
 use super::macros::{inherited_effective, inherited_olist, join_desired_effective, mfc_oifs};
-use super::mroute::{REG_VIF, Upcall, UpcallKind};
+use super::mroute::{PimForwardingPlane, REG_VIF, Upcall, UpcallKind};
 use super::rpf::RpfState;
 
 /// Join/Prune holdtime we advertise and the downstream expiry we run

--- a/zebra-rs/src/pim/vrf.rs
+++ b/zebra-rs/src/pim/vrf.rs
@@ -25,7 +25,7 @@ use crate::config::{CommandPath, ConfigOp, ConfigRequest, Message, RibSubscriber
 use crate::context::{ProtoContext, Task};
 
 use super::inst::{self, Pim};
-use super::mroute::ForwardingPlane;
+use super::mroute::{Mrt4, PimForwardingPlane};
 use super::socket::{igmp_socket, pim_socket};
 
 /// Handle to one running per-VRF PIM task, stashed on the parent's
@@ -102,7 +102,7 @@ pub fn spawn_pim_vrf(
             return None;
         }
     };
-    let fp = match ForwardingPlane::new(&probe, table_id) {
+    let fp = match Mrt4::new(&probe, table_id) {
         Ok(fp) => fp,
         Err(e) => {
             tracing::warn!(vrf = %name, "pim: vrf instance not started (mroute socket: {e})");


### PR DESCRIPTION
## Summary

Second of three compiling sub-slices of Phase 2b. Introduces the `PimForwardingPlane<A: PimAf>` trait — the **one seam the `Pim` → `Pim<A>` flip actually requires**, since the `Pim.fp` field type must be trait-bound before `Pim` can be generic.

### What changed
- New `PimForwardingPlane<A>` trait (`new`/`vif_add`/`vif_del`/`vif`/`ifindex_of`/`mfc_add`/`mfc_del`) in `mroute.rs`.
- Rename the concrete IPv4 plane `ForwardingPlane` → `Mrt4`, now `impl PimForwardingPlane<Ipv4> for Mrt4`.
- `Upcall<A: PimAf = Ipv4>` (kernel upcall) generic; `src`/`grp` → `A::Addr`. `parse_upcall` stays concrete and yields `Upcall<Ipv4>` (the IPv6 read task will yield `Upcall<Ipv6>` from `mrt6msg`).
- `Pim` stays **concrete-IPv4**, holding an `Mrt4`.
- Mechanical trait-in-scope imports at every `fp.*` call site (`link.rs`/`register.rs`/`tib.rs`) and the two `Mrt4::new` sites (`pim/vrf.rs`, `config/pim.rs`).

An `Mrt6` (MRT6/MIF/MFC over `linux/mroute6.h`) slots in behind the same trait in Phase 5.

### Scope change (recorded in the plan doc)
The `Gm<A>` membership-engine extraction originally sketched for 2b.2 **moves to Phase 4**. Extracting the shared engine with only the IGMP codec present designs the engine/codec seam blind; **MLD is the second codec that validates it**. Through Phases 2–3 the membership FSM stays as `impl<A> Pim<A>` methods (already `A`-generic after 2b.3), which is all the flip needs.

## Test plan
- 16 pim unit tests, incl. the `mroute` ABI-layout (`Vifctl`/`Mfcctl`) and `parse_upcall` tests.
- `cargo fmt --check` clean.
- Forced-clean workspace `cargo clippy --all-targets -D warnings` → exit 0.
- Full workspace suite (`--exclude bdd`) green.
- `@pim_ssm` + `@pim_asm` live BDD pass (4 scenarios) with the daemon binary md5 **identical before and after** (`47c05ac3…`), no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)