### PR TITLE
pim: per-VRF Pim<Ipv6> (Phase 7b)

### DIFF
--- a/bdd/tests/configs/pim6_vrf/r1.yaml
+++ b/bdd/tests/configs/pim6_vrf/r1.yaml
@@ -1,0 +1,21 @@
+vrf:
+- name: mvrf
+interface:
+- if-name: eth1
+  vrf: mvrf
+  ipv6:
+    address: 2001:db8:13::1/64
+- if-name: eth3
+  vrf: mvrf
+  ipv6:
+    address: 2001:db8:14::1/64
+router:
+  pim:
+    vrf:
+    - name: mvrf
+      ipv6:
+        interface:
+        - if-name: eth1
+          dr-priority: 1
+        - if-name: eth3
+          dr-priority: 1

--- a/bdd/tests/configs/pim6_vrf/r2.yaml
+++ b/bdd/tests/configs/pim6_vrf/r2.yaml
@@ -1,0 +1,30 @@
+vrf:
+- name: mvrf
+interface:
+- if-name: eth2
+  vrf: mvrf
+  ipv6:
+    address: 2001:db8:13::2/64
+- if-name: eth5
+  vrf: mvrf
+  ipv6:
+    address: 2001:db8:15::1/64
+router:
+  static:
+    vrf:
+    - name: mvrf
+      ipv6:
+        route:
+        - prefix: 2001:db8:14::/64
+          nexthop:
+          - address: 2001:db8:13::1
+  pim:
+    vrf:
+    - name: mvrf
+      ipv6:
+        interface:
+        - if-name: eth2
+          dr-priority: 1
+        - if-name: eth5
+          mld:
+            enabled: true

--- a/bdd/tests/features/pim6_vrf.feature
+++ b/bdd/tests/features/pim6_vrf.feature
@@ -1,0 +1,68 @@
+@serial
+@pim6_vrf
+Feature: PIMv6 SSM forwarding inside a VRF
+  As a network operator
+  I want `router pim vrf <name> ipv6` to run a full per-VRF PIMv6
+  instance — sockets bound into the VRF, the kernel MRT6 table selected
+  with MRT6_TABLE, MLD and Join/Prune state scoped to the VRF — so IPv6
+  multicast in one VRF neither sees nor disturbs the default table.
+
+  Same shape as the pim6_ssm feature, but every router interface is
+  enslaved to VRF mvrf and all PIMv6/MLD config lives under
+  `router pim vrf mvrf ipv6`. The parent's per-VRF Pim<Ipv4> child spawns
+  a per-VRF Pim<Ipv6> grandchild; the default IPv6 instance is never
+  configured and must stay absent.
+
+  Test Topology (all router interfaces in VRF mvrf):
+  ```
+    h1 (2001:db8:14::10, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (2001:db8:15::10, receiver)
+                                       2001:db8:14::1   2001:db8:13::1/.2       2001:db8:15::1
+  ```
+
+  Scenario: SSM join builds the (S,G) tree in the VRF and traffic flows
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "r1" interface "eth1" to namespace "r2" interface "eth2"
+    And I connect namespace "r1" interface "eth3" to namespace "h1" interface "eth4"
+    And I connect namespace "r2" interface "eth5" to namespace "h2" interface "eth6"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "2001:db8:14::10/64" to interface "eth4" in namespace "h1"
+    And I add address "2001:db8:15::10/64" to interface "eth6" in namespace "h2"
+
+    # The per-VRF IPv6 grandchild converges inside the VRF, and the
+    # default IPv6 instance (never configured) stays empty — isolation.
+    Then show command "show pim vrf mvrf ipv6 neighbor" in namespace "r2" should eventually contain "fe80"
+    And show command "show pim ipv6 neighbor" in namespace "r2" should not contain "fe80"
+
+    # h2 source-specifically joins (2001:db8:14::10, ff3e::8) — MLD,
+    # upstream join and TIB all inside the VRF.
+    When I spawn "timeout 150 python3 tests/scripts/ssm_recv6.py ff3e::8 2001:db8:14::10 eth6 5001 /tmp/pim6_vrf_rx" in namespace "h2"
+    Then show command "show pim vrf mvrf ipv6 mld groups" in namespace "r2" should eventually contain "ff3e::8"
+    And show command "show pim vrf mvrf ipv6 upstream" in namespace "r2" should eventually contain "Joined"
+    And show command "show pim vrf mvrf ipv6 mroute" in namespace "r2" should eventually contain "ff3e::8"
+    And show command "show pim vrf mvrf ipv6 mroute" in namespace "r1" should eventually contain "ff3e::8"
+
+    # Kernel MRT6 MFCs live in the VRF's multicast table.
+    And command "ip -6 mroute show table all" in namespace "r1" should eventually contain "Iif: eth3"
+    And command "ip -6 mroute show table all" in namespace "r2" should eventually contain "Iif: eth2"
+
+    # The datapath proof: h1's datagrams reach h2 through both VRF
+    # forwarding caches.
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send6.py ff3e::8 5001 eth4 90" in namespace "h1"
+    Then command "cat /tmp/pim6_vrf_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim6_vrf_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1844,6 +1844,39 @@ mod yang_load_tests {
         }
     }
 
