### PR TITLE
pim: IPv6 assert election (Phase 7a) + fix pim_assert log gating

### DIFF
--- a/bdd/tests/configs/pim6_assert/r0.yaml
+++ b/bdd/tests/configs/pim6_assert/r0.yaml
@@ -1,0 +1,15 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:61::1/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:60::1/64
+router:
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth2
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_assert/r1.yaml
+++ b/bdd/tests/configs/pim6_assert/r1.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:61::2/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:62::2/64
+router:
+  static:
+    ipv6:
+      route:
+      # Higher metric than r2, so r1 loses the assert on swB by RPF
+      # cost — the winner is deterministic (link-local tiebreak is never
+      # reached).
+      - prefix: 2001:db8:60::/64
+        metric: 20
+        nexthop:
+        - address: 2001:db8:61::1
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth2
+        dr-priority: 1
+        mld:
+          enabled: true

--- a/bdd/tests/configs/pim6_assert/r2.yaml
+++ b/bdd/tests/configs/pim6_assert/r2.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:61::3/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:62::3/64
+router:
+  static:
+    ipv6:
+      route:
+      # Lower metric than r1, so r2 wins the assert on swB by RPF cost.
+      - prefix: 2001:db8:60::/64
+        metric: 10
+        nexthop:
+        - address: 2001:db8:61::1
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      # Highest DR priority on swB, so r2 is the DR deterministically and
+      # serves h2 directly (the other forwarder is r1 via r3's Join).
+      - if-name: eth2
+        dr-priority: 100
+        mld:
+          enabled: true

--- a/bdd/tests/configs/pim6_assert/r3.yaml
+++ b/bdd/tests/configs/pim6_assert/r3.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:62::1/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:63::1/64
+router:
+  static:
+    ipv6:
+      route:
+      # RPF toward the source is pinned at r1 (2001:db8:62::2, matched via
+      # r1's Hello secondary address), so r3's (S,G) Join goes to r1 and
+      # makes r1 forward onto swB — the non-DR forwarder the assert needs.
+      - prefix: 2001:db8:60::/64
+        nexthop:
+        - address: 2001:db8:62::2
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth2
+        mld:
+          enabled: true

--- a/bdd/tests/configs/pim_assert/r1.yaml
+++ b/bdd/tests/configs/pim_assert/r1.yaml
@@ -13,6 +13,8 @@ router:
         nexthop:
         - address: 10.6.1.1
   pim:
+    tracing:
+      all: null
     interface:
     - if-name: eth1
       dr-priority: 1

--- a/bdd/tests/configs/pim_assert/r2.yaml
+++ b/bdd/tests/configs/pim_assert/r2.yaml
@@ -13,6 +13,8 @@ router:
         nexthop:
         - address: 10.6.1.1
   pim:
+    tracing:
+      all: null
     interface:
     - if-name: eth1
       dr-priority: 1

