### PR TITLE
pim: default-table IPv6 BSR (Phase 8a)

### DIFF
--- a/bdd/tests/configs/pim6_bsr/r1.yaml
+++ b/bdd/tests/configs/pim6_bsr/r1.yaml
@@ -1,0 +1,15 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:21::1/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:22::1/64
+router:
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth2
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_bsr/r2.yaml
+++ b/bdd/tests/configs/pim6_bsr/r2.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: eth3
+  ipv6:
+    address: 2001:db8:22::2/64
+- if-name: eth4
+  ipv6:
+    address: 2001:db8:23::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:21::/64
+        nexthop:
+        - address: 2001:db8:22::1
+  pim:
+    ipv6:
+      bsr:
+        candidate-bsr:
+          address: 2001:db8:22::2
+          priority: 100
+        candidate-rp:
+          address: 2001:db8:22::2
+      interface:
+      - if-name: eth3
+        dr-priority: 1
+      - if-name: eth4
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_bsr/r3.yaml
+++ b/bdd/tests/configs/pim6_bsr/r3.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: eth5
+  ipv6:
+    address: 2001:db8:23::2/64
+- if-name: eth6
+  ipv6:
+    address: 2001:db8:24::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:22::/64
+        nexthop:
+        - address: 2001:db8:23::1
+      - prefix: 2001:db8:21::/64
+        nexthop:
+        - address: 2001:db8:23::1
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth5
+        dr-priority: 1
+      - if-name: eth6
+        mld:
+          enabled: true

--- a/bdd/tests/features/pim6_bsr.feature
+++ b/bdd/tests/features/pim6_bsr.feature
@@ -1,0 +1,71 @@
+@serial
+@pim6_bsr
+Feature: PIMv6 Bootstrap Router election and RP-set distribution
+  As a network operator
+  I want a candidate BSR to win the election, collect candidate-RP
+  advertisements, and flood the RP-set in Bootstrap messages so every
+  PIMv6 router learns the group-to-RP mapping without static config —
+  then run the ASM control loop on the BSR-learned RP.
+
+  r2 is candidate-BSR and candidate-RP (2001:db8:22::2). r1 and r3 must
+  learn both the elected BSR and the RP purely from flooded BSMs. The
+  Bootstrap messages are link-local-sourced multicast (like Hellos); the
+  BSR / RP addresses they carry are the configured globals, so the
+  election and RP mapping are deterministic.
+
+  Test Topology:
+  ```
+    h1 (2001:db8:21::10, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(C-BSR,C-RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (2001:db8:24::10, receiver)
+                                       2001:db8:21::1   2001:db8:22::1/.2         2001:db8:23::1/.2         2001:db8:24::1
+  ```
+
+  Scenario: BSR election, RP-set distribution and ASM traffic
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "h1" interface "eth0" to namespace "r1" interface "eth1"
+    And I connect namespace "r1" interface "eth2" to namespace "r2" interface "eth3"
+    And I connect namespace "r2" interface "eth4" to namespace "r3" interface "eth5"
+    And I connect namespace "r3" interface "eth6" to namespace "h2" interface "eth7"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I add address "2001:db8:21::10/64" to interface "eth0" in namespace "h1"
+    And I add address "2001:db8:24::10/64" to interface "eth7" in namespace "h2"
+
+    # r2 claims the BSR role; r1 and r3 learn it from flooded BSMs.
+    Then show command "show pim ipv6 bsr" in namespace "r2" should eventually contain "Elected"
+    And show command "show pim ipv6 bsr" in namespace "r1" should eventually contain "2001:db8:22::2"
+    And show command "show pim ipv6 bsr" in namespace "r3" should eventually contain "2001:db8:22::2"
+
+    # The RP mapping arrives via the BSM RP-set — no static config.
+    And show command "show pim ipv6 rp-info" in namespace "r1" should eventually contain "bsr"
+    And show command "show pim ipv6 rp-info" in namespace "r3" should eventually contain "2001:db8:22::2"
+
+    # The ASM control loop runs on the learned RP: shared tree from h2's
+    # join, register cycle from h1's traffic, payload delivered.
+    When I spawn "timeout 160 python3 tests/scripts/asm_recv6.py ff0e::9 eth7 5001 /tmp/pim6_bsr_rx" in namespace "h2"
+    Then show command "show pim ipv6 upstream" in namespace "r3" should eventually contain "(*, ff0e::9)"
+    And show command "show pim ipv6 mroute" in namespace "r2" should eventually contain "(*, ff0e::9)"
+    When I spawn "timeout 130 python3 tests/scripts/mcast_send6.py ff0e::9 5001 eth0 100" in namespace "h1"
+    Then show command "show pim ipv6 mroute" in namespace "r2" should eventually contain "2001:db8:21::10"
+    And show command "show pim ipv6 upstream" in namespace "r1" should eventually contain "RegPrune"
+    And command "cat /tmp/pim6_bsr_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim6_bsr_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1877,6 +1877,39 @@ mod yang_load_tests {
         }
     }
 
