### PR TITLE
pim: monomorphize the actor as Pim<A> (Phase 2 slice 2b.3)

### DIFF
--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -573,11 +573,17 @@ consistent with the arc's smallest-safe-slice rule:
     `ForwardingPlane`→`Mrt4`, `Upcall`→`Upcall<A>`), with `Mrt4: PimForwardingPlane<Ipv4>`.
     This is the one seam the flip *requires* — the `Pim.fp` field type must be trait-bound
     before `Pim` can be generic. `Pim` stays concrete, holding `Mrt4`.
-  - **2b.3 — the actor flip.** `Pim` → `Pim<A>`, `Message<A>`, `PimSend<A>`, all `impl`
-    blocks to `impl<A: PimAf>` (the membership FSM in `igmp/` flips generically *in place* —
-    it becomes `A`-generic without being extracted); callbacks/show typed over `A`; add
-    wire-conversion (`from_ip`/`to_ip`) + transport-spawn methods to `PimAf` and route the
-    `IpAddr::V4` sites through them. Spawn `Pim::<Ipv4>::new` only — still IPv4-runtime-only.
+  - **2b.3 — the actor flip (DONE).** `Pim` → `Pim<A>`, `Message<A>`, `PimSend<A>`,
+    `IgmpSend<A>`, `Upcall<A>`, `ShowCallback<A>`, `Callback<A>`, and every `impl Pim` →
+    `impl<A: PimAf> Pim<A>` (the membership FSM in `igmp/` flipped generically *in place* —
+    `A`-generic, not extracted; IGMP wire fields convert at the boundary via `from_ip`).
+    Only the leaf constructors stay concrete: `Pim<Ipv4>::new` (wires the IPv4 sockets +
+    `Mrt4`), `callback_build`/`show_build` (parse/render IPv4 CLI). The `PimAf` surface grew
+    to match §4.2: `type Fp`, `ALL_PIM_ROUTERS`/`GENERAL_QUERY_DST` consts, `from_ip`/`to_ip`,
+    `prefix_from_ipnet`/`link_prefixes`, `is_unspecified`, `null_register_payload`/
+    `register_inner_sg` — each landed with its caller. Only `Pim::<Ipv4>` is spawned; still
+    IPv4-runtime-only. Verified: unit + workspace tests, forced-clean clippy, full pim BDD
+    suite live with identical binary md5.
 
   **`Gm<A>` engine extraction deferred to Phase 4.** §6's standalone `Gm<A>` engine +
   `GmCodec` adapter (rename `igmp/`→`gm/`) is *not* done in Phase 2. Extracting the shared

--- a/zebra-rs/src/pim/af.rs
+++ b/zebra-rs/src/pim/af.rs
@@ -17,8 +17,14 @@
 
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
+use std::net::IpAddr;
 
+use ipnet::IpNet;
 use serde::Serialize;
+
+use crate::rib::Link;
+
+use super::mroute::PimForwardingPlane;
 
 /// Marker, associated types and pure address-family semantics for one
 /// PIM address family.
@@ -27,6 +33,40 @@ pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static 
     type Addr: Copy + Ord + Eq + Hash + Display + Debug + Send + Sync + Serialize + 'static;
     /// A multicast / RP group range.
     type Prefix: Copy + Eq + Ord + Display + Debug + Send + Sync + 'static;
+    /// The kernel forwarding plane for this family (`Mrt4` / `Mrt6`).
+    /// `Send + Sync + 'static` because it lives inside the `Pim<A>`
+    /// actor that is spawned onto the tokio runtime and borrowed across
+    /// awaits.
+    type Fp: PimForwardingPlane<Self> + Send + Sync + 'static;
+
+    /// The ALL-PIM-ROUTERS multicast address (RFC 7761 §4.3.1):
+    /// `224.0.0.13` / `ff02::d`.
+    const ALL_PIM_ROUTERS: Self::Addr;
+
+    /// General-query destination for the membership protocol:
+    /// `224.0.0.1` (IGMP all-hosts) / `ff02::1` (MLD).
+    const GENERAL_QUERY_DST: Self::Addr;
+
+    /// Whether `a` is the unspecified address (`0.0.0.0` / `::`) — a
+    /// membership report sourced from it carries no reporter identity.
+    fn is_unspecified(a: Self::Addr) -> bool;
+
+    /// Convert a wire `IpAddr` (from a `pim-packet` encoded address)
+    /// into this family's address, rejecting the other family. This is
+    /// the single ingress conversion point — cross-family addresses are
+    /// dropped here.
+    fn from_ip(ip: IpAddr) -> Option<Self::Addr>;
+    /// Convert back to a wire `IpAddr` for emission.
+    fn to_ip(a: Self::Addr) -> IpAddr;
+
+    /// Narrow a RIB `IpNet` to this family's prefix (`None` for the
+    /// other family) — the per-address ingress from `AddrAdd`/`AddrDel`.
+    fn prefix_from_ipnet(net: IpNet) -> Option<Self::Prefix>;
+
+    /// This family's on-link prefixes for a RIB link, in order; the
+    /// first is the Hello-source / DR-candidate identity. IPv4 reads
+    /// `addr4`; IPv6 will read the link-local(s) then `addr6`.
+    fn link_prefixes(link: &Link) -> Vec<Self::Prefix>;
 
     /// Default SSM range: `232.0.0.0/8` (RFC 4607) / `ff3x::/32`.
     const DEFAULT_SSM_RANGE: Self::Prefix;
@@ -59,4 +99,13 @@ pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static 
 
     /// The prefix's network address.
     fn prefix_addr(p: &Self::Prefix) -> Self::Addr;
+
+    /// A minimal inner header naming `(src, grp)` for a Null-Register
+    /// (RFC 7761 §4.4.1): a 20-byte IPv4 header / a 40-byte IPv6 header.
+    fn null_register_payload(src: Self::Addr, grp: Self::Addr) -> Vec<u8>;
+
+    /// Extract `(src, grp)` from a Register's inner packet (or
+    /// Null-Register dummy header). `None` if the inner family does not
+    /// match this AF or the header is malformed.
+    fn register_inner_sg(data: &[u8]) -> Option<(Self::Addr, Self::Addr)>;
 }

--- a/zebra-rs/src/pim/assert_fsm.rs
+++ b/zebra-rs/src/pim/assert_fsm.rs
@@ -11,7 +11,6 @@
 //! out; a loser whose state expires simply resumes forwarding and
 //! the next duplicate re-runs the election.
 
-use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
 
 use pim_packet::{EncodedGroup, EncodedUnicast, PimAssert, PimPacket, PimPayload};
@@ -20,7 +19,6 @@ use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::ipv4::Ipv4;
 use super::macros::inherited_olist;
-use super::socket::ALL_PIM_ROUTERS;
 use super::tib::SgKey;
 
 /// Assert Time (RFC 7761 §4.11): loser state lifetime.
@@ -69,10 +67,10 @@ pub struct AssertState<A: PimAf = Ipv4> {
     pub expires: Instant,
 }
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// Our assert metric for `key` on `ifindex`: RPF cost toward the
     /// source, our address on the contested interface as tiebreak.
