### PR TITLE
pim: static-RP config + unicast IPv6 Register (Phase 6a)

### DIFF
--- a/bdd/tests/configs/pim6_register/r1.yaml
+++ b/bdd/tests/configs/pim6_register/r1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  pim:
+    ipv6:
+      rp:
+        static:
+        - address: 2001:db8:12::2
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth2
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_register/r2.yaml
+++ b/bdd/tests/configs/pim6_register/r2.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: eth3
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  pim:
+    ipv6:
+      rp:
+        static:
+        - address: 2001:db8:12::2
+      interface:
+      - if-name: eth3
+        dr-priority: 1

--- a/bdd/tests/features/pim6_register.feature
+++ b/bdd/tests/features/pim6_register.feature
@@ -1,0 +1,60 @@
+@serial
+@pim6_register
+Feature: PIMv6 FHR Register to a static RP over unicast IPv6
+  As a network operator
+  I want a first-hop router to encapsulate a new IPv6 source's traffic
+  in a PIM Register and unicast it to the statically configured RP, and
+  the RP to answer Register-Stop so the FHR settles in suppression — the
+  PIMv6 unicast Register control loop (transport slice of ASM), before
+  the full shared-tree datapath.
+
+  Unlike link-local PIM control (Hello / J/P / Assert to ff02::d), the
+  Register and Register-Stop are unicast between the FHR and the RP: the
+  FHR sources them from a routable (non-link-local) address so the RP can
+  reply, and the RP accepts a non-link-local source on a unicast
+  destination. There is no receiver, so the RP has no shared tree and
+  answers Register-Stop immediately; the FHR's register state settles in
+  RegPrune.
+
+  Test Topology:
+  ```
+    h1 (2001:db8:1::9, source) --- eth0/eth1 --- r1 (FHR) --- eth2/eth3 --- r2 (RP, 2001:db8:12::2)
+                                       2001:db8:1::1        2001:db8:12::1/.2
+  ```
+
+  Scenario: FHR registers and the RP stops it
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I connect namespace "h1" interface "eth0" to namespace "r1" interface "eth1"
+    And I connect namespace "r1" interface "eth2" to namespace "r2" interface "eth3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "2001:db8:1::9/64" to interface "eth0" in namespace "h1"
+
+    # PIMv6 neighborship on the transit link, and the RP knows it is the RP.
+    Then show command "show pim ipv6 neighbor" in namespace "r1" should eventually contain "fe80"
+    And show command "show pim ipv6 neighbor" in namespace "r2" should eventually contain "fe80"
+
+    # h1 sends to the ASM group ff0e::1: r1 (FHR/DR) encapsulates the
+    # source in a unicast PIM Register to the RP.
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send6.py ff0e::1 5001 eth0 90" in namespace "h1"
+
+    # The RP received the Register and created the (S,G) for the source.
+    Then show command "show pim ipv6 upstream" in namespace "r2" should eventually contain "ff0e::1"
+    And show command "show pim ipv6 upstream" in namespace "r2" should eventually contain "2001:db8:1::9"
+
+    # The RP answered Register-Stop (no receiver); r1 settles in
+    # suppression — the proof that the unicast Register round-trip closed.
+    And show command "show pim ipv6 upstream" in namespace "r1" should eventually contain "RegPrune"
+
+  Scenario: Teardown topology
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "h1"
+    Then the test environment should be clean

--- a/zebra-rs/src/pim/af.rs
+++ b/zebra-rs/src/pim/af.rs
@@ -94,6 +94,12 @@ pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static 
     /// scopes for IPv6).
     fn is_reserved_group(a: Self::Addr) -> bool;
 
+    /// Whether `a` is a link-local unicast address (`169.254.0.0/16` /
+    /// `fe80::/10`). A unicast PIM message (Register / Register-Stop) must
+    /// not be sourced from one — it has to be domain-routable so the RP
+    /// can reply. See [`Pim::unicast_source`](super::inst::Pim).
+    fn is_link_local(a: Self::Addr) -> bool;
+
     /// Build a prefix from a network address and length; `None` if the
     /// length is invalid for the family.
     fn prefix_new(addr: Self::Addr, len: u8) -> Option<Self::Prefix>;

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -3,6 +3,10 @@
 //! the interface through [`Pim::reconcile_by_name`], so enable /
 //! disable is independent of config-line and link-event ordering.
 
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+
 use crate::config::{Args, ConfigOp};
 
 use super::af::PimAf;
