### PR TITLE
pim: wire show pim ipv6 upstream and mroute

### DIFF
--- a/bdd/tests/features/pim6_ssm.feature
+++ b/bdd/tests/features/pim6_ssm.feature
@@ -50,6 +50,12 @@ Feature: PIMv6 SSM (S,G) forwarding end to end across two routers
     When I spawn "timeout 150 python3 tests/scripts/ssm_recv6.py ff3e::1 2001:db8:14::2 eth6 5001 /tmp/pim6_ssm_rx" in namespace "h2"
     Then show command "show pim ipv6 mld groups" in namespace "r2" should eventually contain "ff3e::1"
 
+    # PIMv6 control-plane view of the (S,G) tree: r2 (LHR) Joined the SPT
+    # upstream, and both routers show the (S,G) in the PIMv6 mroute table.
+    And show command "show pim ipv6 upstream" in namespace "r2" should eventually contain "Joined"
+    And show command "show pim ipv6 mroute" in namespace "r2" should eventually contain "ff3e::1"
+    And show command "show pim ipv6 mroute" in namespace "r1" should eventually contain "ff3e::1"
+
     # Kernel MRT6 MFC on both routers, with the expected IIF/OIF split.
     # r1 learned the (S,G) from r2's PIMv6 Join — no MLD on that path.
     And command "ip -6 mroute show" in namespace "r1" should eventually contain "Iif: eth3"

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -59,8 +59,16 @@ impl Pim<Ipv6> {
             .set(show_pim_interface)
             .path("/show/pim/neighbor")
             .set(show_pim_neighbor)
+            .path("/show/pim/upstream")
+            .set(show_pim_upstream)
             .path("/show/pim/mld/groups")
             .set(show_igmp_groups)
+            // `show pim ipv6 mroute`: the parent strips the `ipv6`
+            // segment (`/show/pim/ipv6/mroute` → `/show/pim/mroute`), so
+            // unlike the v4 top-level `show mroute` the v6 form is under
+            // the `pim` container.
+            .path("/show/pim/mroute")
+            .set(show_mroute)
             .map();
     }
 }
@@ -346,7 +354,11 @@ struct UpstreamBrief {
     uptime: String,
 }
 
-fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_pim_upstream<A: PimAf>(
+    pim: &Pim<A>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
     let mut rows: Vec<UpstreamBrief> = vec![];
 
     for (key, entry) in pim.tib.iter() {
@@ -540,7 +552,7 @@ struct MrouteBrief {
     uptime: String,
 }
 
-fn show_mroute(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_mroute<A: PimAf>(pim: &Pim<A>, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
     let mut rows: Vec<MrouteBrief> = vec![];
 
     for (key, entry) in pim.tib.iter() {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1055,6 +1055,14 @@ module exec {
           ext:help "PIMv6 neighbor";
           presence "PIMv6 neighbor";
         }
+        container upstream {
+          ext:help "PIMv6 upstream (S,G) join state";
+          presence "PIMv6 upstream";
+        }
+        container mroute {
+          ext:help "PIMv6 multicast routing table (MRT6 MFC)";
+          presence "PIMv6 mroute";
+        }
         container mld {
           ext:help "MLD membership state";
           container groups {


### PR DESCRIPTION
## Summary

`show_pim_upstream` and `show_mroute` render only generic TIB state but were pinned to `Pim<Ipv4>`, so the IPv6 child had no upstream / mroute view. This genericizes both to `Pim<A>` (mirroring the already-generic interface / neighbor / groups handlers) and registers them in `Pim<Ipv6>::show_build`, exposed via new `upstream` / `mroute` presence containers under `show pim ipv6` in `exec.yang`.

The default-table split forwards `/show/pim/ipv6/…` to the child with the `ipv6` segment stripped (`af6_split`), so the v6 mroute view lands at `/show/pim/mroute` (under the `pim` container) rather than the v4 top-level `show mroute`.

## Test plan

The `@pim6_ssm` BDD now also asserts:
- `show pim ipv6 upstream` on the LHR shows `Joined`
- `show pim ipv6 mroute` lists the (S,G) on both routers

Proven live — 2 scenarios, 36 steps (was 33), all passed.

Gates green locally: live BDD; `cargo fmt`; forced-clean workspace `clippy -D warnings`; lua-feature `clippy -D warnings`; workspace tests (39 ok, 0 failures). Fresh binary installed with md5 verified before/after; no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)