### PR TITLE
pim: add `router pim tracing` conditional logging

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1803,6 +1803,47 @@ mod yang_load_tests {
         }
     }
 
+    /// Pin the `zebra-pim-tracing` augment: every `router pim tracing`
+    /// category must resolve as a settable path. A new augment module that
+    /// forgets to `import` into `config.yang` (or a renamed leaf) fails
+    /// here in the unit suite instead of only at live apply as an "unknown
+    /// key". Mirrors `enabled_activation_leaf_paths_parse`.
+    #[test]
+    fn pim_tracing_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router pim tracing all",
+            "set router pim tracing neighbor",
+            "set router pim tracing interface",
+            "set router pim tracing membership",
+            "set router pim tracing tib",
+            "set router pim tracing join-prune",
+            "set router pim tracing assert",
+            "set router pim tracing register",
+            "set router pim tracing bsr",
+            "set router pim tracing mroute",
+            "set router pim tracing event",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for `remove-private-as`. The IETF model
     /// (`ietf-bgp`) shipped a `remove-private-as` identityref leaf on the
     /// neighbor whose IANA base this libyang can't resolve to a value

--- a/zebra-rs/src/pim/af6.rs
+++ b/zebra-rs/src/pim/af6.rs
@@ -37,6 +37,7 @@ pub fn af6_proto_label() -> String {
 pub fn spawn_pim_v6(
     rib_subscriber: &RibSubscriber,
     config_tx: &Sender<Message>,
+    trace: bool,
 ) -> Option<PimAf6Handle> {
     let proto = af6_proto_label();
 
@@ -82,7 +83,13 @@ pub fn spawn_pim_v6(
     let cm_tx = pim.cm.tx.clone();
     let show_tx = pim.show.tx.clone();
     let task = inst::serve(pim);
-    tracing::info!("pim6: spawned default-table IPv6 instance");
+    if trace {
+        tracing::info!(
+            proto = "pim",
+            category = "event",
+            "pim6: spawned default-table IPv6 instance"
+        );
+    }
 
     Some(PimAf6Handle {
         cm_tx,

--- a/zebra-rs/src/pim/assert_fsm.rs
+++ b/zebra-rs/src/pim/assert_fsm.rs
@@ -20,6 +20,7 @@ use super::inst::{Pim, PimSend};
 use super::ipv4::Ipv4;
 use super::macros::inherited_olist;
 use super::tib::SgKey;
+use crate::pim_trace;
 
 /// Assert Time (RFC 7761 §4.11): loser state lifetime.
 pub const ASSERT_TIME: Duration = Duration::from_secs(180);
@@ -145,7 +146,9 @@ impl<A: PimAf> Pim<A> {
                         expires: now + ASSERT_REFRESH,
                     },
                 );
-                tracing::info!(
+                pim_trace!(
+                    self.tracing,
+                    Assert,
                     "pim: {} assert winner on {} (data trigger)",
                     key,
                     self.ifname(ifindex)
@@ -214,7 +217,9 @@ impl<A: PimAf> Pim<A> {
                             expires: now + ASSERT_TIME,
                         },
                     );
-                    tracing::info!(
+                    pim_trace!(
+                        self.tracing,
+                        Assert,
                         "pim: {} assert loser on {} (winner {})",
                         key,
                         self.ifname(ifindex),
@@ -232,7 +237,13 @@ impl<A: PimAf> Pim<A> {
                         },
                     );
                     if current.is_none() {
-                        tracing::info!("pim: {} assert winner on {}", key, self.ifname(ifindex));
+                        pim_trace!(
+                            self.tracing,
+                            Assert,
+                            "pim: {} assert winner on {}",
+                            key,
+                            self.ifname(ifindex)
+                        );
                     }
                     self.assert_send(key, ifindex, &mine);
                 }
@@ -259,7 +270,9 @@ impl<A: PimAf> Pim<A> {
                             expires: now + ASSERT_REFRESH,
                         },
                     );
-                    tracing::info!(
+                    pim_trace!(
+                        self.tracing,
+                        Assert,
                         "pim: {} re-asserting on {} against {}",
                         key,
                         self.ifname(ifindex),
@@ -311,7 +324,9 @@ impl<A: PimAf> Pim<A> {
                     if let Some(entry) = self.tib.get_mut(&key) {
                         entry.asserts.remove(&ifindex);
                     }
-                    tracing::info!(
+                    pim_trace!(
+                        self.tracing,
+                        Assert,
                         "pim: {} assert expired on {} — resuming forwarding",
                         key,
                         self.ifname(ifindex)

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -20,6 +20,7 @@ use pim_packet::{
 use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::ipv4::Ipv4;
+use crate::pim_trace;
 
 /// BSM origination period at the elected BSR (RFC 5059 §5).
 const BS_PERIOD: Duration = Duration::from_secs(60);
@@ -170,7 +171,7 @@ impl<A: PimAf> Pim<A> {
                 // claims first when several start together.
                 let delay = Duration::from_millis(3000 + (255 - priority) as u64 * 20);
                 self.bsr.role = Some(BsrRole::Pending { until: now + delay });
-                tracing::info!("pim: candidate-BSR pending election");
+                pim_trace!(self.tracing, Bsr, "pim: candidate-BSR pending election");
             }
             (None, role) if role != BsrRole::None => {
                 if role == BsrRole::Elected {
@@ -179,7 +180,7 @@ impl<A: PimAf> Pim<A> {
                     self.bsr_rp_set_flush();
                 }
                 self.bsr.role = Some(BsrRole::None);
-                tracing::info!("pim: candidate-BSR disabled");
+                pim_trace!(self.tracing, Bsr, "pim: candidate-BSR disabled");
             }
             _ => {}
         }
@@ -258,7 +259,9 @@ impl<A: PimAf> Pim<A> {
         // Preferred (or refreshing) BSR: adopt.
         let new_bsr = self.bsr.elected != Some(candidate);
         if new_bsr {
-            tracing::info!(
+            pim_trace!(
+                self.tracing,
+                Bsr,
                 "pim: elected BSR is {} (priority {})",
                 bsr,
                 bsm.bsr_priority
@@ -366,7 +369,13 @@ impl<A: PimAf> Pim<A> {
             changed = true;
         }
         if changed {
-            tracing::info!("pim: C-RP {} registered by {} at the BSR", rp, src);
+            pim_trace!(
+                self.tracing,
+                Bsr,
+                "pim: C-RP {} registered by {} at the BSR",
+                rp,
+                src
+            );
             self.rp_reevaluate();
             // Push the updated RP-set out promptly instead of waiting
             // for the periodic BSM.
@@ -504,7 +513,13 @@ impl<A: PimAf> Pim<A> {
             self.bsr.role = Some(BsrRole::Elected);
             self.bsr.elected = Some((priority, addr));
             self.bsr.bsm_expires = None;
-            tracing::info!("pim: elected BSR (self, {} priority {})", addr, priority);
+            pim_trace!(
+                self.tracing,
+                Bsr,
+                "pim: elected BSR (self, {} priority {})",
+                addr,
+                priority
+            );
             // Absorb our own candidate-RP first so the very first BSM
             // already carries it.
             if self.bsr_config.crp().is_some() {
@@ -526,7 +541,7 @@ impl<A: PimAf> Pim<A> {
         if let Some(t) = self.bsr.bsm_expires
             && t <= now
         {
-            tracing::info!("pim: elected BSR timed out");
+            pim_trace!(self.tracing, Bsr, "pim: elected BSR timed out");
             self.bsr.bsm_expires = None;
             self.bsr.elected = None;
             if let Some(old) = self.bsr.rpf_target.take() {

--- a/zebra-rs/src/pim/gm/mod.rs
+++ b/zebra-rs/src/pim/gm/mod.rs
@@ -187,6 +187,10 @@ pub struct GmIfCtx<A: PimAf> {
     pub config: IgmpConfig,
     pub is_dr: bool,
     pub my_addr: Option<A::Addr>,
+    /// Whether the `membership` tracing category is enabled on the owning
+    /// instance — the engine gates its info logs on it (it has no direct
+    /// handle to the instance's `PimTracing`).
+    pub trace: bool,
 }
 
 /// The transport + wire seam. One implementor per address family
@@ -332,7 +336,14 @@ impl<A: PimAf> Gm<A> {
             if let QuerierState::NonQuerier { until, .. } = gmif.querier
                 && until <= now
             {
-                tracing::info!("gm: {} other querier expired, taking over", ifctx.name);
+                if ifctx.trace {
+                    tracing::info!(
+                        proto = "pim",
+                        category = "membership",
+                        "gm: {} other querier expired, taking over",
+                        ifctx.name
+                    );
+                }
                 gmif.querier = QuerierState::Querier;
                 gmif.next_query = now;
             }
@@ -399,7 +410,15 @@ impl<A: PimAf> Gm<A> {
                         });
                     }
                 }
-                tracing::info!("gm: group {} expired on {}", group_addr, ifctx.name);
+                if ifctx.trace {
+                    tracing::info!(
+                        proto = "pim",
+                        category = "membership",
+                        "gm: group {} expired on {}",
+                        group_addr,
+                        ifctx.name
+                    );
+                }
             }
             for group_addr in sync {
                 events.extend(self.sync(ifindex, group_addr, ifctx));
@@ -511,8 +530,14 @@ impl<A: PimAf> Gm<A> {
         let Some(gmif) = self.ifs.get_mut(&ifindex) else {
             return;
         };
-        if gmif.querier == QuerierState::Querier {
-            tracing::info!("gm: {} lost querier election to {}", ctx.name, src);
+        if gmif.querier == QuerierState::Querier && ctx.trace {
+            tracing::info!(
+                proto = "pim",
+                category = "membership",
+                "gm: {} lost querier election to {}",
+                ctx.name,
+                src
+            );
         }
         gmif.querier = QuerierState::NonQuerier {
             querier: src,

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -40,6 +40,8 @@ use super::network_v6::{read_packet_v6, write_packet_v6};
 use super::rp::RpSet;
 use super::rpf::RpfEntry;
 use super::tib::{SgKey, TibEntry};
+use super::tracing::{PimTracing, TraceCategory};
+use crate::pim_trace;
 
 /// `show pim ...` dispatch handler, mirroring
 /// [`crate::nd::inst::ShowCallback`].
@@ -140,6 +142,10 @@ pub struct Pim<A: PimAf = Ipv4> {
     /// Buffered `router pim ipv6 …` intent, so the child can be despawned
     /// when its block is fully deleted (mirrors `vrf_log`).
     pub(crate) af6_log: Vec<(Vec<CommandPath>, ConfigOp)>,
+    /// Conditional-tracing toggles (`router pim tracing`). The default
+    /// instance's block is written by config and the same lines are
+    /// forwarded live to any running IPv6 / per-VRF child.
+    pub(crate) tracing: PimTracing,
     _read_task: Task<()>,
     _write_task: Task<()>,
     _mroute_read_task: Task<()>,
@@ -211,6 +217,7 @@ impl Pim<Ipv4> {
             rib_known_vrfs: BTreeMap::new(),
             af6: None,
             af6_log: Vec::new(),
+            tracing: PimTracing::default(),
             _read_task: read_task,
             _write_task: write_task,
             _mroute_read_task: mroute_read_task,
@@ -282,6 +289,7 @@ impl Pim<Ipv6> {
             rib_known_vrfs: BTreeMap::new(),
             af6: None,
             af6_log: Vec::new(),
+            tracing: PimTracing::default(),
             _read_task: read_task,
             _write_task: write_task,
             // No kernel mroute read task in Phase 3 (Mrt6 is a stub).
@@ -364,6 +372,7 @@ impl<A: PimAf> Pim<A> {
             config: self.link_config(&link.name).igmp,
             is_dr: self.i_am_dr(ifindex),
             my_addr: link.primary_addr(),
+            trace: self.tracing.should_trace(TraceCategory::Membership),
         })
     }
 
@@ -469,6 +478,29 @@ impl<A: PimAf> Pim<A> {
         let (path, args) = path_from_command(&msg.paths);
         if let Some(f) = self.callbacks.get(&path).copied() {
             f(self, args, msg.op);
+        } else if path.starts_with("/router/pim/tracing") {
+            // Not in the callback table — the category names are YANG
+            // presence leaves, so a single subtree dispatcher parses the
+            // path tail (mirrors IS-IS's `config_tracing_dispatch`).
+            super::tracing::config_tracing_dispatch(self, &path, msg.op);
+            // Forward the same line to any running IPv6 / per-VRF child so
+            // `router pim tracing` covers every PIM instance, not just the
+            // default table. (Children have no children of their own, so
+            // this does not recurse.)
+            self.tracing_forward_children(&msg.paths, msg.op);
+        }
+    }
+
+    /// Forward a `/router/pim/tracing/…` line to every running child
+    /// (default-table IPv6 and per-VRF), so a single `router pim tracing`
+    /// block drives all PIM instances. Live only — a child spawned after
+    /// the line was applied starts with tracing off until the next change.
+    fn tracing_forward_children(&self, paths: &[CommandPath], op: ConfigOp) {
+        if let Some(handle) = &self.af6 {
+            let _ = handle.cm_tx.send(ConfigRequest::new(paths.to_vec(), op));
+        }
+        for handle in self.vrf_registry.values() {
+            let _ = handle.cm_tx.send(ConfigRequest::new(paths.to_vec(), op));
         }
     }
 
@@ -489,7 +521,11 @@ impl<A: PimAf> Pim<A> {
         if self.proto_label != "pim" || self.af6.is_some() {
             return;
         }
-        self.af6 = super::af6::spawn_pim_v6(&self.rib_subscriber, &self.config_tx);
+        self.af6 = super::af6::spawn_pim_v6(
+            &self.rib_subscriber,
+            &self.config_tx,
+            self.tracing.should_trace(TraceCategory::Event),
+        );
     }
 
     /// CommitEnd: despawn the IPv6 child if its `router pim ipv6` block
@@ -504,7 +540,11 @@ impl<A: PimAf> Pim<A> {
             if self.af6.take().is_some() {
                 self.rib_subscriber
                     .send_proto_cleanup(&super::af6::af6_proto_label());
-                tracing::info!("pim6: default-table IPv6 instance despawned");
+                pim_trace!(
+                    self.tracing,
+                    Event,
+                    "pim6: default-table IPv6 instance despawned"
+                );
             }
             return;
         }
@@ -545,9 +585,14 @@ impl<A: PimAf> Pim<A> {
             return;
         }
         let log = self.vrf_log.get(name).cloned().unwrap_or_default();
-        if let Some(handle) =
-            super::vrf::spawn_pim_vrf(name, table_id, &self.rib_subscriber, &self.config_tx, &log)
-        {
+        if let Some(handle) = super::vrf::spawn_pim_vrf(
+            name,
+            table_id,
+            &self.rib_subscriber,
+            &self.config_tx,
+            &log,
+            self.tracing.should_trace(TraceCategory::Event),
+        ) {
             self.vrf_registry.insert(name.to_string(), handle);
         }
     }
@@ -569,7 +614,12 @@ impl<A: PimAf> Pim<A> {
         }
         self.rib_known_vrfs.remove(&name);
         if self.vrf_registry.remove(&name).is_some() {
-            super::vrf::despawn_pim_vrf(&name, &self.config_tx, &self.rib_subscriber);
+            super::vrf::despawn_pim_vrf(
+                &name,
+                &self.config_tx,
+                &self.rib_subscriber,
+                self.tracing.should_trace(TraceCategory::Event),
+            );
         }
     }
 
@@ -586,7 +636,12 @@ impl<A: PimAf> Pim<A> {
         for name in emptied {
             self.vrf_log.remove(&name);
             if self.vrf_registry.remove(&name).is_some() {
-                super::vrf::despawn_pim_vrf(&name, &self.config_tx, &self.rib_subscriber);
+                super::vrf::despawn_pim_vrf(
+                    &name,
+                    &self.config_tx,
+                    &self.rib_subscriber,
+                    self.tracing.should_trace(TraceCategory::Event),
+                );
             }
         }
         for handle in self.vrf_registry.values() {

--- a/zebra-rs/src/pim/jp.rs
+++ b/zebra-rs/src/pim/jp.rs
@@ -15,6 +15,7 @@ use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::rpf::RpfState;
 use super::tib::{JP_HOLDTIME, JoinState, SgKey};
+use crate::pim_trace;
 
 /// Periodic J/P refresh interval (t_periodic, RFC 7761 §4.11).
 pub const JP_PERIOD: Duration = Duration::from_secs(60);
@@ -127,7 +128,9 @@ impl<A: PimAf> Pim<A> {
                     && entry.rpf == bucket
                 {
                     suppress = true;
-                    tracing::info!(
+                    pim_trace!(
+                        self.tracing,
+                        JoinPrune,
                         "pim: {} join suppressed by {} toward {}",
                         key,
                         sender,
@@ -155,7 +158,13 @@ impl<A: PimAf> Pim<A> {
                 .or_insert(deadline);
         }
         for key in overrides {
-            tracing::info!("pim: {} prune override join toward {}", key, upstream);
+            pim_trace!(
+                self.tracing,
+                JoinPrune,
+                "pim: {} prune override join toward {}",
+                key,
+                upstream
+            );
             self.jp_send_entry(ifindex, upstream, key, true);
         }
     }

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use rand::RngExt;
 
 use crate::context::Timer;
+use crate::pim_trace;
 use crate::rib::Link;
 use crate::rib::link::LinkAddr;
 
@@ -15,6 +16,7 @@ use super::inst::{Message, Pim};
 use super::ipv4::Ipv4;
 use super::mroute::PimForwardingPlane;
 use super::neighbor::Neighbor;
+use super::tracing::TraceCategory;
 
 pub const PIM_HELLO_PERIOD: u16 = 30;
 pub const PIM_DEFAULT_DR_PRIORITY: u32 = 1;
@@ -159,7 +161,12 @@ impl<A: PimAf> Pim<A> {
             gm.enable_if(ifindex, std::time::Instant::now());
         }
         if let Some(link) = self.links.get(&ifindex) {
-            tracing::info!("igmp: interface {} enabled", link.name);
+            pim_trace!(
+                self.tracing,
+                Interface,
+                "igmp: interface {} enabled",
+                link.name
+            );
         }
     }
 
@@ -171,7 +178,12 @@ impl<A: PimAf> Pim<A> {
             None => vec![],
         };
         if let Some(link) = self.links.get(&ifindex) {
-            tracing::info!("igmp: interface {} disabled", link.name);
+            pim_trace!(
+                self.tracing,
+                Interface,
+                "igmp: interface {} disabled",
+                link.name
+            );
         }
         self.apply_gm_events(events);
     }
@@ -228,13 +240,19 @@ impl<A: PimAf> Pim<A> {
             self.link_config(&link.name).hello_interval()
         };
         A::join_pim_if(&self.sock, ifindex);
-        self.fp.vif_add(ifindex);
+        self.fp
+            .vif_add(ifindex, self.tracing.should_trace(TraceCategory::Mroute));
         let timer = hello_timer(&self.tx, ifindex, interval);
         let link = self.links.get_mut(&ifindex).unwrap();
         link.enabled = true;
         link.gen_id = rand::rng().random();
         link.hello_timer = Some(timer);
-        tracing::info!("pim: interface {} enabled", link.name);
+        pim_trace!(
+            self.tracing,
+            Interface,
+            "pim: interface {} enabled",
+            link.name
+        );
         // Triggered hello so neighbors learn us without waiting a
         // full hello period, then elect (initially ourselves).
         self.hello_send(ifindex);
@@ -252,11 +270,17 @@ impl<A: PimAf> Pim<A> {
         link.hello_timer = None;
         link.nbrs.clear();
         link.dr = None;
-        tracing::info!("pim: interface {} disabled", link.name);
+        pim_trace!(
+            self.tracing,
+            Interface,
+            "pim: interface {} disabled",
+            link.name
+        );
         // Drop every TIB facet on this interface, then the VIF (MFC
         // entries referencing it were just rewritten).
         self.tib_iface_purge(ifindex);
-        self.fp.vif_del(ifindex);
+        self.fp
+            .vif_del(ifindex, self.tracing.should_trace(TraceCategory::Mroute));
     }
 
     /// Effective config for an interface: the configured entry, or
@@ -296,7 +320,9 @@ impl<A: PimAf> Pim<A> {
         }
         let dr = Some(best.1);
         if link.dr != dr {
-            tracing::info!(
+            pim_trace!(
+                self.tracing,
+                Interface,
                 "pim: interface {} DR changed {:?} -> {:?}",
                 link.name,
                 link.dr,

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -29,4 +29,5 @@ pub mod rpf;
 pub mod show;
 pub mod socket;
 pub mod tib;
+pub mod tracing;
 pub mod vrf;

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -166,9 +166,11 @@ pub trait PimForwardingPlane<A: PimAf>: Sized {
     /// init sockopt) — the per-VRF path.
     fn new(ctx: &ProtoContext, table_id: u32) -> std::io::Result<Self>;
     /// Allocate and program a VIF/MIF for `ifindex` (idempotent).
-    fn vif_add(&mut self, ifindex: u32);
-    /// Remove the VIF/MIF for `ifindex`.
-    fn vif_del(&mut self, ifindex: u32);
+    /// `trace` gates the `mroute`-category info log (the plane has no
+    /// handle to the instance's `PimTracing`).
+    fn vif_add(&mut self, ifindex: u32, trace: bool);
+    /// Remove the VIF/MIF for `ifindex`. `trace` gates the info log.
+    fn vif_del(&mut self, ifindex: u32, trace: bool);
     /// The VIF/MIF index currently mapped to `ifindex`.
     fn vif(&self, ifindex: u32) -> Option<u16>;
     /// The ifindex mapped to a VIF/MIF index (upcall arrival lookup).
@@ -241,7 +243,7 @@ impl PimForwardingPlane<Ipv4> for Mrt4 {
             .map(|(ifindex, _)| *ifindex)
     }
 
-    fn vif_add(&mut self, ifindex: u32) {
+    fn vif_add(&mut self, ifindex: u32, trace: bool) {
         if self.vifs.contains_key(&ifindex) {
             return;
         }
@@ -265,13 +267,19 @@ impl PimForwardingPlane<Ipv4> for Mrt4 {
         match mrt_setsockopt(self.sock.get_ref(), MRT_ADD_VIF, &vc) {
             Ok(()) => {
                 self.vifs.insert(ifindex, vif);
-                tracing::info!("mroute: VIF {vif} added for ifindex {ifindex}");
+                if trace {
+                    tracing::info!(
+                        proto = "pim",
+                        category = "mroute",
+                        "mroute: VIF {vif} added for ifindex {ifindex}"
+                    );
+                }
             }
             Err(e) => tracing::warn!("mroute: MRT_ADD_VIF ifindex {ifindex} failed: {e}"),
         }
     }
 
-    fn vif_del(&mut self, ifindex: u32) {
+    fn vif_del(&mut self, ifindex: u32, trace: bool) {
         let Some(vif) = self.vifs.remove(&ifindex) else {
             return;
         };
@@ -285,8 +293,12 @@ impl PimForwardingPlane<Ipv4> for Mrt4 {
         };
         if let Err(e) = mrt_setsockopt(self.sock.get_ref(), MRT_DEL_VIF, &vc) {
             tracing::debug!("mroute: MRT_DEL_VIF ifindex {ifindex} failed: {e}");
-        } else {
-            tracing::info!("mroute: VIF {vif} deleted for ifindex {ifindex}");
+        } else if trace {
+            tracing::info!(
+                proto = "pim",
+                category = "mroute",
+                "mroute: VIF {vif} deleted for ifindex {ifindex}"
+            );
         }
     }
 
@@ -343,8 +355,8 @@ impl PimForwardingPlane<Ipv6> for Mrt6 {
     fn new(_ctx: &ProtoContext, _table_id: u32) -> std::io::Result<Self> {
         Ok(Mrt6)
     }
-    fn vif_add(&mut self, _ifindex: u32) {}
-    fn vif_del(&mut self, _ifindex: u32) {}
+    fn vif_add(&mut self, _ifindex: u32, _trace: bool) {}
+    fn vif_del(&mut self, _ifindex: u32, _trace: bool) {}
     fn vif(&self, _ifindex: u32) -> Option<u16> {
         None
     }

--- a/zebra-rs/src/pim/neighbor.rs
+++ b/zebra-rs/src/pim/neighbor.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use pim_packet::PimHello;
 
 use crate::context::Timer;
+use crate::pim_trace;
 
 use super::af::PimAf;
 use super::inst::{Message, Pim};
@@ -117,7 +118,13 @@ impl<A: PimAf> Pim<A> {
         link.nbrs.get_mut(&src).unwrap().expiry = timer;
 
         if is_new {
-            tracing::info!("pim: neighbor {} up on {}", src, link.name);
+            pim_trace!(
+                self.tracing,
+                Neighbor,
+                "pim: neighbor {} up on {}",
+                src,
+                link.name
+            );
             // Triggered hello so a newly-heard neighbor learns us
             // without waiting out our hello period (RFC 7761 §4.3.1).
             self.hello_send(ifindex);
@@ -125,7 +132,9 @@ impl<A: PimAf> Pim<A> {
             // join now.
             self.tib_neighbor_up(ifindex, src);
         } else if bounced {
-            tracing::info!(
+            pim_trace!(
+                self.tracing,
+                Neighbor,
                 "pim: neighbor {} on {} restarted (GenID change)",
                 src,
                 link.name
@@ -148,7 +157,14 @@ impl<A: PimAf> Pim<A> {
             return;
         };
         if link.nbrs.remove(&addr).is_some() {
-            tracing::info!("pim: neighbor {} down on {} ({})", addr, link.name, reason);
+            pim_trace!(
+                self.tracing,
+                Neighbor,
+                "pim: neighbor {} down on {} ({})",
+                addr,
+                link.name,
+                reason
+            );
             self.dr_election(ifindex);
             self.tib_neighbor_down(ifindex, addr);
         }

--- a/zebra-rs/src/pim/register.rs
+++ b/zebra-rs/src/pim/register.rs
@@ -20,6 +20,7 @@ use super::af::PimAf;
 use super::inst::{Pim, PimSend};
 use super::mroute::{PimForwardingPlane, Upcall};
 use super::tib::{JoinState, KEEPALIVE_PERIOD, RegState, SgKey};
+use crate::pim_trace;
 
 /// Register suppression: how long a Register-Stop silences the DR.
 const REGISTER_SUPPRESS: Duration = Duration::from_secs(55);
@@ -53,7 +54,12 @@ impl<A: PimAf> Pim<A> {
         let entry = self.tib.get_mut(&key).unwrap();
         if entry.reg_state == RegState::NoInfo {
             entry.reg_state = RegState::Join;
-            tracing::info!("pim: {} registering toward the RP (FHR)", key);
+            pim_trace!(
+                self.tracing,
+                Register,
+                "pim: {} registering toward the RP (FHR)",
+                key
+            );
         }
     }
 
@@ -159,7 +165,12 @@ impl<A: PimAf> Pim<A> {
                 entry.reg_state = RegState::Prune {
                     until: Instant::now() + REGISTER_SUPPRESS,
                 };
-                tracing::info!("pim: {} register suppressed (Register-Stop)", key);
+                pim_trace!(
+                    self.tracing,
+                    Register,
+                    "pim: {} register suppressed (Register-Stop)",
+                    key
+                );
                 self.tib_update(key);
             }
             RegState::Prune { .. } => {
@@ -203,7 +214,12 @@ impl<A: PimAf> Pim<A> {
                 RegState::JoinPending { .. } => {
                     if let Some(entry) = self.tib.get_mut(&key) {
                         entry.reg_state = RegState::Join;
-                        tracing::info!("pim: {} register probe unanswered — registering", key);
+                        pim_trace!(
+                            self.tracing,
+                            Register,
+                            "pim: {} register probe unanswered — registering",
+                            key
+                        );
                     }
                     self.tib_update(key);
                 }

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -24,6 +24,7 @@ use super::ipv4::Ipv4;
 use super::macros::{inherited_effective, inherited_olist, join_desired_effective, mfc_oifs};
 use super::mroute::{PimForwardingPlane, REG_VIF, Upcall, UpcallKind};
 use super::rpf::RpfState;
+use crate::pim_trace;
 
 /// Join/Prune holdtime we advertise and the downstream expiry we run
 /// (3.5 × the 60 s J/P period).
@@ -177,7 +178,7 @@ impl<A: PimAf> Pim<A> {
                 entry.rpf = self.rpf_acquire(addr);
             }
             self.tib.insert(key, entry);
-            tracing::info!("pim: {} created", key);
+            pim_trace!(self.tracing, Tib, "pim: {} created", key);
         }
         self.tib.get_mut(&key).unwrap()
     }
@@ -331,7 +332,14 @@ impl<A: PimAf> Pim<A> {
         if let Some(entry) = self.tib.get_mut(&key) {
             entry.rpf = state;
         }
-        tracing::info!("pim: {} RPF change {:?} -> {:?}", key, old, state);
+        pim_trace!(
+            self.tracing,
+            Tib,
+            "pim: {} RPF change {:?} -> {:?}",
+            key,
+            old,
+            state
+        );
         self.tib_update(key);
     }
 
@@ -362,7 +370,13 @@ impl<A: PimAf> Pim<A> {
         entry.join_state = JoinState::NotJoined;
         entry.rpf_target = target;
         entry.rpf = new_rpf;
-        tracing::info!("pim: {} re-targeted to {:?}", key, target);
+        pim_trace!(
+            self.tracing,
+            Tib,
+            "pim: {} re-targeted to {:?}",
+            key,
+            target
+        );
         self.tib_update(key);
     }
 
@@ -484,7 +498,7 @@ impl<A: PimAf> Pim<A> {
             if let Some(addr) = target {
                 self.rpf_release(addr);
             }
-            tracing::info!("pim: {} deleted", key);
+            pim_trace!(self.tracing, Tib, "pim: {} deleted", key);
             self.tib_cascade(key);
             return;
         }
@@ -527,12 +541,12 @@ impl<A: PimAf> Pim<A> {
             self.tib.get_mut(&key).unwrap().join_state = JoinState::Joined;
             self.jp_send_entry(ifindex, nexthop, key, true);
             self.jp_refresh_arm(ifindex, nexthop);
-            tracing::info!("pim: {} joined toward {}", key, nexthop);
+            pim_trace!(self.tracing, Tib, "pim: {} joined toward {}", key, nexthop);
         } else if !want_joined && is_joined {
             self.tib.get_mut(&key).unwrap().join_state = JoinState::NotJoined;
             if let Some((ifindex, nexthop)) = upstream_nbr {
                 self.jp_send_entry(ifindex, nexthop, key, false);
-                tracing::info!("pim: {} pruned toward {}", key, nexthop);
+                pim_trace!(self.tracing, Tib, "pim: {} pruned toward {}", key, nexthop);
             }
         }
 
@@ -616,7 +630,9 @@ impl<A: PimAf> Pim<A> {
             return;
         }
         if let RpfState::Gateway { ifindex, nexthop } = star_entry.rpf {
-            tracing::info!(
+            pim_trace!(
+                self.tracing,
+                Tib,
                 "pim: {} SPT bit set — pruning ({}, {}) off the RPT",
                 key,
                 src,

--- a/zebra-rs/src/pim/tracing.rs
+++ b/zebra-rs/src/pim/tracing.rs
@@ -1,0 +1,267 @@
+//! PIM conditional tracing — consistent with IS-IS (`zebra-isis-tracing`),
+//! OSPF (`zebra-ospf-tracing`) and BGP (`zebra-bgp-tracing`).
+//!
+//! The `router pim tracing { ... }` config tree (defined in
+//! `zebra-pim-tracing.yang`) is written through [`config_tracing_dispatch`]
+//! into the typed [`PimTracing`] block held on each `Pim<A>` instance; the
+//! gated [`pim_trace!`] macro consults it via [`PimTracing::should_trace`]
+//! before emitting a `proto="pim"` `tracing::info!` event, so PIM's
+//! informational logging can be turned on per category at runtime without a
+//! rebuild. With no `tracing` config every category is silent.
+//!
+//! Unlike IS-IS/OSPF, the PIM `tracing::info!` sites are protocol *events*
+//! rather than per-PDU send/receive points, so each category is a bare
+//! presence toggle (`type empty`) with no direction/level refinement. The
+//! categories partition every info-level site in the module: adjacency
+//! (`neighbor`), interface enable/disable (`interface`), IGMP/MLD
+//! membership (`membership`), the (S,G)/(*,G) tree state (`tib`),
+//! Join/Prune processing (`join-prune`), the assert FSM (`assert`), PIM
+//! Register (`register`), the Bootstrap Router / RP-set (`bsr`), the kernel
+//! MRT/MIF/MFC datapath (`mroute`), and instance lifecycle (`event`).
+
+use super::af::PimAf;
+use super::inst::Pim;
+use crate::config::ConfigOp;
+
+// ============================================================
+// Tracing categories
+// ============================================================
+
+/// A PIM tracing category, selected at a trace site. Each maps to one
+/// presence toggle in the `tracing` block; `as_str` is the structured
+/// `category` field value and the YANG node name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceCategory {
+    /// PIM neighbor (adjacency) up / down / restart.
+    Neighbor,
+    /// PIM / IGMP / MLD interface enable / disable.
+    Interface,
+    /// IGMP / MLD group-membership (querier election, group expiry).
+    Membership,
+    /// (S,G) / (*,G) tree state: create, delete, RPF change, retarget,
+    /// upstream join / prune, SPT-bit.
+    Tib,
+    /// Join/Prune message processing (overhear, prune-override).
+    JoinPrune,
+    /// PIM assert FSM transitions.
+    Assert,
+    /// PIM Register / Register-Stop (FHR encapsulation path).
+    Register,
+    /// Bootstrap Router election and Candidate-RP advertisement (RFC 5059).
+    Bsr,
+    /// Kernel multicast-routing datapath (VIF/MIF add / delete).
+    Mroute,
+    /// Instance lifecycle: per-VRF and default-table IPv6 child spawn /
+    /// despawn.
+    Event,
+}
+
+impl TraceCategory {
+    /// The category's YANG node name and structured `category` field value.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            TraceCategory::Neighbor => "neighbor",
+            TraceCategory::Interface => "interface",
+            TraceCategory::Membership => "membership",
+            TraceCategory::Tib => "tib",
+            TraceCategory::JoinPrune => "join-prune",
+            TraceCategory::Assert => "assert",
+            TraceCategory::Register => "register",
+            TraceCategory::Bsr => "bsr",
+            TraceCategory::Mroute => "mroute",
+            TraceCategory::Event => "event",
+        }
+    }
+}
+
+/// Conditional PIM tracing configuration. One instance lives on each
+/// `Pim<A>` (default IPv4, default-table IPv6 child, and each per-VRF
+/// child); `router pim tracing` writes the default instance's block and
+/// the same lines are forwarded live to any running children.
+#[derive(Debug, Clone, Default)]
+pub struct PimTracing {
+    /// Master switch — when set, every category is traced regardless of
+    /// its individual toggle.
+    pub all: bool,
+    pub neighbor: bool,
+    pub interface: bool,
+    pub membership: bool,
+    pub tib: bool,
+    pub join_prune: bool,
+    pub assert: bool,
+    pub register: bool,
+    pub bsr: bool,
+    pub mroute: bool,
+    pub event: bool,
+}
+
+impl PimTracing {
+    /// Whether `cat` should be traced. The `all` master switch applies on
+    /// top of the per-category toggle.
+    pub fn should_trace(&self, cat: TraceCategory) -> bool {
+        if self.all {
+            return true;
+        }
+        match cat {
+            TraceCategory::Neighbor => self.neighbor,
+            TraceCategory::Interface => self.interface,
+            TraceCategory::Membership => self.membership,
+            TraceCategory::Tib => self.tib,
+            TraceCategory::JoinPrune => self.join_prune,
+            TraceCategory::Assert => self.assert,
+            TraceCategory::Register => self.register,
+            TraceCategory::Bsr => self.bsr,
+            TraceCategory::Mroute => self.mroute,
+            TraceCategory::Event => self.event,
+        }
+    }
+}
+
+// ============================================================
+// Config dispatch
+// ============================================================
+
+/// Apply one committed `…/tracing/<rest>` config line to a [`PimTracing`].
+/// `rest` is the path tail after the `tracing` node (e.g. `/all`,
+/// `/neighbor`, `/join-prune`). Each category is a bare presence toggle,
+/// so Set enables and Delete disables; there are no values to read.
+/// Returns `None` (ignored) for an unknown category — only reachable on a
+/// malformed path, since the YANG constrains the leaf set.
+fn apply_tracing(t: &mut PimTracing, rest: &str, op: ConfigOp) -> Option<()> {
+    let set = op.is_set();
+    match rest.strip_prefix('/')? {
+        "all" => t.all = set,
+        "neighbor" => t.neighbor = set,
+        "interface" => t.interface = set,
+        "membership" => t.membership = set,
+        "tib" => t.tib = set,
+        "join-prune" => t.join_prune = set,
+        "assert" => t.assert = set,
+        "register" => t.register = set,
+        "bsr" => t.bsr = set,
+        "mroute" => t.mroute = set,
+        "event" => t.event = set,
+        _ => return None,
+    }
+    Some(())
+}
+
+/// Dispatch a committed `/router/pim/tracing/…` Set/Delete path to this
+/// instance's [`PimTracing`] and apply it.
+///
+/// Called from `Pim::process_cm_msg` for paths the regular callback table
+/// does not claim. The category names are YANG presence leaves, so the
+/// category lives in the *path*, not in `args`; a single parser handles
+/// the whole subtree. Returns `None` (ignored) for non-tracing paths and
+/// malformed tails.
+pub fn config_tracing_dispatch<A: PimAf>(pim: &mut Pim<A>, path: &str, op: ConfigOp) -> Option<()> {
+    let rest = path.strip_prefix("/router/pim/tracing")?;
+    apply_tracing(&mut pim.tracing, rest, op)
+}
+
+// ============================================================
+// Gated category macro
+// ============================================================
+
+/// Conditional PIM info trace. `$tracing` resolves to a [`PimTracing`] (or
+/// `&PimTracing`) — normally `self.tracing`; `$cat` is a [`TraceCategory`]
+/// variant. Emits a `proto="pim"`, `category=<cat>` `tracing::info!` event
+/// only when the category (or the `all` master switch) is enabled.
+#[macro_export]
+macro_rules! pim_trace {
+    ($tracing:expr, $cat:ident, $($arg:tt)*) => {{
+        let __t = &$tracing;
+        if __t.should_trace($crate::pim::tracing::TraceCategory::$cat) {
+            tracing::info!(
+                proto = "pim",
+                category = $crate::pim::tracing::TraceCategory::$cat.as_str(),
+                $($arg)*
+            );
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn master_all_traces_every_category() {
+        let mut t = PimTracing::default();
+        // Nothing traces by default.
+        assert!(!t.should_trace(TraceCategory::Neighbor));
+        assert!(!t.should_trace(TraceCategory::Mroute));
+
+        apply_tracing(&mut t, "/all", ConfigOp::Set);
+        assert!(t.all);
+        for cat in [
+            TraceCategory::Neighbor,
+            TraceCategory::Interface,
+            TraceCategory::Membership,
+            TraceCategory::Tib,
+            TraceCategory::JoinPrune,
+            TraceCategory::Assert,
+            TraceCategory::Register,
+            TraceCategory::Bsr,
+            TraceCategory::Mroute,
+            TraceCategory::Event,
+        ] {
+            assert!(t.should_trace(cat), "all must trace {}", cat.as_str());
+        }
+
+        apply_tracing(&mut t, "/all", ConfigOp::Delete);
+        assert!(!t.all);
+        assert!(!t.should_trace(TraceCategory::Bsr));
+    }
+
+    #[test]
+    fn individual_toggles_are_independent() {
+        let mut t = PimTracing::default();
+        apply_tracing(&mut t, "/neighbor", ConfigOp::Set);
+        assert!(t.should_trace(TraceCategory::Neighbor));
+        // Enabling one category leaves the others silent.
+        assert!(!t.should_trace(TraceCategory::Register));
+
+        apply_tracing(&mut t, "/join-prune", ConfigOp::Set);
+        assert!(t.should_trace(TraceCategory::JoinPrune));
+
+        apply_tracing(&mut t, "/neighbor", ConfigOp::Delete);
+        assert!(!t.should_trace(TraceCategory::Neighbor));
+        assert!(t.should_trace(TraceCategory::JoinPrune));
+    }
+
+    #[test]
+    fn every_category_name_round_trips() {
+        // Each category's YANG name must be a settable toggle, and its
+        // `as_str()` must match the name the dispatcher accepts.
+        for cat in [
+            TraceCategory::Neighbor,
+            TraceCategory::Interface,
+            TraceCategory::Membership,
+            TraceCategory::Tib,
+            TraceCategory::JoinPrune,
+            TraceCategory::Assert,
+            TraceCategory::Register,
+            TraceCategory::Bsr,
+            TraceCategory::Mroute,
+            TraceCategory::Event,
+        ] {
+            let mut t = PimTracing::default();
+            let path = format!("/{}", cat.as_str());
+            assert_eq!(
+                apply_tracing(&mut t, &path, ConfigOp::Set),
+                Some(()),
+                "{} must be a known category",
+                cat.as_str()
+            );
+            assert!(t.should_trace(cat));
+        }
+    }
+
+    #[test]
+    fn unknown_tail_is_ignored() {
+        let mut t = PimTracing::default();
+        assert_eq!(apply_tracing(&mut t, "/bogus", ConfigOp::Set), None);
+        assert_eq!(apply_tracing(&mut t, "/packet/hello", ConfigOp::Set), None);
+    }
+}

--- a/zebra-rs/src/pim/vrf.rs
+++ b/zebra-rs/src/pim/vrf.rs
@@ -81,6 +81,7 @@ pub fn spawn_pim_vrf(
     rib_subscriber: &RibSubscriber,
     config_tx: &Sender<Message>,
     buffered: &[(Vec<CommandPath>, ConfigOp)],
+    trace: bool,
 ) -> Option<PimVrfHandle> {
     let proto = vrf_proto_label(name);
 
@@ -138,7 +139,15 @@ pub fn spawn_pim_vrf(
     let _ = cm_tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
 
     let task = inst::serve(pim);
-    tracing::info!(vrf = %name, table_id, "pim: spawned per-VRF instance");
+    if trace {
+        tracing::info!(
+            proto = "pim",
+            category = "event",
+            vrf = %name,
+            table_id,
+            "pim: spawned per-VRF instance"
+        );
+    }
 
     Some(PimVrfHandle { cm_tx, task })
 }
@@ -147,10 +156,22 @@ pub fn spawn_pim_vrf(
 /// caller removes the handle from `vrf_registry`, which drops the
 /// `Task` and aborts the event loop — closing the sockets runs the
 /// kernel's implicit MRT_DONE cleanup for the VRF table.
-pub fn despawn_pim_vrf(name: &str, config_tx: &Sender<Message>, rib_subscriber: &RibSubscriber) {
+pub fn despawn_pim_vrf(
+    name: &str,
+    config_tx: &Sender<Message>,
+    rib_subscriber: &RibSubscriber,
+    trace: bool,
+) {
     let _ = config_tx.try_send(Message::UnsubscribeShowVrf {
         key: vrf_show_key(name),
     });
     rib_subscriber.send_proto_cleanup(&vrf_proto_label(name));
-    tracing::info!(vrf = %name, "pim: despawned per-VRF instance");
+    if trace {
+        tracing::info!(
+            proto = "pim",
+            category = "event",
+            vrf = %name,
+            "pim: despawned per-VRF instance"
+        );
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -109,6 +109,10 @@ module config {
     prefix zitr;
   }
 
+  import zebra-pim-tracing {
+    prefix zptr;
+  }
+
   import zebra-bgp-color-policy {
     prefix zbcp;
   }

--- a/zebra-rs/yang/zebra-pim-tracing.yang
+++ b/zebra-rs/yang/zebra-pim-tracing.yang
@@ -1,0 +1,144 @@
+module zebra-pim-tracing {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-pim-tracing";
+  prefix "zptr";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Conditional PIM tracing, attachable at the `router pim` instance:
+
+       * `router pim tracing { ... }`
+
+     This mirrors the IS-IS / OSPF / BGP `tracing` model (a typed config
+     block consulted by a gated log macro, so categories can be turned on
+     at runtime without a rebuild). Unlike those protocols the PIM
+     `info!` sites are protocol *events* rather than per-PDU send/receive
+     points, so each category is a bare presence toggle with no direction
+     or level refinement. One `router pim tracing` block drives every PIM
+     instance — the default IPv4 table, the default-table IPv6 child, and
+     each per-VRF child.
+
+     Example:
+
+       router pim {
+         tracing {
+           neighbor;
+           tib;
+           register;
+         }
+       }
+
+     Each category is a `type empty` leaf — name it to enable, delete it
+     to disable; absence means the category is silent. Enabling by
+     presence (rather than a `true` value) matches IS-IS / OSPF / BGP
+     `tracing`: the config dispatch keys off set vs delete and never reads
+     a value, so `type empty` is the honest type here. With no `tracing`
+     block every category is silent (PIM emits no info-level logs).";
+
+  revision 2026-07-18 {
+    description
+      "Initial revision — `router pim tracing` on the IS-IS / OSPF / BGP
+       presence-toggle model. Categories: an `all` master switch plus the
+       per-subsystem toggles neighbor, interface, membership (IGMP/MLD),
+       tib ((S,G)/(*,G) tree state), join-prune, assert, register, bsr
+       (Bootstrap Router / RP-set), mroute (kernel MRT/MIF/MFC datapath),
+       and event (instance lifecycle). No direction / level refinement:
+       the PIM trace sites are events, not per-PDU points, and PIM has no
+       IS-IS-style levels.";
+  }
+
+  grouping pim-tracing-extension {
+    description
+      "The `tracing` block attached to the `router pim` instance.";
+
+    container tracing {
+      ext:help "PIM conditional tracing";
+      description
+        "Per-category PIM log toggles, applied to every PIM instance
+         (default IPv4, default-table IPv6, and per-VRF).";
+
+      leaf all {
+        ext:help "Enable every tracing category";
+        type empty;
+        description
+          "Master switch — when present, every category below is traced
+           regardless of its individual toggle.";
+      }
+      leaf neighbor {
+        ext:help "Trace PIM neighbor (adjacency) up / down / restart";
+        type empty;
+      }
+      leaf interface {
+        ext:help "Trace PIM / IGMP / MLD interface enable / disable and DR change";
+        type empty;
+      }
+      leaf membership {
+        ext:help "Trace IGMP / MLD group membership (querier election, group expiry)";
+        type empty;
+      }
+      leaf tib {
+        ext:help "Trace (S,G) / (*,G) tree state (create, delete, RPF, join, prune, SPT)";
+        type empty;
+      }
+      leaf join-prune {
+        ext:help "Trace Join/Prune message processing";
+        type empty;
+      }
+      leaf assert {
+        ext:help "Trace the PIM assert state machine";
+        type empty;
+      }
+      leaf register {
+        ext:help "Trace PIM Register / Register-Stop (FHR encapsulation)";
+        type empty;
+      }
+      leaf bsr {
+        ext:help "Trace Bootstrap Router election and Candidate-RP (RFC 5059)";
+        type empty;
+      }
+      leaf mroute {
+        ext:help "Trace the kernel multicast-routing datapath (VIF/MIF add/delete)";
+        type empty;
+      }
+      leaf event {
+        ext:help "Trace instance lifecycle (per-VRF / IPv6 child spawn / despawn)";
+        type empty;
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/config:pim" {
+    description
+      "`router pim tracing` in the candidate-set subtree.";
+    uses pim-tracing-extension;
+  }
+
+  augment "/configure:delete/config:router/config:pim" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router pim tracing ...` is path-valid.";
+    uses pim-tracing-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Gate every PIM `tracing::info!` behind a per-category `router pim tracing` config block, mirroring the IS-IS / OSPF / BGP tracing model (a typed block consulted by a gated log macro, so categories toggle at runtime without a rebuild). **With no `tracing` block PIM emits no info-level logs.**

New `zebra-pim-tracing.yang` augments `router pim` with an `all` master switch plus bare presence toggles that partition all 40 info-level sites in the module:

| category | covers |
|---|---|
| `neighbor` | PIM adjacency up / down / restart |
| `interface` | PIM / IGMP / MLD interface enable / disable, DR change |
| `membership` | IGMP / MLD querier election, group expiry |
| `tib` | (S,G)/(*,G) tree state: create/delete/RPF/join/prune/SPT |
| `join-prune` | Join/Prune message processing |
| `assert` | assert FSM transitions |
| `register` | PIM Register / Register-Stop (FHR) |
| `bsr` | Bootstrap Router election + Candidate-RP (RFC 5059) |
| `mroute` | kernel MRT/MIF/MFC datapath (VIF add/delete) |
| `event` | per-VRF / IPv6 child spawn / despawn |

Unlike IS-IS/OSPF the PIM sites are events (not per-PDU points), so there is no direction/level refinement.

## Design

- `PimTracing` lives on each `Pim<A>`; `config_tracing_dispatch` parses the `/router/pim/tracing/…` subtree.
- The same line is forwarded live to any running IPv6 / per-VRF child, so one block drives every PIM instance.
- `pim_trace!(self.tracing, Category, …)` gates the `Pim<A>`-method sites; the `Gm<A>` engine reads a `trace` bool threaded through `GmIfCtx`; the forwarding-plane VIF logs and the lifecycle free functions take a `trace: bool`.

## Test plan

- New `pim::tracing` unit tests (toggle / `should_trace` / unknown-path).
- New `pim_tracing_paths_parse` manager test pinning the augment (mirrors `enabled_activation_leaf_paths_parse`) — a module that forgets to `import` into `config.yang` fails here, not only at live apply.
- `cargo fmt`, workspace `clippy --all-targets -D warnings` (forced-clean), lua-feature clippy `-D warnings`, full workspace test suite (39 test-result-ok, 0 failures) all green locally.
- No BDD — consistent with IS-IS/OSPF/BGP tracing (log output isn't BDD-observable).

Generated with [Claude Code](https://claude.com/claude-code)