-    fn assert_my_metric(&self, key: SgKey, ifindex: u32) -> Option<AssertMetric> {
+    fn assert_my_metric(&self, key: SgKey<A>, ifindex: u32) -> Option<AssertMetric<A>> {
         let addr = self.links.get(&ifindex)?.primary_addr()?;
         let entry = self.tib.get(&key)?;
         let (pref, metric) = match entry.rpf_target {
@@ -87,13 +85,13 @@ impl Pim {
         })
     }
 
-    fn assert_send(&self, key: SgKey, ifindex: u32, metric: &AssertMetric) {
+    fn assert_send(&self, key: SgKey<A>, ifindex: u32, metric: &AssertMetric<A>) {
         let SgKey::Sg { src, grp } = key else {
             return;
         };
         let packet = PimPacket::new(PimPayload::Assert(PimAssert {
-            group: EncodedGroup::new(IpAddr::V4(grp)),
-            source: EncodedUnicast::new(IpAddr::V4(src)),
+            group: EncodedGroup::new(A::to_ip(grp)),
+            source: EncodedUnicast::new(A::to_ip(src)),
             rpt_bit: metric.rpt_bit,
             metric_preference: metric.pref,
             metric: metric.metric,
@@ -101,13 +99,13 @@ impl Pim {
         let _ = self.send_tx.send(PimSend {
             packet,
             ifindex,
-            dst: ALL_PIM_ROUTERS,
+            dst: A::ALL_PIM_ROUTERS,
         });
     }
 
     /// Duplicate data seen on an interface we forward to (WRONGVIF on
     /// an OIL member): assert ourselves.
-    pub(crate) fn assert_data_trigger(&mut self, key: SgKey, ifindex: u32) {
+    pub(crate) fn assert_data_trigger(&mut self, key: SgKey<A>, ifindex: u32) {
         let Some(mine) = self.assert_my_metric(key, ifindex) else {
             return;
         };
@@ -157,7 +155,7 @@ impl Pim {
     }
 
     /// Assert packet RX: run the election on the receiving interface.
-    pub(crate) fn assert_recv(&mut self, ifindex: u32, sender: Ipv4Addr, assert: &PimAssert) {
+    pub(crate) fn assert_recv(&mut self, ifindex: u32, sender: A::Addr, assert: &PimAssert) {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
@@ -171,7 +169,10 @@ impl Pim {
             );
             return;
         }
-        let (IpAddr::V4(grp), IpAddr::V4(src)) = (assert.group.addr, assert.source.addr) else {
+        let (Some(grp), Some(src)) = (
+            A::from_ip(assert.group.addr),
+            A::from_ip(assert.source.addr),
+        ) else {
             return;
         };
         let key = SgKey::Sg { src, grp };
@@ -273,7 +274,7 @@ impl Pim {
     /// Assert deadlines: winners refresh, expired losers resume
     /// forwarding.
     pub(crate) fn assert_tick(&mut self, now: Instant) {
-        let due: Vec<(SgKey, u32, AssertRole)> = self
+        let due: Vec<(SgKey<A>, u32, AssertRole<A>)> = self
             .tib
             .iter()
             .flat_map(|(key, e)| {

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -10,10 +10,8 @@
 //! range.
 
 use std::collections::BTreeMap;
-use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
 
-use ipnet::Ipv4Net;
 use pim_packet::{
     BsmGroup, BsmRp, EncodedGroup, EncodedUnicast, PimBootstrap, PimCandRpAdv, PimPacket,
     PimPayload,
@@ -22,7 +20,6 @@ use pim_packet::{
 use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::ipv4::Ipv4;
-use super::socket::ALL_PIM_ROUTERS;
 
 /// BSM origination period at the elected BSR (RFC 5059 §5).
 const BS_PERIOD: Duration = Duration::from_secs(60);
@@ -63,21 +60,21 @@ impl<A: PimAf> Default for BsrConfig<A> {
     }
 }
 
-impl BsrConfig {
-    fn cbsr(&self) -> Option<(Ipv4Addr, u8)> {
+impl<A: PimAf> BsrConfig<A> {
+    fn cbsr(&self) -> Option<(A::Addr, u8)> {
         if !self.cbsr_enabled {
             return None;
         }
         Some((self.cbsr_addr?, self.cbsr_priority.unwrap_or(64)))
     }
 
-    fn crp(&self) -> Option<(Ipv4Addr, Ipv4Net, u8)> {
+    fn crp(&self) -> Option<(A::Addr, A::Prefix, u8)> {
         if !self.crp_enabled {
             return None;
         }
         Some((
             self.crp_addr?,
-            self.crp_group.unwrap_or(Ipv4::DEFAULT_RP_RANGE),
+            self.crp_group.unwrap_or(A::DEFAULT_RP_RANGE),
             self.crp_priority.unwrap_or(192),
         ))
     }
@@ -137,29 +134,29 @@ impl<A: PimAf> Default for BsrRun<A> {
     }
 }
 
-impl BsrRun {
+impl<A: PimAf> BsrRun<A> {
     fn role(&self) -> BsrRole {
         self.role.unwrap_or(BsrRole::None)
     }
 }
 
 /// Higher (priority, address) wins the BSR election (RFC 5059 §3.1).
-fn preferred(a: (u8, Ipv4Addr), b: (u8, Ipv4Addr)) -> bool {
+fn preferred<T: Ord>(a: (u8, T), b: (u8, T)) -> bool {
     a > b
 }
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// The BSR-learned RP for `grp`: longest matching range, then
     /// lowest priority, then highest address; expired entries are
     /// skipped (swept by the tick).
-    pub(crate) fn bsr_rp_lookup(&self, grp: Ipv4Addr) -> Option<Ipv4Addr> {
+    pub(crate) fn bsr_rp_lookup(&self, grp: A::Addr) -> Option<A::Addr> {
         let now = Instant::now();
         self.bsr
             .rp_set
             .iter()
-            .filter(|((range, _), e)| Ipv4::prefix_contains(range, &grp) && e.expires > now)
+            .filter(|((range, _), e)| A::prefix_contains(range, &grp) && e.expires > now)
             .max_by_key(|((range, rp), e)| {
-                (Ipv4::prefix_len(range), std::cmp::Reverse(e.priority), *rp)
+                (A::prefix_len(range), std::cmp::Reverse(e.priority), *rp)
             })
             .map(|((_, rp), _)| *rp)
     }
@@ -203,7 +200,7 @@ impl Pim {
 
     /// Track the RPF toward the adopted BSR so the flooding check
     /// has a reverse path to compare against.
-    fn bsr_track(&mut self, bsr: Ipv4Addr) {
+    fn bsr_track(&mut self, bsr: A::Addr) {
         if self.bsr.rpf_target == Some(bsr) {
             return;
         }
@@ -216,14 +213,14 @@ impl Pim {
 
     /// BSM RX (RFC 5059 §3.1): adopt preferred BSRs, absorb the
     /// RP-set, re-flood hop-by-hop on the other PIM interfaces.
-    pub(crate) fn bootstrap_recv(&mut self, ifindex: u32, src: Ipv4Addr, bsm: &PimBootstrap) {
+    pub(crate) fn bootstrap_recv(&mut self, ifindex: u32, src: A::Addr, bsm: &PimBootstrap) {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
         if !link.enabled || link.is_my_addr(&src) {
             return;
         }
-        let Some(bsr) = bsm.bsr_v4() else {
+        let Some(bsr) = A::from_ip(bsm.bsr_addr.addr) else {
             return;
         };
         // Our own BSM flooded back: ignore.
@@ -281,15 +278,15 @@ impl Pim {
         let now = Instant::now();
         let mut changed = false;
         for group in &bsm.groups {
-            let IpAddr::V4(range_addr) = group.group.addr else {
+            let Some(range_addr) = A::from_ip(group.group.addr) else {
                 continue;
             };
-            let Some(range) = Ipv4::prefix_new(range_addr, group.group.masklen) else {
+            let Some(range) = A::prefix_new(range_addr, group.group.masklen) else {
                 continue;
             };
             self.bsr.rp_set.retain(|(r, _), _| *r != range);
             for rp in &group.rps {
-                let IpAddr::V4(rp_addr) = rp.addr.addr else {
+                let Some(rp_addr) = A::from_ip(rp.addr.addr) else {
                     continue;
                 };
                 if rp.holdtime == 0 {
@@ -322,7 +319,7 @@ impl Pim {
             let _ = self.send_tx.send(PimSend {
                 packet: packet.clone(),
                 ifindex: oif,
-                dst: ALL_PIM_ROUTERS,
+                dst: A::ALL_PIM_ROUTERS,
             });
         }
 
@@ -332,25 +329,25 @@ impl Pim {
         }
     }
 
-    fn rpf_state_ifindex(&self, addr: Ipv4Addr) -> Option<u32> {
+    fn rpf_state_ifindex(&self, addr: A::Addr) -> Option<u32> {
         self.rpf.get(&addr).and_then(|e| e.state.ifindex())
     }
 
     /// C-RP advertisement RX — meaningful at the elected BSR only.
-    pub(crate) fn cand_rp_adv_recv(&mut self, src: Ipv4Addr, adv: &PimCandRpAdv) {
+    pub(crate) fn cand_rp_adv_recv(&mut self, src: A::Addr, adv: &PimCandRpAdv) {
         if self.bsr.role() != BsrRole::Elected {
             return;
         }
-        let IpAddr::V4(rp) = adv.rp_addr.addr else {
+        let Some(rp) = A::from_ip(adv.rp_addr.addr) else {
             return;
         };
         let now = Instant::now();
         let mut changed = false;
         for group in &adv.groups {
-            let IpAddr::V4(range_addr) = group.addr else {
+            let Some(range_addr) = A::from_ip(group.addr) else {
                 continue;
             };
-            let Some(range) = Ipv4::prefix_new(range_addr, group.masklen) else {
+            let Some(range) = A::prefix_new(range_addr, group.masklen) else {
                 continue;
             };
             if adv.holdtime == 0 {
@@ -384,13 +381,13 @@ impl Pim {
         };
         self.bsr.fragment_tag = self.bsr.fragment_tag.wrapping_add(1);
         let now = Instant::now();
-        let mut by_range: BTreeMap<Ipv4Net, Vec<BsmRp>> = BTreeMap::new();
+        let mut by_range: BTreeMap<A::Prefix, Vec<BsmRp>> = BTreeMap::new();
         for ((range, rp), entry) in self.bsr.rp_set.iter() {
             if entry.expires <= now {
                 continue;
             }
             by_range.entry(*range).or_default().push(BsmRp {
-                addr: EncodedUnicast::new(IpAddr::V4(*rp)),
+                addr: EncodedUnicast::new(A::to_ip(*rp)),
                 holdtime: entry.holdtime,
                 priority: entry.priority,
             });
@@ -401,8 +398,8 @@ impl Pim {
                 group: EncodedGroup {
                     bidir: false,
                     zone: false,
-                    masklen: Ipv4::prefix_len(&range),
-                    addr: IpAddr::V4(Ipv4::prefix_addr(&range)),
+                    masklen: A::prefix_len(&range),
+                    addr: A::to_ip(A::prefix_addr(&range)),
                 },
                 rp_count: rps.len() as u8,
                 rps,
@@ -412,7 +409,7 @@ impl Pim {
             fragment_tag: self.bsr.fragment_tag,
             hash_mask_len: HASH_MASK_LEN,
             bsr_priority: priority,
-            bsr_addr: EncodedUnicast::new(IpAddr::V4(addr)),
+            bsr_addr: EncodedUnicast::new(A::to_ip(addr)),
             groups,
         };
         let packet = PimPacket::new(PimPayload::Bootstrap(bsm));
@@ -426,7 +423,7 @@ impl Pim {
             let _ = self.send_tx.send(PimSend {
                 packet: packet.clone(),
                 ifindex: oif,
-                dst: ALL_PIM_ROUTERS,
+                dst: A::ALL_PIM_ROUTERS,
             });
         }
     }
@@ -456,12 +453,12 @@ impl Pim {
         let adv = PimCandRpAdv {
             priority,
             holdtime: CRP_HOLDTIME,
-            rp_addr: EncodedUnicast::new(IpAddr::V4(rp)),
+            rp_addr: EncodedUnicast::new(A::to_ip(rp)),
             groups: vec![EncodedGroup {
                 bidir: false,
                 zone: false,
-                masklen: Ipv4::prefix_len(&range),
-                addr: IpAddr::V4(Ipv4::prefix_addr(&range)),
+                masklen: A::prefix_len(&range),
+                addr: A::to_ip(A::prefix_addr(&range)),
             }],
         };
         let packet = PimPacket::new(PimPayload::CandRpAdv(adv));

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -9,9 +9,11 @@ use super::af::PimAf;
 use super::inst::Pim;
 use super::ipv4::Ipv4;
 
-pub type Callback = fn(&mut Pim, Args, ConfigOp) -> Option<()>;
+pub type Callback<A = Ipv4> = fn(&mut Pim<A>, Args, ConfigOp) -> Option<()>;
 
-impl Pim {
+/// The `router pim` callbacks parse IPv4 CLI addresses/prefixes, so
+/// they are the concrete-IPv4 configuration surface.
+impl Pim<Ipv4> {
     pub fn callback_build(&mut self) {
         self.callback_add("/router/pim/interface", config_interface);
         self.callback_add("/router/pim/interface/dr-priority", config_dr_priority);

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -7,7 +7,7 @@
 //! SSM phase on.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
 
 use pim_packet::{IgmpGroupMessage, IgmpGroupRecord, IgmpPacket, IgmpRecordType, IgmpV3Query};
@@ -17,7 +17,6 @@ use super::af::PimAf;
 use super::inst::{IgmpSend, Pim};
 use super::ipv4::Ipv4;
 use super::link::LinkConfig;
-use super::socket::IGMP_ALL_HOSTS;
 use super::tib::SgKey;
 
 /// Robustness Variable (RFC 3376 §8.1). Fixed at the protocol
@@ -146,11 +145,11 @@ impl<A: PimAf> IgmpIf<A> {
 }
 
 /// Build and queue a general (group `None`) or group-specific query.
-fn send_query(
-    tx: &UnboundedSender<IgmpSend>,
+fn send_query<A: PimAf>(
+    tx: &UnboundedSender<IgmpSend<A>>,
     cfg: &LinkConfig,
     ifindex: u32,
-    group: Option<Ipv4Addr>,
+    group: Option<A::Addr>,
 ) {
     // Max Resp is in units of 1/10 s; group-specific queries use the
     // Last Member Query Interval (1 s). The exponent-coded form
@@ -162,16 +161,21 @@ fn send_query(
         ),
         Some(_) => 10,
     };
-    let dst = group.unwrap_or(IGMP_ALL_HOSTS);
+    let dst = group.unwrap_or(A::GENERAL_QUERY_DST);
+    // The IGMP wire form is IPv4; a general query carries 0.0.0.0.
+    let wire_group = match group.map(A::to_ip) {
+        Some(IpAddr::V4(v4)) => v4,
+        _ => Ipv4Addr::UNSPECIFIED,
+    };
     let packet = if cfg.igmp.version() == 2 {
         IgmpPacket::QueryV2(IgmpGroupMessage {
             max_resp,
-            group: group.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            group: wire_group,
         })
     } else {
         IgmpPacket::QueryV3(IgmpV3Query {
             max_resp_code: max_resp,
-            group: group.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            group: wire_group,
             suppress: false,
             qrv: IGMP_ROBUSTNESS as u8,
             // QQIC in seconds, exponent-coded above 127.
@@ -186,7 +190,7 @@ fn send_query(
     });
 }
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// Earliest IGMP deadline across all interfaces — the event
     /// loop's sleep target. `None` parks the arm forever.
     pub(crate) fn igmp_next_wakeup(&self) -> Option<Instant> {
@@ -254,8 +258,8 @@ impl Pim {
                 igmp.next_query = now + interval;
             }
 
-            let mut expired: Vec<Ipv4Addr> = vec![];
-            let mut sync: Vec<Ipv4Addr> = vec![];
+            let mut expired: Vec<A::Addr> = vec![];
+            let mut sync: Vec<A::Addr> = vec![];
             for (group_addr, group) in igmp.groups.iter_mut() {
                 if let Some(t) = group.v2_host_until
                     && t <= now
@@ -287,7 +291,7 @@ impl Pim {
                     sync.push(*group_addr);
                 }
             }
-            let mut prune: Vec<SgKey> = vec![];
+            let mut prune: Vec<SgKey<A>> = vec![];
             for group_addr in expired {
                 if let Some(group) = igmp.groups.remove(&group_addr) {
                     for src in group.synced {
@@ -321,7 +325,7 @@ impl Pim {
     /// immediate, but presents an empty view here — so a DR→non-DR
     /// transition withdraws everything and non-DR→DR re-adds it, both
     /// through the same diff.
-    pub(crate) fn igmp_tib_sync(&mut self, ifindex: u32, grp: Ipv4Addr) {
+    pub(crate) fn igmp_tib_sync(&mut self, ifindex: u32, grp: A::Addr) {
         let is_dr = self.i_am_dr(ifindex);
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
@@ -332,16 +336,15 @@ impl Pim {
         let Some(group) = igmp.groups.get_mut(&grp) else {
             return;
         };
-        let current: BTreeSet<Ipv4Addr> = if is_dr && group.filter_mode == FilterMode::Include {
+        let current: BTreeSet<A::Addr> = if is_dr && group.filter_mode == FilterMode::Include {
             group.sources.keys().copied().collect()
         } else {
             BTreeSet::new()
         };
-        let added: Vec<Ipv4Addr> = current.difference(&group.synced).copied().collect();
-        let removed: Vec<Ipv4Addr> = group.synced.difference(&current).copied().collect();
+        let added: Vec<A::Addr> = current.difference(&group.synced).copied().collect();
+        let removed: Vec<A::Addr> = group.synced.difference(&current).copied().collect();
         group.synced = current;
-        let asm_desired =
-            is_dr && group.filter_mode == FilterMode::Exclude && !super::rp::is_ssm(grp);
+        let asm_desired = is_dr && group.filter_mode == FilterMode::Exclude && !A::is_ssm(grp);
         let asm_was = group.asm_synced;
         group.asm_synced = asm_desired;
         for src in added {
@@ -357,7 +360,7 @@ impl Pim {
         }
     }
 
-    pub(crate) fn igmp_recv(&mut self, ifindex: u32, src: Ipv4Addr, packet: IgmpPacket) {
+    pub(crate) fn igmp_recv(&mut self, ifindex: u32, src: A::Addr, packet: IgmpPacket) {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
@@ -372,18 +375,27 @@ impl Pim {
                 self.igmp_other_querier(ifindex, &name, src, &cfg, now);
             }
             IgmpPacket::ReportV1(msg) | IgmpPacket::ReportV2(msg) => {
-                self.igmp_v2_report(ifindex, src, msg.group, &cfg, now);
+                let Some(grp) = A::from_ip(IpAddr::V4(msg.group)) else {
+                    return;
+                };
+                self.igmp_v2_report(ifindex, src, grp, &cfg, now);
                 // A v2 report flips the group to EXCLUDE — any
                 // previously synced INCLUDE sources leave the TIB.
-                self.igmp_tib_sync(ifindex, msg.group);
+                self.igmp_tib_sync(ifindex, grp);
             }
             IgmpPacket::LeaveV2(msg) => {
-                self.igmp_leave(ifindex, msg.group, &cfg, now);
+                let Some(grp) = A::from_ip(IpAddr::V4(msg.group)) else {
+                    return;
+                };
+                self.igmp_leave(ifindex, grp, &cfg, now);
             }
             IgmpPacket::ReportV3(report) => {
                 for record in report.records {
-                    self.igmp_apply_record(ifindex, src, &record, &cfg, now);
-                    self.igmp_tib_sync(ifindex, record.group);
+                    let Some(grp) = A::from_ip(IpAddr::V4(record.group)) else {
+                        continue;
+                    };
+                    self.igmp_apply_record(ifindex, src, grp, &record, &cfg, now);
+                    self.igmp_tib_sync(ifindex, grp);
                 }
             }
             IgmpPacket::Unknown { typ, .. } => {
@@ -398,7 +410,7 @@ impl Pim {
         &mut self,
         ifindex: u32,
         name: &str,
-        src: Ipv4Addr,
+        src: A::Addr,
         cfg: &LinkConfig,
         now: Instant,
     ) {
@@ -408,7 +420,7 @@ impl Pim {
         let Some(my_addr) = link.primary_addr() else {
             return;
         };
-        if src.is_unspecified() || src >= my_addr {
+        if A::is_unspecified(src) || src >= my_addr {
             return;
         }
         let Some(igmp) = link.igmp.as_mut() else {
@@ -428,12 +440,12 @@ impl Pim {
     fn igmp_v2_report(
         &mut self,
         ifindex: u32,
-        src: Ipv4Addr,
-        group_addr: Ipv4Addr,
+        src: A::Addr,
+        group_addr: A::Addr,
         cfg: &LinkConfig,
         now: Instant,
     ) {
-        if !Ipv4::is_multicast(group_addr) {
+        if !A::is_multicast(group_addr) {
             return;
         }
         let Some(igmp) = self.link_igmp_mut(ifindex) else {
@@ -446,14 +458,14 @@ impl Pim {
         group.filter_mode = FilterMode::Exclude;
         group.expires = Some(now + cfg.igmp.gmi());
         group.v2_host_until = Some(now + cfg.igmp.gmi());
-        if !src.is_unspecified() {
+        if !A::is_unspecified(src) {
             group.last_reporter = Some(src);
         }
     }
 
     /// v2 Leave (RFC 2236 §4): as querier, lower the group timer to
     /// LMQT and send a group-specific query.
-    fn igmp_leave(&mut self, ifindex: u32, group_addr: Ipv4Addr, cfg: &LinkConfig, now: Instant) {
+    fn igmp_leave(&mut self, ifindex: u32, group_addr: A::Addr, cfg: &LinkConfig, now: Instant) {
         let mut query = false;
         {
             let Some(igmp) = self.link_igmp_mut(ifindex) else {
@@ -481,14 +493,22 @@ impl Pim {
     fn igmp_apply_record(
         &mut self,
         ifindex: u32,
-        src: Ipv4Addr,
+        src: A::Addr,
+        grp: A::Addr,
         record: &IgmpGroupRecord,
         cfg: &LinkConfig,
         now: Instant,
     ) {
-        if !Ipv4::is_multicast(record.group) {
+        if !A::is_multicast(grp) {
             return;
         }
+        // The record's source list is IPv4 wire; keep only this
+        // family's addresses.
+        let rec_sources: Vec<A::Addr> = record
+            .sources
+            .iter()
+            .filter_map(|s| A::from_ip(IpAddr::V4(*s)))
+            .collect();
         let gmi = cfg.igmp.gmi();
         let lmqt = now + LAST_MEMBER_QUERY_TIME;
         let mut query = false;
@@ -502,41 +522,41 @@ impl Pim {
                 ModeIsExclude | ChangeToExclude => {
                     let group = igmp
                         .groups
-                        .entry(record.group)
+                        .entry(grp)
                         .or_insert_with(|| IgmpGroup::new(now, FilterMode::Exclude));
                     group.filter_mode = FilterMode::Exclude;
                     group.expires = Some(now + gmi);
-                    if !src.is_unspecified() {
+                    if !A::is_unspecified(src) {
                         group.last_reporter = Some(src);
                     }
                 }
                 ModeIsInclude | AllowNewSources => {
-                    if record.sources.is_empty() {
+                    if rec_sources.is_empty() {
                         return;
                     }
                     let group = igmp
                         .groups
-                        .entry(record.group)
+                        .entry(grp)
                         .or_insert_with(|| IgmpGroup::new(now, FilterMode::Include));
-                    for source in &record.sources {
+                    for source in &rec_sources {
                         group.sources.insert(*source, now + gmi);
                     }
-                    if !src.is_unspecified() {
+                    if !A::is_unspecified(src) {
                         group.last_reporter = Some(src);
                     }
                 }
                 ChangeToInclude => {
                     let group = igmp
                         .groups
-                        .entry(record.group)
+                        .entry(grp)
                         .or_insert_with(|| IgmpGroup::new(now, FilterMode::Include));
-                    for source in &record.sources {
+                    for source in &rec_sources {
                         group.sources.insert(*source, now + gmi);
                     }
-                    if !src.is_unspecified() {
+                    if !A::is_unspecified(src) {
                         group.last_reporter = Some(src);
                     }
-                    if record.sources.is_empty() {
+                    if rec_sources.is_empty() {
                         // TO_IN {} is the v3 leave. In EXCLUDE mode
                         // lower the group timer; in INCLUDE mode age
                         // the remaining sources out at LMQT.
@@ -554,11 +574,11 @@ impl Pim {
                     }
                 }
                 BlockOldSources => {
-                    let Some(group) = igmp.groups.get_mut(&record.group) else {
+                    let Some(group) = igmp.groups.get_mut(&grp) else {
                         return;
                     };
                     if group.filter_mode == FilterMode::Include {
-                        for source in &record.sources {
+                        for source in &rec_sources {
                             if let Some(exp) = group.sources.get_mut(source) {
                                 *exp = (*exp).min(lmqt);
                             }
@@ -572,11 +592,11 @@ impl Pim {
             }
         }
         if query {
-            send_query(&self.igmp_send_tx, cfg, ifindex, Some(record.group));
+            send_query(&self.igmp_send_tx, cfg, ifindex, Some(grp));
         }
     }
 
-    fn link_igmp_mut(&mut self, ifindex: u32) -> Option<&mut IgmpIf> {
+    fn link_igmp_mut(&mut self, ifindex: u32) -> Option<&mut IgmpIf<A>> {
         self.links.get_mut(&ifindex)?.igmp.as_mut()
     }
 }

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -9,7 +9,6 @@
 //! phases (see docs/design/pim-sm-ssm-architecture.md).
 
 use std::collections::{BTreeMap, HashMap};
-use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -26,86 +25,87 @@ use crate::config::{
 use crate::context::{ProtoContext, Task};
 use crate::rib::api::RibRx;
 
+use super::af::PimAf;
 use super::bsr::{BsrConfig, BsrRun};
 use super::config::Callback;
+use super::ipv4::Ipv4;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
 use super::mroute::{Mrt4, Upcall};
 use super::network::{igmp_read_packet, igmp_write_packet, mroute_read, read_packet, write_packet};
 use super::rp::RpSet;
 use super::rpf::RpfEntry;
-use super::socket::ALL_PIM_ROUTERS;
 use super::tib::{SgKey, TibEntry};
 
 /// `show pim ...` dispatch handler, mirroring
 /// [`crate::nd::inst::ShowCallback`].
-pub type ShowCallback = fn(&Pim, Args, bool) -> Result<String, std::fmt::Error>;
+pub type ShowCallback<A = Ipv4> = fn(&Pim<A>, Args, bool) -> Result<String, std::fmt::Error>;
 
 /// Internal events: parsed packets from the read task and timer
 /// expirations. Every FSM timer is a [`crate::context::Timer`] whose
 /// callback sends one of these.
 #[derive(Debug)]
-pub enum Message {
+pub enum Message<A: PimAf = Ipv4> {
     Recv {
         packet: PimPacket,
-        src: Ipv4Addr,
+        src: A::Addr,
         ifindex: u32,
     },
     Igmp {
         packet: IgmpPacket,
-        src: Ipv4Addr,
+        src: A::Addr,
         ifindex: u32,
     },
-    Upcall(Upcall),
+    Upcall(Upcall<A>),
     HelloTimer(u32),
-    NeighborExpiry(u32, Ipv4Addr),
+    NeighborExpiry(u32, A::Addr),
 }
 
 /// Outbound message for the write task: `packet` to `dst`, egress
 /// pinned to `ifindex` via `IP_PKTINFO`.
 #[derive(Debug)]
-pub struct PimSend {
+pub struct PimSend<A: PimAf = Ipv4> {
     pub packet: PimPacket,
     pub ifindex: u32,
-    pub dst: Ipv4Addr,
+    pub dst: A::Addr,
 }
 
 /// Outbound IGMP message (queries) for the IGMP write task.
 #[derive(Debug)]
-pub struct IgmpSend {
+pub struct IgmpSend<A: PimAf = Ipv4> {
     pub packet: IgmpPacket,
     pub ifindex: u32,
-    pub dst: Ipv4Addr,
+    pub dst: A::Addr,
 }
 
-pub struct Pim {
-    pub tx: UnboundedSender<Message>,
-    rx: UnboundedReceiver<Message>,
+pub struct Pim<A: PimAf = Ipv4> {
+    pub tx: UnboundedSender<Message<A>>,
+    rx: UnboundedReceiver<Message<A>>,
     /// Runtime interface table, keyed by ifindex, built from RibRx
     /// link / address events.
-    pub links: BTreeMap<u32, PimLink>,
+    pub links: BTreeMap<u32, PimLink<A>>,
     /// Desired per-interface config keyed by interface name — the
     /// source of truth the reconciler compares runtime state against.
     pub if_config: BTreeMap<String, LinkConfig>,
     /// The Tree Information Base: (*,G) / (S,G) / (S,G,rpt) state.
-    pub tib: BTreeMap<SgKey, TibEntry>,
+    pub tib: BTreeMap<SgKey<A>, TibEntry<A>>,
     /// RPF cache keyed by tracked address (sources and RPs).
-    pub rpf: BTreeMap<Ipv4Addr, RpfEntry>,
+    pub rpf: BTreeMap<A::Addr, RpfEntry<A>>,
     /// Static RP mappings.
-    pub rp_set: RpSet,
+    pub rp_set: RpSet<A>,
     /// Bootstrap-router config + runtime (RFC 5059).
-    pub bsr_config: BsrConfig,
-    pub bsr: BsrRun,
+    pub bsr_config: BsrConfig<A>,
+    pub bsr: BsrRun<A>,
     /// Kernel dataplane: mroute socket, VIFs, MFC.
-    pub(crate) fp: Mrt4,
+    pub(crate) fp: A::Fp,
     /// Periodic J/P refresh deadlines per (ifindex, upstream nbr).
-    pub(crate) jp_refresh: BTreeMap<(u32, Ipv4Addr), std::time::Instant>,
-    pub(crate) send_tx: UnboundedSender<PimSend>,
-    pub(crate) igmp_send_tx: UnboundedSender<IgmpSend>,
+    pub(crate) jp_refresh: BTreeMap<(u32, A::Addr), std::time::Instant>,
+    pub(crate) send_tx: UnboundedSender<PimSend<A>>,
+    pub(crate) igmp_send_tx: UnboundedSender<IgmpSend<A>>,
     rib_rx: UnboundedReceiver<RibRx>,
     pub cm: ConfigChannel,
     pub show: ShowChannel,
-    pub show_cb: HashMap<String, ShowCallback>,
-    pub callbacks: HashMap<String, Callback>,
+    pub show_cb: HashMap<String, ShowCallback<A>>,
+    pub callbacks: HashMap<String, Callback<A>>,
     pub(crate) sock: Arc<AsyncFd<Socket>>,
     pub(crate) igmp_sock: Arc<AsyncFd<Socket>>,
     /// RIB client context — carries the NHT registrations for RPF.
@@ -135,7 +135,10 @@ pub struct Pim {
     _mroute_read_task: Task<()>,
 }
 
-impl Pim {
+/// The concrete IPv4 constructor: it wires the IPv4 raw sockets and
+/// the `Mrt4` plane and spawns the read/write tasks, so it lives on
+/// `Pim<Ipv4>`. Everything else is generic over the address family.
+impl Pim<Ipv4> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: ProtoContext,
@@ -215,7 +218,9 @@ impl Pim {
         pim.show_build();
         pim
     }
+}
 
+impl<A: PimAf> Pim<A> {
     async fn event_loop(&mut self) {
         // Drain RIB's initial link / address replay up to EoR before
         // serving the other channels, so config callbacks always see
@@ -258,7 +263,7 @@ impl Pim {
         }
     }
 
-    fn process_msg(&mut self, msg: Message) {
+    fn process_msg(&mut self, msg: Message<A>) {
         match msg {
             Message::Recv {
                 packet,
@@ -421,7 +426,7 @@ impl Pim {
         }
     }
 
-    fn packet_recv(&mut self, packet: PimPacket, src: Ipv4Addr, ifindex: u32) {
+    fn packet_recv(&mut self, packet: PimPacket, src: A::Addr, ifindex: u32) {
         match &packet.payload {
             PimPayload::Hello(hello) => self.hello_recv(ifindex, src, hello),
             PimPayload::JoinPrune(jp) => self.jp_recv(ifindex, src, jp),
@@ -442,7 +447,7 @@ impl Pim {
         }
     }
 
-    fn hello_packet(&self, link: &PimLink, config: &LinkConfig, holdtime: u16) -> PimPacket {
+    fn hello_packet(&self, link: &PimLink<A>, config: &LinkConfig, holdtime: u16) -> PimPacket {
         let mut tlvs = vec![
             HelloTlv::Holdtime(holdtime),
             HelloTlv::LanPruneDelay {
@@ -461,7 +466,7 @@ impl Pim {
             .addrs
             .iter()
             .skip(1)
-            .map(|p| pim_packet::EncodedUnicast::new(std::net::IpAddr::V4(p.addr())))
+            .map(|p| pim_packet::EncodedUnicast::new(A::to_ip(A::prefix_addr(p))))
             .collect();
         if !secondary.is_empty() {
             tlvs.push(HelloTlv::AddressList(secondary));
@@ -484,7 +489,7 @@ impl Pim {
         let _ = self.send_tx.send(PimSend {
             packet,
             ifindex,
-            dst: ALL_PIM_ROUTERS,
+            dst: A::ALL_PIM_ROUTERS,
         });
     }
 
@@ -505,12 +510,12 @@ impl Pim {
         let _ = self.send_tx.send(PimSend {
             packet,
             ifindex,
-            dst: ALL_PIM_ROUTERS,
+            dst: A::ALL_PIM_ROUTERS,
         });
     }
 }
 
-pub fn serve(mut pim: Pim) -> Task<()> {
+pub fn serve<A: PimAf>(mut pim: Pim<A>) -> Task<()> {
     Task::spawn(async move {
         pim.event_loop().await;
     })

--- a/zebra-rs/src/pim/ipv4.rs
+++ b/zebra-rs/src/pim/ipv4.rs
@@ -1,10 +1,13 @@
 //! The IPv4 [`PimAf`] marker and its pure address-family semantics.
 
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 
-use ipnet::Ipv4Net;
+use ipnet::{IpNet, Ipv4Net};
+
+use crate::rib::Link;
 
 use super::af::PimAf;
+use super::mroute::Mrt4;
 
 /// IPv4 address-family marker. The ordering / hash / default derives
 /// are what let `#[derive(Ord, Hash, Default)]` on the generic data
@@ -15,6 +18,39 @@ pub struct Ipv4;
 impl PimAf for Ipv4 {
     type Addr = Ipv4Addr;
     type Prefix = Ipv4Net;
+    type Fp = Mrt4;
+
+    const ALL_PIM_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 13);
+    const GENERAL_QUERY_DST: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
+
+    fn is_unspecified(a: Ipv4Addr) -> bool {
+        a.is_unspecified()
+    }
+
+    fn from_ip(ip: IpAddr) -> Option<Ipv4Addr> {
+        match ip {
+            IpAddr::V4(a) => Some(a),
+            IpAddr::V6(_) => None,
+        }
+    }
+
+    fn to_ip(a: Ipv4Addr) -> IpAddr {
+        IpAddr::V4(a)
+    }
+
+    fn prefix_from_ipnet(net: IpNet) -> Option<Ipv4Net> {
+        match net {
+            IpNet::V4(p) => Some(p),
+            IpNet::V6(_) => None,
+        }
+    }
+
+    fn link_prefixes(link: &Link) -> Vec<Ipv4Net> {
+        link.addr4
+            .iter()
+            .filter_map(|a| Self::prefix_from_ipnet(a.addr))
+            .collect()
+    }
 
     // `Ipv4Net::new_assert` is a const fn, so the canonical ranges are
     // true associated consts. `232.0.0.0/8` is the RFC 4607 SSM range;
@@ -49,6 +85,28 @@ impl PimAf for Ipv4 {
 
     fn prefix_addr(p: &Ipv4Net) -> Ipv4Addr {
         p.addr()
+    }
+
+    fn null_register_payload(src: Ipv4Addr, grp: Ipv4Addr) -> Vec<u8> {
+        // A minimal inner IPv4 header naming (S,G).
+        let mut header = vec![0u8; 20];
+        header[0] = 0x45;
+        header[3] = 20; // total length
+        header[8] = 64; // ttl
+        header[12..16].copy_from_slice(&src.octets());
+        header[16..20].copy_from_slice(&grp.octets());
+        header
+    }
+
+    fn register_inner_sg(data: &[u8]) -> Option<(Ipv4Addr, Ipv4Addr)> {
+        // The inner packet (or Null-Register dummy) is an IPv4 header:
+        // version nibble 4, (S,G) at the source/destination fields.
+        if data.len() < 20 || data[0] >> 4 != 4 {
+            return None;
+        }
+        let src = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
+        let grp = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
+        Some((src, grp))
     }
 }
 

--- a/zebra-rs/src/pim/jp.rs
+++ b/zebra-rs/src/pim/jp.rs
@@ -5,16 +5,15 @@
 //! riding the (*,G) refresh toward the RP (RFC 7761 §4.5.7).
 
 use std::collections::BTreeMap;
-use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
 
 use pim_packet::{
     EncodedGroup, EncodedSource, EncodedUnicast, JpGroup, PimJoinPrune, PimPacket, PimPayload,
 };
 
+use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::rpf::RpfState;
-use super::socket::ALL_PIM_ROUTERS;
 use super::tib::{JP_HOLDTIME, JoinState, SgKey};
 
 /// Periodic J/P refresh interval (t_periodic, RFC 7761 §4.11).
@@ -25,10 +24,10 @@ pub const JP_PERIOD: Duration = Duration::from_secs(60);
 /// 1.1–1.4 randomization band).
 pub const JP_SUPPRESS: Duration = Duration::from_secs(75);
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     // ---- RX ----
 
-    pub(crate) fn jp_recv(&mut self, ifindex: u32, src: Ipv4Addr, jp: &PimJoinPrune) {
+    pub(crate) fn jp_recv(&mut self, ifindex: u32, src: A::Addr, jp: &PimJoinPrune) {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
@@ -38,7 +37,7 @@ impl Pim {
         // Process J/P entries addressed to one of our addresses on
         // this interface; messages targeting another upstream router
         // only matter for suppression/override (later phase).
-        let IpAddr::V4(upstream) = jp.upstream_neighbor.addr else {
+        let Some(upstream) = A::from_ip(jp.upstream_neighbor.addr) else {
             return;
         };
         if !link.is_my_addr(&upstream) {
@@ -49,11 +48,11 @@ impl Pim {
         }
         let holdtime = jp.holdtime;
         for group in &jp.groups {
-            let IpAddr::V4(grp) = group.group.addr else {
+            let Some(grp) = A::from_ip(group.group.addr) else {
                 continue;
             };
             for join in &group.joins {
-                let IpAddr::V4(addr) = join.addr else {
+                let Some(addr) = A::from_ip(join.addr) else {
                     continue;
                 };
                 match (join.wildcard, join.rpt) {
@@ -73,7 +72,7 @@ impl Pim {
                 }
             }
             for prune in &group.prunes {
-                let IpAddr::V4(addr) = prune.addr else {
+                let Some(addr) = A::from_ip(prune.addr) else {
                     continue;
                 };
                 match (prune.wildcard, prune.rpt) {
@@ -102,27 +101,19 @@ impl Pim {
     ///     our next periodic refresh;
     ///   * another router's Prune for state we still want triggers an
     ///     override Join so the upstream keeps forwarding.
-    fn jp_overhear(
-        &mut self,
-        ifindex: u32,
-        sender: Ipv4Addr,
-        upstream: Ipv4Addr,
-        jp: &PimJoinPrune,
-    ) {
+    fn jp_overhear(&mut self, ifindex: u32, sender: A::Addr, upstream: A::Addr, jp: &PimJoinPrune) {
         let bucket = RpfState::Gateway {
             ifindex,
             nexthop: upstream,
         };
-        let mut overrides: Vec<SgKey> = vec![];
+        let mut overrides: Vec<SgKey<A>> = vec![];
         let mut suppress = false;
         for group in &jp.groups {
-            let IpAddr::V4(grp) = group.group.addr else {
+            let Some(grp) = A::from_ip(group.group.addr) else {
                 continue;
             };
-            let key_of = |source: &EncodedSource| -> Option<SgKey> {
-                let IpAddr::V4(addr) = source.addr else {
-                    return None;
-                };
+            let key_of = |source: &EncodedSource| -> Option<SgKey<A>> {
+                let addr = A::from_ip(source.addr)?;
                 match (source.wildcard, source.rpt) {
                     (true, true) => Some(SgKey::StarG { grp }),
                     (false, false) => Some(SgKey::Sg { src: addr, grp }),
@@ -171,10 +162,10 @@ impl Pim {
 
     // ---- TX ----
 
-    fn encode_key(&self, key: SgKey) -> Option<EncodedSource> {
+    fn encode_key(&self, key: SgKey<A>) -> Option<EncodedSource> {
         match key {
-            SgKey::Sg { src, .. } => Some(EncodedSource::sg(IpAddr::V4(src))),
-            SgKey::SgRpt { src, .. } => Some(EncodedSource::sg_rpt(IpAddr::V4(src))),
+            SgKey::Sg { src, .. } => Some(EncodedSource::sg(A::to_ip(src))),
+            SgKey::SgRpt { src, .. } => Some(EncodedSource::sg_rpt(A::to_ip(src))),
             SgKey::StarG { grp } => {
                 // The (*,G) "source" is RP(G).
                 let rp = self
@@ -182,39 +173,39 @@ impl Pim {
                     .get(&key)
                     .and_then(|e| e.rpf_target)
                     .or_else(|| self.rp_lookup(grp))?;
-                Some(EncodedSource::star_g(IpAddr::V4(rp)))
+                Some(EncodedSource::star_g(A::to_ip(rp)))
             }
         }
     }
 
     /// Triggered single-entry Join (`join == true`) or Prune toward
     /// `nbr` out `ifindex`.
-    pub(crate) fn jp_send_entry(&self, ifindex: u32, nbr: Ipv4Addr, key: SgKey, join: bool) {
+    pub(crate) fn jp_send_entry(&self, ifindex: u32, nbr: A::Addr, key: SgKey<A>, join: bool) {
         let Some(source) = self.encode_key(key) else {
             return;
         };
         let group = JpGroup {
-            group: EncodedGroup::new(IpAddr::V4(key.grp())),
+            group: EncodedGroup::new(A::to_ip(key.grp())),
             joins: if join { vec![source] } else { vec![] },
             prunes: if join { vec![] } else { vec![source] },
         };
         self.jp_send(ifindex, nbr, vec![group]);
     }
 
-    fn jp_send(&self, ifindex: u32, nbr: Ipv4Addr, groups: Vec<JpGroup>) {
-        let mut jp = PimJoinPrune::new(EncodedUnicast::new(IpAddr::V4(nbr)), JP_HOLDTIME);
+    fn jp_send(&self, ifindex: u32, nbr: A::Addr, groups: Vec<JpGroup>) {
+        let mut jp = PimJoinPrune::new(EncodedUnicast::new(A::to_ip(nbr)), JP_HOLDTIME);
         jp.groups = groups;
         let packet = PimPacket::new(PimPayload::JoinPrune(jp));
         let _ = self.send_tx.send(PimSend {
             packet,
             ifindex,
-            dst: ALL_PIM_ROUTERS,
+            dst: A::ALL_PIM_ROUTERS,
         });
     }
 
     /// Make sure a periodic refresh is scheduled for this upstream
     /// neighbor.
-    pub(crate) fn jp_refresh_arm(&mut self, ifindex: u32, nbr: Ipv4Addr) {
+    pub(crate) fn jp_refresh_arm(&mut self, ifindex: u32, nbr: A::Addr) {
         self.jp_refresh
             .entry((ifindex, nbr))
             .or_insert_with(|| Instant::now() + JP_PERIOD);
@@ -226,7 +217,7 @@ impl Pim {
     /// sources switched to a diverging SPT; drop the bucket when
     /// nothing uses that neighbor anymore.
     pub(crate) fn jp_tick(&mut self, now: Instant) {
-        let due: Vec<(u32, Ipv4Addr)> = self
+        let due: Vec<(u32, A::Addr)> = self
             .jp_refresh
             .iter()
             .filter(|(_, t)| **t <= now)
@@ -237,9 +228,9 @@ impl Pim {
                 ifindex,
                 nexthop: nbr,
             };
-            let mut by_group: BTreeMap<Ipv4Addr, (Vec<EncodedSource>, Vec<EncodedSource>)> =
+            let mut by_group: BTreeMap<A::Addr, (Vec<EncodedSource>, Vec<EncodedSource>)> =
                 BTreeMap::new();
-            let mut star_groups: Vec<Ipv4Addr> = vec![];
+            let mut star_groups: Vec<A::Addr> = vec![];
             for (key, entry) in self.tib.iter() {
                 if entry.join_state != JoinState::Joined || entry.rpf != bucket {
                     continue;
@@ -265,7 +256,7 @@ impl Pim {
                                 && e.join_state == JoinState::Joined
                                 && e.rpf != bucket =>
                         {
-                            Some(EncodedSource::sg_rpt(IpAddr::V4(*src)))
+                            Some(EncodedSource::sg_rpt(A::to_ip(*src)))
                         }
                         _ => None,
                     })
@@ -281,7 +272,7 @@ impl Pim {
             let groups: Vec<JpGroup> = by_group
                 .into_iter()
                 .map(|(grp, (joins, prunes))| JpGroup {
-                    group: EncodedGroup::new(IpAddr::V4(grp)),
+                    group: EncodedGroup::new(A::to_ip(grp)),
                     joins,
                     prunes,
                 })

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -2,9 +2,7 @@
 //! enable/disable reconciliation and DR election (RFC 7761 §4.3.2).
 
 use std::collections::BTreeMap;
-use std::net::Ipv4Addr;
 
-use ipnet::IpNet;
 use rand::RngExt;
 
 use crate::context::Timer;
@@ -75,16 +73,9 @@ pub struct PimLink<A: PimAf = Ipv4> {
     pub igmp: Option<IgmpIf<A>>,
 }
 
-impl PimLink<Ipv4> {
+impl<A: PimAf> PimLink<A> {
     pub fn from_link(link: &Link) -> Self {
-        let addrs = link
-            .addr4
-            .iter()
-            .filter_map(|a| match a.addr {
-                IpNet::V4(v4) => Some(v4),
-                IpNet::V6(_) => None,
-            })
-            .collect();
+        let addrs = A::link_prefixes(link);
         Self {
             ifindex: link.index,
             name: link.name.clone(),
@@ -99,12 +90,12 @@ impl PimLink<Ipv4> {
         }
     }
 
-    pub fn primary_addr(&self) -> Option<Ipv4Addr> {
-        self.addrs.first().map(|p| p.addr())
+    pub fn primary_addr(&self) -> Option<A::Addr> {
+        self.addrs.first().map(|p| A::prefix_addr(p))
     }
 
-    pub fn is_my_addr(&self, addr: &Ipv4Addr) -> bool {
-        self.addrs.iter().any(|p| p.addr() == *addr)
+    pub fn is_my_addr(&self, addr: &A::Addr) -> bool {
+        self.addrs.iter().any(|p| A::prefix_addr(p) == *addr)
     }
 
     /// Is `addr` a live PIM neighbor on this link — matching either a
@@ -112,12 +103,16 @@ impl PimLink<Ipv4> {
     /// addresses (RFC 7761 §4.3.4)? The RIB's resolved RPF nexthop
     /// may be any address the neighbor owns, not just its hello
     /// source.
-    pub fn neighbor_covers(&self, addr: &Ipv4Addr) -> bool {
+    pub fn neighbor_covers(&self, addr: &A::Addr) -> bool {
         self.nbrs.contains_key(addr) || self.nbrs.values().any(|n| n.secondary.contains(addr))
     }
 }
 
-fn hello_timer(tx: &tokio::sync::mpsc::UnboundedSender<Message>, ifindex: u32, sec: u16) -> Timer {
+fn hello_timer<A: PimAf>(
+    tx: &tokio::sync::mpsc::UnboundedSender<Message<A>>,
+    ifindex: u32,
+    sec: u16,
+) -> Timer {
     let tx = tx.clone();
     Timer::repeat(sec as u64, move || {
         let tx = tx.clone();
@@ -127,7 +122,7 @@ fn hello_timer(tx: &tokio::sync::mpsc::UnboundedSender<Message>, ifindex: u32, s
     })
 }
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// Converge one interface's running state onto its desired state.
     /// Called from every input that can change either side: config
     /// set/delete, LinkAdd/Up/Down/Del, AddrAdd/AddrDel. PIM runs on
@@ -179,7 +174,7 @@ impl Pim {
         };
         // Withdraw every local membership this interface fed into
         // the TIB before dropping the state.
-        let mut prune: Vec<super::tib::SgKey> = vec![];
+        let mut prune: Vec<super::tib::SgKey<A>> = vec![];
         if let Some(igmp) = link.igmp.take() {
             for (grp, group) in igmp.groups {
                 for src in group.synced {
@@ -335,7 +330,7 @@ impl Pim {
     /// Membership tracking in `IgmpIf` is kept warm regardless, so
     /// failover is immediate.
     pub(crate) fn dr_membership_reeval(&mut self, ifindex: u32) {
-        let groups: Vec<Ipv4Addr> = match self.links.get(&ifindex).and_then(|l| l.igmp.as_ref()) {
+        let groups: Vec<A::Addr> = match self.links.get(&ifindex).and_then(|l| l.igmp.as_ref()) {
             Some(igmp) => igmp.groups.keys().copied().collect(),
             None => return,
         };
@@ -380,7 +375,7 @@ impl Pim {
         let Some(link) = self.links.get_mut(&addr.ifindex) else {
             return;
         };
-        let IpNet::V4(prefix) = addr.addr else {
+        let Some(prefix) = A::prefix_from_ipnet(addr.addr) else {
             return;
         };
         if !link.addrs.contains(&prefix) {
@@ -393,7 +388,7 @@ impl Pim {
         let Some(link) = self.links.get_mut(&addr.ifindex) else {
             return;
         };
-        let IpNet::V4(prefix) = addr.addr else {
+        let Some(prefix) = A::prefix_from_ipnet(addr.addr) else {
             return;
         };
         link.addrs.retain(|p| *p != prefix);

--- a/zebra-rs/src/pim/macros.rs
+++ b/zebra-rs/src/pim/macros.rs
@@ -5,13 +5,17 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use super::af::PimAf;
 use super::assert_fsm::AssertRole;
 use super::tib::{DsState, SgKey, TibEntry};
 
 /// `immediate_olist(key)`: interfaces with local (IGMP) membership
 /// or downstream Join state on this entry. A PrunePending interface
 /// still forwards until its timer fires (RFC 7761 §4.5.2).
-pub fn immediate_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+pub fn immediate_olist<A: PimAf>(
+    tib: &BTreeMap<SgKey<A>, TibEntry<A>>,
+    key: SgKey<A>,
+) -> BTreeSet<u32> {
     let Some(entry) = tib.get(&key) else {
         return BTreeSet::new();
     };
@@ -30,7 +34,10 @@ pub fn immediate_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<
 /// set — immediate (S,G) state plus the shared tree's olist minus
 /// interfaces holding an (S,G,rpt) prune. For non-(S,G) keys it is
 /// the immediate olist.
-pub fn inherited_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+pub fn inherited_olist<A: PimAf>(
+    tib: &BTreeMap<SgKey<A>, TibEntry<A>>,
+    key: SgKey<A>,
+) -> BTreeSet<u32> {
     let SgKey::Sg { src, grp } = key else {
         return immediate_olist(tib, key);
     };
@@ -48,7 +55,10 @@ pub fn inherited_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<
 /// Interfaces where this entry lost an assert election — excluded
 /// from forwarding and from JoinDesired while the winner is alive
 /// (RFC 7761 `lost_assert(S,G,I)`).
-pub fn assert_losers(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+pub fn assert_losers<A: PimAf>(
+    tib: &BTreeMap<SgKey<A>, TibEntry<A>>,
+    key: SgKey<A>,
+) -> BTreeSet<u32> {
     let Some(entry) = tib.get(&key) else {
         return BTreeSet::new();
     };
@@ -62,7 +72,10 @@ pub fn assert_losers(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u3
 
 /// The inherited olist minus assert-lost interfaces — what actually
 /// counts for JoinDesired's traffic-driven clause and the MFC.
-pub fn inherited_effective(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+pub fn inherited_effective<A: PimAf>(
+    tib: &BTreeMap<SgKey<A>, TibEntry<A>>,
+    key: SgKey<A>,
+) -> BTreeSet<u32> {
     let mut olist = inherited_olist(tib, key);
     for ifindex in assert_losers(tib, key) {
         olist.remove(&ifindex);
@@ -72,7 +85,10 @@ pub fn inherited_effective(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTree
 
 /// `JoinDesired` restricted to interfaces we would actually forward
 /// to (immediate olist minus assert losses).
-pub fn join_desired_effective(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> bool {
+pub fn join_desired_effective<A: PimAf>(
+    tib: &BTreeMap<SgKey<A>, TibEntry<A>>,
+    key: SgKey<A>,
+) -> bool {
     let mut olist = immediate_olist(tib, key);
     for ifindex in assert_losers(tib, key) {
         olist.remove(&ifindex);
@@ -82,7 +98,7 @@ pub fn join_desired_effective(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> bo
 
 /// The (S,G) MFC outgoing set: the effective inherited olist minus
 /// the incoming interface (loop-free guard — never emit OIF == IIF).
-pub fn mfc_oifs(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+pub fn mfc_oifs<A: PimAf>(tib: &BTreeMap<SgKey<A>, TibEntry<A>>, key: SgKey<A>) -> BTreeSet<u32> {
     let mut oifs = inherited_effective(tib, key);
     if let Some(iif) = tib.get(&key).and_then(|e| e.rpf.ifindex()) {
         oifs.remove(&iif);

--- a/zebra-rs/src/pim/neighbor.rs
+++ b/zebra-rs/src/pim/neighbor.rs
@@ -2,7 +2,6 @@
 //! option tracking (holdtime, DR priority, Generation ID, LAN Prune
 //! Delay), holdtime expiry and Generation-ID bounce detection.
 
-use std::net::Ipv4Addr;
 use std::time::Instant;
 
 use pim_packet::PimHello;
@@ -37,10 +36,10 @@ pub struct Neighbor<A: PimAf = Ipv4> {
     pub expiry: Option<Timer>,
 }
 
-fn expiry_timer(
-    tx: &tokio::sync::mpsc::UnboundedSender<Message>,
+fn expiry_timer<A: PimAf>(
+    tx: &tokio::sync::mpsc::UnboundedSender<Message<A>>,
     ifindex: u32,
-    addr: Ipv4Addr,
+    addr: A::Addr,
     holdtime: u16,
 ) -> Option<Timer> {
     if holdtime == HOLDTIME_INFINITE {
@@ -55,8 +54,8 @@ fn expiry_timer(
     }))
 }
 
-impl Pim {
-    pub(crate) fn hello_recv(&mut self, ifindex: u32, src: Ipv4Addr, hello: &PimHello) {
+impl<A: PimAf> Pim<A> {
+    pub(crate) fn hello_recv(&mut self, ifindex: u32, src: A::Addr, hello: &PimHello) {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
@@ -76,14 +75,11 @@ impl Pim {
         }
 
         let gen_id = hello.generation_id();
-        let secondary: Vec<Ipv4Addr> = hello
+        let secondary: Vec<A::Addr> = hello
             .address_list()
             .unwrap_or(&[])
             .iter()
-            .filter_map(|a| match a.addr {
-                std::net::IpAddr::V4(v4) => Some(v4),
-                std::net::IpAddr::V6(_) => None,
-            })
+            .filter_map(|a| A::from_ip(a.addr))
             .collect();
         let timer = expiry_timer(&self.tx, ifindex, src, holdtime);
         let link = self.links.get_mut(&ifindex).unwrap();
@@ -143,11 +139,11 @@ impl Pim {
         self.dr_election(ifindex);
     }
 
-    pub(crate) fn neighbor_expiry(&mut self, ifindex: u32, addr: Ipv4Addr) {
+    pub(crate) fn neighbor_expiry(&mut self, ifindex: u32, addr: A::Addr) {
         self.neighbor_delete(ifindex, addr, "holdtime expired");
     }
 
-    fn neighbor_delete(&mut self, ifindex: u32, addr: Ipv4Addr, reason: &str) {
+    fn neighbor_delete(&mut self, ifindex: u32, addr: A::Addr, reason: &str) {
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };

--- a/zebra-rs/src/pim/register.rs
+++ b/zebra-rs/src/pim/register.rs
@@ -10,7 +10,6 @@
 //! matching the "switch to SPT immediately" policy. Native traffic
 //! takes over as soon as the (S,G) join propagates.
 
-use std::net::{IpAddr, Ipv4Addr};
 use std::time::{Duration, Instant};
 
 use pim_packet::{
@@ -19,9 +18,7 @@ use pim_packet::{
 
 use super::af::PimAf;
 use super::inst::{Pim, PimSend};
-use super::ipv4::Ipv4;
 use super::mroute::{PimForwardingPlane, Upcall};
-use super::rp::is_ssm;
 use super::tib::{JoinState, KEEPALIVE_PERIOD, RegState, SgKey};
 
 /// Register suppression: how long a Register-Stop silences the DR.
@@ -31,15 +28,15 @@ const REGISTER_SUPPRESS: Duration = Duration::from_secs(55);
 /// suppression would lapse.
 const REGISTER_PROBE: Duration = Duration::from_secs(5);
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// First-hop-router check on NOCACHE: start registering when we
     /// are the DR on the directly-connected source's interface, the
     /// group is ASM with a known RP, and we are not the RP ourselves.
-    pub(crate) fn register_check_fhr(&mut self, key: SgKey, vif: u16) {
+    pub(crate) fn register_check_fhr(&mut self, key: SgKey<A>, vif: u16) {
         let SgKey::Sg { src, grp } = key else {
             return;
         };
-        if is_ssm(grp) || self.i_am_rp(grp) || self.rp_lookup(grp).is_none() {
+        if A::is_ssm(grp) || self.i_am_rp(grp) || self.rp_lookup(grp).is_none() {
             return;
         }
         let Some(ifindex) = self.fp.ifindex_of(vif) else {
@@ -48,7 +45,7 @@ impl Pim {
         let directly_connected = self
             .links
             .get(&ifindex)
-            .map(|l| l.enabled && l.addrs.iter().any(|p| p.contains(&src)))
+            .map(|l| l.enabled && l.addrs.iter().any(|p| A::prefix_contains(p, &src)))
             .unwrap_or(false);
         if !directly_connected || !self.i_am_dr(ifindex) {
             return;
@@ -62,7 +59,7 @@ impl Pim {
 
     /// WHOLEPKT upcall: the kernel punted a full packet through the
     /// register VIF — encapsulate and unicast it to RP(G).
-    pub(crate) fn register_wholepkt(&mut self, upcall: Upcall) {
+    pub(crate) fn register_wholepkt(&mut self, upcall: Upcall<A>) {
         let key = SgKey::Sg {
             src: upcall.src,
             grp: upcall.grp,
@@ -81,7 +78,7 @@ impl Pim {
         self.register_send(rp, upcall.payload, false);
     }
 
-    fn register_send(&self, rp: Ipv4Addr, data: Vec<u8>, null: bool) {
+    fn register_send(&self, rp: A::Addr, data: Vec<u8>, null: bool) {
         let packet = PimPacket::new(PimPayload::Register(PimRegister {
             border: false,
             null_register: null,
@@ -95,34 +92,19 @@ impl Pim {
         });
     }
 
-    /// A minimal inner IPv4 header naming (S,G) — the Null-Register
-    /// payload (RFC 7761 §4.4.1).
-    fn null_register_payload(src: Ipv4Addr, grp: Ipv4Addr) -> Vec<u8> {
-        let mut header = vec![0u8; 20];
-        header[0] = 0x45;
-        header[3] = 20; // total length
-        header[8] = 64; // ttl
-        header[12..16].copy_from_slice(&src.octets());
-        header[16..20].copy_from_slice(&grp.octets());
-        header
-    }
-
     // ---- RP side ----
 
     /// Register RX at the RP: (re)create the (S,G), keep it alive,
     /// let `tib_update` fire the SPT join (KAT + inherited olist),
     /// and answer Register-Stop once the source tree is joined — or
     /// immediately when nobody is listening.
-    pub(crate) fn register_recv(&mut self, outer_src: Ipv4Addr, register: &PimRegister) {
+    pub(crate) fn register_recv(&mut self, outer_src: A::Addr, register: &PimRegister) {
         // The inner packet (or Null-Register dummy header) names (S,G).
-        let data = &register.data;
-        if data.len() < 20 || data[0] >> 4 != 4 {
+        let Some((src, grp)) = A::register_inner_sg(&register.data) else {
             tracing::debug!("pim: malformed register from {}", outer_src);
             return;
-        }
-        let src = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
-        let grp = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
-        if !Ipv4::is_multicast(grp) || is_ssm(grp) {
+        };
+        if !A::is_multicast(grp) || A::is_ssm(grp) {
             return;
         }
         if !self.i_am_rp(grp) {
@@ -148,10 +130,10 @@ impl Pim {
         }
     }
 
-    fn register_stop_send(&self, dr: Ipv4Addr, src: Ipv4Addr, grp: Ipv4Addr) {
+    fn register_stop_send(&self, dr: A::Addr, src: A::Addr, grp: A::Addr) {
         let packet = PimPacket::new(PimPayload::RegisterStop(PimRegisterStop {
-            group: EncodedGroup::new(IpAddr::V4(grp)),
-            source: EncodedUnicast::new(IpAddr::V4(src)),
+            group: EncodedGroup::new(A::to_ip(grp)),
+            source: EncodedUnicast::new(A::to_ip(src)),
         }));
         let _ = self.send_tx.send(PimSend {
             packet,
@@ -162,7 +144,8 @@ impl Pim {
 
     /// Register-Stop RX at the DR: suppress.
     pub(crate) fn register_stop_recv(&mut self, stop: &PimRegisterStop) {
-        let (IpAddr::V4(grp), IpAddr::V4(src)) = (stop.group.addr, stop.source.addr) else {
+        let (Some(grp), Some(src)) = (A::from_ip(stop.group.addr), A::from_ip(stop.source.addr))
+        else {
             return;
         };
         let key = SgKey::Sg { src, grp };
@@ -189,7 +172,7 @@ impl Pim {
     /// Register FSM deadlines: suppression lapse → Null-Register
     /// probe; probe unanswered → resume registering.
     pub(crate) fn register_tick(&mut self, now: Instant) {
-        let due: Vec<(SgKey, RegState)> = self
+        let due: Vec<(SgKey<A>, RegState)> = self
             .tib
             .iter()
             .filter_map(|(key, e)| match e.reg_state {
@@ -207,7 +190,7 @@ impl Pim {
                     // Probe: Null-Register; a live RP answers with
                     // another Stop before the window closes.
                     if let Some(rp) = self.rp_lookup(grp) {
-                        self.register_send(rp, Self::null_register_payload(src, grp), true);
+                        self.register_send(rp, A::null_register_payload(src, grp), true);
                     }
                     if let Some(entry) = self.tib.get_mut(&key) {
                         entry.reg_state = RegState::JoinPending {

--- a/zebra-rs/src/pim/rp.rs
+++ b/zebra-rs/src/pim/rp.rs
@@ -3,19 +3,11 @@
 //! mapping changes. Provenance is static-only until the BSR phase.
 
 use std::collections::BTreeMap;
-use std::net::Ipv4Addr;
 
 use super::af::PimAf;
 use super::inst::Pim;
 use super::ipv4::Ipv4;
 use super::tib::SgKey;
-
-/// Default SSM range (RFC 4607): no RP, no register, (S,G) only.
-/// Concrete-IPv4 wrapper over [`Ipv4::is_ssm`] kept for the existing
-/// call sites in `register.rs`/`igmp`.
-pub fn is_ssm(grp: Ipv4Addr) -> bool {
-    Ipv4::is_ssm(grp)
-}
 
 /// Static RP table: RP address → served group range.
 #[derive(Debug, Clone)]
@@ -31,27 +23,27 @@ impl<A: PimAf> Default for RpSet<A> {
     }
 }
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// RP(G): longest-prefix match across the static entries; when
     /// no static range covers the group, fall back to the
     /// BSR-learned set (static beats BSR). SSM groups never map to
     /// an RP.
-    pub(crate) fn rp_lookup(&self, grp: Ipv4Addr) -> Option<Ipv4Addr> {
-        if Ipv4::is_ssm(grp) || !Ipv4::is_multicast(grp) {
+    pub(crate) fn rp_lookup(&self, grp: A::Addr) -> Option<A::Addr> {
+        if A::is_ssm(grp) || !A::is_multicast(grp) {
             return None;
         }
         self.rp_set
             .statics
             .iter()
-            .filter(|(_, range)| Ipv4::prefix_contains(range, &grp))
-            .max_by_key(|(_, range)| Ipv4::prefix_len(range))
+            .filter(|(_, range)| A::prefix_contains(range, &grp))
+            .max_by_key(|(_, range)| A::prefix_len(range))
             .map(|(rp, _)| *rp)
             .or_else(|| self.bsr_rp_lookup(grp))
     }
 
     /// I_am_RP(G): the mapped RP address is one of our interface
     /// addresses.
-    pub(crate) fn i_am_rp(&self, grp: Ipv4Addr) -> bool {
+    pub(crate) fn i_am_rp(&self, grp: A::Addr) -> bool {
         let Some(rp) = self.rp_lookup(grp) else {
             return false;
         };
@@ -62,7 +54,7 @@ impl Pim {
     /// differs from the one it is built on gets re-targeted — prune
     /// the old upstream, move the RPF tracking, re-evaluate.
     pub(crate) fn rp_reevaluate(&mut self) {
-        let stars: Vec<(SgKey, Option<Ipv4Addr>)> = self
+        let stars: Vec<(SgKey<A>, Option<A::Addr>)> = self
             .tib
             .iter()
             .filter_map(|(key, entry)| match key {

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -4,7 +4,7 @@
 //! first; everything else follows the tracked RIB resolution.
 
 use std::collections::BTreeMap;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 
 use crate::rib;
 use crate::rib::nht::NexthopResolution;
@@ -44,11 +44,11 @@ pub struct RpfEntry<A: PimAf = Ipv4> {
     resolution: Option<NexthopResolution>,
 }
 
-impl Pim {
+impl<A: PimAf> Pim<A> {
     /// Take a reference on the RPF state for `src`, registering NHT
     /// interest on first use. The immediate `NexthopUpdate` echo from
     /// RIB refines the state asynchronously.
-    pub(crate) fn rpf_acquire(&mut self, src: Ipv4Addr) -> RpfState {
+    pub(crate) fn rpf_acquire(&mut self, src: A::Addr) -> RpfState<A> {
         if let Some(entry) = self.rpf.get_mut(&src) {
             entry.refs += 1;
             return entry.state;
@@ -56,7 +56,7 @@ impl Pim {
         let state = compute_rpf(&self.links, src, None);
         let _ = self.ctx.rib.send(rib::Message::NexthopRegister {
             proto: self.proto_label.clone(),
-            nh: IpAddr::V4(src),
+            nh: A::to_ip(src),
             vrf_id: self.ctx.vrf_id(),
         });
         self.rpf.insert(
@@ -70,7 +70,7 @@ impl Pim {
         state
     }
 
-    pub(crate) fn rpf_release(&mut self, src: Ipv4Addr) {
+    pub(crate) fn rpf_release(&mut self, src: A::Addr) {
         let Some(entry) = self.rpf.get_mut(&src) else {
             return;
         };
@@ -79,7 +79,7 @@ impl Pim {
             self.rpf.remove(&src);
             let _ = self.ctx.rib.send(rib::Message::NexthopUnregister {
                 proto: self.proto_label.clone(),
-                nh: IpAddr::V4(src),
+                nh: A::to_ip(src),
                 vrf_id: self.ctx.vrf_id(),
             });
         }
@@ -87,7 +87,7 @@ impl Pim {
 
     /// RIB pushed a new resolution for a tracked address.
     pub(crate) fn rpf_nexthop_update(&mut self, nh: IpAddr, resolution: NexthopResolution) {
-        let IpAddr::V4(src) = nh else {
+        let Some(src) = A::from_ip(nh) else {
             return;
         };
         let Some(entry) = self.rpf.get_mut(&src) else {
@@ -105,7 +105,7 @@ impl Pim {
     /// source (connected-ness may have flipped even without a RIB
     /// resolution change).
     pub(crate) fn rpf_recompute_all(&mut self) {
-        let sources: Vec<Ipv4Addr> = self.rpf.keys().copied().collect();
+        let sources: Vec<A::Addr> = self.rpf.keys().copied().collect();
         for src in sources {
             let Some(entry) = self.rpf.get_mut(&src) else {
                 continue;
@@ -121,7 +121,7 @@ impl Pim {
     /// Assert-metric inputs for a tracked address: (preference,
     /// metric). Connected beats any gateway route; unresolved is
     /// infinitely bad.
-    pub(crate) fn rpf_pref_metric(&self, addr: Ipv4Addr) -> (u32, u32) {
+    pub(crate) fn rpf_pref_metric(&self, addr: A::Addr) -> (u32, u32) {
         match self.rpf.get(&addr).map(|e| e.state) {
             Some(RpfState::Connected { .. }) => (0, 0),
             Some(RpfState::Gateway { .. }) => {
@@ -140,8 +140,8 @@ impl Pim {
     /// Propagate an RPF change into every TIB entry tracking that
     /// address ((S,G) sources and (*,G) RPs alike): prune off the old
     /// upstream, adopt the new state, re-evaluate.
-    fn rpf_changed(&mut self, addr: Ipv4Addr, state: RpfState) {
-        let keys: Vec<SgKey> = self
+    fn rpf_changed(&mut self, addr: A::Addr, state: RpfState<A>) {
+        let keys: Vec<SgKey<A>> = self
             .tib
             .iter()
             .filter(|(_, e)| e.rpf_target == Some(addr))
@@ -153,15 +153,15 @@ impl Pim {
     }
 }
 
-fn compute_rpf(
-    links: &BTreeMap<u32, super::link::PimLink>,
-    src: Ipv4Addr,
+fn compute_rpf<A: PimAf>(
+    links: &BTreeMap<u32, super::link::PimLink<A>>,
+    src: A::Addr,
     resolution: Option<&NexthopResolution>,
-) -> RpfState {
+) -> RpfState<A> {
     // On-link check first: a directly-connected source needs no
     // upstream neighbor regardless of what the RIB says.
     for link in links.values() {
-        if link.link_up && link.addrs.iter().any(|p| p.contains(&src)) {
+        if link.link_up && link.addrs.iter().any(|p| A::prefix_contains(p, &src)) {
             return RpfState::Connected {
                 ifindex: link.ifindex,
             };
@@ -178,7 +178,7 @@ fn compute_rpf(
     let Some(nexthop) = resolution.nexthops.first() else {
         return RpfState::Unresolved;
     };
-    let IpAddr::V4(gw) = nexthop.addr else {
+    let Some(gw) = A::from_ip(nexthop.addr) else {
         return RpfState::Unresolved;
     };
     if gw == src {

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -9,14 +9,18 @@ use std::time::Instant;
 
 use crate::config::{Args, Builder};
 
+use super::af::PimAf;
 use super::assert_fsm::AssertRole;
 use super::igmp::{FilterMode, QuerierState};
 use super::inst::{Pim, ShowCallback};
+use super::ipv4::Ipv4;
 use super::macros::mfc_oifs;
 use super::rpf::RpfState;
 use super::tib::{JoinState, RegState};
 
-impl Pim {
+/// `show pim …` handlers render the concrete-IPv4 state, so their
+/// registration lives on `Pim<Ipv4>`.
+impl Pim<Ipv4> {
     pub fn show_build(&mut self) {
         self.show_cb = Builder::<ShowCallback>::default()
             .path("/show/pim")
@@ -41,7 +45,9 @@ impl Pim {
             .set(show_mroute)
             .map();
     }
+}
 
+impl<A: PimAf> Pim<A> {
     pub(crate) fn ifname(&self, ifindex: u32) -> String {
         self.links
             .get(&ifindex)

--- a/zebra-rs/src/pim/socket.rs
+++ b/zebra-rs/src/pim/socket.rs
@@ -21,9 +21,6 @@ pub const PIM_IP_PROTO: i32 = 103;
 /// IGMP is IP protocol 2.
 pub const IGMP_IP_PROTO: i32 = 2;
 
-/// All-hosts group — general queries go here.
-pub const IGMP_ALL_HOSTS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
-
 /// All-routers group — IGMPv2 Leaves are sent here.
 pub const IGMP_ALL_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 2);
 

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -15,7 +15,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
 use super::af::PimAf;
@@ -164,8 +163,8 @@ impl<A: PimAf> Default for TibEntry<A> {
     }
 }
 
-impl Pim {
-    pub(crate) fn tib_get_or_create(&mut self, key: SgKey) -> &mut TibEntry {
+impl<A: PimAf> Pim<A> {
+    pub(crate) fn tib_get_or_create(&mut self, key: SgKey<A>) -> &mut TibEntry<A> {
         if !self.tib.contains_key(&key) {
             let target = match key {
                 SgKey::Sg { src, .. } => Some(src),
@@ -185,12 +184,12 @@ impl Pim {
 
     // ---- TIB bridge (IGMP membership → PIM state) ----
 
-    pub(crate) fn tib_local_join(&mut self, key: SgKey, ifindex: u32) {
+    pub(crate) fn tib_local_join(&mut self, key: SgKey<A>, ifindex: u32) {
         self.tib_get_or_create(key).local.insert(ifindex);
         self.tib_update(key);
     }
 
-    pub(crate) fn tib_local_prune(&mut self, key: SgKey, ifindex: u32) {
+    pub(crate) fn tib_local_prune(&mut self, key: SgKey<A>, ifindex: u32) {
         if let Some(entry) = self.tib.get_mut(&key) {
             entry.local.remove(&ifindex);
             self.tib_update(key);
@@ -199,7 +198,7 @@ impl Pim {
 
     // ---- downstream Join/Prune RX (per-interface FSM) ----
 
-    pub(crate) fn downstream_join(&mut self, ifindex: u32, key: SgKey, holdtime: u16) {
+    pub(crate) fn downstream_join(&mut self, ifindex: u32, key: SgKey<A>, holdtime: u16) {
         let now = Instant::now();
         let entry = self.tib_get_or_create(key);
         entry.downstream.insert(
@@ -212,7 +211,7 @@ impl Pim {
         self.tib_update(key);
     }
 
-    pub(crate) fn downstream_prune(&mut self, ifindex: u32, key: SgKey) {
+    pub(crate) fn downstream_prune(&mut self, ifindex: u32, key: SgKey<A>) {
         let Some(entry) = self.tib.get_mut(&key) else {
             return;
         };
@@ -241,7 +240,7 @@ impl Pim {
 
     /// (S,G,rpt) prune RX: record the pruned interface on the SgRpt
     /// entry — it drops out of the (S,G) inherited olist.
-    pub(crate) fn downstream_rpt_prune(&mut self, ifindex: u32, key: SgKey, holdtime: u16) {
+    pub(crate) fn downstream_rpt_prune(&mut self, ifindex: u32, key: SgKey<A>, holdtime: u16) {
         let now = Instant::now();
         let entry = self.tib_get_or_create(key);
         entry.downstream.insert(
@@ -255,7 +254,7 @@ impl Pim {
     }
 
     /// (S,G,rpt) join RX cancels a recorded prune.
-    pub(crate) fn downstream_rpt_join(&mut self, ifindex: u32, key: SgKey) {
+    pub(crate) fn downstream_rpt_join(&mut self, ifindex: u32, key: SgKey<A>) {
         if let Some(entry) = self.tib.get_mut(&key) {
             entry.downstream.remove(&ifindex);
             self.tib_update(key);
@@ -264,10 +263,10 @@ impl Pim {
 
     // ---- upcalls from the kernel dataplane ----
 
-    pub(crate) fn process_upcall(&mut self, upcall: Upcall) {
+    pub(crate) fn process_upcall(&mut self, upcall: Upcall<A>) {
         match upcall.kind {
             UpcallKind::Nocache => {
-                if !Ipv4::is_multicast(upcall.grp) || Ipv4::is_reserved_group(upcall.grp) {
+                if !A::is_multicast(upcall.grp) || A::is_reserved_group(upcall.grp) {
                     return;
                 }
                 let key = SgKey::Sg {
@@ -314,7 +313,7 @@ impl Pim {
 
     // ---- RPF change propagation ----
 
-    pub(crate) fn tib_rpf_change(&mut self, key: SgKey, state: RpfState) {
+    pub(crate) fn tib_rpf_change(&mut self, key: SgKey<A>, state: RpfState<A>) {
         let Some(entry) = self.tib.get_mut(&key) else {
             return;
         };
@@ -338,7 +337,7 @@ impl Pim {
 
     /// Re-point an entry at a different RPF target (RP mapping
     /// changed for a (*,G)).
-    pub(crate) fn tib_retarget(&mut self, key: SgKey, target: Option<Ipv4Addr>) {
+    pub(crate) fn tib_retarget(&mut self, key: SgKey<A>, target: Option<A::Addr>) {
         let Some(entry) = self.tib.get(&key) else {
             return;
         };
@@ -374,7 +373,7 @@ impl Pim {
     /// nexthop (which can be the neighbor's hello source *or* a
     /// secondary address), so re-evaluate the whole set and let
     /// `tib_update`'s coverage check decide join/prune.
-    fn gateway_keys_on(&self, ifindex: u32) -> Vec<SgKey> {
+    fn gateway_keys_on(&self, ifindex: u32) -> Vec<SgKey<A>> {
         self.tib
             .iter()
             .filter(|(_, e)| matches!(e.rpf, RpfState::Gateway { ifindex: i, .. } if i == ifindex))
@@ -384,7 +383,7 @@ impl Pim {
 
     /// A new PIM neighbor appeared: entries parked for lack of an
     /// upstream neighbor on this interface may now join.
-    pub(crate) fn tib_neighbor_up(&mut self, ifindex: u32, _addr: Ipv4Addr) {
+    pub(crate) fn tib_neighbor_up(&mut self, ifindex: u32, _addr: A::Addr) {
         for key in self.gateway_keys_on(ifindex) {
             self.tib_update(key);
         }
@@ -393,7 +392,7 @@ impl Pim {
     /// A PIM neighbor vanished (already removed from the link's
     /// table): entries joined through it lose coverage in
     /// `tib_update` and fall back to NotJoined with no prune TX.
-    pub(crate) fn tib_neighbor_down(&mut self, ifindex: u32, _addr: Ipv4Addr) {
+    pub(crate) fn tib_neighbor_down(&mut self, ifindex: u32, _addr: A::Addr) {
         for key in self.gateway_keys_on(ifindex) {
             self.tib_update(key);
         }
@@ -404,8 +403,8 @@ impl Pim {
     /// (toward the entry's actual RPF nexthop, which the restarted
     /// neighbor owns) for every entry joined through that neighbor,
     /// so its tree is rebuilt without waiting a full refresh period.
-    pub(crate) fn tib_genid_resync(&mut self, ifindex: u32, addr: Ipv4Addr) {
-        let targets: Vec<(SgKey, Ipv4Addr)> = self
+    pub(crate) fn tib_genid_resync(&mut self, ifindex: u32, addr: A::Addr) {
+        let targets: Vec<(SgKey<A>, A::Addr)> = self
             .tib
             .iter()
             .filter_map(|(key, e)| match e.rpf {
@@ -434,7 +433,7 @@ impl Pim {
     /// PIM stopped on an interface: drop every per-interface facet
     /// that references it.
     pub(crate) fn tib_iface_purge(&mut self, ifindex: u32) {
-        let keys: Vec<SgKey> = self.tib.keys().copied().collect();
+        let keys: Vec<SgKey<A>> = self.tib.keys().copied().collect();
         for key in keys {
             if let Some(entry) = self.tib.get_mut(&key) {
                 let touched = entry.local.remove(&ifindex)
@@ -454,7 +453,7 @@ impl Pim {
     /// Join/Prune state, kernel MFC. (*,G)/(S,G,rpt) changes cascade
     /// into the same-group (S,G) entries whose inherited olist they
     /// feed.
-    pub(crate) fn tib_update(&mut self, key: SgKey) {
+    pub(crate) fn tib_update(&mut self, key: SgKey<A>) {
         let Some(entry) = self.tib.get(&key) else {
             return;
         };
@@ -576,12 +575,12 @@ impl Pim {
 
     /// A (*,G) or (S,G,rpt) change feeds the inherited olists of the
     /// same-group (S,G) entries — re-evaluate them.
-    fn tib_cascade(&mut self, key: SgKey) {
+    fn tib_cascade(&mut self, key: SgKey<A>) {
         if matches!(key, SgKey::Sg { .. }) {
             return;
         }
         let grp = key.grp();
-        let sgs: Vec<SgKey> = self
+        let sgs: Vec<SgKey<A>> = self
             .tib
             .keys()
             .filter(|k| matches!(k, SgKey::Sg { .. }) && k.grp() == grp)
@@ -595,7 +594,7 @@ impl Pim {
     /// Native source-tree traffic confirmed for a joined (S,G): mark
     /// the SPT bit and send the triggered (S,G,rpt) prune toward the
     /// shared tree when the paths diverge.
-    fn spt_bit_set(&mut self, key: SgKey) {
+    fn spt_bit_set(&mut self, key: SgKey<A>) {
         let SgKey::Sg { src, grp } = key else {
             return;
         };
@@ -659,7 +658,7 @@ impl Pim {
     }
 
     pub(crate) fn tib_tick(&mut self, now: Instant) {
-        let mut touched: Vec<SgKey> = vec![];
+        let mut touched: Vec<SgKey<A>> = vec![];
         for (key, entry) in self.tib.iter_mut() {
             let before = entry.downstream.len();
             entry.downstream.retain(|_, ds| {


### PR DESCRIPTION
## Summary

The **final** slice of Phase 2b: flip the PIM actor and its entire `impl` surface generic over `A: PimAf`, so the protocol engine is reusable per address family. **Still IPv4 at runtime** — only `Pim::<Ipv4>` is spawned. This completes Phase 2 (`Pim<A>` genericization).

### What changed
- `Pim<A>`, `Message<A>`, `PimSend<A>`, `IgmpSend<A>`, `Upcall<A>`, `ShowCallback<A>`, `Callback<A>`, and every `impl Pim` → `impl<A: PimAf> Pim<A>` (tib/jp/rpf/assert/register/bsr/rp/neighbor/link/igmp).
- The IGMP membership FSM flips generic **in place** — its wire fields (`IgmpPacket` is IPv4) convert to `A::Addr` at the boundary via `A::from_ip`. The standalone `Gm<A>` engine extraction stays **deferred to Phase 4** (validated there by MLD as the second codec), per the earlier decision.
- **Leaf constructors stay concrete on `Pim<Ipv4>`**: `new` (wires the IPv4 raw sockets + `Mrt4`, spawns read/write tasks) and `callback_build`/`show_build` (parse/render IPv4 CLI). Nothing generic calls these, so there is no generic→concrete boundary to police.
- `PimAf` grew to the §4.2 surface, each method landing with its caller: `type Fp` (`+ Send + Sync + 'static`); `ALL_PIM_ROUTERS` / `GENERAL_QUERY_DST` consts; `from_ip`/`to_ip`; `prefix_from_ipnet`/`link_prefixes`; `is_unspecified`; `null_register_payload`/`register_inner_sg`.

**Byte-identical IPv4 behavior** — a types-and-dispatch refactor, not a logic change. Every `IpAddr::V4` wire site routes through `A::from_ip`/`A::to_ip`; for `A = Ipv4` those are the identity.

## Test plan
- 16 pim unit tests.
- `cargo fmt --check` clean.
- Forced-clean workspace `cargo clippy --all-targets -D warnings` → exit 0.
- Full workspace suite (`--exclude bdd`) green.
- **Full live pim BDD suite** — `pim_adjacency`, `pim_igmp`, `pim_ssm`, `pim_asm`, `pim_assert`, `pim_bsr`, `pim_vrf` (7 features, 14 scenarios) — **all pass**, with the daemon binary md5 **identical before and after** (`756c2008…`), no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)