### PR TITLE
pim: real Mrt6 IPv6 datapath + PIMv6 SSM end to end (Phase 5)

### DIFF
--- a/bdd/tests/configs/pim6_ssm/r1.yaml
+++ b/bdd/tests/configs/pim6_ssm/r1.yaml
@@ -1,0 +1,15 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:13::1/64
+- if-name: eth3
+  ipv6:
+    address: 2001:db8:14::1/64
+router:
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth3
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_ssm/r2.yaml
+++ b/bdd/tests/configs/pim6_ssm/r2.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:13::2/64
+- if-name: eth5
+  ipv6:
+    address: 2001:db8:15::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:14::/64
+        nexthop:
+        - address: 2001:db8:13::1
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth2
+        dr-priority: 1
+      - if-name: eth5
+        mld:
+          enabled: true

--- a/bdd/tests/features/pim6_ssm.feature
+++ b/bdd/tests/features/pim6_ssm.feature
@@ -1,0 +1,72 @@
+@serial
+@pim6_ssm
+Feature: PIMv6 SSM (S,G) forwarding end to end across two routers
+  As a network operator
+  I want an MLDv2 source-specific join at the last-hop router to build
+  an IPv6 (S,G) shortest-path tree back to the first-hop router and
+  program the kernel MRT6 forwarding cache on both, so real IPv6 traffic
+  from the source reaches the receiver — the first complete PIMv6
+  control-plane-to-dataplane slice (MLD + PIMv6 J/P + the MRT6/MIF/MFC
+  datapath).
+
+  h1 sends UDPv6 to the SSM group ff3e::1. h2 issues a source-specific
+  join for (2001:db8:14::2, ff3e::1). r2 (LHR) must translate the MLDv2
+  membership into a PIMv6 (S,G) Join toward r1 — its RPF nexthop is r1's
+  global on the transit link (a static route), which r1 advertises as a
+  Hello secondary address so r2's neighbor_covers() matches it; the Join
+  itself is sourced from r2's link-local. r1 (FHR, source directly
+  connected) accepts the Join into its downstream state, and both
+  install kernel MRT6 MFC entries that forward h1's datagrams to h2.
+
+  Test Topology:
+  ```
+    h1 (2001:db8:14::2, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (2001:db8:15::2, receiver)
+                                       2001:db8:14::1   2001:db8:13::1/.2       2001:db8:15::1
+  ```
+
+  Scenario: SSM join builds the IPv6 (S,G) tree and traffic flows
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "r1" interface "eth1" to namespace "r2" interface "eth2"
+    And I connect namespace "r1" interface "eth3" to namespace "h1" interface "eth4"
+    And I connect namespace "r2" interface "eth5" to namespace "h2" interface "eth6"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "2001:db8:14::2/64" to interface "eth4" in namespace "h1"
+    And I add address "2001:db8:15::2/64" to interface "eth6" in namespace "h2"
+
+    # Both transit interfaces run PIMv6 and form a link-local neighborship.
+    Then show command "show pim ipv6 interface" in namespace "r1" should eventually contain "Up"
+    And show command "show pim ipv6 interface" in namespace "r2" should eventually contain "Up"
+    And show command "show pim ipv6 neighbor" in namespace "r2" should eventually contain "fe80"
+
+    # h2 source-specifically joins (2001:db8:14::2, ff3e::1): r2 turns the
+    # MLDv2 membership into an (S,G) Join toward r1.
+    When I spawn "timeout 150 python3 tests/scripts/ssm_recv6.py ff3e::1 2001:db8:14::2 eth6 5001 /tmp/pim6_ssm_rx" in namespace "h2"
+    Then show command "show pim ipv6 mld groups" in namespace "r2" should eventually contain "ff3e::1"
+
+    # Kernel MRT6 MFC on both routers, with the expected IIF/OIF split.
+    # r1 learned the (S,G) from r2's PIMv6 Join — no MLD on that path.
+    And command "ip -6 mroute show" in namespace "r1" should eventually contain "Iif: eth3"
+    And command "ip -6 mroute show" in namespace "r1" should eventually contain "eth1"
+    And command "ip -6 mroute show" in namespace "r2" should eventually contain "Iif: eth2"
+    And command "ip -6 mroute show" in namespace "r2" should eventually contain "eth5"
+
+    # The datapath proof: h1's IPv6 datagrams arrive at h2's receiver.
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send6.py ff3e::1 5001 eth4 90" in namespace "h1"
+    Then command "cat /tmp/pim6_ssm_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim6_ssm_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/bdd/tests/scripts/mcast_send6.py
+++ b/bdd/tests/scripts/mcast_send6.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""IPv6 multicast UDP sender for BDD datapath tests.
+
+Usage: mcast_send6.py GROUP PORT IFNAME COUNT
+
+Sends one small datagram per second to GROUP:PORT out interface IFNAME,
+hop limit 8 so it survives a router hop or two.
+"""
+
+import socket
+import sys
+import time
+
+group, port, ifname, count = sys.argv[1:5]
+ifindex = socket.if_nametoindex(ifname)
+
+sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_IF, ifindex)
+sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_HOPS, 8)
+
+for _ in range(int(count)):
+    sock.sendto(b"ssm-hello", (group, int(port)))
+    time.sleep(1)

--- a/bdd/tests/scripts/ssm_recv6.py
+++ b/bdd/tests/scripts/ssm_recv6.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""IPv6 SSM receiver: source-specific join + received-payload logging.
+
+Usage: ssm_recv6.py GROUP SOURCE IFNAME PORT OUTFILE
+
+Joins (SOURCE, GROUP) on interface IFNAME via MCAST_JOIN_SOURCE_GROUP
+(the kernel emits an MLDv2 source-specific report), then appends every
+received UDP payload to OUTFILE — the end-to-end datapath proof for the
+PIMv6 SSM BDD feature. OUTFILE is created immediately so pollers can
+`cat` it before traffic arrives.
+"""
+
+import socket
+import struct
+import sys
+
+MCAST_JOIN_SOURCE_GROUP = 46
+
+group, source, ifname, port, outfile = sys.argv[1:6]
+ifindex = socket.if_nametoindex(ifname)
+
+sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind((group, int(port)))
+
+
+def sockaddr_in6(addr):
+    """A `struct sockaddr_in6` padded out to `sockaddr_storage` (128 B)."""
+    # sin6_family, sin6_port, sin6_flowinfo, sin6_addr[16], sin6_scope_id
+    sa = struct.pack(
+        "HHI16sI",
+        socket.AF_INET6,
+        0,
+        0,
+        socket.inet_pton(socket.AF_INET6, addr),
+        0,
+    )
+    return sa + b"\x00" * (128 - len(sa))
+
+
+# struct group_source_req { uint32_t gsr_interface; sockaddr_storage
+# gsr_group; sockaddr_storage gsr_source; } — the storage members are
+# 8-byte aligned, so 4 bytes of padding follow gsr_interface.
+req = (
+    struct.pack("I", ifindex)
+    + b"\x00" * 4
+    + sockaddr_in6(group)
+    + sockaddr_in6(source)
+)
+sock.setsockopt(socket.IPPROTO_IPV6, MCAST_JOIN_SOURCE_GROUP, req)
+
+with open(outfile, "w", buffering=1) as out:
+    out.write("joined\n")
+    while True:
+        data, _ = sock.recvfrom(2048)
+        out.write(data.decode(errors="replace") + "\n")

