### PR TITLE
bgp: allow one MUP VRF to bind both st1 and st2 directions

### DIFF
--- a/bdd/tests/configs/bgp_mup_single_vrf_dual_st/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_single_vrf_dual_st/z1.yaml
@@ -1,0 +1,67 @@
+# z1 — MUP Controller (MUP-C) with a SINGLE dual-direction VRF (issue
+# #1947: one N6 interface / one VRF for a bidirectional UPF). AS 65001,
+# iBGP to z2 (192.168.0.2) with the mup afi-safi negotiated; PFCP/N4
+# listener on 192.168.0.1:8805.
+#
+# ONE VRF `mobile` (rd 65000:1) binds BOTH directions to the same Network
+# Instance `internet`:
+#   * `afi-safi mup route st1` (downlink) — a session originates a Type-1
+#     ST (UE prefix + access tunnel).
+#   * `afi-safi mup route st2` (uplink, Direct segment id `1:2`) — the
+#     same session also originates a Type-2 ST (core endpoint + GTP TEID).
+#
+# When pfcp-inject programs one session whose Network Instance is
+# `internet`, z1 originates BOTH STs from this one VRF — both under rd
+# 65000:1 — and advertises them to z2. (Previously each direction needed
+# its own VRF; configuring both on one VRF was last-wins.)
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bb01::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile
+      rd: "65000:1"
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: internet
+          - type: st2
+            network-instance: internet
+            mup-ext-comm: "1:2"
+    mup-c:
+      enabled: true
+      controller-address: fcbb:bb01::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
+      srv6:
+        locator: LOC1
+# Top-level VRF: the MUP export route-target lives here (same
+# `route-target {import|export}` framework as ipv4 / ipv6). One VRF, so
+# both STs carry the same export RT.
+vrf:
+- name: mobile
+  mup:
+    route-target:
+      export:
+      - "65000:200"

--- a/bdd/tests/configs/bgp_mup_single_vrf_dual_st/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_single_vrf_dual_st/z2.yaml
@@ -1,0 +1,29 @@
+# z2 — MUP route receiver. AS 65001, iBGP to z1 (192.168.0.1) with the
+# mup afi-safi negotiated. Plain BGP speaker: no controller, originates
+# nothing, but receives BOTH the Type-1 (ST1) and Type-2 (ST2)
+# Session-Transformed routes z1's single dual-direction VRF originates
+# from one PFCP session — both under rd 65000:1 — and shows them under
+# `show bgp mup`.
+vrf:
+- name: mobile
+  mup:
+    route-target:
+      import:
+      - "65000:200"
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile
+      rd: "65000:1"

