### PR TITLE
pim: IPv6 Embedded-RP (RFC 3956) — Phase 9

### DIFF
--- a/bdd/tests/configs/pim6_embedded_rp/r1.yaml
+++ b/bdd/tests/configs/pim6_embedded_rp/r1.yaml
@@ -1,0 +1,15 @@
+interface:
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:21::1/64
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:22::1/64
+router:
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth1
+        dr-priority: 1
+      - if-name: eth2
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_embedded_rp/r2.yaml
+++ b/bdd/tests/configs/pim6_embedded_rp/r2.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: eth3
+  ipv6:
+    address: 2001:db8:22::2/64
+- if-name: eth4
+  ipv6:
+    address: 2001:db8:23::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:21::/64
+        nexthop:
+        - address: 2001:db8:22::1
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth3
+        dr-priority: 1
+      - if-name: eth4
+        dr-priority: 1

--- a/bdd/tests/configs/pim6_embedded_rp/r3.yaml
+++ b/bdd/tests/configs/pim6_embedded_rp/r3.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: eth5
+  ipv6:
+    address: 2001:db8:23::2/64
+- if-name: eth6
+  ipv6:
+    address: 2001:db8:24::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:22::/64
+        nexthop:
+        - address: 2001:db8:23::1
+      - prefix: 2001:db8:21::/64
+        nexthop:
+        - address: 2001:db8:23::1
+  pim:
+    ipv6:
+      interface:
+      - if-name: eth5
+        dr-priority: 1
+      - if-name: eth6
+        mld:
+          enabled: true

--- a/bdd/tests/features/pim6_embedded_rp.feature
+++ b/bdd/tests/features/pim6_embedded_rp.feature
@@ -1,0 +1,70 @@
+@serial
+@pim6_embedded_rp
+Feature: PIMv6 Embedded-RP (RFC 3956) ASM with no RP configuration
+  As a network operator
+  I want an IPv6 multicast group that embeds its RP address in its own
+  bits (RFC 3956, ff70::/12) to run the full ASM control loop with no
+  static RP and no BSR — every router derives the same RP straight from
+  the group address.
+
+  The group ff7e:240:2001:db8:22::9 embeds RP 2001:db8:22::2 (flags R=P=T,
+  RIID 2, prefix length 64, network prefix 2001:db8:22::). r2 owns that
+  address and therefore acts as the RP purely by derivation. No router
+  carries any `rp static` or `bsr` config.
+
+  Test Topology:
+  ```
+    h1 (2001:db8:21::10, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(RP=2001:db8:22::2) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (2001:db8:24::10, receiver)
+                                       2001:db8:21::1   2001:db8:22::1/.2         2001:db8:23::1/.2         2001:db8:24::1
+  ```
+
+  Scenario: The embedded RP is derived and the ASM loop runs
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "h1" interface "eth0" to namespace "r1" interface "eth1"
+    And I connect namespace "r1" interface "eth2" to namespace "r2" interface "eth3"
+    And I connect namespace "r2" interface "eth4" to namespace "r3" interface "eth5"
+    And I connect namespace "r3" interface "eth6" to namespace "h2" interface "eth7"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I add address "2001:db8:21::10/64" to interface "eth0" in namespace "h1"
+    And I add address "2001:db8:24::10/64" to interface "eth7" in namespace "h2"
+
+    # Neighborship on both transit links.
+    Then show command "show pim ipv6 neighbor" in namespace "r1" should eventually contain "fe80"
+    And show command "show pim ipv6 neighbor" in namespace "r3" should eventually contain "fe80"
+
+    # h2 joins the embedded-RP group: r3 derives RP 2001:db8:22::2 from the
+    # group bits and builds the shared tree toward it — no RP config exists.
+    When I spawn "timeout 160 python3 tests/scripts/asm_recv6.py ff7e:240:2001:db8:22::9 eth7 5001 /tmp/pim6_erp_rx" in namespace "h2"
+    Then show command "show pim ipv6 upstream" in namespace "r3" should eventually contain "(*, ff7e:240:2001:db8:22::9)"
+    And show command "show pim ipv6 mroute" in namespace "r2" should eventually contain "(*, ff7e:240:2001:db8:22::9)"
+
+    # h1 sends: r1 (FHR) registers to the derived RP and settles in
+    # suppression once the RP has joined the source tree.
+    When I spawn "timeout 130 python3 tests/scripts/mcast_send6.py ff7e:240:2001:db8:22::9 5001 eth0 100" in namespace "h1"
+    Then show command "show pim ipv6 mroute" in namespace "r2" should eventually contain "2001:db8:21::10"
+    And show command "show pim ipv6 upstream" in namespace "r1" should eventually contain "RegPrune"
+
+    # The datapath proof: h1's datagrams reach h2 via the derived-RP tree.
+    And command "cat /tmp/pim6_erp_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim6_erp_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/zebra-rs/src/pim/af.rs
+++ b/zebra-rs/src/pim/af.rs
@@ -131,6 +131,13 @@ pub trait PimAf: Copy + Eq + Ord + Hash + Debug + Send + Sync + Sized + 'static 
     /// the 128-bit masked group / RP XOR-folded to 32 bits (deterministic
     /// and domain-agreed within zebra-rs).
     fn bsr_hash(group: Self::Addr, rp: Self::Addr, mask_len: u8) -> u32;