--- a/docs/design/pim-ipv6-architecture.md
+++ b/docs/design/pim-ipv6-architecture.md
@@ -541,7 +541,7 @@ Each phase is one reviewable PR leaving the tree tested and useful.
 | 3.0 | Extract the shared `Gm<A>` engine + `GmCodec` (rename `igmp/`→`gm/`); the membership transport moves off `Pim<A>` into the engine so `Pim<Ipv6>` needs no IGMP fields. IPv4-only runtime | IPv4 membership BDD unchanged (`pim_igmp`) |
 | 3.1 | **DONE** — `Ipv6` marker + `Mrt6` stub + PIMv6 socket, Hello/neighbor/DR over LL, AF-split spawn of a default-table `Pim<Ipv6>` (`af6_split` forwards config + show; `PimSend.src` for the v6 checksum; generic interface knobs) | `@pim6_adjacency` two-router link-local neighborship passes; IPv4 pim features green |
 | 4 | **DONE** — MLDv1/v2 codec via `Gm<Ipv6>` + TIB bridge (the second `GmCodec`, plugged into the engine from 3.0; `send_query` gained a `src` param for the pinned LL source) | `@pim6_mld` (host MLD join → router learns the group) passes; IPv4 membership green |
-| 5 | `Mrt6` plane + generic RPF + SSM end-to-end | UDPv6 delivery + kernel MIF/MFC asserts (MVP gate) |
+| 5 | **DONE** — real `Mrt6` MRT6/MIF/MFC plane (`mroute_read_v6` upcalls, `parse_upcall_v6`, ABI layout tests) + `jp_send` pins the egress link-local so the v6 (S,G) Join transmits (RPF nexthop = FHR global, matched via the Hello secondary address list) | `@pim6_ssm` two-router MLDv2 → (S,G) → kernel MRT6 MFC → UDPv6 delivery passes live (33 steps); IPv4 pim features green |
 | 6 | Static-RP ASM, IPv6 Register path, SPT | three-router ASM traffic proof |
 | 7 | IPv6 assert + per-VRF `Pim<Ipv6>` | LAN election + VRF isolation BDD |
 | 8 | IPv6 BSR (hash + fragmentation as acceptance criteria) | election/discovery BDD + FRR interop |