--- a/bdd/tests/features/pim6_assert.feature
+++ b/bdd/tests/features/pim6_assert.feature
@@ -1,0 +1,118 @@
+@serial
+@pim6_assert
+Feature: PIMv6 assert election and LAN Join/Prune behaviors
+  As a network operator
+  I want duplicate forwarders on a shared IPv6 LAN to elect a single
+  assert winner, routers sharing an upstream LAN to suppress each other's
+  periodic Joins, and a Prune overheard on a LAN to be overridden by
+  routers that still want the traffic — the RFC 7761 multi-access
+  behaviors that keep exactly one copy of each packet on every LAN.
+
+  r1 and r2 both connect the upstream LAN swA (toward r0 and the source)
+  and the contested LAN swB. They must forward the same (S,G) onto swB by
+  two independent mechanisms — so that DR gating cannot collapse the test
+  to a single forwarder:
+
+    * r2 is the DR on swB (highest dr-priority) and forwards for h2, a
+      receiver attached directly to swB.
+    * r1 is NOT the DR on swB; it forwards because r3 (downstream, with
+      receiver h3) has its RPF toward the source pointed at r1.
+
+  Both forward onto swB and the duplicate data triggers the assert. The
+  IPv6 assert tiebreak is the link-local source (non-deterministic on
+  veths), so the winner is made deterministic by RPF cost instead: r2's
+  static route to the source has a lower metric than r1's, so r2 wins and
+  r1 steps down, prunes toward r0, and r2 overrides that Prune — the
+  assert winner then carries swB for both receivers.
+
+  Test Topology:
+  ```
+    h1(src) - r0 - [swA 2001:db8:61/64] - r1(::2) - [swB 2001:db8:62/64] - r2(::3, DR) - h2(::10 direct)
+                                             |             |
+                                          r0 also        r3(::1) - h3   (r3 RPFs to r1)
+  ```
+
+  Scenario: Assert election, join suppression and prune override on LANs
+    Given a clean test environment
+    When I create namespace "swa"
+    And I create namespace "swb"
+    And I create namespace "r0"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I create namespace "h3"
+    And I connect namespace "r0" interface "eth1" to namespace "swa" interface "pa0"
+    And I connect namespace "r1" interface "eth1" to namespace "swa" interface "pa1"
+    And I connect namespace "r2" interface "eth1" to namespace "swa" interface "pa2"
+    And I connect namespace "r1" interface "eth2" to namespace "swb" interface "pb1"
+    And I connect namespace "r2" interface "eth2" to namespace "swb" interface "pb2"
+    And I connect namespace "r3" interface "eth1" to namespace "swb" interface "pb3"
+    And I connect namespace "h2" interface "eth0" to namespace "swb" interface "pb4"
+    And I connect namespace "r0" interface "eth2" to namespace "h1" interface "eth0"
+    And I connect namespace "r3" interface "eth2" to namespace "h3" interface "eth0"
+    And I execute "ip link add bra type bridge mcast_snooping 0" in namespace "swa"
+    And I execute "ip link set pa0 master bra" in namespace "swa"
+    And I execute "ip link set pa1 master bra" in namespace "swa"
+    And I execute "ip link set pa2 master bra" in namespace "swa"
+    And I execute "ip link set bra up" in namespace "swa"
+    And I execute "ip link add brb type bridge mcast_snooping 0" in namespace "swb"
+    And I execute "ip link set pb1 master brb" in namespace "swb"
+    And I execute "ip link set pb2 master brb" in namespace "swb"
+    And I execute "ip link set pb3 master brb" in namespace "swb"
+    And I execute "ip link set pb4 master brb" in namespace "swb"
+    And I execute "ip link set brb up" in namespace "swb"
+    And I start zebra-rs in namespace "r0"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r0.yaml" to namespace "r0"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I add address "2001:db8:60::10/64" to interface "eth0" in namespace "h1"
+    And I add address "2001:db8:62::10/64" to interface "eth0" in namespace "h2"
+    And I add address "2001:db8:63::10/64" to interface "eth0" in namespace "h3"
+
+    # Neighborship on the contested LAN.
+    Then show command "show pim ipv6 neighbor" in namespace "r1" should eventually contain "fe80"
+
+    # Both receivers source-specifically join. r2 (DR on swB) serves h2
+    # directly; r3 turns h3's membership into an (S,G) Join toward r1, so
+    # r1 forwards onto swB too. Each router overhears the other's Join on swA.
+    When I spawn "timeout 260 python3 tests/scripts/ssm_recv6.py ff3e::6 2001:db8:60::10 eth0 5001 /tmp/pim6_assert_h2" in namespace "h2"
+    And I spawn "timeout 260 python3 tests/scripts/ssm_recv6.py ff3e::6 2001:db8:60::10 eth0 5001 /tmp/pim6_assert_h3" in namespace "h3"
+    Then show command "show pim ipv6 upstream" in namespace "r1" should eventually contain "Joined"
+    And show command "show pim ipv6 upstream" in namespace "r2" should eventually contain "Joined"
+
+    # The sender starts: both forward onto swB, the duplicates trigger
+    # the assert, and the lower RPF metric (r2) wins deterministically.
+    # (Join suppression and prune override are generic LAN J/P behaviors
+    # already proven in the IPv4 `pim_assert`; here the point is that the
+    # Assert itself elects a winner over the PIMv6 transport.)
+    When I spawn "timeout 200 python3 tests/scripts/mcast_send6.py ff3e::6 5001 eth0 170" in namespace "h1"
+    Then show command "show pim ipv6 assert" in namespace "r2" should eventually contain "Winner"
+    And show command "show pim ipv6 assert" in namespace "r1" should eventually contain "Loser"
+
+    # Steady state: the assert winner carries swB for both receivers.
+    And command "cat /tmp/pim6_assert_h2" in namespace "h2" should eventually contain "ssm-hello"
+    And command "cat /tmp/pim6_assert_h3" in namespace "h3" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim6_assert_h2" in namespace "h2"
+    And I execute "rm -f /tmp/pim6_assert_h3" in namespace "h3"
+    And I stop zebra-rs in namespace "r0"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r0"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "swa"
+    And I delete namespace "swb"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    And I delete namespace "h3"
+    Then the test environment should be clean