+
+    /// The Embedded-RP address a group carries in its own bits (RFC 3956),
+    /// or `None` when the group is not an Embedded-RP group. IPv4 has no
+    /// Embedded-RP, so it is always `None`; IPv6 decodes an `ff70::/12`
+    /// (R=P=T=1) address — validating the reserved field, RIID and prefix
+    /// length — into `network-prefix(plen) :: RIID`.
+    fn embedded_rp(group: Self::Addr) -> Option<Self::Addr>;
 }
 
 /// The RFC 2362 §3.7 hash recurrence on 32-bit words:

--- a/zebra-rs/src/pim/ipv4.rs
+++ b/zebra-rs/src/pim/ipv4.rs
@@ -132,6 +132,11 @@ impl PimAf for Ipv4 {
         };
         super::af::bsr_hash_value(u32::from(group) & mask, u32::from(rp))
     }
+
+    fn embedded_rp(_group: Ipv4Addr) -> Option<Ipv4Addr> {
+        // No Embedded-RP for IPv4 (RFC 3956 is IPv6-only).
+        None
+    }
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/pim/ipv6.rs
+++ b/zebra-rs/src/pim/ipv6.rs
@@ -165,6 +165,40 @@ impl PimAf for Ipv6 {
         let c = u128::from_be_bytes(rp.octets());
         super::af::bsr_hash_value(fold(gm), fold(c))
     }
+
+    fn embedded_rp(group: Ipv6Addr) -> Option<Ipv6Addr> {
+        // RFC 3956 §2 group layout:
+        //   FF | flgs(4) | scop(4) | rsvd(4) | RIID(4) | plen(8)
+        //      | network prefix(64) | group ID(32)
+        let o = group.octets();
+        // ff70::/12 — R-bit set (RFC 3956 also mandates P=1, T=1, so the
+        // flags nibble is 0x7).
+        if o[0] != 0xff || (o[1] & 0xf0) != 0x70 {
+            return None;
+        }
+        let rsvd = o[2] >> 4;
+        let riid = o[2] & 0x0f;
+        let plen = o[3];
+        // Reserved must be zero, RIID non-zero, and the prefix must fit in
+        // the 64-bit network-prefix field.
+        if rsvd != 0 || riid == 0 || plen == 0 || plen > 64 {
+            return None;
+        }
+        // RP = the top `plen` bits of the network prefix (bytes 4..12),
+        // zero-filled, with the RIID in the last 4 bits.
+        let mut rp = [0u8; 16];
+        rp[..8].copy_from_slice(&o[4..12]);
+        let full = (plen / 8) as usize;
+        let rem = plen % 8;
+        if rem != 0 {
+            rp[full] &= 0xffu8 << (8 - rem);
+            rp[full + 1..8].fill(0);
+        } else {
+            rp[full..8].fill(0);
+        }
+        rp[15] = riid;
+        Some(Ipv6Addr::from(rp))
+    }
 }
 
 #[cfg(test)]