@@ -602,7 +602,7 @@ default-table `Pim<Ipv6>` child exactly like a VRF child. This reuses proven mac
 reaches live PIMv6 adjacency with the least churn; the supervisor refactor lands once the
 `(vrf, af)` product makes the parent-instance tree awkward (Phase 7).
 
-### MVP gate — after Phase 5
+### MVP gate — after Phase 5 — **ACHIEVED** (`@pim6_ssm` live)
 
 - MLDv2 INCLUDE report creates IPv6 `(S,G)` state on the DR only.
 - PIMv6 J/P converges across two routers with LL transport and secondary matching.

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -36,7 +36,7 @@ use super::ipv6::Ipv6;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
 use super::mroute::{Mrt4, Mrt6, Upcall};
 use super::network::{mroute_read, read_packet, write_packet};
-use super::network_v6::{read_packet_v6, write_packet_v6};
+use super::network_v6::{mroute_read_v6, read_packet_v6, write_packet_v6};
 use super::rp::RpSet;
 use super::rpf::RpfEntry;
 use super::tib::{SgKey, TibEntry};
@@ -259,6 +259,12 @@ impl Pim<Ipv6> {
         });
         // MLD membership engine over its own ICMPv6 socket.
         let gm = Gm::new(Box::new(MldCodec::new(mld_sock, tx.clone())));
+        // MRT6 upcalls (NOCACHE / WHOLEPKT / …) drive the same typed FSM.
+        let mroute_sock = fp.sock.clone();
+        let mroute_tx = tx.clone();
+        let mroute_read_task = Task::spawn(async move {
+            mroute_read_v6(mroute_sock, mroute_tx).await;
+        });
 
         let mut pim = Self {
             tx,
@@ -292,8 +298,7 @@ impl Pim<Ipv6> {
             tracing: PimTracing::default(),
             _read_task: read_task,
             _write_task: write_task,
-            // No kernel mroute read task in Phase 3 (Mrt6 is a stub).
-            _mroute_read_task: Task::spawn(async {}),
+            _mroute_read_task: mroute_read_task,
         };
         pim.callback_build();
         pim.show_build();

--- a/zebra-rs/src/pim/jp.rs
+++ b/zebra-rs/src/pim/jp.rs
@@ -209,7 +209,11 @@ impl<A: PimAf> Pim<A> {
             packet,
             ifindex,
             dst: A::ALL_PIM_ROUTERS,
-            src: None,
+            // PIMv6 control must be sourced from the egress link-local
+            // (`write_packet_v6` drops a send with no pinned source);
+            // the IPv4 write task ignores `src`, so this is byte-identical
+            // there.
+            src: self.links.get(&ifindex).and_then(|l| l.primary_addr()),
         });
     }
 

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -346,25 +346,264 @@ impl PimForwardingPlane<Ipv4> for Mrt4 {
     }
 }
 
