### PR TITLE
pim: RFC 2362 group-to-RP hash for BSR (Phase 8b)

### DIFF
--- a/zebra-rs/src/pim/af.rs
+++ b/zebra-rs/src/pim/af.rs
@@ -121,4 +121,90 @@ pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static 
     /// Null-Register dummy header). `None` if the inner family does not
     /// match this AF or the header is malformed.
     fn register_inner_sg(data: &[u8]) -> Option<(Self::Addr, Self::Addr)>;
+
+    /// The RFC 2362 §3.7 group-to-RP hash `Value(G, M, C)`, used to break
+    /// ties between candidate RPs of equal longest-match range and equal
+    /// (lowest) priority so every router in the domain converges on the
+    /// same RP for a group. `mask_len` masks the group with the BSR's
+    /// advertised hash-mask length; the highest value wins. IPv4 uses the
+    /// standard 32-bit arithmetic; IPv6 applies the same recurrence over
+    /// the 128-bit masked group / RP XOR-folded to 32 bits (deterministic
+    /// and domain-agreed within zebra-rs).
+    fn bsr_hash(group: Self::Addr, rp: Self::Addr, mask_len: u8) -> u32;
+}
+
+/// The RFC 2362 §3.7 hash recurrence on 32-bit words:
+/// `Value = (1103515245 · ((1103515245·gm + 12345) XOR c) + 12345) mod 2^31`.
+/// `gm` is the masked group (or an XOR-fold of it for IPv6); `c` is the
+/// candidate RP (likewise). Shared by both `PimAf::bsr_hash` impls.
+pub(crate) fn bsr_hash_value(gm: u32, c: u32) -> u32 {
+    1103515245u32
+        .wrapping_mul(1103515245u32.wrapping_mul(gm).wrapping_add(12345) ^ c)
+        .wrapping_add(12345)
+        & 0x7fff_ffff
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pim::ipv4::Ipv4;
+    use crate::pim::ipv6::Ipv6;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    // Reference values from the RFC 2362 §3.7 recurrence (verified against
+    // an independent Python computation of the formula); pin the exact
+    // arithmetic so a refactor of `bsr_hash_value` is caught.
+    #[test]
+    fn hash_recurrence_known_vectors() {
+        assert_eq!(bsr_hash_value(1, 1), 1_480_916_820);
+        assert_eq!(
+            Ipv4::bsr_hash(
+                "239.1.2.3".parse().unwrap(),
+                "10.0.0.5".parse().unwrap(),
+                30
+            ),
+            1_036_833_733
+        );
+        assert_eq!(
+            Ipv6::bsr_hash(
+                "ff0e::10".parse().unwrap(),
+                "2001:db8::5".parse().unwrap(),
+                32
+            ),
+            572_234_093
+        );
+    }
+
+    #[test]
+    fn hash_masks_group_to_a_block() {
+        // Groups sharing the top `mask_len` bits hash identically (the
+        // RFC 2362 load-splitting granularity); a different block differs.
+        let rp4: Ipv4Addr = "10.0.0.5".parse().unwrap();
+        let g_a: Ipv4Addr = "239.1.2.10".parse().unwrap();
+        let g_b: Ipv4Addr = "239.1.2.200".parse().unwrap(); // same /24
+        let g_c: Ipv4Addr = "239.1.3.10".parse().unwrap(); // different /24
+        assert_eq!(Ipv4::bsr_hash(g_a, rp4, 24), Ipv4::bsr_hash(g_b, rp4, 24));
+        assert_ne!(Ipv4::bsr_hash(g_a, rp4, 24), Ipv4::bsr_hash(g_c, rp4, 24));
+
+        let rp6: Ipv6Addr = "2001:db8::5".parse().unwrap();
+        let h_a: Ipv6Addr = "ff0e::1:10".parse().unwrap();
+        let h_b: Ipv6Addr = "ff0e::1:99".parse().unwrap(); // same /96
+        assert_eq!(Ipv6::bsr_hash(h_a, rp6, 96), Ipv6::bsr_hash(h_b, rp6, 96));
+    }
+
+    #[test]
+    fn hash_is_rp_sensitive() {
+        // Different candidate RPs (generally) hash to different values, so
+        // the hash actually breaks a same-priority, same-range tie.
+        let g4: Ipv4Addr = "239.1.2.3".parse().unwrap();
+        assert_ne!(
+            Ipv4::bsr_hash(g4, "10.0.0.1".parse().unwrap(), 30),
+            Ipv4::bsr_hash(g4, "10.0.0.2".parse().unwrap(), 30)
+        );
+        let g6: Ipv6Addr = "ff0e::3".parse().unwrap();
+        assert_ne!(
+            Ipv6::bsr_hash(g6, "2001:db8::1".parse().unwrap(), 32),
+            Ipv6::bsr_hash(g6, "2001:db8::2".parse().unwrap(), 32)
+        );
+    }
 }