@@ -81,6 +85,10 @@ impl Pim<Ipv6> {
             "/router/pim/interface/mld/query-max-response-time",
             config_igmp_query_max_resp,
         );
+        // Static RP (ASM) — the same generic handlers the IPv4 surface
+        // uses; the parent strips the `ipv6` segment before forwarding.
+        self.callback_add("/router/pim/rp/static", config_rp_static);
+        self.callback_add("/router/pim/rp/static/group", config_rp_static_group);
     }
 }
 
@@ -193,13 +201,13 @@ fn config_igmp_query_interval<A: PimAf>(
     Some(())
 }
 
-fn config_rp_static(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
-    let address = args.v4addr()?;
+fn config_rp_static<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
+    let address = A::from_ip(args.string()?.parse::<IpAddr>().ok()?)?;
     if op.is_set() {
         pim.rp_set
             .statics
             .entry(address)
-            .or_insert(Ipv4::DEFAULT_RP_RANGE);
+            .or_insert(A::DEFAULT_RP_RANGE);
     } else {
         pim.rp_set.statics.remove(&address);
     }
@@ -207,13 +215,13 @@ fn config_rp_static(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
-fn config_rp_static_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
-    let address = args.v4addr()?;
+fn config_rp_static_group<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
+    let address = A::from_ip(args.string()?.parse::<IpAddr>().ok()?)?;
     if op.is_set() {
-        let range = args.string()?.parse().ok()?;
+        let range = A::prefix_from_ipnet(args.string()?.parse::<IpNet>().ok()?)?;
         pim.rp_set.statics.insert(address, range);
     } else if let Some(range) = pim.rp_set.statics.get_mut(&address) {
-        *range = Ipv4::DEFAULT_RP_RANGE;
+        *range = A::DEFAULT_RP_RANGE;
     }
     pim.rp_reevaluate();
     Some(())

--- a/zebra-rs/src/pim/ipv4.rs
+++ b/zebra-rs/src/pim/ipv4.rs
@@ -81,6 +81,11 @@ impl PimAf for Ipv4 {
         a.octets()[..3] == [224, 0, 0]
     }
 
+    fn is_link_local(a: Ipv4Addr) -> bool {
+        // 169.254.0.0/16 (RFC 3927).
+        a.is_link_local()
+    }
+
     fn prefix_new(addr: Ipv4Addr, len: u8) -> Option<Ipv4Net> {
         Ipv4Net::new(addr, len).ok()
     }

--- a/zebra-rs/src/pim/ipv6.rs
+++ b/zebra-rs/src/pim/ipv6.rs
@@ -105,6 +105,12 @@ impl PimAf for Ipv6 {
         o[0] == 0xff && (o[1] & 0x0f) <= 0x02
     }
 
+    fn is_link_local(a: Ipv6Addr) -> bool {
+        // fe80::/10 — the unicast link-local scope.
+        let o = a.octets();
+        o[0] == 0xfe && (o[1] & 0xc0) == 0x80
+    }
+
     fn prefix_new(addr: Ipv6Addr, len: u8) -> Option<Ipv6Net> {
         Ipv6Net::new(addr, len).ok()
     }

--- a/zebra-rs/src/pim/network_v6.rs
+++ b/zebra-rs/src/pim/network_v6.rs
@@ -62,9 +62,13 @@ pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Mess
                 let dst: Ipv6Addr = Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr);
                 let ifindex = pktinfo.ipi6_ifindex;
 
-                // RFC 7761 §4.3.1: PIMv6 control is link-local sourced.
-                if !is_link_local(&src) {
-                    tracing::debug!("pim6: non-link-local source {src} dropped");
+                // RFC 7761 §4.3.1: link-local *multicast* PIM control
+                // (Hello / Join-Prune / Assert to ff02::d) must be
+                // link-local sourced. Unicast Register / Register-Stop
+                // arrive from a routable (global) source — exempt them by
+                // gating the check on a multicast destination.
+                if dst.is_multicast() && !is_link_local(&src) {
+                    tracing::debug!("pim6: non-link-local multicast source {src} dropped");
                     return Err(ErrorKind::InvalidData.into());
                 }
 

--- a/zebra-rs/src/pim/register.rs
+++ b/zebra-rs/src/pim/register.rs
@@ -84,6 +84,23 @@ impl<A: PimAf> Pim<A> {
         self.register_send(rp, upcall.payload, false);
     }
 
+    /// Pick a domain-routable source for a unicast PIM message
+    /// (Register / Register-Stop): the highest non-link-local interface
+    /// address (RFC 7761 §4.4.1 / the IPv6 plan §5.2). IPv6 hellos are
+    /// link-local-sourced, but `write_packet_v6` needs a routable source
+    /// pinned for the pseudo-header checksum and for the RP to reply to;
+    /// the IPv4 write task ignores `src` (no pseudo-header), so this is
+    /// byte-identical there. `None` if the router has only link-local
+    /// addresses.
+    pub(crate) fn unicast_source(&self) -> Option<A::Addr> {
+        self.links
+            .values()
+            .flat_map(|l| l.addrs.iter())
+            .map(|p| A::prefix_addr(p))
+            .filter(|a| !A::is_link_local(*a) && !A::is_unspecified(*a))
+            .max()
+    }
+
     fn register_send(&self, rp: A::Addr, data: Vec<u8>, null: bool) {
         let packet = PimPacket::new(PimPayload::Register(PimRegister {
             border: false,
@@ -95,7 +112,7 @@ impl<A: PimAf> Pim<A> {
             packet,
             ifindex: 0,
             dst: rp,
-            src: None,
+            src: self.unicast_source(),
         });
     }
 
@@ -146,7 +163,9 @@ impl<A: PimAf> Pim<A> {
             packet,
             ifindex: 0,
             dst: dr,
-            src: None,
+            // Transport source (distinct from the inner `src` above): a
+            // routable address so the DR can validate the reply.
+            src: self.unicast_source(),
         });
     }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4115,8 +4115,23 @@ module config {
           // The default `router pim` task forwards every `ipv6 ...`
           // line — with the `ipv6` container stripped — to a
           // default-table Pim<Ipv6> instance whose PIMv6 socket runs
-          // over link-local transport. Adjacency-only subset (MLD and
-          // IPv6 RP/BSR arrive in later phases).
+          // over link-local transport.
+          container rp {
+            ext:help "Rendezvous Point configuration";
+            list static {
+              ext:help "Static RP address for a group range";
+              key "address";
+              leaf address {
+                ext:help "RP address";
+                type inet:ipv6-address;
+              }
+              leaf group {
+                ext:help "Multicast group prefix served by this RP";
+                type inet:ipv6-prefix;
+                default "ff00::/8";
+              }
+            }
+          }
           list interface {
             ext:help "Per-interface PIMv6 configuration";
             key "if-name";


### PR DESCRIPTION
## Summary

The PIMv6 unicast Register control loop — the transport slice of ASM, before the full shared-tree datapath (6b).

- **Static RP (ASM) config for IPv6**: genericize `config_rp_static` / `config_rp_static_group` to `Pim<A>` (parse via `A::from_ip` / `A::prefix_from_ipnet`) and register them on `Pim<Ipv6>`, with a `rp` container under `router pim ipv6` in config.yang. `rp.rs` (RpSet / rp_lookup / i_am_rp) was already generic.
- **Unicast Register source selection**: `Pim::unicast_source` picks the highest non-link-local interface address (RFC 7761 §4.4.1 / plan §5.2); `register_send` / `register_stop_send` use it. `write_packet_v6` drops a send with no pinned source and needs it for the pseudo-header checksum; the IPv4 write task ignores `src`, so this is byte-identical there. New `PimAf::is_link_local` (v4 169.254/16, v6 fe80::/10).
- **RP receive**: `read_packet_v6` gated its link-local-source rule on a multicast destination, so a unicast Register / Register-Stop from a routable source is no longer dropped (RFC 7761 §4.3.1 is about link-local *multicast* control).

The FHR encapsulation (NOCACHE → `REG_VIF` in the MFC → WHOLEPKT → Register) and the RP Register-Stop FSM were already generic; this makes them transmit/receive over IPv6.

## Test plan

BDD `pim6_register`: 2-router FHR→RP round-trip — h1's `ff0e::1` traffic is encapsulated to the RP, the RP creates the (S,G) for source `2001:db8:1::9` and answers Register-Stop, and the FHR settles in `RegPrune`. Proven live (2 scenarios, 23 steps).

Gates green locally: live BDD; `cargo fmt`; forced-clean workspace `clippy -D warnings`; lua-feature `clippy -D warnings`; workspace tests (39 ok, 0 failures). Fresh binary md5-verified; no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)