-/// The IPv6 multicast-forwarding plane. Phase 3 (PIMv6 adjacency) uses
-/// a no-op stub so `Pim<Ipv6>` can run without forwarding; the real
-/// MRT6 / MIF / MFC datapath over `linux/mroute6.h` lands in Phase 5.
-pub struct Mrt6;
+// linux/mroute6.h — MRT6_* sockopts at level IPPROTO_IPV6 (same
+// numeric base as MRT_*, but a distinct option namespace).
+const MRT6_INIT: c_int = 200;
+const MRT6_ADD_MIF: c_int = 202;
+const MRT6_DEL_MIF: c_int = 203;
+const MRT6_ADD_MFC: c_int = 204;
+const MRT6_DEL_MFC: c_int = 205;
+const MRT6_PIM: c_int = 208;
+const MRT6_TABLE: c_int = 209;
+
+const MIFF_REGISTER: u8 = 0x1;
+/// MLD/MRT6 supports 32 MIFs.
+const MAXMIFS: usize = 32;
+/// The register MIF: slot 0, kernel materializes `pim6reg`.
+const REG_MIF: u16 = 0;
+
+const MRT6MSG_NOCACHE: u8 = 1;
+const MRT6MSG_WRONGMIF: u8 = 2;
+const MRT6MSG_WHOLEPKT: u8 = 3;
+const MRT6MSG_WRMIFWHOLE: u8 = 4;
+
+#[repr(C)]
+struct Mif6ctl {
+    mif6c_mifi: u16,
+    mif6c_flags: u8,
+    vifc_threshold: u8,
+    mif6c_pifi: u16,
+    vifc_rate_limit: u32,
+}
+
+/// `struct if_set` — a MIF bitmap (`IF_SETSIZE` = 256 bits / `if_mask`
+/// = u32 ⇒ 8 words).
+#[repr(C)]
+struct IfSet {
+    ifs_bits: [u32; 8],
+}
+
+#[repr(C)]
+struct Mf6cctl {
+    mf6cc_origin: libc::sockaddr_in6,
+    mf6cc_mcastgrp: libc::sockaddr_in6,
+    mf6cc_parent: u16,
+    mf6cc_ifset: IfSet,
+}
+
+fn mrt6_setsockopt<T>(sock: &Socket, opt: c_int, val: &T) -> std::io::Result<()> {
+    let ret = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            opt,
+            val as *const T as *const libc::c_void,
+            std::mem::size_of::<T>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Build a `sockaddr_in6` naming `addr` (family only; port/scope zero).
+fn sockaddr_in6(addr: Ipv6Addr) -> libc::sockaddr_in6 {
+    let mut sa: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+    sa.sin6_family = libc::AF_INET6 as u16;
+    sa.sin6_addr = libc::in6_addr {
+        s6_addr: addr.octets(),
+    };
+    sa
+}
+
+/// The IPv6 multicast-forwarding plane (`linux/mroute6.h`): the ICMPv6
+/// mroute socket, the MIF table and the kernel MFC. Dropping it closes
+/// the socket, running the implicit `MRT6_DONE` cleanup.
+pub struct Mrt6 {
+    pub sock: Arc<AsyncFd<Socket>>,
+    /// ifindex → MIF. Slot 0 stays reserved for the register MIF.
+    mifs: BTreeMap<u32, u16>,
+}
 
 impl PimForwardingPlane<Ipv6> for Mrt6 {
-    fn new(_ctx: &ProtoContext, _table_id: u32) -> std::io::Result<Self> {
-        Ok(Mrt6)
+    fn new(ctx: &ProtoContext, table_id: u32) -> std::io::Result<Self> {
+        // The MRT6 socket is a raw ICMPv6 socket; MRT6_INIT claims the
+        // (per-table) v6 multicast-routing instance.
+        let sock = ctx.raw_socket(Domain::IPV6, Protocol::from(super::socket::IPPROTO_ICMPV6))?;
+        sock.set_nonblocking(true)?;
+        let _ = sock.set_recv_buffer_size(1024 * 1024);
+        if table_id != 0 {
+            mrt6_setsockopt(&sock, MRT6_TABLE, &table_id)?;
+        }
+        let one: c_int = 1;
+        mrt6_setsockopt(&sock, MRT6_INIT, &one)?;
+        if let Err(e) = mrt6_setsockopt(&sock, MRT6_PIM, &one) {
+            tracing::warn!("mroute6: MRT6_PIM failed ({e}); register handling degraded");
+        }
+        // The register MIF (slot 0) — kernel creates `pim6reg`.
+        let mc = Mif6ctl {
+            mif6c_mifi: REG_MIF,
+            mif6c_flags: MIFF_REGISTER,
+            vifc_threshold: 1,
+            mif6c_pifi: 0,
+            vifc_rate_limit: 0,
+        };
+        if let Err(e) = mrt6_setsockopt(&sock, MRT6_ADD_MIF, &mc) {
+            tracing::warn!("mroute6: register MIF add failed ({e}); registers degraded");
+        }
+        Ok(Self {
+            sock: Arc::new(AsyncFd::new(sock)?),
+            mifs: BTreeMap::new(),
+        })
     }
-    fn vif_add(&mut self, _ifindex: u32, _trace: bool) {}
-    fn vif_del(&mut self, _ifindex: u32, _trace: bool) {}
-    fn vif(&self, _ifindex: u32) -> Option<u16> {
-        None
+    fn vif(&self, ifindex: u32) -> Option<u16> {
+        self.mifs.get(&ifindex).copied()
     }
-    fn ifindex_of(&self, _vif: u16) -> Option<u32> {
-        None
+
+    fn ifindex_of(&self, vif: u16) -> Option<u32> {
+        self.mifs
+            .iter()
+            .find(|(_, v)| **v == vif)
+            .map(|(ifindex, _)| *ifindex)
     }
-    fn mfc_add(&self, _src: Ipv6Addr, _grp: Ipv6Addr, _iif: u16, _oifs: &[u16]) {}
-    fn mfc_del(&self, _src: Ipv6Addr, _grp: Ipv6Addr) {}
+
+    fn vif_add(&mut self, ifindex: u32, trace: bool) {
+        if self.mifs.contains_key(&ifindex) {
+            return;
+        }
+        // `mif6c_pifi` is 16-bit; refuse an unrepresentable ifindex
+        // rather than truncate it.
+        if u16::try_from(ifindex).is_err() {
+            tracing::warn!("mroute6: ifindex {ifindex} exceeds 16-bit MIF pifi");
+            return;
+        }
+        let mut mif: u16 = 1;
+        while self.mifs.values().any(|v| *v == mif) {
+            mif += 1;
+        }
+        if mif as usize >= MAXMIFS {
+            tracing::warn!("mroute6: out of MIFs for ifindex {ifindex}");
+            return;
+        }
+        let mc = Mif6ctl {
+            mif6c_mifi: mif,
+            mif6c_flags: 0,
+            vifc_threshold: 1,
+            mif6c_pifi: ifindex as u16,
+            vifc_rate_limit: 0,
+        };
+        match mrt6_setsockopt(self.sock.get_ref(), MRT6_ADD_MIF, &mc) {
+            Ok(()) => {
+                self.mifs.insert(ifindex, mif);
+                if trace {
+                    tracing::info!(
+                        proto = "pim",
+                        category = "mroute",
+                        "mroute6: MIF {mif} added for ifindex {ifindex}"
+                    );
+                }
+            }
+            Err(e) => tracing::warn!("mroute6: MRT6_ADD_MIF ifindex {ifindex} failed: {e}"),
+        }
+    }
+
+    fn vif_del(&mut self, ifindex: u32, trace: bool) {
+        let Some(mif) = self.mifs.remove(&ifindex) else {
+            return;
+        };
+        let mc = Mif6ctl {
+            mif6c_mifi: mif,
+            mif6c_flags: 0,
+            vifc_threshold: 1,
+            mif6c_pifi: ifindex as u16,
+            vifc_rate_limit: 0,
+        };
+        if let Err(e) = mrt6_setsockopt(self.sock.get_ref(), MRT6_DEL_MIF, &mc) {
+            tracing::debug!("mroute6: MRT6_DEL_MIF ifindex {ifindex} failed: {e}");
+        } else if trace {
+            tracing::info!(
+                proto = "pim",
+                category = "mroute",
+                "mroute6: MIF {mif} deleted for ifindex {ifindex}"
+            );
+        }
+    }
+
+    fn mfc_add(&self, src: Ipv6Addr, grp: Ipv6Addr, iif: u16, oifs: &[u16]) {
+        let mut ifset = IfSet {
+            ifs_bits: [0u32; 8],
+        };
+        for oif in oifs {
+            if (*oif as usize) < MAXMIFS && *oif != iif {
+                ifset.ifs_bits[(*oif as usize) >> 5] |= 1u32 << (*oif % 32);
+            }
+        }
+        let mc = Mf6cctl {
+            mf6cc_origin: sockaddr_in6(src),
+            mf6cc_mcastgrp: sockaddr_in6(grp),
+            mf6cc_parent: iif,
+            mf6cc_ifset: ifset,
+        };
+        if let Err(e) = mrt6_setsockopt(self.sock.get_ref(), MRT6_ADD_MFC, &mc) {
+            tracing::warn!("mroute6: MRT6_ADD_MFC ({src},{grp}) failed: {e}");
+        } else {
+            tracing::debug!("mroute6: MFC ({src},{grp}) iif {iif} oifs {oifs:?}");
+        }
+    }
+
+    fn mfc_del(&self, src: Ipv6Addr, grp: Ipv6Addr) {
+        let mc = Mf6cctl {
+            mf6cc_origin: sockaddr_in6(src),
+            mf6cc_mcastgrp: sockaddr_in6(grp),
+            mf6cc_parent: 0,
+            mf6cc_ifset: IfSet {
+                ifs_bits: [0u32; 8],
+            },
+        };
+        if let Err(e) = mrt6_setsockopt(self.sock.get_ref(), MRT6_DEL_MFC, &mc) {
+            tracing::debug!("mroute6: MRT6_DEL_MFC ({src},{grp}) failed: {e}");
+        } else {
+            tracing::debug!("mroute6: MFC ({src},{grp}) deleted");
+        }
+    }
+}
+
+/// Parse one datagram read from the MRT6 socket. `None` for anything
+/// that is not an upcall: `im6_mbz` (the first byte) is zero for a
+/// kernel upcall and a nonzero ICMPv6 type for genuine traffic — there
+/// is no outer header to inspect, so the discriminator differs from the
+/// IPv4 protocol-field trick.
+pub fn parse_upcall_v6(buf: &[u8]) -> Option<Upcall<Ipv6>> {
+    if buf.len() < 40 || buf[0] != 0 {
+        return None;
+    }
+    let kind = match buf[1] {
+        MRT6MSG_NOCACHE => UpcallKind::Nocache,
+        MRT6MSG_WRONGMIF => UpcallKind::WrongVif,
+        MRT6MSG_WHOLEPKT => UpcallKind::WholePkt,
+        MRT6MSG_WRMIFWHOLE => UpcallKind::WrVifWhole,
+        other => {
+            tracing::debug!("mroute6: unknown upcall type {other}");
+            return None;
+        }
+    };
+    let payload = if matches!(kind, UpcallKind::WholePkt | UpcallKind::WrVifWhole) {
+        buf[40..].to_vec()
+    } else {
+        Vec::new()
+    };
+    let mut src = [0u8; 16];
+    let mut grp = [0u8; 16];
+    src.copy_from_slice(&buf[8..24]);
+    grp.copy_from_slice(&buf[24..40]);
+    Some(Upcall {
+        kind,
+        vif: buf[2] as u16 | ((buf[3] as u16) << 8),
+        src: Ipv6Addr::from(src),
+        grp: Ipv6Addr::from(grp),
+        payload,
+    })
 }
 
 #[cfg(test)]
@@ -397,6 +636,48 @@ mod tests {
         assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_pkt_cnt), 44);
         assert_eq!(std::mem::offset_of!(Mfcctl, mfcc_expire), 56);
         assert_eq!(MAXVIFS, 32);
+    }
+
+    // Layout of the hand-declared `linux/mroute6.h` structs.
+    #[test]
+    fn mif6ctl_layout() {
+        assert_eq!(std::mem::size_of::<Mif6ctl>(), 12);
+        assert_eq!(std::mem::offset_of!(Mif6ctl, mif6c_mifi), 0);
+        assert_eq!(std::mem::offset_of!(Mif6ctl, mif6c_flags), 2);
+        assert_eq!(std::mem::offset_of!(Mif6ctl, vifc_threshold), 3);
+        assert_eq!(std::mem::offset_of!(Mif6ctl, mif6c_pifi), 4);
+        assert_eq!(std::mem::offset_of!(Mif6ctl, vifc_rate_limit), 8);
+    }
+
+    #[test]
+    fn mf6cctl_layout() {
+        // `if_set` is 256 bits / 32-bit words = 8 words = 32 bytes.
+        assert_eq!(std::mem::size_of::<IfSet>(), 32);
+        // sockaddr_in6 is 28 bytes; parent follows the two of them, then
+        // the MIF bitmap (4-byte aligned).
+        assert_eq!(std::mem::offset_of!(Mf6cctl, mf6cc_origin), 0);
+        assert_eq!(std::mem::offset_of!(Mf6cctl, mf6cc_mcastgrp), 28);
+        assert_eq!(std::mem::offset_of!(Mf6cctl, mf6cc_parent), 56);
+        assert_eq!(std::mem::offset_of!(Mf6cctl, mf6cc_ifset), 60);
+        assert_eq!(MAXMIFS, 32);
+    }
+
+    #[test]
+    fn parse_upcall_v6_discriminates_and_extracts() {
+        let mut b = [0u8; 40];
+        b[0] = 0; // im6_mbz — zero marks an upcall
+        b[1] = MRT6MSG_NOCACHE;
+        b[2] = 5; // mif
+        b[8..24].copy_from_slice(&"2001:db8::2".parse::<Ipv6Addr>().unwrap().octets());
+        b[24..40].copy_from_slice(&"ff3e::1".parse::<Ipv6Addr>().unwrap().octets());
+        let u = parse_upcall_v6(&b).expect("nocache upcall");
+        assert!(matches!(u.kind, UpcallKind::Nocache));
+        assert_eq!(u.vif, 5);
+        assert_eq!(u.src, "2001:db8::2".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(u.grp, "ff3e::1".parse::<Ipv6Addr>().unwrap());
+        // A genuine ICMPv6 packet has a nonzero type in the first byte.
+        b[0] = 130;
+        assert!(parse_upcall_v6(&b).is_none());
     }
 
     fn upcall_buf(kind: u8, mbz: u8, vif: u16, src: [u8; 4], grp: [u8; 4]) -> [u8; 20] {

--- a/zebra-rs/src/pim/network_v6.rs
+++ b/zebra-rs/src/pim/network_v6.rs
@@ -21,6 +21,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::inst::{Message, PimSend};
 use super::ipv6::Ipv6;
+use super::mroute::parse_upcall_v6;
 
 /// Whether `a` is a unicast link-local (`fe80::/10`). PIMv6 control
 /// messages MUST be sourced from a link-local (RFC 7761 §4.3.1); a
@@ -86,6 +87,38 @@ pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Mess
                     ifindex,
                 });
 
+                Ok(())
+            })
+            .await;
+        if tx.is_closed() {
+            return;
+        }
+    }
+}
+
+/// Drain the MRT6 socket: kernel `mrt6msg` upcalls (first byte zero)
+/// become [`Message::Upcall`]; genuine ICMPv6 the kernel also delivers
+/// here is dropped by [`parse_upcall_v6`].
+pub async fn mroute_read_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message<Ipv6>>) {
+    let mut buf = [0u8; 1024 * 16];
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let n = unsafe {
+                    libc::recv(
+                        sock.as_raw_fd(),
+                        buf.as_mut_ptr() as *mut libc::c_void,
+                        buf.len(),
+                        0,
+                    )
+                };
+                if n < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if let Some(upcall) = parse_upcall_v6(&buf[..n as usize]) {
+                    let _ = tx.send(Message::Upcall(upcall));
+                }
                 Ok(())
             })
             .await;