+    /// Pin the per-VRF PIMv6 config subtree (`router pim vrf <name> ipv6
+    /// …`), which the default `Pim<Ipv4>` strips to `router pim ipv6 …`
+    /// and forwards to a per-VRF `Pim<Ipv6>` grandchild. A malformed
+    /// duplication of the `ipv6` container fails here, not only at apply.
+    #[test]
+    fn pim_vrf_ipv6_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router pim vrf blue ipv6 interface eth0 dr-priority 20",
+            "set router pim vrf blue ipv6 interface eth0 mld enabled true",
+            "set router pim vrf blue ipv6 rp static 2001:db8::1",
+            "set router pim vrf blue ipv6 rp static 2001:db8::1 group ff3e::/32",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for `remove-private-as`. The IETF model
     /// (`ietf-bgp`) shipped a `remove-private-as` identityref leaf on the
     /// neighbor whose IANA base this libyang can't resolve to a value

--- a/zebra-rs/src/pim/af6.rs
+++ b/zebra-rs/src/pim/af6.rs
@@ -26,49 +26,68 @@ pub struct PimAf6Handle {
 }
 
 /// Namespaces the IPv6 child's name-keyed RIB registrations away from
-/// the parent's `"pim"`.
-pub fn af6_proto_label() -> String {
-    "pim:ipv6".to_string()
+/// the parent's `"pim"` / `"pim:vrf:<name>"`: `"pim:ipv6"` for the
+/// default table, `"pim:vrf:<name>:ipv6"` for a per-VRF IPv6 child.
+pub fn af6_proto_label(vrf_ifname: Option<&str>) -> String {
+    match vrf_ifname {
+        None => "pim:ipv6".to_string(),
+        Some(name) => format!("pim:vrf:{name}:ipv6"),
+    }
 }
 
-/// Build + spawn the default-table `Pim<Ipv6>` task. Returns `None`
-/// when the v6 socket cannot be opened (missing kernel support), so the
-/// caller leaves the slot empty and a later event retries.
+/// Build + spawn a `Pim<Ipv6>` task, either default-table
+/// (`vrf_ifname == None`, `vrf_id == 0`) or per-VRF (the child of a
+/// per-VRF `Pim<Ipv4>`). The sockets and the MRT6 instance are scoped to
+/// the VRF exactly as `spawn_pim_vrf` scopes the IPv4 ones. Returns
+/// `None` when the v6 socket cannot be opened (missing kernel support),
+/// so the caller leaves the slot empty and a later event retries.
 pub fn spawn_pim_v6(
     rib_subscriber: &RibSubscriber,
     config_tx: &Sender<Message>,
+    vrf_id: u32,
+    vrf_ifname: Option<String>,
     trace: bool,
 ) -> Option<PimAf6Handle> {
-    let proto = af6_proto_label();
+    let proto = af6_proto_label(vrf_ifname.as_deref());
+    let scope = match &vrf_ifname {
+        None => "default-table".to_string(),
+        Some(name) => format!("VRF {name}"),
+    };
 
-    // Open the socket before subscribing so a failure can't leave a
-    // dead RibRx receiver queued in RIB's inbox (same contract as the
-    // IPv4 spawn).
-    let probe = ProtoContext::default_table_no_rib();
+    // Open the sockets — inside the VRF when scoped — before subscribing
+    // so a failure can't leave a dead RibRx receiver queued in RIB's
+    // inbox (same contract as the IPv4 spawn).
+    let probe = match &vrf_ifname {
+        None => ProtoContext::default_table_no_rib(),
+        Some(name) => ProtoContext::for_vrf_no_rib(vrf_id, name.clone()),
+    };
     let sock = match pim_socket_v6(&probe) {
         Ok(sock) => sock,
         Err(e) => {
-            tracing::warn!("pim6: default-table instance not started ({e})");
+            tracing::warn!("pim6: {scope} instance not started ({e})");
             return None;
         }
     };
     let mld_sock = match mld_socket(&probe) {
         Ok(sock) => sock,
         Err(e) => {
-            tracing::warn!("pim6: default-table instance not started (mld socket: {e})");
+            tracing::warn!("pim6: {scope} instance not started (mld socket: {e})");
             return None;
         }
     };
-    let fp = match Mrt6::new(&probe, 0) {
+    let fp = match Mrt6::new(&probe, vrf_id) {
         Ok(fp) => fp,
         Err(e) => {
-            tracing::warn!("pim6: default-table instance not started (mroute6: {e})");
+            tracing::warn!("pim6: {scope} instance not started (mroute6: {e})");
             return None;
         }
     };
 
-    let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, 0);
-    let ctx = ProtoContext::default_table(rib_client);
+    let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, vrf_id);
+    let ctx = match &vrf_ifname {
+        None => ProtoContext::default_table(rib_client),
+        Some(name) => ProtoContext::for_vrf(rib_client, vrf_id, name.clone()),
+    };
 
     let pim = Pim::<Ipv6>::new(
         ctx,
@@ -87,7 +106,7 @@ pub fn spawn_pim_v6(
         tracing::info!(
             proto = "pim",
             category = "event",
-            "pim6: spawned default-table IPv6 instance"
+            "pim6: spawned {scope} IPv6 instance"
         );
     }
 

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -135,9 +135,11 @@ pub struct Pim<A: PimAf = Ipv4> {
     /// Kernel VRF masters from `RibRx::VrfAdd` (parent only):
     /// name → (table_id, ifindex).
     pub(crate) rib_known_vrfs: BTreeMap<String, (u32, u32)>,
-    /// The default-table IPv6 child (parent only): spawned on the first
-    /// `router pim ipv6 …` line, fed the `ipv6`-stripped config, and the
-    /// forwarding target for `show pim ipv6 …`.
+    /// This instance's IPv6 child: the default parent's default-table
+    /// `Pim<Ipv6>`, or a per-VRF `Pim<Ipv4>` child's per-VRF `Pim<Ipv6>`
+    /// grandchild. Spawned on the first `ipv6 …` line, fed the
+    /// `ipv6`-stripped config, and the forwarding target for
+    /// `show … ipv6 …`.
     pub(crate) af6: Option<super::af6::PimAf6Handle>,
     /// Buffered `router pim ipv6 …` intent, so the child can be despawned
     /// when its block is fully deleted (mirrors `vrf_log`).
@@ -519,16 +521,27 @@ impl<A: PimAf> Pim<A> {
         self.af6_log.push((rewritten, op));
     }
 
-    /// Spawn the IPv6 child on first intent. The default multicast table
-    /// always exists, so — unlike a VRF child — there is no kernel-event
-    /// gating.
+    /// Spawn the IPv6 child on first intent. Every IPv4 instance — the
+    /// default `pim` table and each per-VRF `pim:vrf:<name>` child —
+    /// parents an IPv6 instance scoped to its own table; an IPv6 instance
+    /// (label ending `:ipv6`) never does, so the recursion stops. The
+    /// multicast table already exists (the parent VRF instance only
+    /// spawned once its kernel VRF appeared), so there is no extra
+    /// kernel-event gating here.
     fn af6_spawn_if_ready(&mut self) {
-        if self.proto_label != "pim" || self.af6.is_some() {
+        if self.af6.is_some() || self.proto_label.ends_with(":ipv6") {
             return;
         }
+        let vrf_id = self.ctx.vrf_id();
+        let vrf_ifname = self
+            .proto_label
+            .strip_prefix("pim:vrf:")
+            .map(str::to_string);
         self.af6 = super::af6::spawn_pim_v6(
             &self.rib_subscriber,
             &self.config_tx,
+            vrf_id,
+            vrf_ifname,
             self.tracing.should_trace(TraceCategory::Event),
         );
     }
@@ -537,19 +550,18 @@ impl<A: PimAf> Pim<A> {
     /// was fully deleted this commit, else forward CommitEnd so it
     /// reconciles.
     fn af6_commit_end(&mut self) {
-        if self.proto_label != "pim" {
+        // IPv4 instances (default + per-VRF) own an IPv6 child; an IPv6
+        // instance (label `…:ipv6`) does not.
+        if self.proto_label.ends_with(":ipv6") {
             return;
         }
         if !super::vrf::vrf_log_active(&self.af6_log) {
             self.af6_log.clear();
             if self.af6.take().is_some() {
+                let vrf_ifname = self.proto_label.strip_prefix("pim:vrf:");
                 self.rib_subscriber
-                    .send_proto_cleanup(&super::af6::af6_proto_label());
-                pim_trace!(
-                    self.tracing,
-                    Event,
-                    "pim6: default-table IPv6 instance despawned"
-                );
+                    .send_proto_cleanup(&super::af6::af6_proto_label(vrf_ifname));
+                pim_trace!(self.tracing, Event, "pim6: IPv6 instance despawned");
             }
             return;
         }
@@ -667,6 +679,10 @@ impl<A: PimAf> Pim<A> {
                     json: msg.json,
                     resp: msg.resp,
                 });
+            } else {
+                // No IPv6 instance configured here — answer empty rather
+                // than leaving the caller waiting on a dropped `resp`.
+                let _ = msg.resp.send(String::new()).await;
             }
             return;
         }

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -392,6 +392,15 @@ impl<A: PimAf> Pim<A> {
         };
         if !link.addrs.contains(&prefix) {
             link.addrs.push(prefix);
+            // Keep link-locals first — the same order `link_prefixes`
+            // seeds at LinkAdd, so `primary_addr` stays the Hello / DR
+            // identity even when the interface link-local arrives as a
+            // *live* AddrAdd after the LinkAdd dump (VRF enslavement
+            // flushes then re-adds the fe80:: address late). Stable sort
+            // preserves the within-group order. For IPv4 no address is
+            // link-local, so the order is unchanged (byte-identical).
+            link.addrs
+                .sort_by_key(|p| !A::is_link_local(A::prefix_addr(p)));
         }
         self.reconcile(addr.ifindex);
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4299,6 +4299,96 @@ module config {
               }
             }
           }
+          container ipv6 {
+            ext:help "PIMv6 (IPv6) configuration in this VRF";
+            // The per-VRF `Pim<Ipv4>` child strips the `ipv6` container
+            // and forwards to a per-VRF `Pim<Ipv6>` grandchild scoped to
+            // the same table.
+            container rp {
+              ext:help "Rendezvous Point configuration";
+              list static {
+                ext:help "Static RP address for a group range";
+                key "address";
+                leaf address {
+                  ext:help "RP address";
+                  type inet:ipv6-address;
+                }
+                leaf group {
+                  ext:help "Multicast group prefix served by this RP";
+                  type inet:ipv6-prefix;
+                  default "ff00::/8";
+                }
+              }
+            }
+            list interface {
+              ext:help "Per-interface PIMv6 configuration";
+              key "if-name";
+              leaf if-name {
+                ext:help "Interface name";
+                ext:dynamic "rib:interface";
+                type string;
+              }
+              leaf dr-priority {
+                ext:help "Designated Router election priority";
+                type uint32;
+                default 1;
+              }
+              container hello {
+                ext:help "PIM Hello parameters";
+                leaf interval {
+                  ext:help "Hello transmit interval (seconds)";
+                  type uint16 {
+                    range "1..18000";
+                  }
+                  units "seconds";
+                  default 30;
+                }
+                leaf holdtime {
+                  ext:help "Neighbor holdtime advertised in Hellos (seconds)";
+                  type uint16 {
+                    range "1..65535";
+                  }
+                  units "seconds";
+                }
+              }
+              leaf passive {
+                ext:help "Do not send or process PIM packets on this interface";
+                type boolean;
+                default false;
+              }
+              container mld {
+                ext:help "MLD on this interface";
+                leaf enabled {
+                  ext:help "Enable MLD membership tracking";
+                  type boolean;
+                  default false;
+                }
+                leaf version {
+                  ext:help "MLD version to run";
+                  type uint8 {
+                    range "1..2";
+                  }
+                  default 2;
+                }
+                leaf query-interval {
+                  ext:help "General query transmit interval (seconds)";
+                  type uint16 {
+                    range "1..1800";
+                  }
+                  units "seconds";
+                  default 125;
+                }
+                leaf query-max-response-time {
+                  ext:help "Max response time advertised in queries (seconds)";
+                  type uint16 {
+                    range "1..25";
+                  }
+                  units "seconds";
+                  default 10;
+                }
+              }
+            }
+          }
         }
       }
       container static {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1106,6 +1106,37 @@ module exec {
           ext:help "Assert state in this VRF";
           type empty;
         }
+        container ipv6 {
+          ext:help "PIMv6 (IPv6) state in this VRF";
+          presence "PIMv6 in this VRF";
+          container interface {
+            ext:help "PIMv6 interface";
+            presence "PIMv6 interface";
+          }
+          container neighbor {
+            ext:help "PIMv6 neighbor";
+            presence "PIMv6 neighbor";
+          }
+          container upstream {
+            ext:help "PIMv6 upstream (S,G) join state";
+            presence "PIMv6 upstream";
+          }
+          container mroute {
+            ext:help "PIMv6 multicast routing table (MRT6 MFC)";
+            presence "PIMv6 mroute";
+          }
+          container assert {
+            ext:help "PIMv6 assert election state";
+            presence "PIMv6 assert";
+          }
+          container mld {
+            ext:help "MLD membership state";
+            container groups {
+              ext:help "MLD group memberships";
+              presence "MLD groups";
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

A full per-VRF PIMv6 instance via `router pim vrf <name> ipv6 …`. The per-VRF `Pim<Ipv4>` child parents a per-VRF `Pim<Ipv6>` grandchild scoped to the same table — extending the default parent-child pattern one level, reusing the generic af6 machinery (the RIB NHT is already VRF-aware and `Mrt6::new` already selects the table with MRT6_TABLE).

- `spawn_pim_v6` generalized to a VRF scope (`vrf_id` + `vrf_ifname`): in-VRF sockets via `ProtoContext::for_vrf_no_rib`, `Mrt6::new(_, table)`, `subscribe_for_vrf(proto, table)`, proto label `pim:vrf:<name>:ipv6`.
- `af6_spawn_if_ready` / `af6_commit_end` no longer gate on the default `"pim"` label — every IPv4 instance parents an IPv6 child; an IPv6 instance (label `…:ipv6`) does not, so recursion stops.
- YANG `router pim vrf <name> ipv6 { rp, interface { … mld } }` + `show pim vrf <name> ipv6 { … }`. Routing unchanged: manager strips `vrf <name>`, per-VRF child strips `ipv6`, both generic. Parse test pins it.
- `process_show_msg` answers empty (not a dropped `resp`) when no IPv6 instance exists, so `show … ipv6 …` never hangs.

## Bug fix (general, surfaced by the VRF case)

VRF enslavement flushes then re-adds the interface `fe80::` address, so it arrives as a *live* AddrAdd after the LinkAdd dump. `addr_add` appended it, leaving the global as `addrs[0]` / `primary_addr` — breaking v6 Hello sourcing. Keep link-locals first with a stable sort (v4 has no link-local address → byte-identical there).

## Test plan

- BDD `pim6_vrf` (mirrors IPv4 `pim_vrf`): all interfaces enslaved to VRF mvrf, PIMv6 config under `router pim vrf mvrf ipv6`. The grandchild forms adjacency and forwards an SSM (S,G) inside the VRF; the default IPv6 instance stays empty (isolation); UDPv6 reaches the receiver. Proven live (33 steps).
- Regression spot-check: `pim6_ssm` still passes (36 steps).
- `cargo fmt`; workspace + lua `clippy -D warnings`; workspace tests (39 ok). Fresh binary md5-verified; no leaked namespaces.

Generated with [Claude Code](https://claude.com/claude-code)