--- a/bdd/tests/features/bgp_mup_single_vrf_dual_st.feature
+++ b/bdd/tests/features/bgp_mup_single_vrf_dual_st.feature
@@ -1,0 +1,100 @@
+@serial
+@bgp_mup_single_vrf_dual_st
+Feature: One MUP VRF binds both st1 and st2 and originates both ST routes
+  As a network operator running a UPF with a single N6 interface (issue
+  #1947), I want ONE `router bgp vrf` to bind BOTH `afi-safi mup route st1`
+  (downlink) and `afi-safi mup route st2` (uplink) to the same Network
+  Instance — so a single PFCP/N4 session originates the Type-1 ST (UE
+  prefix + access tunnel) AND the Type-2 ST (core endpoint + GTP TEID)
+  under ONE RD, instead of requiring two single-direction VRFs (and with
+  them two N6-facing interfaces).
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+  ```
+
+  z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1)
+  with a SINGLE VRF `mobile` (rd 65000:1) whose `afi-safi mup` block binds
+  both `route st1` and `route st2` (the st2 entry carrying Direct segment
+  id `1:2`) to Network Instance `internet`. `pfcp-inject` plays the SMF: it
+  sends an Association Setup + Session Establishment for UE 192.0.2.5 with
+  an ACCESS-side F-TEID (gNB endpoint 10.0.0.1 / TEID 0x12345678) and a
+  CORE-side F-TEID (endpoint 10.9.0.1 / TEID 0x87654321), Network Instance
+  `internet`. z1 originates BOTH Session-Transformed routes from the one
+  VRF — both under rd 65000:1 — and advertises them to z2.
+
+  NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+  binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
+  `cargo build --release -p pfcp-inject` and copy `target/release/pfcp-inject`
+  to /usr/bin, the same way the zebra-rs / vtyctl binaries are staged.
+
+  Scenario: Setup topology and establish iBGP session with MUP capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    # The MUP VRFs block renders BOTH direction bindings on the one VRF line.
+    And show command "show bgp mup" in namespace "z1" should contain "mobile: rd=65000:1 encap/ST1 ni=internet decap/ST2 ni=internet"
+
+  Scenario: One PFCP session originates both STs from the single dual-direction VRF
+    Given the test topology exists
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.9.0.1 --network-instance internet" in namespace "z1"
+    # PFCP ingest learned the single session (with an access-side and a
+    # core-side F-TEID).
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    # The st1 binding originates the Type-1 ST: UE prefix + ACCESS tunnel
+    # endpoint (gNB, 10.0.0.1), Source Address from the core-side endpoint.
+    And show command "show bgp mup" in namespace "z1" should contain "[ST1][65000:1][ue=192.0.2.5/32][teid=305419896]"
+    And show command "show bgp mup" in namespace "z1" should contain "[ep=10.0.0.1:src=10.9.0.1]"
+    # The st2 binding originates the Type-2 ST from the SAME session and the
+    # SAME VRF/RD: the distinct CORE endpoint (10.9.0.1) + its own TEID
+    # (0x87654321), plus the Direct segment id.
+    And show command "show bgp mup" in namespace "z1" should contain "[ST2][65000:1][ep=10.9.0.1][teid=2271560481]"
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65000:200 mup:1:2"
+    # The originating VRF's own view holds BOTH its ST routes (RD-origin
+    # self-show) — the single-N6 UPF sees its whole session in one VRF.
+    And show command "show bgp vrf mobile mup" in namespace "z1" should contain "[ST1][65000:1][ue=192.0.2.5/32]"
+    And show command "show bgp vrf mobile mup" in namespace "z1" should contain "[ST2][65000:1][ep=10.9.0.1]"
+    # The peer receives both Session-Transformed routes under the one RD.
+    And show command "show bgp mup" in namespace "z2" should eventually contain "[ST1][65000:1][ue=192.0.2.5/32][teid=305419896]"
+    And show command "show bgp mup" in namespace "z2" should contain "[ST2][65000:1][ep=10.9.0.1][teid=2271560481]"
+
+  # Session deletion / withdraw of BOTH STs is covered by the
+  # `mup_dual_direction_vrf_originates_and_reconciles_both_sts` unit test
+  # (bgp/vrf/inst.rs); a BDD assertion is omitted because `pfcp-inject` is
+  # one-shot (establish+delete in a single run) and the controller allocates
+  # a fresh SEID per establish, so a back-to-back establish/delete can't be
+  # deterministically observed on the receiver across propagation delay
+  # (same rationale as bgp_mup_e2e.feature).
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -8276,10 +8276,12 @@ mod mup_dual_origination_tests {
     //! VRF-first MUP origination splits into a pure NI→VRF correlation
     //! (`mup_session_targets`) and per-direction NLRI building
     //! (`build_mup_st_route`). `mup_session_targets` fans one PFCP session out
-    //! to *every* VRF whose `afi-safi mup route {st1|st2}` binding matches the
-    //! session's Network Instance — so a single session under `internet`
-    //! targets both the downlink (st1 / N6) and uplink (st2 / N3) VRF —
-    //! and `build_mup_st_route` builds the RD-free T1ST / T2ST NLRI.
+    //! to *every* `afi-safi mup route {st1|st2}` binding matching the
+    //! session's Network Instance — a single session under `internet`
+    //! targets both the downlink (st1) and uplink (st2) binding, whether
+    //! those live on two VRFs (the classic split) or on ONE dual-direction
+    //! VRF (single-N6 UPF, issue #1947) — and `build_mup_st_route` builds
+    //! the RD-free T1ST / T2ST NLRI.
 
     use std::collections::BTreeMap;
     use std::str::FromStr;
@@ -8290,7 +8292,7 @@ mod mup_dual_origination_tests {
     use super::super::inst::Bgp;
     use super::super::route::build_mup_st_route;
     use super::super::vrf::inst::mup_session_targets;
-    use super::super::vrf_config::{BgpVrfConfig, MupSrv6Direction, MupSrv6Mobile};
+    use super::super::vrf_config::{BgpVrfConfig, MupRouteBinding, MupSrv6Direction};
 
     fn fresh_bgp() -> Bgp {
         let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
@@ -8409,11 +8411,13 @@ mod mup_dual_origination_tests {
             rd: Some(RouteDistinguisher::from_str(rd).unwrap()),
             ..BgpVrfConfig::default()
         };
-        cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
+        cfg.mobile_uplane.routes.insert(
             direction,
-            network_instance: Some(ni.to_string()),
-            mup_ext_comm: ext.map(|e| RouteDistinguisher::from_str(e).unwrap()),
-        });
+            MupRouteBinding {
+                network_instance: Some(ni.to_string()),
+                mup_ext_comm: ext.map(|e| RouteDistinguisher::from_str(e).unwrap()),
+            },
+        );
         cfg
     }
 
@@ -8467,6 +8471,39 @@ mod mup_dual_origination_tests {
                 .any(|(_, d, _)| matches!(d, MupSrv6Direction::Decapsulation)),
             "uplink st2 (N3) is a target",
         );
+    }
+
+    /// ONE VRF binding both st1 and st2 to the same NI (single-N6 UPF,
+    /// issue #1947) yields two targets under the same VRF name — the
+    /// session's T1ST and T2ST both originate from that VRF, under one RD.
+    #[test]
+    fn one_session_targets_both_directions_of_one_vrf() {
+        let mut vrfs = BTreeMap::new();
+        let mut cfg = mup_vrf("65000:1", MupSrv6Direction::Encapsulation, "internet", None);
+        cfg.mobile_uplane.routes.insert(
+            MupSrv6Direction::Decapsulation,
+            MupRouteBinding {
+                network_instance: Some("internet".to_string()),
+                mup_ext_comm: Some(RouteDistinguisher::from_str("100:1").unwrap()),
+            },
+        );
+        vrfs.insert("mobile".to_string(), cfg);
+
+        let mut targets = mup_session_targets(&vrfs, &session("internet"));
+        targets.sort_by_key(|(_, d, _)| *d);
+        assert_eq!(targets.len(), 2, "one dual-direction VRF → two targets");
+        assert!(
+            targets.iter().all(|(name, _, _)| name == "mobile"),
+            "both targets name the same VRF"
+        );
+        assert!(matches!(
+            targets[0],
+            (_, MupSrv6Direction::Decapsulation, Some(_))
+        ));
+        assert!(matches!(
+            targets[1],
+            (_, MupSrv6Direction::Encapsulation, None)
+        ));
     }
 
     /// A session whose NI matches no VRF binding targets nothing.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4714,7 +4714,7 @@ fn render_mup_vrfs(
             .get(name)
             .map(|k| k.mup_export_rts.len())
             .unwrap_or(0);
-        if mup.srv6_mobile.is_none() && rts == 0 {
+        if mup.routes.is_empty() && rts == 0 {
             continue;
         }
         if !any {
@@ -4730,20 +4730,28 @@ fn render_mup_vrfs(
             MupDataplane::EndDt46 => "end-dt46",
             MupDataplane::Gtp => "gtp",
         };
-        match &mup.srv6_mobile {
-            Some(sm) => {
-                let (dir, st) = match sm.direction {
-                    MupSrv6Direction::Decapsulation => ("decap", "ST2"),
-                    MupSrv6Direction::Encapsulation => ("encap", "ST1"),
-                };
-                let ni = sm.network_instance.as_deref().unwrap_or("-");
-                writeln!(
-                    buf,
-                    "  {name}: rd={rd} {dir}/{st} ni={ni} dataplane={dp} route-targets={rts}"
-                )?;
-            }
-            None => writeln!(buf, "  {name}: rd={rd} dataplane={dp} route-targets={rts}")?,
+        // One `{dir}/{st} ni={ni}` chunk per bound direction, st1 before
+        // st2 — a dual-direction VRF (single-N6 UPF, issue #1947) renders
+        // both on its line; a single-direction VRF keeps the classic form.
+        let mut svc = String::new();
+        for direction in [
+            MupSrv6Direction::Encapsulation,
+            MupSrv6Direction::Decapsulation,
+        ] {
+            let Some(binding) = mup.routes.get(&direction) else {
+                continue;
+            };
+            let (dir, st) = match direction {
+                MupSrv6Direction::Decapsulation => ("decap", "ST2"),
+                MupSrv6Direction::Encapsulation => ("encap", "ST1"),
+            };
+            let ni = binding.network_instance.as_deref().unwrap_or("-");
+            write!(svc, " {dir}/{st} ni={ni}")?;
         }
+        writeln!(
+            buf,
+            "  {name}: rd={rd}{svc} dataplane={dp} route-targets={rts}"
+        )?;
     }
     Ok(buf)
 }
@@ -5924,17 +5932,19 @@ mod detail_tests {
     fn render_mup_vrfs_lists_configured_services() {
         use super::super::inst::RibKnownVrf;
         use super::super::vrf_config::{
-            BgpVrfConfig, BgpVrfMobileUplane, MupSrv6Direction, MupSrv6Mobile,
+            BgpVrfConfig, BgpVrfMobileUplane, MupRouteBinding, MupSrv6Direction,
         };
         use std::collections::BTreeMap;
+        let mup_binding = |ni: &str| MupRouteBinding {
+            network_instance: Some(ni.to_string()),
+            mup_ext_comm: None,
+        };
         let n3 = BgpVrfConfig {
             rd: Some("65000:1".parse().unwrap()),
             mobile_uplane: BgpVrfMobileUplane {
-                srv6_mobile: Some(MupSrv6Mobile {
-                    direction: MupSrv6Direction::Decapsulation,
-                    network_instance: Some("core-ni".to_string()),
-                    mup_ext_comm: None,
-                }),
+                routes: [(MupSrv6Direction::Decapsulation, mup_binding("core-ni"))]
+                    .into_iter()
+                    .collect(),
                 segment: None,
                 mup_ext_comm: None,
                 interwork_prefix: None,
@@ -5945,11 +5955,27 @@ mod detail_tests {
         let n6 = BgpVrfConfig {
             rd: Some("65000:2".parse().unwrap()),
             mobile_uplane: BgpVrfMobileUplane {
-                srv6_mobile: Some(MupSrv6Mobile {
-                    direction: MupSrv6Direction::Encapsulation,
-                    network_instance: Some("access-ni".to_string()),
-                    mup_ext_comm: None,
-                }),
+                routes: [(MupSrv6Direction::Encapsulation, mup_binding("access-ni"))]
+                    .into_iter()
+                    .collect(),
+                segment: None,
+                mup_ext_comm: None,
+                interwork_prefix: None,
+                dataplane: Default::default(),
+            },
+            ..Default::default()
+        };
+        // A dual-direction VRF (single-N6 UPF, issue #1947) renders both
+        // bindings on one line, st1 before st2.
+        let mobile = BgpVrfConfig {
+            rd: Some("65000:3".parse().unwrap()),
+            mobile_uplane: BgpVrfMobileUplane {
+                routes: [
+                    (MupSrv6Direction::Encapsulation, mup_binding("internet")),
+                    (MupSrv6Direction::Decapsulation, mup_binding("internet")),
+                ]
+                .into_iter()
+                .collect(),
                 segment: None,
                 mup_ext_comm: None,
                 interwork_prefix: None,
@@ -5960,6 +5986,7 @@ mod detail_tests {
         let mut vrfs: BTreeMap<String, BgpVrfConfig> = BTreeMap::new();
         vrfs.insert("N3".to_string(), n3);
         vrfs.insert("N6".to_string(), n6);
+        vrfs.insert("mobile".to_string(), mobile);
 
         // The export RTs now come from `rib_known_vrfs` (the top-level
         // `vrf <name> mup route-target export`).
@@ -5988,6 +6015,13 @@ mod detail_tests {
             out.contains(
                 "N6: rd=65000:2 encap/ST1 ni=access-ni dataplane=end-dt46 route-targets=1"
             )
+        );
+        assert!(
+            out.contains(
+                "mobile: rd=65000:3 encap/ST1 ni=internet decap/ST2 ni=internet \
+                 dataplane=end-dt46 route-targets=0"
+            ),
+            "dual-direction VRF renders both bindings: {out}"
         );
 
         // No mup config anywhere → empty section.

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -179,8 +179,9 @@ pub struct BgpVrf {
     /// VRF-first MUP origination tracking: per PFCP SEID, the RD-free ST
     /// prefixes this VRF exported to the global SAFI-85 RIB. Lets a Session
     /// Deletion / Modification (`MupWithdrawOriginate`) withdraw exactly the
-    /// routes that session created. A VRF binds one direction, so this is
-    /// normally one prefix per SEID.
+    /// routes that session created. Up to one prefix per bound direction —
+    /// a single-direction VRF holds one, a dual-direction VRF (single-N6
+    /// UPF, issue #1947) holds the session's T1ST and T2ST together.
     pub mup_originated: std::collections::BTreeMap<u64, Vec<bgp_packet::MupPrefix>>,
     /// VRF-first MUP segment tracking: the RD-free DSD/ISD prefix this VRF
     /// currently has exported (`MupSegmentOriginate`), or `None`. A VRF has at
@@ -517,13 +518,15 @@ pub fn dispatch_mup(
     }
 }
 
-/// The VRFs a PFCP session should originate ST routes in: every VRF whose
-/// `afi-safi mup route {st1|st2}` binding (`srv6_mobile.network_instance`)
-/// matches the session's Network Instance, paired with its resolved direction
+/// The (VRF, direction) pairs a PFCP session should originate ST routes in:
+/// every `afi-safi mup route {st1|st2}` binding whose `network-instance`
+/// matches the session's Network Instance, paired with its direction
 /// (st1 = Encapsulation / st2 = Decapsulation) and st2 Direct-segment
-/// ext-comm. This is the dual-ST fan-out: one NI bound by both an st1 and an
-/// st2 VRF yields two targets. Pure (no I/O) so the correlation is unit
-/// testable; [`dispatch_mup_session`] turns each target into a `MupOriginate`.
+/// ext-comm. This is the dual-ST fan-out, in either topology: one NI bound
+/// by an st1 and an st2 VRF yields one target each, and one VRF binding
+/// BOTH directions (single-N6 UPF, issue #1947) yields two targets under
+/// the same VRF name. Pure (no I/O) so the correlation is unit testable;
+/// [`dispatch_mup_session`] groups the targets per VRF into `MupOriginate`.
 pub fn mup_session_targets(
     vrfs: &std::collections::BTreeMap<String, super::super::vrf_config::BgpVrfConfig>,
     session: &crate::mup_c::session::MupSession,
@@ -536,12 +539,12 @@ pub fn mup_session_targets(
         return Vec::new();
     };
     vrfs.iter()
-        .filter_map(|(name, cfg)| {
-            let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
-            if sm.network_instance.as_deref() != Some(ni) {
-                return None;
-            }
-            Some((name.clone(), sm.direction, sm.mup_ext_comm))
+        .flat_map(|(name, cfg)| {
+            cfg.mobile_uplane
+                .routes
+                .iter()
+                .filter(|(_, binding)| binding.network_instance.as_deref() == Some(ni))
+                .map(|(direction, binding)| (name.clone(), *direction, binding.mup_ext_comm))
         })
         .collect()
 }
@@ -578,14 +581,28 @@ pub fn dispatch_mup_session(
     vrf_registry: &std::collections::BTreeMap<String, super::spawn::BgpVrfHandle>,
     session: &crate::mup_c::session::MupSession,
 ) {
+    // Group the per-direction targets by VRF so each matched VRF receives
+    // ONE `MupOriginate` carrying its full desired direction set — the
+    // per-VRF handler reconciles prior exports against exactly that set, so
+    // a dual-direction VRF (issue #1947) must not see its directions as two
+    // competing messages.
+    let mut grouped: std::collections::BTreeMap<
+        String,
+        Vec<(
+            super::super::vrf_config::MupSrv6Direction,
+            Option<bgp_packet::RouteDistinguisher>,
+        )>,
+    > = std::collections::BTreeMap::new();
     for (name, direction, ext_comm) in mup_session_targets(vrfs, session) {
+        grouped.entry(name).or_default().push((direction, ext_comm));
+    }
+    for (name, bindings) in grouped {
         let Some(handle) = vrf_registry.get(&name) else {
             continue;
         };
         let _ = handle.inbox.send(BgpVrfMsg::MupOriginate {
             session: session.clone(),
-            direction,
-            ext_comm,
+            bindings,
         });
     }
 }
@@ -2335,39 +2352,44 @@ impl BgpVrf {
                     }
                 }
             }
-            // VRF-first MUP origination: build the RD-free ST NLRI from the
-            // dispatched session + resolved direction, and export it to the
-            // global SAFI-85 RIB. The global export handler applies the RD,
-            // export route-targets and controller next-hop; the resulting
-            // route is mirrored back here (RT/RD-origin) so this VRF's own
-            // `show bgp vrf <name> mup` reflects it. A Modification replaces —
-            // but the ST keys exclude the session-transform fields (an ST1
-            // keys on RD+Prefix alone, §3.2.1), so a handover that only moves
-            // the tunnel (new TEID/QFI/endpoint) rebuilds the *same* NLRI key:
-            // re-export it and let the Loc-RIB replace in place (an implicit
-            // withdraw on the wire). Only a prior export whose key actually
-            // changed (UE prefix / ST2 core tunnel) — or one the modified
-            // session no longer builds — gets an explicit withdraw, so peers
-            // and the dataplane never see the route flap mid-handover.
-            BgpVrfMsg::MupOriginate {
-                session,
-                direction,
-                ext_comm,
-            } => {
-                let built = super::super::route::build_mup_st_route(&session, direction, ext_comm);
+            // VRF-first MUP origination: build the RD-free ST NLRI for every
+            // dispatched direction binding — a dual-direction VRF (single-N6
+            // UPF, issue #1947) builds the session's T1ST AND T2ST here — and
+            // export each to the global SAFI-85 RIB. The global export
+            // handler applies the RD, export route-targets and controller
+            // next-hop; the resulting routes are mirrored back here
+            // (RT/RD-origin) so this VRF's own `show bgp vrf <name> mup`
+            // reflects them. A Modification reconciles against the prior
+            // exports as a set — the ST keys exclude the session-transform
+            // fields (an ST1 keys on RD+Prefix alone, §3.2.1), so a handover
+            // that only moves the tunnel (new TEID/QFI/endpoint) rebuilds the
+            // *same* NLRI key: re-export it and let the Loc-RIB replace in
+            // place (an implicit withdraw on the wire). Only a prior export
+            // no longer among the built keys — a changed UE prefix / ST2 core
+            // tunnel, an ST the modified session no longer builds, or a
+            // direction unbound since — gets an explicit withdraw, so peers
+            // and the dataplane never see the surviving routes flap
+            // mid-handover.
+            BgpVrfMsg::MupOriginate { session, bindings } => {
+                let built: Vec<_> = bindings
+                    .into_iter()
+                    .filter_map(|(direction, ext_comm)| {
+                        super::super::route::build_mup_st_route(&session, direction, ext_comm)
+                    })
+                    .collect();
                 let prior = self
                     .mup_originated
                     .remove(&session.seid)
                     .unwrap_or_default();
                 for old in prior {
-                    if built.as_ref().map(|(p, _, _)| p) != Some(&old) {
+                    if !built.iter().any(|(p, _, _)| p == &old) {
                         let _ = self.global_tx.send(BgpGlobalMsg::WithdrawMupExport {
                             vrf: self.name.clone(),
                             prefix: old,
                         });
                     }
                 }
-                if let Some((prefix, st1, attr)) = built {
+                for (prefix, st1, attr) in built {
                     self.mup_originated
                         .entry(session.seid)
                         .or_default()
@@ -2939,8 +2961,7 @@ mod tests {
         // Establishment: one export, nothing withdrawn.
         vrf.process_global_msg(BgpVrfMsg::MupOriginate {
             session: session(Some("10.0.1.1"), 0x100),
-            direction: MupSrv6Direction::Encapsulation,
-            ext_comm: None,
+            bindings: vec![(MupSrv6Direction::Encapsulation, None)],
         });
         let first = global_rx.try_recv().expect("establishment exports");
         let BgpGlobalMsg::MupExport {
@@ -2960,8 +2981,7 @@ mod tests {
         // Handover: same seid + UE prefix, new endpoint/TEID.
         vrf.process_global_msg(BgpVrfMsg::MupOriginate {
             session: session(Some("10.0.2.1"), 0x200),
-            direction: MupSrv6Direction::Encapsulation,
-            ext_comm: None,
+            bindings: vec![(MupSrv6Direction::Encapsulation, None)],
         });
         let second = global_rx.try_recv().expect("handover re-exports");
         let BgpGlobalMsg::MupExport {
@@ -2984,8 +3004,7 @@ mod tests {
         // builds → the prior export is withdrawn explicitly.
         vrf.process_global_msg(BgpVrfMsg::MupOriginate {
             session: session(None, 0),
-            direction: MupSrv6Direction::Encapsulation,
-            ext_comm: None,
+            bindings: vec![(MupSrv6Direction::Encapsulation, None)],
         });
         let third = global_rx.try_recv().expect("unbuildable ST withdraws");
         let BgpGlobalMsg::WithdrawMupExport { prefix: gone, .. } = third else {
@@ -2996,6 +3015,131 @@ mod tests {
         assert!(
             vrf.mup_originated.is_empty(),
             "nothing is tracked once the session exports no ST"
+        );
+    }
+
+    /// A VRF binding BOTH directions (single-N6 UPF, issue #1947) receives
+    /// one `MupOriginate` carrying both bindings and exports the session's
+    /// T1ST and T2ST together under its own RD. A handover that only moves
+    /// the access tunnel withdraws nothing (both keys unchanged), and
+    /// unbinding one direction (the next dispatch carries only the other)
+    /// withdraws exactly that direction's export while the survivor
+    /// re-exports.
+    #[tokio::test]
+    async fn mup_dual_direction_vrf_originates_and_reconciles_both_sts() {
+        use crate::bgp::vrf_config::MupSrv6Direction;
+        use crate::mup_c::session::MupSession;
+
+        fn session(endpoint: &str, teid: u32) -> MupSession {
+            MupSession {
+                seid: 9,
+                cp_seid: 0x2222,
+                peer: "10.0.0.2:8805".parse().unwrap(),
+                ue_ipv4: Some("192.0.2.5".parse().unwrap()),
+                ue_ipv6: None,
+                teid,
+                endpoint: Some(endpoint.parse().unwrap()),
+                core_teid: 0x9000,
+                core_endpoint: Some("10.0.12.2".parse().unwrap()),
+                network_instance: Some("internet".to_string()),
+                qfi: Some(9),
+            }
+        }
+        let both = || {
+            vec![
+                (MupSrv6Direction::Encapsulation, None),
+                (MupSrv6Direction::Decapsulation, None),
+            ]
+        };
+        fn recv_exports(
+            rx: &mut tokio::sync::mpsc::UnboundedReceiver<BgpGlobalMsg>,
+            n: usize,
+        ) -> Vec<bgp_packet::MupPrefix> {
+            let mut prefixes = Vec::new();
+            for _ in 0..n {
+                match rx.try_recv().expect("expected another MupExport") {
+                    BgpGlobalMsg::MupExport { prefix, .. } => prefixes.push(prefix),
+                    other => panic!("expected MupExport, got {other:?}"),
+                }
+            }
+            assert!(rx.try_recv().is_err(), "no extra messages");
+            prefixes
+        }
+
+        let (global_tx, mut global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(13, "vrf-dual");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-dual".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        // Establishment: BOTH the T1ST and the T2ST export, nothing withdrawn.
+        vrf.process_global_msg(BgpVrfMsg::MupOriginate {
+            session: session("10.0.1.1", 0x100),
+            bindings: both(),
+        });
+        let first = recv_exports(&mut global_rx, 2);
+        assert!(
+            first
+                .iter()
+                .any(|p| matches!(p, bgp_packet::MupPrefix::T1st { .. })),
+            "dual-direction VRF exports the downlink T1ST"
+        );
+        assert!(
+            first
+                .iter()
+                .any(|p| matches!(p, bgp_packet::MupPrefix::T2st { .. })),
+            "dual-direction VRF exports the uplink T2ST"
+        );
+        assert_eq!(
+            vrf.mup_originated.get(&9).map(Vec::len),
+            Some(2),
+            "both STs tracked under the one seid"
+        );
+
+        // Handover: the access tunnel moves, the core tunnel stays. Both
+        // NLRI keys are unchanged (an ST1 keys on RD+Prefix alone), so both
+        // re-export in place with NO withdraw — the old single-direction
+        // bookkeeping would have withdrawn the sibling ST here.
+        vrf.process_global_msg(BgpVrfMsg::MupOriginate {
+            session: session("10.0.2.1", 0x200),
+            bindings: both(),
+        });
+        recv_exports(&mut global_rx, 2);
+
+        // Unbind st1 (the next dispatch carries only the st2 binding): the
+        // T1ST is withdrawn explicitly, the T2ST re-exports.
+        vrf.process_global_msg(BgpVrfMsg::MupOriginate {
+            session: session("10.0.2.1", 0x200),
+            bindings: vec![(MupSrv6Direction::Decapsulation, None)],
+        });
+        let mut saw_withdraw_t1 = false;
+        let mut saw_export_t2 = false;
+        while let Ok(msg) = global_rx.try_recv() {
+            match msg {
+                BgpGlobalMsg::WithdrawMupExport { prefix, .. } => {
+                    assert!(matches!(prefix, bgp_packet::MupPrefix::T1st { .. }));
+                    saw_withdraw_t1 = true;
+                }
+                BgpGlobalMsg::MupExport { prefix, .. } => {
+                    assert!(matches!(prefix, bgp_packet::MupPrefix::T2st { .. }));
+                    saw_export_t2 = true;
+                }
+                other => panic!("unexpected message {other:?}"),
+            }
+        }
+        assert!(saw_withdraw_t1, "unbound st1's T1ST withdrawn");
+        assert!(saw_export_t2, "surviving st2's T2ST re-exported");
+        assert_eq!(
+            vrf.mup_originated.get(&9).map(Vec::len),
+            Some(1),
+            "only the surviving direction stays tracked"
         );
     }
 }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -94,24 +94,29 @@ pub enum BgpVrfMsg {
         prefix: bgp_packet::MupPrefix,
     },
 
-    /// Originate a controller Session-Transformed (ST1/ST2) route in this
+    /// Originate the controller Session-Transformed (ST1/ST2) routes in this
     /// VRF (VRF-first MUP origination). The global task correlates a PFCP
     /// session's Network Instance to the matching VRF(s) and forwards the
-    /// session here with the resolved `direction` (st1=Encapsulation /
-    /// st2=Decapsulation) and the optional st2 Direct-segment ext-comm. The
-    /// per-VRF task builds the **RD-free** ST NLRI and emits
-    /// [`BgpGlobalMsg::MupExport`]; the global export handler applies the RD,
-    /// export route-targets and controller next-hop. One session can fan out
-    /// to several VRFs (an st1 and an st2 VRF sharing the NI) — each gets its
-    /// own `MupOriginate` for its direction. A repeat for a known seid (PFCP
-    /// Modification) re-exports in place when the rebuilt NLRI key is
-    /// unchanged — an ST1 keys on RD+Prefix alone, so a handover's new
-    /// TEID/QFI/endpoint replaces without a withdraw — and explicitly
-    /// withdraws only a prior export whose key changed.
+    /// session here with every matched direction binding (st1=Encapsulation /
+    /// st2=Decapsulation, each with its optional st2 Direct-segment
+    /// ext-comm) — one message per (VRF, session) carrying the VRF's full
+    /// desired direction set. A VRF binding both directions (single-N6 UPF,
+    /// issue #1947) builds both the T1ST and the T2ST here; the classic
+    /// two-VRF split gets one binding each. The per-VRF task builds the
+    /// **RD-free** ST NLRIs and emits [`BgpGlobalMsg::MupExport`]; the global
+    /// export handler applies the RD, export route-targets and controller
+    /// next-hop. A repeat for a known seid (PFCP Modification) reconciles
+    /// against the prior exports: an unchanged NLRI key re-exports in place —
+    /// an ST1 keys on RD+Prefix alone, so a handover's new TEID/QFI/endpoint
+    /// replaces without a withdraw — and only a prior export whose key is no
+    /// longer built (changed key, or its direction unbound since) is
+    /// withdrawn explicitly.
     MupOriginate {
         session: crate::mup_c::session::MupSession,
-        direction: crate::bgp::vrf_config::MupSrv6Direction,
-        ext_comm: Option<RouteDistinguisher>,
+        bindings: Vec<(
+            crate::bgp::vrf_config::MupSrv6Direction,
+            Option<RouteDistinguisher>,
+        )>,
     },
 
     /// Withdraw every ST route this VRF originated for `seid` (PFCP Session

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -130,9 +130,10 @@ impl<N: Ord> Default for BgpVrfAfConfig<N> {
 
 /// SRv6 mobile user-plane direction for a per-VRF MUP service
 /// (zebra-bgp-vrf.yang `afi-safi mup route {st1|st2}`). `Decapsulation`
-/// is the `st2` egress/uplink (Type-2 ST, the N3 VRF); `Encapsulation`
-/// is the `st1` ingress/downlink (Type-1 ST, the N6 VRF).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// is the `st2` egress/uplink (Type-2 ST, the N3 side); `Encapsulation`
+/// is the `st1` ingress/downlink (Type-1 ST, the N6 side). Ordered so it
+/// can key the per-direction `routes` map on [`BgpVrfMobileUplane`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MupSrv6Direction {
     Decapsulation,
     Encapsulation,
@@ -142,7 +143,7 @@ pub enum MupSrv6Direction {
 /// (zebra-bgp-vrf.yang `afi-safi mup segment {direct|interwork}`).
 /// `Direct` originates a Direct Segment Discovery (DSD, type 2) route
 /// carrying the VRF's End.DT46 SID; `Interwork` an Interwork Segment
-/// Discovery (ISD, type 1) route. Independent of [`MupSrv6Mobile`], which
+/// Discovery (ISD, type 1) route. Independent of [`MupRouteBinding`], which
 /// is the controller-side Session-Transformed origination binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MupSegmentMode {
@@ -183,23 +184,25 @@ impl MupDataplane {
     }
 }
 
-/// `afi-safi mup route {st1|st2} { network-instance <ni>; [mup-ext-comm
-/// <2:4>;] }` for one VRF: the ST route type (as a direction) plus the
-/// session network-instance matched, and (st2 only) the Direct-segment
-/// MUP Extended Community the originated ST2 routes resolve to. Surfaced
-/// in `show bgp mup` (the `MUP VRFs:` block) and consumed by the
-/// P5 MUP controller when it originates ST routes (st2/Decapsulation →
-/// Type-2 ST, the N3 VRF; st1/Encapsulation → Type-1 ST, the N6 VRF).
-#[derive(Debug, Clone)]
-pub struct MupSrv6Mobile {
-    pub direction: MupSrv6Direction,
+/// One `afi-safi mup route {st1|st2} { network-instance <ni>;
+/// [mup-ext-comm <2:4>;] }` list entry for one VRF: the session
+/// network-instance matched, and (st2 only) the Direct-segment MUP
+/// Extended Community the originated ST2 routes resolve to. Keyed by
+/// its [`MupSrv6Direction`] in [`BgpVrfMobileUplane::routes`], so one
+/// VRF may bind BOTH directions and serve a bidirectional UPF behind a
+/// single N6 interface (issue #1947). Surfaced in `show bgp mup` (the
+/// `MUP VRFs:` block) and consumed by the P5 MUP controller when it
+/// originates ST routes (st2/Decapsulation → Type-2 ST;
+/// st1/Encapsulation → Type-1 ST).
+#[derive(Default, Debug, Clone)]
+pub struct MupRouteBinding {
     pub network_instance: Option<String>,
     /// `afi-safi mup route st2 mup-ext-comm <2:4>` — the BGP MUP Extended
     /// Community (Direct-Type Segment Identifier, draft-mpmz-bess-mup-safi
     /// §3.2 / §3.3.10) attached to the Type-2 ST routes this VRF
     /// originates, so a receiving PE resolves the (endpoint, TEID) tunnel
-    /// onto the matching End.DT46 Direct segment. Set only for the
-    /// Decapsulation (st2) direction; `None` for st1.
+    /// onto the matching End.DT46 Direct segment. Meaningful only on the
+    /// Decapsulation (st2) binding; `None` for st1.
     pub mup_ext_comm: Option<RouteDistinguisher>,
 }
 
@@ -211,12 +214,16 @@ pub struct MupSrv6Mobile {
 /// `rib_known_vrfs`), the same framework as ipv4 / ipv6.
 #[derive(Default, Debug, Clone)]
 pub struct BgpVrfMobileUplane {
-    pub srv6_mobile: Option<MupSrv6Mobile>,
+    /// `afi-safi mup route {st1|st2}` — the controller-side ST origination
+    /// bindings, keyed by direction. One VRF may carry both an `st1` and an
+    /// `st2` entry (a bidirectional UPF behind a single N6 interface/VRF,
+    /// issue #1947); the two-VRF split (one direction each) remains valid.
+    pub routes: BTreeMap<MupSrv6Direction, MupRouteBinding>,
     /// `afi-safi mup segment {direct|interwork}` — PE-side Segment
     /// Discovery origination for this VRF. `Direct` → DSD (type 2, NLRI =
     /// RD + router-id); `Interwork` → ISD (type 1, NLRI = RD +
     /// [`Self::interwork_prefix`]). Both carry the VRF's End.DT46 SID.
-    /// Independent of `srv6_mobile`.
+    /// Independent of `routes`.
     pub segment: Option<MupSegmentMode>,
     /// `afi-safi mup segment direct mup-ext-comm <2:4>` — the BGP MUP
     /// Extended Community (transitive type 0x0c, sub-type 0x00 =
@@ -389,25 +396,21 @@ fn mup_route_direction(key: &str) -> Option<MupSrv6Direction> {
     }
 }
 
-/// Borrow-or-create the per-VRF `srv6_mobile` binding for the given ST
-/// direction, forcing the direction (the single binding flips st1↔st2 if
-/// the VRF is reconfigured). Lets the `network-instance` / `mup-ext-comm`
-/// child-leaf handlers accumulate into the same binding regardless of the
-/// order their callbacks fire.
-fn mup_route_binding(cfg: &mut BgpVrfConfig, direction: MupSrv6Direction) -> &mut MupSrv6Mobile {
-    let sm = cfg.mobile_uplane.srv6_mobile.get_or_insert(MupSrv6Mobile {
-        direction,
-        network_instance: None,
-        mup_ext_comm: None,
-    });
-    sm.direction = direction;
-    sm
+/// Borrow-or-create the per-VRF `route {st1|st2}` binding for the given
+/// ST direction. Each direction is its own map entry, so one VRF may
+/// bind both st1 and st2 (issue #1947); the `network-instance` /
+/// `mup-ext-comm` child-leaf handlers accumulate into their direction's
+/// binding regardless of the order their callbacks fire.
+fn mup_route_binding(cfg: &mut BgpVrfConfig, direction: MupSrv6Direction) -> &mut MupRouteBinding {
+    cfg.mobile_uplane.routes.entry(direction).or_default()
 }
 
 /// `set router bgp vrf <NAME> afi-safi mup route {st1|st2}` — list-key
 /// handler. Establishes the ST direction binding (st1 = Encapsulation /
 /// downlink, st2 = Decapsulation / uplink); the session network-instance
 /// and (st2) the Direct-segment `mup-ext-comm` hang off child leaves.
+/// The delete removes only that direction's entry, leaving a sibling
+/// direction's binding intact.
 pub fn config_vrf_mup_route(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let direction = mup_route_direction(&args.string()?)?;
@@ -416,15 +419,8 @@ pub fn config_vrf_mup_route(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
         ConfigOp::Set => {
             mup_route_binding(cfg, direction);
         }
-        ConfigOp::Delete
-            if cfg
-                .mobile_uplane
-                .srv6_mobile
-                .as_ref()
-                .map(|sm| sm.direction)
-                == Some(direction) =>
-        {
-            cfg.mobile_uplane.srv6_mobile = None;
+        ConfigOp::Delete => {
+            cfg.mobile_uplane.routes.remove(&direction);
         }
         _ => {}
     }
@@ -450,10 +446,8 @@ pub fn config_vrf_mup_route_network_instance(
             mup_route_binding(cfg, direction).network_instance = Some(ni);
         }
         ConfigOp::Delete => {
-            if let Some(sm) = cfg.mobile_uplane.srv6_mobile.as_mut()
-                && sm.direction == direction
-            {
-                sm.network_instance = None;
+            if let Some(binding) = cfg.mobile_uplane.routes.get_mut(&direction) {
+                binding.network_instance = None;
             }
         }
         _ => {}
@@ -464,7 +458,7 @@ pub fn config_vrf_mup_route_network_instance(
 /// `set router bgp vrf <NAME> afi-safi mup route st2 mup-ext-comm <2:4>` —
 /// the BGP MUP Extended Community (Direct-Type Segment Identifier) the
 /// originated Type-2 ST routes resolve to (draft §3.3.10). Meaningful only
-/// under `route st2` (Decapsulation); stored on the `srv6_mobile` binding.
+/// under `route st2` (Decapsulation); stored on that direction's binding.
 pub fn config_vrf_mup_route_mup_ext_comm(
     bgp: &mut Bgp,
     mut args: Args,
@@ -480,10 +474,8 @@ pub fn config_vrf_mup_route_mup_ext_comm(
                 Some(RouteDistinguisher::from_str(&raw).ok()?);
         }
         ConfigOp::Delete => {
-            if let Some(sm) = cfg.mobile_uplane.srv6_mobile.as_mut()
-                && sm.direction == direction
-            {
-                sm.mup_ext_comm = None;
+            if let Some(binding) = cfg.mobile_uplane.routes.get_mut(&direction) {
+                binding.mup_ext_comm = None;
             }
         }
         _ => {}
@@ -1119,34 +1111,43 @@ mod tests {
     #[test]
     fn mobile_uplane_default_is_empty() {
         let mup = BgpVrfConfig::default().mobile_uplane;
-        assert!(mup.srv6_mobile.is_none());
+        assert!(mup.routes.is_empty());
     }
 
     #[test]
-    fn mobile_uplane_srv6_decap_and_encap() {
+    fn mobile_uplane_binds_both_directions() {
+        // One VRF may bind both st1 and st2 (single-N6 UPF, issue #1947):
+        // each direction is an independent map entry, and removing one
+        // leaves the other intact.
         let mut cfg = BgpVrfConfig::default();
-        cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
-            direction: MupSrv6Direction::Decapsulation,
-            network_instance: Some("core-ni".to_string()),
-            mup_ext_comm: Some("1:2".parse().unwrap()),
-        });
-        let sm = cfg.mobile_uplane.srv6_mobile.as_ref().unwrap();
-        assert_eq!(sm.direction, MupSrv6Direction::Decapsulation);
-        assert_eq!(sm.network_instance.as_deref(), Some("core-ni"));
-        assert_eq!(sm.mup_ext_comm, Some("1:2".parse().unwrap()));
-
-        cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
-            direction: MupSrv6Direction::Encapsulation,
-            network_instance: Some("access-ni".to_string()),
-            mup_ext_comm: None,
-        });
-        assert_eq!(
-            cfg.mobile_uplane.srv6_mobile.as_ref().unwrap().direction,
-            MupSrv6Direction::Encapsulation
+        cfg.mobile_uplane.routes.insert(
+            MupSrv6Direction::Decapsulation,
+            MupRouteBinding {
+                network_instance: Some("internet".to_string()),
+                mup_ext_comm: Some("1:2".parse().unwrap()),
+            },
         );
+        cfg.mobile_uplane.routes.insert(
+            MupSrv6Direction::Encapsulation,
+            MupRouteBinding {
+                network_instance: Some("internet".to_string()),
+                mup_ext_comm: None,
+            },
+        );
+        assert_eq!(cfg.mobile_uplane.routes.len(), 2);
+        let st2 = &cfg.mobile_uplane.routes[&MupSrv6Direction::Decapsulation];
+        assert_eq!(st2.network_instance.as_deref(), Some("internet"));
+        assert_eq!(st2.mup_ext_comm, Some("1:2".parse().unwrap()));
 
-        cfg.mobile_uplane.srv6_mobile = None;
-        assert!(cfg.mobile_uplane.srv6_mobile.is_none());
+        cfg.mobile_uplane
+            .routes
+            .remove(&MupSrv6Direction::Decapsulation);
+        assert!(
+            cfg.mobile_uplane
+                .routes
+                .contains_key(&MupSrv6Direction::Encapsulation),
+            "removing st2 leaves the st1 binding intact"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First slice of #1947 (single external N6 interface/VRF for the GTP MUP UPF datapath): the control-plane change that lets ONE `router bgp vrf` bind BOTH `afi-safi mup route st1` (downlink) and `route st2` (uplink), so a single PFCP session originates the Type-1 ST and the Type-2 ST under one RD — instead of requiring two single-direction VRFs and, with them, two N6-facing interfaces.

- `BgpVrfMobileUplane` stages `route {st1|st2}` per direction (`routes: BTreeMap<MupSrv6Direction, MupRouteBinding>`, replacing the single last-wins `srv6_mobile` binding; the YANG `route` list was already keyed `{st1|st2}`). Deleting one direction leaves the sibling intact.
- `mup_session_targets` emits one target per matching binding; `dispatch_mup_session` groups them so each matched VRF receives ONE `MupOriginate` carrying its full direction set, and the per-VRF handler reconciles prior exports against the built key set. A handover re-exports both STs in place (no withdraw); a direction unbound since is withdrawn on the next session event while the survivor stays up.
- `show bgp mup` MUP VRFs renders every binding on the VRF line (st1 before st2); single-direction output is byte-identical.

The GTP dataplane reconcilers, RT import and cradle FIB tee are already direction-agnostic (RIB-driven per route type), so no dataplane change is needed: a dual-direction `dataplane gtp` VRF installs both the decap PDR and the UE-prefix encap routes into one cradle table. The single-N6 lab collapse + round-trip/iperf3 proof and docs follow in the next slices.

## Test plan

- New units: `one_session_targets_both_directions_of_one_vrf` (config.rs), `mup_dual_direction_vrf_originates_and_reconciles_both_sts` (vrf/inst.rs — dual originate, handover no-withdraw, unbind withdraws only that direction), dual-binding `render_mup_vrfs` case.
- Full workspace suite (2463 tests) green; `cargo fmt` + workspace clippy clean.
- New BDD `@bgp_mup_single_vrf_dual_st`: one VRF `mobile` (rd 65000:1) binds both directions to NI `internet`; one pfcp-inject session yields both `[ST1][65000:1]` and `[ST2][65000:1]` on originator + iBGP receiver, plus the per-VRF view; teardown scenario included. (BDD is CI-excluded; config grammar pre-flighted against an isolated daemon.)
- Live-validated non-root: standalone controller + pfcp-inject → both STs under rd 65000:1, `show bgp vrf mobile mup` shows both.

Part of #1947.

Generated with [Claude Code](https://claude.com/claude-code)