--- a/zebra-rs/src/pim/socket.rs
+++ b/zebra-rs/src/pim/socket.rs
@@ -83,7 +83,7 @@ fn set_ipv6_pktinfo(socket: &Socket) {
 pub const MLD_V2_REPORT_GROUP: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x0016);
 
 /// ICMPv6 protocol number.
-const IPPROTO_ICMPV6: i32 = 58;
+pub const IPPROTO_ICMPV6: i32 = 58;
 /// `ICMP6_FILTER` sockopt name (kernel ABI value 1 on Linux; not in
 /// libc as a constant on all targets).
 const ICMP6_FILTER_OPT: c_int = 1;


### PR DESCRIPTION
## Summary

The **MVP gate** for the IPv6 PIM arc: real IPv6 multicast traffic forwarded router-to-router.

Replaces the no-op `Mrt6` stub with the real MRT6/MIF/MFC datapath over `linux/mroute6.h`:

- **Datapath (`mroute.rs`)**: `MRT6_INIT`/`MRT6_PIM` + register-MIF in `new`; `mif6ctl` MIF add/del (16-bit pifi guard); `mf6cctl` MFC add/del with the `if_set` OIF bitmap; `parse_upcall_v6` for `mrt6msg` NOCACHE/WHOLEPKT upcalls (`im6_mbz==0` first byte discriminates them from genuine ICMPv6 the kernel also delivers). ABI layout tests for `Mif6ctl`/`Mf6cctl`/`IfSet` + a `parse_upcall_v6` test.
- **Upcall read (`network_v6.rs`)**: `mroute_read_v6` drains the MRT6 socket into `Message::Upcall`, wired into the `Pim<Ipv6>` actor.
- **Control-plane fix (`jp.rs`)**: `jp_send` now pins the egress link-local as the PIMv6 source. `write_packet_v6` drops a send with no pinned source, so the IPv6 (S,G) Join would never have left the LHR. The IPv4 write task ignores `src`, so this is **byte-identical** for v4. r2's RPF nexthop is r1's global on the transit link (a static route), which r1 already advertises as a Hello secondary address, so `neighbor_covers()` matches it and the Join is accepted.

## Test plan

New two-router BDD **`@pim6_ssm`** — proven live (2 scenarios, 33 steps, all passed):

- h2 issues an MLDv2 source-specific join for `(2001:db8:14::2, ff3e::1)`
- r2 (LHR) builds a PIMv6 (S,G) SPT back to r1 (FHR); both program kernel MRT6 MFC entries (`ip -6 mroute show`: r1 `Iif eth3 → eth1`, r2 `Iif eth2 → eth5`)
- **h1's UDPv6 to `ff3e::1` reaches h2** — the datapath proof
- teardown asserts a clean environment

New v6 traffic scripts: `ssm_recv6.py` (`MCAST_JOIN_SOURCE_GROUP`), `mcast_send6.py`.

Gates green locally: live BDD; `cargo fmt`; forced-clean workspace `clippy -D warnings`; lua-feature `clippy -D warnings`; workspace tests (39 ok, 0 failures; `pim::mroute` 8 incl. the mroute6 ABI layout tests). Fresh binary installed with md5 verified before/after; no leaked namespaces.

Design doc updated — Phase 5 **DONE**, MVP gate **ACHIEVED**.

Generated with [Claude Code](https://claude.com/claude-code)