--- a/zebra-rs/src/pim/assert_fsm.rs
+++ b/zebra-rs/src/pim/assert_fsm.rs
@@ -101,7 +101,10 @@ impl<A: PimAf> Pim<A> {
             packet,
             ifindex,
             dst: A::ALL_PIM_ROUTERS,
-            src: None,
+            // PIMv6 control must be sourced from the egress link-local
+            // (`write_packet_v6` drops a send with no pinned source); the
+            // IPv4 write task ignores `src`, so this is byte-identical.
+            src: self.links.get(&ifindex).and_then(|l| l.primary_addr()),
         });
     }
 

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -61,6 +61,8 @@ impl Pim<Ipv6> {
             .set(show_pim_neighbor)
             .path("/show/pim/upstream")
             .set(show_pim_upstream)
+            .path("/show/pim/assert")
+            .set(show_pim_assert)
             .path("/show/pim/mld/groups")
             .set(show_igmp_groups)
             // `show pim ipv6 mroute`: the parent strips the `ipv6`
@@ -455,7 +457,11 @@ struct AssertBrief {
     expires: u64,
 }
 
-fn show_pim_assert(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_pim_assert<A: PimAf>(
+    pim: &Pim<A>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
     let now = Instant::now();
     let mut rows: Vec<AssertBrief> = vec![];
     for (key, entry) in pim.tib.iter() {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1063,6 +1063,10 @@ module exec {
           ext:help "PIMv6 multicast routing table (MRT6 MFC)";
           presence "PIMv6 mroute";
         }
+        container assert {
+          ext:help "PIMv6 assert election state";
+          presence "PIMv6 assert";
+        }
         container mld {
           ext:help "MLD membership state";
           container groups {


### PR DESCRIPTION
## Summary

IPv6 assert election, plus a fix for a regression the `router pim tracing` PR introduced in the IPv4 `pim_assert`.

**IPv6 assert:**
- `assert_send` pins the egress link-local as the PIMv6 source (the deferred Phase-5 fix). `write_packet_v6` drops a send with no pinned source, so v6 Asserts never transmitted. IPv4 write ignores `src` → byte-identical. The assert FSM / metrics were already generic.
- Genericize `show_pim_assert` to `Pim<A>` and register it on `Pim<Ipv6>`, exposed as `show pim ipv6 assert` in exec.yang.

**Regression fix:** the IPv4 `pim_assert` asserts on daemon logs (`"join suppressed"`, `"assert loser"`, `"pruned toward"`, `"prune override"`) that #2019 gated behind tracing. Since CI excludes bdd, this slipped through. Enable `router pim tracing all` on its r1/r2 so those logs fire again (consistent with the opt-in-logging design).

## Test plan

- BDD `pim6_assert` (mirrors the 6-namespace IPv4 `pim_assert`): r1 and r2 both forward the same (S,G) onto contested LAN swB (r2 as DR for h2; r1 via r3's downstream Join). The IPv6 Assert tiebreak is the link-local source (non-deterministic on veths), so the winner is made deterministic **by RPF cost** — r2's static route to the source has a lower metric than r1's. Proven live (67 steps): r2 `Winner`, r1 `Loser`, native delivery to both receivers.
- IPv4 `pim_assert` green again (75 steps) — verified live alongside the new test.
- `cargo fmt`; forced-clean workspace + lua `clippy -D warnings`; workspace tests (39 ok). Fresh binary md5-verified; no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)