### PR TITLE
bdd: fix two stale post-review-fix assertions + teardown/leak-guard robustness

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use bdd::netns;
 use cucumber::tag::Ext as _;
@@ -69,9 +70,21 @@ async fn clean_test_environment(world: &mut World) {
     // /tmp matching this feature points to a live process, abort. The
     // operator should wait for the other run to finish (or use a
     // different feature for parallelism).
+    //
+    // Only the feature's FIRST clean in this process refuses: a feature's
+    // scenarios run sequentially in one worker, so once we've cleaned for
+    // it a live pid file can only be our own leftover from an earlier
+    // scenario whose step failure skipped its remaining teardown steps —
+    // sweep it instead of wedging every later scenario of the feature.
+    static FEATURES_CLEANED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let first_clean_in_process = FEATURES_CLEANED
+        .get_or_init(|| Mutex::new(HashSet::new()))
+        .lock()
+        .unwrap()
+        .insert(world.feature_tag.clone());
     if let Ok(pidfiles) = netns::list_pidfiles(Path::new("/tmp"), &pid_prefix).await {
         for path in &pidfiles {
-            if netns::pidfile_alive(path).await {
+            if first_clean_in_process && netns::pidfile_alive(path).await {
                 panic!(
                     "another run of feature {} is in progress (live pid file {:?}); refusing to clobber its resources",
                     world.feature_tag, path

--- a/bdd/tests/features/bgp_vrf_show.feature
+++ b/bdd/tests/features/bgp_vrf_show.feature
@@ -55,16 +55,22 @@ Feature: BGP per-VRF show command
     And show command "show bgp vrf vrf-blue ipv4" in namespace "z1" should contain "Network"
     And show command "show bgp vrf vrf-blue ipv6" in namespace "z1" should contain "Network"
 
-  Scenario: Remove the BGP VRF block and observe the RD clear
+  Scenario: Remove the BGP VRF block and observe the VRF despawn
     # vtyctl apply replaces the subtrees present in the file: z1-1.yaml
-    # carries `router bgp` without the vrf block, so the per-VRF RD is
-    # deleted — but the top-level vrf (absent from the file) persists,
-    # so the row and its running task remain with an empty RD.
+    # carries `router bgp` without the vrf block, so the whole
+    # `router bgp vrf vrf-blue` subtree is deleted. Since the despawn
+    # fix (review finding #3) that delete despawns the
+    # per-VRF task and row outright (PR #1981) — the exports are
+    # withdrawn and the service label returns to the pool — so the
+    # table reports no VRFs
+    # (the top-level system vrf, absent from the file, still exists but
+    # carries no BGP instance).
     Given the test topology exists
     When I apply config "z1-1.yaml" to namespace "z1"
     And I wait 2 seconds for BGP to operate
     Then show command "show bgp vrf" in namespace "z1" should not contain "65001:100"
-    And show command "show bgp vrf" in namespace "z1" should contain "vrf-blue"
+    And show command "show bgp vrf" in namespace "z1" should not contain "vrf-blue"
+    And show command "show bgp vrf" in namespace "z1" should contain "no VRFs configured"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/ospfv2_min_ls_arrival.feature
+++ b/bdd/tests/features/ospfv2_min_ls_arrival.feature
@@ -35,7 +35,9 @@ Feature: OSPFv2 MinLSArrival received-LSA rate limit is configurable
     And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
     And ping from "a" to "10.0.0.2" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv2_spf_interval.feature
+++ b/bdd/tests/features/ospfv2_spf_interval.feature
@@ -34,7 +34,9 @@ Feature: OSPFv2 adaptive SPF throttle (spf-interval)
     And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
     And ping from "a" to "10.0.0.2" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv2_virtual_link.feature
+++ b/bdd/tests/features/ospfv2_virtual_link.feature
@@ -53,15 +53,9 @@ Feature: OSPFv2 virtual links connect a remote ABR to the backbone
     And show command "show ospf route" in namespace "r3" should contain "10.0.0.1/32"
     And ping from "r3" to "10.0.0.1" should succeed
     And ping from "r1" to "10.0.0.3" should succeed
-
-    # Teardown.
-    When I stop zebra-rs in namespace "r1"
-    And I stop zebra-rs in namespace "r2"
-    And I stop zebra-rs in namespace "r3"
-    And I delete namespace "r1"
-    And I delete namespace "r2"
-    And I delete namespace "r3"
-    Then the test environment should be clean
+    # No inline teardown: the next scenario's clean-environment sweep
+    # reclaims this topology even if a step above failed, and the final
+    # Teardown scenario cleans up after the last one.
 
   Scenario: Multi-hop transit — the ABRs are two hops apart through the transit area
     # r1 -- rm -- r2 inside area 1: the VL endpoints are NOT
@@ -105,17 +99,6 @@ Feature: OSPFv2 virtual links connect a remote ABR to the backbone
     And ping from "r3" to "10.0.0.1" should succeed
     And ping from "r1" to "10.0.0.3" should succeed
 
-    # Teardown.
-    When I stop zebra-rs in namespace "r1"
-    And I stop zebra-rs in namespace "rm"
-    And I stop zebra-rs in namespace "r2"
-    And I stop zebra-rs in namespace "r3"
-    And I delete namespace "r1"
-    And I delete namespace "rm"
-    And I delete namespace "r2"
-    And I delete namespace "r3"
-    Then the test environment should be clean
-
   Scenario: Virtual link with MD5 authentication forms and carries routes
     # RFC 2328 §15: the VL has its own authentication (message-digest
     # key VLSECRET on both ends), independent of the unauthenticated
@@ -142,7 +125,10 @@ Feature: OSPFv2 virtual links connect a remote ABR to the backbone
     And show command "show ospf route" in namespace "r3" should contain "10.0.0.1/32"
     And ping from "r3" to "10.0.0.1" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Cleans the MD5 scenario's topology (r1/r2/r3 — rm was swept by
+    # that scenario's clean-environment step). Separate scenario so
+    # cleanup still runs when a step above fails.
     When I stop zebra-rs in namespace "r1"
     And I stop zebra-rs in namespace "r2"
     And I stop zebra-rs in namespace "r3"

--- a/bdd/tests/features/pim_assert.feature
+++ b/bdd/tests/features/pim_assert.feature
@@ -3,8 +3,9 @@
 Feature: PIM assert election and LAN Join/Prune behaviors
   As a network operator
   I want duplicate forwarders on a shared LAN to elect a single
-  assert winner, routers sharing an upstream LAN to suppress each
-  other's periodic Joins, and a Prune overheard on a LAN to be
+  assert winner, a router's overheard Join on a shared upstream LAN
+  to suppress the other joined router's periodic refresh (leaving
+  one refresher per LAN), and a Prune overheard on a LAN to be
   overridden by routers that still want the traffic — the RFC 7761
   multi-access behaviors that keep exactly one copy of each packet
   on every LAN.
@@ -84,12 +85,17 @@ Feature: PIM assert election and LAN Join/Prune behaviors
 
     # Both receivers join. r2 (DR on swB) serves h2 directly; r3 turns
     # h3's membership into an (S,G) Join toward r1, so r1 forwards onto
-    # swB too. Each router overhears the other's Join on swA.
+    # swB too. On swA, r2 joins first (h2's report reaches the DR
+    # directly) and r1 joins ~0.5s later (h3's membership rides the
+    # extra r3 hop); r1's immediate initial Join is overheard by the
+    # already-joined r2, which suppresses its own refresh
+    # (RFC 7761 §4.5.7) and therefore never sends a Join for r1 to
+    # overhear in turn — suppression keeps exactly one periodic
+    # refresher per LAN, so only r2 logs it.
     When I spawn "timeout 220 python3 tests/scripts/ssm_recv.py 232.6.6.6 10.6.0.10 10.6.2.10 5001 /tmp/pim_assert_h2" in namespace "h2"
     And I spawn "timeout 220 python3 tests/scripts/ssm_recv.py 232.6.6.6 10.6.0.10 10.6.3.10 5001 /tmp/pim_assert_h3" in namespace "h3"
     Then show command "show pim upstream" in namespace "r1" should eventually contain "Joined"
     And show command "show pim upstream" in namespace "r2" should eventually contain "Joined"
-    And daemon log in namespace "r1" should eventually contain "join suppressed"
     And daemon log in namespace "r2" should eventually contain "join suppressed"
 
     # The sender starts: both forward onto swB, the duplicates trigger


### PR DESCRIPTION
Full-suite BDD verification after the review-fix wave (#1997–#2012 + PIM #2000–#2031): two features asserted behavior the fixes deliberately changed, and a harness defect turned any mid-scenario failure into a cascade of fake deterministic failures. No daemon changes.

## Test fixes

- **bgp_vrf_show**: the "remove the BGP VRF block" scenario asserted the pre-fix bug — the VRF row surviving a `router bgp vrf` subtree delete with an empty RD (child-leaf delete callbacks used to resurrect the entry). Since the despawn fix (review finding #3, PR #1981) the delete despawns the per-VRF task and row; assert that. The vpnv4/v6 export features were updated by the fix itself; this scenario was missed.
- **pim_assert**: required "join suppressed" in **both** r1's and r2's logs, which is not a reachable steady state under RFC 7761: r2 (DR, fed directly by h2's report) joins ~0.5 s before r1 (h3 → r3 → PIM-Join chain), r1's immediate initial Join suppresses the already-joined r2, and a suppressed router stops sending the periodic Joins the other side would need to overhear — one refresher per LAN. The symmetric assertion could only pass when both initial Joins landed in the same dispatch instant (pre-DR-gating topology). Assert the deterministic direction only, matching pim6_assert.

## Harness robustness

A failed step skips the rest of its scenario — including inline teardown — so the feature's later scenarios found live pid files and the clean-env guard refused to run ("another run in progress"), cascading one real failure into every later scenario and leaking root daemons/namespaces that then poisoned re-runs of the same feature.

- The guard now refuses only on the feature's **first** clean per process (preserving the cross-process double-run protection); later scenarios treat live same-feature pid files as their own leftovers and sweep them.
- `ospfv2_spf_interval` / `ospfv2_min_ls_arrival` / `ospfv2_virtual_link` move inline teardowns to the conventional `Scenario: Teardown topology` (virtual_link's first two topologies are reclaimed by the successor scenario's sweep).

## Verification

Two full-suite runs at `--concurrency=8` (240 features) on the same binary:
- Before fixes: 233/240 — failures: the two stale assertions above, plus ospfv2_{spf_interval,min_ls_arrival,virtual_link}, isis_sr_switchover, bgp_tcp_ao_auth.
- After fixes: 236/240 — **all seven previous failures pass**; the 4 new failures (bgp_as4, bgp_remove_private_as, isis_srv6_replace, ospfv3_tilfa_srv6) have zero overlap with run 1, are convergence-window shaped, and each passes on solo re-run. c=8 shows a roaming ~2–4-feature load-margin floor on this box (suite grew 200→240 with the PIM wave); no feature failed twice across runs — no evidence of a functional regression from the review-fix wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)