+    /// Pin the default-table PIMv6 Bootstrap Router config subtree
+    /// (`router pim ipv6 bsr …`), stripped to `router pim bsr …` and
+    /// forwarded to the default-table `Pim<Ipv6>`.
+    #[test]
+    fn pim_ipv6_bsr_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router pim ipv6 bsr candidate-bsr address 2001:db8::1",
+            "set router pim ipv6 bsr candidate-bsr priority 200",
+            "set router pim ipv6 bsr candidate-rp address 2001:db8::1",
+            "set router pim ipv6 bsr candidate-rp group ff3e::/32",
+            "set router pim ipv6 bsr candidate-rp priority 10",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for `remove-private-as`. The IETF model
     /// (`ietf-bgp`) shipped a `remove-private-as` identityref leaf on the
     /// neighbor whose IANA base this libyang can't resolve to a value

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -323,7 +323,9 @@ impl<A: PimAf> Pim<A> {
                 packet: packet.clone(),
                 ifindex: oif,
                 dst: A::ALL_PIM_ROUTERS,
-                src: None,
+                // Link-local multicast control: pin the egress link-local
+                // (write_packet_v6 drops a send with no source; v4 ignores).
+                src: self.links.get(&oif).and_then(|l| l.primary_addr()),
             });
         }
 
@@ -434,7 +436,8 @@ impl<A: PimAf> Pim<A> {
                 packet: packet.clone(),
                 ifindex: oif,
                 dst: A::ALL_PIM_ROUTERS,
-                src: None,
+                // Link-local multicast control: pin the egress link-local.
+                src: self.links.get(&oif).and_then(|l| l.primary_addr()),
             });
         }
     }