--- a/zebra-rs/src/pim/bsr.rs
+++ b/zebra-rs/src/pim/bsr.rs
@@ -3,11 +3,11 @@
 //! and the BSR-learned RP-set that `rp_lookup` falls back to when no
 //! static mapping covers a group.
 //!
-//! Simplifications, documented: RP selection inside the learned set
-//! is longest-prefix → lowest priority → highest address (the RFC
-//! 2362 hash for same-priority load-splitting is not implemented),
-//! and BSM fragments are treated as whole-set replacements per group
-//! range.
+//! RP selection inside the learned set is longest-prefix → lowest
+//! priority → RFC 2362 §3.7 group-to-RP hash → highest address (see
+//! [`PimAf::bsr_hash`](super::af::PimAf::bsr_hash)), so the whole domain
+//! converges on the same RP for a group. Simplification, documented: BSM
+//! fragments are treated as whole-set replacements per group range.
 
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
@@ -157,7 +157,16 @@ impl<A: PimAf> Pim<A> {
             .iter()
             .filter(|((range, _), e)| A::prefix_contains(range, &grp) && e.expires > now)
             .max_by_key(|((range, rp), e)| {
-                (A::prefix_len(range), std::cmp::Reverse(e.priority), *rp)
+                // RFC 2362 §3.7: longest match, then lowest priority, then
+                // the group-to-RP hash (highest value wins) so the whole
+                // domain converges on the same RP, with the RP address as
+                // the final deterministic tiebreak.
+                (
+                    A::prefix_len(range),
+                    std::cmp::Reverse(e.priority),
+                    A::bsr_hash(grp, *rp, HASH_MASK_LEN),
+                    *rp,
+                )
             })
             .map(|((_, rp), _)| *rp)
     }

--- a/zebra-rs/src/pim/ipv4.rs
+++ b/zebra-rs/src/pim/ipv4.rs
@@ -123,6 +123,15 @@ impl PimAf for Ipv4 {
         let grp = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
         Some((src, grp))
     }
+
+    fn bsr_hash(group: Ipv4Addr, rp: Ipv4Addr, mask_len: u8) -> u32 {
+        let mask = if mask_len == 0 {
+            0
+        } else {
+            u32::MAX << (32 - mask_len.min(32))
+        };
+        super::af::bsr_hash_value(u32::from(group) & mask, u32::from(rp))
+    }
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/pim/ipv6.rs
+++ b/zebra-rs/src/pim/ipv6.rs
@@ -149,6 +149,22 @@ impl PimAf for Ipv6 {
         g.copy_from_slice(&data[24..40]);
         Some((Ipv6Addr::from(s), Ipv6Addr::from(g)))
     }
+
+    fn bsr_hash(group: Ipv6Addr, rp: Ipv6Addr, mask_len: u8) -> u32 {
+        // Mask the 128-bit group, then XOR-fold both the masked group and
+        // the RP to 32 bits before the RFC 2362 recurrence — a defined,
+        // deterministic extension so every zebra-rs router agrees.
+        let mask = if mask_len == 0 {
+            0
+        } else {
+            u128::MAX << (128 - mask_len.min(128))
+        };
+        let fold =
+            |x: u128| -> u32 { (x >> 96) as u32 ^ (x >> 64) as u32 ^ (x >> 32) as u32 ^ x as u32 };
+        let gm = u128::from_be_bytes(group.octets()) & mask;
+        let c = u128::from_be_bytes(rp.octets());
+        super::af::bsr_hash_value(fold(gm), fold(c))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`bsr_rp_lookup` broke ties between equal-range, equal-priority candidate RPs by raw RP address, so different routers could pick different RPs for the same group. This implements the RFC 2362 §3.7 hash so the whole domain converges on the same RP.

- `PimAf::bsr_hash(group, rp, mask_len) -> u32`, with the recurrence `(1103515245·((1103515245·(G&M)+12345) XOR C)+12345) mod 2^31` shared by both families (`bsr_hash_value`). IPv4 uses the standard 32-bit arithmetic; IPv6 masks the 128-bit group and XOR-folds the masked group / RP to 32 bits before the same recurrence — deterministic and domain-agreed (FRR interop of the v6 fold is a §11.4 follow-up).
- Wired into `bsr_rp_lookup`: the tiebreak is now longest-match → lowest priority → highest hash → highest address.

## Test plan

- Unit tests (the acceptance criterion the design §9 asks for): known hash vectors (verified against an independent computation), the mask collapses a group to its hash block, and the hash is RP-sensitive (so it actually breaks a same-priority tie).
- Single-RP selection is unchanged, so `pim_bsr` / `pim6_bsr` are unaffected (no BDD needed).
- `cargo fmt`; workspace + lua `clippy -D warnings`; workspace tests (39 ok, incl. 3 new hash tests).

Generated with [Claude Code](https://claude.com/claude-code)