@@ -228,5 +262,30 @@ mod tests {
         );
         // An IPv4 inner header is rejected by the IPv6 codec.
         assert_eq!(Ipv6::register_inner_sg(&[0x45; 40]), None);
+    }
+
+    #[test]
+    fn embedded_rp_decodes_and_validates() {
+        // RFC 3956 §5 example: FF7E:0140:2001:DB8::1234 embeds 2001:db8::1
+        // (scope E, RIID 1, plen 64, network prefix 2001:db8::).
+        assert_eq!(
+            Ipv6::embedded_rp(a("ff7e:140:2001:db8::1234")),
+            Some(a("2001:db8::1"))
+        );
+        // A shorter prefix keeps only `plen` bits and still carries RIID.
+        assert_eq!(
+            Ipv6::embedded_rp(a("ff7e:240:2001:db8:22::9")),
+            Some(a("2001:db8:22::2"))
+        );
+
+        // Not an Embedded-RP group (R-bit clear): plain ASM / SSM.
+        assert_eq!(Ipv6::embedded_rp(a("ff0e::1")), None);
+        assert_eq!(Ipv6::embedded_rp(a("ff3e::1")), None);
+        // RIID 0 is invalid.
+        assert_eq!(Ipv6::embedded_rp(a("ff7e:040:2001:db8::1")), None);
+        // A non-zero reserved nibble is invalid.
+        assert_eq!(Ipv6::embedded_rp(a("ff7e:1140:2001:db8::1")), None);
+        // plen > 64 (does not fit the network-prefix field) is invalid.
+        assert_eq!(Ipv6::embedded_rp(a("ff7e:0180:2001:db8::1")), None);
     }
 }

--- a/zebra-rs/src/pim/rp.rs
+++ b/zebra-rs/src/pim/rp.rs
@@ -38,6 +38,9 @@ impl<A: PimAf> Pim<A> {
             .filter(|(_, range)| A::prefix_contains(range, &grp))
             .max_by_key(|(_, range)| A::prefix_len(range))
             .map(|(rp, _)| *rp)
+            // Embedded-RP (RFC 3956): the group carries its own RP —
+            // precedence above BSR, below an explicit static mapping.
+            .or_else(|| A::embedded_rp(grp))
             .or_else(|| self.bsr_rp_lookup(grp))
     }
 


### PR DESCRIPTION
## Summary

`ff70::/12` IPv6 groups embed their own RP (RFC 3956) — the RP is derived from the group with no static or BSR config, and every router derives the same one.

- `PimAf::embedded_rp` — IPv4 `None`; IPv6 decodes the RFC 3956 §2 layout (validates reserved 0, RIID != 0, 0 < plen <= 64) → `network-prefix(plen) :: RIID`.
- `rp_lookup` consults it between static and BSR (RFC 3956 precedence). `i_am_rp` flows through, so a router owning the derived address becomes the RP with no extra wiring. IPv4 selection byte-identical.

## Test plan

Unit tests: RFC §5 example + validation rejects. BDD `pim6_embedded_rp` (three routers, no RP config): every router derives RP `2001:db8:22::2`; shared tree + register (→ RegPrune) + UDPv6 delivered. Proven live (37 steps). `cargo fmt`; workspace + lua `clippy -D warnings`; workspace tests (39 ok).

Completes the IPv6 PIM arc.

Generated with [Claude Code](https://claude.com/claude-code)