@@ -477,7 +480,8 @@ impl<A: PimAf> Pim<A> {
             packet,
             ifindex: 0,
             dst: bsr,
-            src: None,
+            // Unicast to the BSR: a routable source (as for Register).
+            src: self.unicast_source(),
         });
     }
 

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -70,8 +70,8 @@ impl Pim<Ipv4> {
 
 /// The IPv6 configuration surface: the shared interface knobs plus MLD
 /// membership (the same AF-agnostic callbacks the IGMP paths use, since
-/// `LinkConfig.igmp` is shared). IPv6 RP and IPv6 BSR arrive in later
-/// phases.
+/// `LinkConfig.igmp` is shared), and the generic static-RP / BSR
+/// callbacks (the parent strips the `ipv6` segment before forwarding).
 impl Pim<Ipv6> {
     pub fn callback_build(&mut self) {
         self.callback_add_interface();
@@ -89,6 +89,17 @@ impl Pim<Ipv6> {
         // uses; the parent strips the `ipv6` segment before forwarding.
         self.callback_add("/router/pim/rp/static", config_rp_static);
         self.callback_add("/router/pim/rp/static/group", config_rp_static_group);
+        // Bootstrap Router (RFC 5059) — same generic handlers.
+        self.callback_add("/router/pim/bsr/candidate-bsr", config_cbsr);
+        self.callback_add("/router/pim/bsr/candidate-bsr/address", config_cbsr_address);
+        self.callback_add(
+            "/router/pim/bsr/candidate-bsr/priority",
+            config_cbsr_priority,
+        );
+        self.callback_add("/router/pim/bsr/candidate-rp", config_crp);
+        self.callback_add("/router/pim/bsr/candidate-rp/address", config_crp_address);
+        self.callback_add("/router/pim/bsr/candidate-rp/group", config_crp_group);
+        self.callback_add("/router/pim/bsr/candidate-rp/priority", config_crp_priority);
     }
 }
 
@@ -227,15 +238,15 @@ fn config_rp_static_group<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: Config
     Some(())
 }
 
-fn config_cbsr(pim: &mut Pim, _args: Args, op: ConfigOp) -> Option<()> {
+fn config_cbsr<A: PimAf>(pim: &mut Pim<A>, _args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.cbsr_enabled = op.is_set();
     pim.bsr_config_changed();
     Some(())
 }
 
-fn config_cbsr_address(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_cbsr_address<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.cbsr_addr = if op.is_set() {
-        Some(args.v4addr()?)
+        Some(A::from_ip(args.string()?.parse::<IpAddr>().ok()?)?)
     } else {
         None
     };
@@ -243,21 +254,21 @@ fn config_cbsr_address(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()
     Some(())
 }
 
-fn config_cbsr_priority(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_cbsr_priority<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.cbsr_priority = if op.is_set() { Some(args.u8()?) } else { None };
     pim.bsr_config_changed();
     Some(())
 }
 
-fn config_crp(pim: &mut Pim, _args: Args, op: ConfigOp) -> Option<()> {
+fn config_crp<A: PimAf>(pim: &mut Pim<A>, _args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.crp_enabled = op.is_set();
     pim.bsr_config_changed();
     Some(())
 }
 
-fn config_crp_address(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_crp_address<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.crp_addr = if op.is_set() {
-        Some(args.v4addr()?)
+        Some(A::from_ip(args.string()?.parse::<IpAddr>().ok()?)?)
     } else {
         None
     };
@@ -265,9 +276,9 @@ fn config_crp_address(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()>
     Some(())
 }
 
-fn config_crp_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_crp_group<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.crp_group = if op.is_set() {
-        Some(args.string()?.parse().ok()?)
+        Some(A::prefix_from_ipnet(args.string()?.parse::<IpNet>().ok()?)?)
     } else {
         None
     };
@@ -275,7 +286,7 @@ fn config_crp_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
-fn config_crp_priority(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_crp_priority<A: PimAf>(pim: &mut Pim<A>, mut args: Args, op: ConfigOp) -> Option<()> {
     pim.bsr_config.crp_priority = if op.is_set() { Some(args.u8()?) } else { None };
     pim.bsr_config_changed();
     Some(())

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -63,6 +63,10 @@ impl Pim<Ipv6> {
             .set(show_pim_upstream)
             .path("/show/pim/assert")
             .set(show_pim_assert)
+            .path("/show/pim/bsr")
+            .set(show_pim_bsr)
+            .path("/show/pim/rp-info")
+            .set(show_pim_rp_info)
             .path("/show/pim/mld/groups")
             .set(show_igmp_groups)
             // `show pim ipv6 mroute`: the parent strips the `ipv6`
@@ -415,7 +419,11 @@ struct BsrBrief {
     candidate_rps: usize,
 }
 
-fn show_pim_bsr(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_pim_bsr<A: PimAf>(
+    pim: &Pim<A>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
     use super::bsr::BsrRole;
     let role = match pim.bsr.role.unwrap_or(BsrRole::None) {
         BsrRole::None => "Non-candidate",
@@ -506,7 +514,11 @@ struct RpInfoBrief {
     is_self: bool,
 }
 
-fn show_pim_rp_info(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_pim_rp_info<A: PimAf>(
+    pim: &Pim<A>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
     let now = Instant::now();
     let mut rows: Vec<RpInfoBrief> = vec![];
     for (rp, range) in pim.rp_set.statics.iter() {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4132,6 +4132,40 @@ module config {
               }
             }
           }
+          container bsr {
+            ext:help "Bootstrap Router (RFC 5059)";
+            container candidate-bsr {
+              ext:help "Run as a candidate Bootstrap Router";
+              presence "Candidate BSR";
+              leaf address {
+                ext:help "Advertised BSR address (one of this router's addresses)";
+                type inet:ipv6-address;
+              }
+              leaf priority {
+                ext:help "BSR election priority (higher wins)";
+                type uint8;
+                default 64;
+              }
+            }
+            container candidate-rp {
+              ext:help "Advertise this router as a candidate RP";
+              presence "Candidate RP";
+              leaf address {
+                ext:help "Advertised RP address (one of this router's addresses)";
+                type inet:ipv6-address;
+              }
+              leaf group {
+                ext:help "Group prefix this RP serves";
+                type inet:ipv6-prefix;
+                default "ff00::/8";
+              }
+              leaf priority {
+                ext:help "Candidate RP priority (lower preferred)";
+                type uint8;
+                default 192;
+              }
+            }
+          }
           list interface {
             ext:help "Per-interface PIMv6 configuration";
             key "if-name";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1067,6 +1067,14 @@ module exec {
           ext:help "PIMv6 assert election state";
           presence "PIMv6 assert";
         }
+        container bsr {
+          ext:help "PIMv6 Bootstrap Router state";
+          presence "PIMv6 BSR";
+        }
+        container rp-info {
+          ext:help "PIMv6 group-to-RP mappings";
+          presence "PIMv6 RP info";
+        }
         container mld {
           ext:help "MLD membership state";
           container groups {


### PR DESCRIPTION
## Summary

Bootstrap Router (RFC 5059) over IPv6 for the default table: `router pim ipv6 bsr candidate-bsr|candidate-rp …`. The BSR election, RP-set collection and re-flooding FSM (`bsr.rs`) were already generic; this wires the v6 transport, config and show.

- **Transport**: the BSM originate / re-flood are link-local multicast — pin the egress link-local (`write_packet_v6` drops a send with no source); the C-RP-Adv is unicast to the elected BSR — pin a routable `unicast_source` (as for Register). IPv4 write ignores `src`, so all four sites are byte-identical there.
- **Config**: genericize the seven `config_cbsr*` / `config_crp*` callbacks to `Pim<A>` (address via `A::from_ip`, group via `A::prefix_from_ipnet`) and register them on `Pim<Ipv6>`; YANG `router pim ipv6 bsr { … }` (default table only — per-VRF-v6 BSR is a follow-up). Parse test pins it.
- **Show**: genericize `show_pim_bsr` / `show_pim_rp_info`; `show pim ipv6 bsr` / `show pim ipv6 rp-info`.

## Test plan

- BDD `pim6_bsr` (mirrors IPv4 `pim_bsr`, five namespaces): r2 is candidate-BSR + candidate-RP; r1 and r3 learn the elected BSR and the RP purely from flooded BSMs (globals carried in the BSM → deterministic), then the ASM control loop runs on the learned RP — shared tree, register cycle (r1 → RegPrune), UDPv6 delivered. Proven live (40 steps).
- v4 `pim_bsr` regression check: still green (40 steps).
- `cargo fmt`; workspace + lua `clippy -D warnings`; workspace tests (39 ok). Fresh binary md5-verified; no leaked namespaces.

The RFC 2362 same-priority RP hash (still unimplemented for both families) lands in Phase 8b.

Generated with [Claude Code](https://claude.com/claude-code)