### PR TITLE
pim: close IPv6 show-parity gaps

### DIFF
--- a/bdd/tests/features/pim6_ssm.feature
+++ b/bdd/tests/features/pim6_ssm.feature
@@ -44,6 +44,10 @@ Feature: PIMv6 SSM (S,G) forwarding end to end across two routers
     Then show command "show pim ipv6 interface" in namespace "r1" should eventually contain "Up"
     And show command "show pim ipv6 interface" in namespace "r2" should eventually contain "Up"
     And show command "show pim ipv6 neighbor" in namespace "r2" should eventually contain "fe80"
+    # The IPv6 instance summary and the MLD interface (querier) table —
+    # the v6 equivalents of `show pim` and `show igmp interface`.
+    And show command "show pim ipv6" in namespace "r1" should eventually contain "PIM-SM"
+    And show command "show pim ipv6 mld interface" in namespace "r2" should eventually contain "Querier"
 
     # h2 source-specifically joins (2001:db8:14::2, ff3e::1): r2 turns the
     # MLDv2 membership into an (S,G) Join toward r1.

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -55,10 +55,16 @@ impl Pim<Ipv4> {
 impl Pim<Ipv6> {
     pub fn show_build(&mut self) {
         self.show_cb = Builder::<ShowCallback<Ipv6>>::default()
+            .path("/show/pim")
+            .set(show_pim)
             .path("/show/pim/interface")
             .set(show_pim_interface)
             .path("/show/pim/neighbor")
             .set(show_pim_neighbor)
+            // `show pim ipv6 mld interface` (mirrors v4 `show igmp
+            // interface`); the shared IgmpConfig/Gm state renders it.
+            .path("/show/pim/mld/interface")
+            .set(show_igmp_interface)
             .path("/show/pim/upstream")
             .set(show_pim_upstream)
             .path("/show/pim/assert")
@@ -104,7 +110,7 @@ struct PimSummary {
     neighbors: usize,
 }
 
-fn show_pim(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_pim<A: PimAf>(pim: &Pim<A>, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
     let summary = PimSummary {
         interfaces: pim.if_config.len(),
         enabled_interfaces: pim.links.values().filter(|l| l.enabled).count(),
@@ -217,7 +223,11 @@ struct IgmpInterfaceBrief {
     groups: usize,
 }
 
-fn show_igmp_interface(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+fn show_igmp_interface<A: PimAf>(
+    pim: &Pim<A>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
     let mut rows: Vec<IgmpInterfaceBrief> = vec![];
 
     for (name, config) in pim.if_config.iter() {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1077,6 +1077,10 @@ module exec {
         }
         container mld {
           ext:help "MLD membership state";
+          container interface {
+            ext:help "MLD interface (querier) state";
+            presence "MLD interface";
+          }
           container groups {
             ext:help "MLD group memberships";
             presence "MLD groups";
@@ -1137,8 +1141,16 @@ module exec {
             ext:help "PIMv6 assert election state";
             presence "PIMv6 assert";
           }
+          container rp-info {
+            ext:help "PIMv6 group-to-RP mappings";
+            presence "PIMv6 RP info";
+          }
           container mld {
             ext:help "MLD membership state";
+            container interface {
+              ext:help "MLD interface (querier) state";
+              presence "MLD interface";
+            }
             container groups {
               ext:help "MLD group memberships";
               presence "MLD groups";


### PR DESCRIPTION
## Summary

Closes the three IPv4-only show commands the gap analysis found (the state is computed identically for v6, it just was not exposed):

- `show pim ipv6` — genericize `show_pim` (instance summary).
- `show pim ipv6 mld interface` — genericize `show_igmp_interface` (+ per-VRF form).
- `show pim vrf <name> ipv6 rp-info` — add to the per-VRF IPv6 show tree (generic handler already registered).

## Test plan

`pim6_ssm` now asserts `show pim ipv6` (→ "PIM-SM") and `show pim ipv6 mld interface` (→ "Querier"), proven live (38 steps). `cargo fmt`; workspace + lua `clippy -D warnings`; workspace tests (39 ok).

Generated with [Claude Code](https://claude.com/claude-code)