### PR TITLE
mup: single-N6 lab collapse + book docs (issue #1947)

### DIFF
--- a/bdd/mup-lab/README.md
+++ b/bdd/mup-lab/README.md
@@ -3,9 +3,14 @@
 The manual lab that first proved end-to-end UE ping through zebra-rs +
 cradle acting as the UPF (`afi-safi mup dataplane gtp`), against a real
 5G core (free5GC v4.0.1) and a real RAN/UE simulator (free-ran-ue), on
-2026-07-14 (issue #1930). The distilled, self-contained regression lives
-in cradle-rs as the `@cradle_mup_gtp_roundtrip` BDD feature; this lab is
-for reproducing the full free5GC stack by hand.
+2026-07-14 (issue #1930). Since issue #1947 the lab uses the
+telco-normal **single-N6** shape: ONE VRF binds both `route st1` and
+`route st2`, so the UPF has one N6-facing interface — uplink and
+downlink are directions of the same N6 network. The distilled,
+self-contained regression lives in cradle-rs as the
+`@cradle_mup_gtp_single_n6` BDD feature (the two-leg original remains
+as `@cradle_mup_gtp_roundtrip`); this lab is for reproducing the full
+free5GC stack by hand.
 
 ```
  host (root netns): free5GC CP on 127.0.0.x SBI, mongodb, webconsole
@@ -15,23 +20,25 @@ for reproducing the full free5GC stack by hand.
 
  mupran: free-ran-ue gNB (N2/N3 on 10.0.1.2; UE link on 127.0.0.1) + UE (ueTun0)
  mupupf: zebra-rs + cradle
-          VRF mobile-dl (table 1): mudl 10.0.61.1/24 ── mupdn: dnd 10.0.61.2  (DL ingress)
-          VRF mobile-ul (table 2): muul 10.0.60.1/24 ── mupdn: dnu 10.0.60.2  (UL egress, ping target)
- mupdn:  route 10.60.0.0/16 (the free5GC UE pool) via 10.0.61.1
+          VRF mobile (table 1, st1+st2): mun6 10.0.60.1/24 ── mupdn: mdn6 10.0.60.2
+ mupdn:  route 10.60.0.0/16 (the free5GC UE pool) via 10.0.60.1
 ```
 
 Key design points
 
-- **N3 lives in the global table**; the MUP VRFs only anchor the st1/st2
-  routes. One VRF binds one direction, hence the two N6 legs: uplink
-  egresses the mobile-ul leg, the DN routes the UE pool back through the
-  mobile-dl leg.
+- **N3 lives in the global table**; the MUP VRF only anchors the
+  st1/st2 routes. **One VRF binds BOTH directions** (zebra-rs PR #2038,
+  issue #1947): its single cradle table holds the uplink decap PDR, the
+  downlink UE-prefix encap route and the N6 connected route together,
+  so one N6 leg carries downlink ingress and uplink egress. (The older
+  one-direction-per-VRF split still works — two VRFs, two legs — but is
+  no longer required.)
 - **PFCP `listen-address` = the N3 address** (10.0.12.2): the
   controller's N4 identity doubles as the F-TEID address fallback, so
   one address keeps the tunnel endpoint consistent.
 - **`network-instance` = the DNN** free5GC puts in the PDI Network
-  Instance (`internet`); the same NI on both VRFs makes one PFCP session
-  fan out to both ST routes.
+  Instance (`internet`); the same NI on both `route` bindings makes one
+  PFCP session fan out to both ST routes.
 - free5GC allocates the UPF's N3 TEID itself (Create PDR → PDI local
   F-TEID, TS 29.244 CH=0) and ignores the Created-PDR F-TEID; mup-c
   honors it as authoritative (commit `eb576cf9`).
@@ -42,7 +49,7 @@ Key design points
 ## Prerequisites
 
 ```sh
-# Install zebra-rs (version >= 26.7.5)
+# Install zebra-rs (needs the dual-direction `afi-safi mup route` binding, PR #2038)
 
 # Install cradle (version >= 0.9.7)
 
@@ -125,13 +132,13 @@ the UE process and start it again — the second attach goes through.
 V=$(git rev-parse --show-toplevel)/target/debug/vtyctl
 sudo ip netns exec mupupf $V show 'show bgp mup-c association'   # SMF peer
 sudo ip netns exec mupupf $V show 'show bgp mup-c session'       # UE addr, Access + Core F-TEIDs
-sudo ip netns exec mupupf $V show 'show bgp vrf mobile-dl mup'   # [ST1] ue=<UE>/32 -> gNB
-sudo ip netns exec mupupf $V show 'show bgp vrf mobile-ul mup'   # [ST2] ep=10.0.12.2, CP-allocated teid
+sudo ip netns exec mupupf $V show 'show bgp vrf mobile mup'      # BOTH: [ST1] ue=<UE>/32 -> gNB
+                                                                 #  and  [ST2] ep=10.0.12.2, CP TEID
 sudo ip netns exec mupupf bpftool map dump name GTP_PDR           # uplink decap key
 sudo ip netns exec mupupf ~/cradle-rs/target/debug/cradle dump ipv4 --grpc unix:cradle/grpc --vrf 1
+# ^ table 1 now holds the UE /32 GTP encap route AND the 10.0.60.0/24 connected route
 
-# seed ARP once, then the end-to-end ping
-sudo ip netns exec mupdn  ping -c1 -W1 10.0.61.1 >/dev/null
+# seed ARP once, then the end-to-end ping through the single N6 leg
 sudo ip netns exec mupdn  ping -c1 -W1 10.0.60.1 >/dev/null
 sudo ip netns exec mupupf ping -c1 -W1 10.0.12.1 >/dev/null
 sudo ip netns exec mupran ping -I ueTun0 -c 5 10.0.60.2
@@ -140,6 +147,38 @@ sudo ip netns exec mupupf ~/cradle-rs/target/debug/cradle stats --grpc unix:crad
 ```
 
 Expected: 0% loss, and `gtp_encap` / `gtp_decap` both counting.
+
+## iperf3 (issue #1947's single-NIC throughput check)
+
+Two things `ping -I ueTun0` silently papered over:
+
+- the UE netns has **no route to the DN via the TUN** (free-ran-ue only
+  assigns the address) — a TCP connect follows the default route out
+  mrVeth and dies. Add the route explicitly.
+- the DN veth's **TX checksum offload** leaves TCP checksums
+  uncomputed; cradle's GTP encap forwards the raw bytes and the UE TUN
+  validates (and drops) them. `setup-topo.sh` turns it off (`ethtool -K
+  mdn6 tx off`); hardware NICs don't have this problem.
+
+```sh
+# server on the N6 side, client on the UE TUN. The UE address comes from
+# the free5GC pool (10.60.0.0/16), so bind the client to it explicitly.
+UEADDR=$(sudo ip netns exec mupran ip -o -4 addr show ueTun0 | awk '{print $4}' | cut -d/ -f1)
+sudo ip netns exec mupran ip route add 10.0.60.0/24 dev ueTun0 src $UEADDR
+# GTP adds 36 bytes on N3; keep TCP MSS inside the 1500-byte links:
+sudo ip netns exec mupran ip link set ueTun0 mtu 1400
+
+sudo ip netns exec mupdn iperf3 -s -D -1
+sudo ip netns exec mupran iperf3 -c 10.0.60.2 -B $UEADDR -t 5 -f m       # uplink
+sudo ip netns exec mupdn iperf3 -s -D -1
+sudo ip netns exec mupran iperf3 -c 10.0.60.2 -B $UEADDR -t 5 -f m -R    # downlink
+sudo ip netns exec mupupf ~/cradle-rs/target/debug/cradle stats --grpc unix:cradle/grpc | grep gtp
+```
+
+Measured on the 2026-07-20 validation run (single box, debug builds,
+free-ran-ue's userspace gNB in the path): **uplink ~1.86 Gbit/s,
+downlink ~2.65 Gbit/s**, `gtp_encap`/`gtp_decap` in the hundreds of
+thousands.
 
 Known gap: if you restart *cradle* under a live zebra-rs, the tee does
 not replay its mirror (tonic reconnects transparently) — restart

--- a/bdd/mup-lab/setup-topo.sh
+++ b/bdd/mup-lab/setup-topo.sh
@@ -5,10 +5,10 @@
 #   |- mrHost 10.0.1.1/24  <-veth->  mupran:mrVeth 10.0.1.2/24   (N2 + N3 transit)
 #   |- muHost 10.0.12.1/24 <-veth->  mupupf:mun3  10.0.12.2/24   (N4 + N3)
 #  mupran: free-ran-ue gNB (N2/N3 on 10.0.1.2, UE link on 127.0.0.1) + UE (TUN)
-#  mupupf: zebra-rs + cradle; VRF mobile-dl(table 1): mudl 10.0.61.1/24
-#                             VRF mobile-ul(table 2): muul 10.0.60.1/24
-#  mupdn:  mdnd 10.0.61.2/24 (downlink ingress), mdnu 10.0.60.2/24 (ping target)
-#          route 10.60.0.0/16 via 10.0.61.1
+#  mupupf: zebra-rs + cradle; ONE VRF mobile (table 1) binds both st1+st2:
+#          mun6 10.0.60.1/24 — the single N6 leg (issue #1947)
+#  mupdn:  mdn6 10.0.60.2/24 (DL ingress AND UL egress / ping target)
+#          route 10.60.0.0/16 via 10.0.60.1
 set -ex
 
 ip netns add mupran
@@ -17,8 +17,7 @@ ip netns add mupdn
 
 ip link add mrHost type veth peer name mrVeth netns mupran
 ip link add muHost type veth peer name mun3 netns mupupf
-ip link add mudl netns mupupf type veth peer name mdnd netns mupdn
-ip link add muul netns mupupf type veth peer name mdnu netns mupdn
+ip link add mun6 netns mupupf type veth peer name mdn6 netns mupdn
 
 # host side
 ip addr add 10.0.1.1/24 dev mrHost
@@ -33,22 +32,25 @@ ip netns exec mupran ip addr add 10.0.1.2/24 dev mrVeth
 ip netns exec mupran ip link set mrVeth up
 ip netns exec mupran ip route add default via 10.0.1.1
 
-# upf ns: only mun3 gets a kernel address here; mudl/muul are addressed and
+# upf ns: only mun3 gets a kernel address here; mun6 is addressed and
 # VRF-enslaved by zebra-rs from upf.yaml. Kernel forwarding OFF: eBPF forwards.
 ip netns exec mupupf ip link set lo up
 ip netns exec mupupf ip addr add 10.0.12.2/24 dev mun3
 ip netns exec mupupf ip link set mun3 up
-ip netns exec mupupf ip link set mudl up
-ip netns exec mupupf ip link set muul up
+ip netns exec mupupf ip link set mun6 up
 ip netns exec mupupf ip route add default via 10.0.12.1
 ip netns exec mupupf sysctl -wq net.ipv4.ip_forward=0
 
-# dn ns
+# dn ns. TX checksum offload OFF: a veth leaves TCP checksums uncomputed
+# (CHECKSUM_PARTIAL), cradle's GTP encap forwards those raw bytes, and the
+# free-ran-ue UE injects them into ueTun0 where the kernel validates — and
+# drops — the bad inner checksum. ICMP is unaffected (ping checksums in
+# software), so a ping-clean lab still fails TCP without this. Hardware
+# NICs compute the checksum at egress, so this is a veth-lab artifact.
 ip netns exec mupdn ip link set lo up
-ip netns exec mupdn ip addr add 10.0.61.2/24 dev mdnd
-ip netns exec mupdn ip addr add 10.0.60.2/24 dev mdnu
-ip netns exec mupdn ip link set mdnd up
-ip netns exec mupdn ip link set mdnu up
-ip netns exec mupdn ip route add 10.60.0.0/16 via 10.0.61.1
+ip netns exec mupdn ip addr add 10.0.60.2/24 dev mdn6
+ip netns exec mupdn ip link set mdn6 up
+ip netns exec mupdn ethtool -K mdn6 tx off
+ip netns exec mupdn ip route add 10.60.0.0/16 via 10.0.60.1
 
 echo "topology up"

--- a/bdd/mup-lab/upf-ports.json
+++ b/bdd/mup-lab/upf-ports.json
@@ -1,7 +1,6 @@
 {
   "ports": [
     { "name": "mun3", "l3": true },
-    { "name": "mudl", "l3": true, "vrf": 1 },
-    { "name": "muul", "l3": true, "vrf": 2 }
+    { "name": "mun6", "l3": true, "vrf": 1 }
   ]
 }

--- a/bdd/mup-lab/upf.yaml
+++ b/bdd/mup-lab/upf.yaml
@@ -2,8 +2,7 @@ system:
   cradle:
     enabled: true
 vrf:
-- name: mobile-dl
-- name: mobile-ul
+- name: mobile
 interface:
 - if-name: lo
   ipv6:
@@ -11,12 +10,8 @@ interface:
 - if-name: mun3
   ipv4:
     address: 10.0.12.2/24
-- if-name: mudl
-  vrf: mobile-dl
-  ipv4:
-    address: 10.0.61.1/24
-- if-name: muul
-  vrf: mobile-ul
+- if-name: mun6
+  vrf: mobile
   ipv4:
     address: 10.0.60.1/24
 router:
@@ -31,7 +26,7 @@ router:
       as: 65000
       router-id: 1.1.1.1
     vrf:
-    - name: mobile-dl
+    - name: mobile
       rd: "65000:1"
       afi-safi:
         mup:
@@ -39,12 +34,6 @@ router:
           route:
           - type: st1
             network-instance: internet
-    - name: mobile-ul
-      rd: "65000:2"
-      afi-safi:
-        mup:
-          dataplane: gtp
-          route:
           - type: st2
             network-instance: internet
     mup-c:

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -246,7 +246,7 @@ on the eBPF data plane) — are scoped in
 
 ### One VRF, both directions — the single-N6 UPF
 
-zebra-rs also support single-N6 UPF: uplink and downlink are directions of the
+zebra-rs also supports a single-N6 UPF: uplink and downlink are directions of the
 same N6-facing interface, not two separate legs. Because a kernel interface
 belongs to exactly one VRF, the older one-direction-per-VRF model forced a
 bidirectional GTP UPF into two VRFs — and with them two N6 interfaces.

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -246,14 +246,10 @@ on the eBPF data plane) — are scoped in
 
 ### One VRF, both directions — the single-N6 UPF
 
-In a typical telco UPF deployment, **N6 is one network**: uplink and
-downlink are directions of the same N6-facing interface, not two
-separate legs. Because a kernel interface belongs to exactly one VRF,
-the older one-direction-per-VRF model forced a bidirectional GTP UPF
-into two VRFs — and with them two N6 interfaces (awkward in
-Kubernetes/Multus deployments, where each leg would consume a
-host-device/VF; issue
-[#1947](https://github.com/zebra-rs/zebra-rs/issues/1947)).
+zebra-rs also support single-N6 UPF: uplink and downlink are directions of the
+same N6-facing interface, not two separate legs. Because a kernel interface
+belongs to exactly one VRF, the older one-direction-per-VRF model forced a
+bidirectional GTP UPF into two VRFs — and with them two N6 interfaces.
 
 Since the `route` list holds one entry **per direction**, a single VRF
 binds both, and the whole UPF collapses onto one N6 interface. This is

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -151,8 +151,11 @@ vrf mobile-up {
   as the anchor UPF self-allocates its own core receive F-TEID, so an ST2
   still originates. A learned core F-TEID always wins over both.
 
-A VRF binds one ST direction to a PFCP Network Instance under `afi-safi
-mup route {st1|st2}`; the two read identically:
+A VRF binds an ST direction to a PFCP Network Instance under `afi-safi
+mup route {st1|st2}` — one entry per direction, and a VRF may carry
+**either or both** (see
+[the single-N6 UPF](#one-vrf-both-directions--the-single-n6-upf) below
+for the both-directions form). The two read identically:
 
 * **Downlink (Type-1 ST).** `afi-safi mup route st1 { network-instance
   <ni>; }` — the N6 VRF originates a **Type-1 ST** route carrying the UE
@@ -178,9 +181,11 @@ session's Network Instance. The export route-targets the ST route carries
 come from the top-level `vrf <name> mup route-target export` — the same
 `route-target` framework as `ipv4` / `ipv6`.
 
-A single PFCP session originates **every** matching ST route: if both an
-st1 VRF and an st2 VRF bind the same Network Instance, one session
-originates both the Type-1 and the Type-2 ST.
+A single PFCP session originates **every** matching ST route: each
+`route {st1|st2}` entry whose Network Instance matches contributes one —
+whether the two directions live on two VRFs (one entry each) or on one
+dual-direction VRF (both entries), one session originates both the
+Type-1 and the Type-2 ST.
 
 For example, an uplink VRF that also originates the Direct segment it
 resolves to:
@@ -238,6 +243,127 @@ whether the FIB install targets the kernel `seg6local` or the eBPF GTP maps.
 forwarding planes — Plan A (End.DT46, mainline kernel) and Plan B (real GTP-U
 on the eBPF data plane) — are scoped in
 [`docs/design/bgp-mup-dataplane-plan.md`](https://github.com/zebra-rs/zebra-rs/blob/main/docs/design/bgp-mup-dataplane-plan.md).
+
+### One VRF, both directions — the single-N6 UPF
+
+In a typical telco UPF deployment, **N6 is one network**: uplink and
+downlink are directions of the same N6-facing interface, not two
+separate legs. Because a kernel interface belongs to exactly one VRF,
+the older one-direction-per-VRF model forced a bidirectional GTP UPF
+into two VRFs — and with them two N6 interfaces (awkward in
+Kubernetes/Multus deployments, where each leg would consume a
+host-device/VF; issue
+[#1947](https://github.com/zebra-rs/zebra-rs/issues/1947)).
+
+Since the `route` list holds one entry **per direction**, a single VRF
+binds both, and the whole UPF collapses onto one N6 interface. This is
+the recommended shape. The complete, validated configuration (the
+`bdd/mup-lab` free5GC lab):
+
+```
+# The kernel VRF and its single N6 interface. N3 (mun3) stays in the
+# GLOBAL table — it carries PFCP/N4 and the outer GTP-U packets, which
+# are terminated by the UPF itself, never routed in the service VRF.
+vrf mobile {
+}
+interface mun3 {
+  ipv4 {
+    address 10.0.12.2/24;      # N3 + N4 (also the PFCP listen address)
+  }
+}
+interface mun6 {
+  vrf mobile;
+  ipv4 {
+    address 10.0.60.1/24;      # the ONE N6 leg, in the service VRF
+  }
+}
+
+router bgp {
+  global {
+    as 65000;
+    router-id 1.1.1.1;
+  }
+  vrf mobile {
+    rd 65000:1;
+    afi-safi mup {
+      dataplane gtp;           # real GTP-U on the eBPF data plane
+      route st1 {
+        network-instance internet;   # downlink: UE prefix -> GTP4.E encap
+      }
+      route st2 {
+        network-instance internet;   # uplink: CP-allocated F-TEID -> decap PDR
+      }
+    }
+  }
+  mup-c {
+    enabled true;
+    controller-address 2001:db8::1;
+    pfcp {
+      listen-address 10.0.12.2;
+    }
+  }
+}
+```
+
+Both `route` entries are independent list entries: each carries its own
+`network-instance` (here the same DNN, `internet`, so one PFCP session
+matches both) and, on the `st2` entry only, an optional `mup-ext-comm`.
+Deleting one entry removes only that direction — the sibling binding,
+and its originated routes, stay up. A handover (PFCP Modification) that
+moves the access tunnel re-exports the affected ST in place without
+ever withdrawing the other direction.
+
+One PFCP session then originates **both** Session-Transformed routes
+from the one VRF, under its single RD (the two NLRI types have disjoint
+keys, so sharing the RD is safe). From the live free5GC validation run:
+
+```
+# show bgp mup
+MUP VRFs:
+  mobile: rd=65000:1 encap/ST1 ni=internet decap/ST2 ni=internet dataplane=gtp route-targets=0
+
+   Network (MUP NLRI)                                   Next Hop
+ *> [ST1][65000:1][ue=10.60.0.1/32][teid=1][qfi=0][ep=10.0.1.2:src=10.0.12.2]
+       next-hop 2001:db8::1  weight 32768
+ *> [ST2][65000:1][ep=10.0.12.2][teid=2]
+       next-hop 2001:db8::1  weight 32768
+```
+
+With `dataplane gtp`, the VRF's one table now holds the whole
+subscriber datapath together:
+
+* the **uplink decap PDR** (`H.M.GTP4.D`, from the ST2's CP-allocated
+  `(endpoint, TEID)`) — a matching G-PDU arriving on N3 is stripped and
+  its inner packet looked up **in this table**;
+* the **downlink encap route** (the ST1's UE `/32` → `GTP4.E` toward
+  the gNB, egressing N3);
+* the **N6 connected route** (from `mun6`'s address).
+
+So an uplink packet decaps and leaves through the N6 connected route,
+and a downlink packet arriving on N6 hits the UE route and tunnels out
+N3 — one leg, both directions. (A side effect: UE↔UE traffic hairpins —
+a decapped uplink packet whose destination is another UE prefix
+re-encapsulates toward that UE's gNB in the same lookup.)
+
+Deployment notes — the Kubernetes/Multus question that motivated this
+shape:
+
+* The **N6 interface needs no XDP at all**: downlink ingress is handled
+  on the eBPF data plane's TC path, and uplink egress is a plain
+  redirect. A macvlan child on a shared host device is fine for N6.
+* The **N3 interface performs the XDP GTP decap**, so it should be a
+  device with **native XDP** (a host-device or SR-IOV VF). On drivers
+  without native XDP the data plane falls back to generic (SKB) mode,
+  where the decap stage is skipped for frames redirected by an upstream
+  TC hop — keep N3 off macvlan.
+
+The single-N6 datapath is regression-tested by the cradle
+`@cradle_mup_gtp_single_n6` BDD (round-trip ICMP plus an iperf3 TCP
+scenario) and was validated against real free5GC v4.0.1 +
+free-ran-ue (`bdd/mup-lab`): UE ping at 0% loss and iperf3 at
+~1.9 Gbit/s uplink / ~2.6 Gbit/s downlink on a single box with debug
+builds. The classic two-VRF split (one direction per VRF, two N6 legs)
+remains fully supported.
 
 ### Segment Discovery routes (`segment direct` / `segment interwork`)
 
@@ -312,9 +438,12 @@ When an SMF establishes a session, the controller:
    endpoint), and the Network Instance from the PFCP Session
    Establishment Request;
 2. correlates the Network Instance against the per-VRF `mup` config to
-   find the matching VRF(s) and the ST route type (`st1` / `st2`), and
-   dispatches the session to each matching VRF task (one session can map
-   to several VRFs — see the dual-ST note above);
+   find every matching `route {st1|st2}` binding, and dispatches the
+   session to each matching VRF task with its matched direction set —
+   one session can map to several VRFs, or to both directions of one
+   dual-direction VRF (see the dual-ST note and
+   [the single-N6 UPF](#one-vrf-both-directions--the-single-n6-upf)
+   above);
 3. each VRF task builds the **RD-free** Session-Transformed NLRI and exports
    it to the global instance, which stamps the VRF's RD, its export
    route-targets and the controller-address next hop **at the export
@@ -419,7 +548,7 @@ MUP Loc-RIB:
 ```
 # show bgp mup
 MUP VRFs:
-  mobile-up: rd=65000:100 encap/ST1 ni=access route-targets=1
+  mobile-up: rd=65000:100 encap/ST1 ni=access dataplane=end-dt46 route-targets=1
 
    Network (MUP NLRI)                                   Next Hop
  *> [ST1][65000:100][ue=192.0.2.5/32][teid=305419896][qfi=0][ep=10.0.0.1]


### PR DESCRIPTION
## Summary

Second slice of #1947, following the dual-direction VRF control plane (#2038):

- **`bdd/mup-lab` collapsed to a single N6 leg**: one VRF `mobile` (rd 65000:1) binds both `route st1` and `route st2`, one `mun6` interface replaces the `mobile-dl`/`mobile-ul` pair, and the README is rewritten for the new topology — including an iperf3 section with the measured numbers and two lab gotchas the run surfaced (the DN veth needs TX checksum offload off — GTP encap forwards the veth's uncomputed TCP checksums and the UE TUN validates-and-drops them, while ICMP is unaffected; and the UE netns needs an explicit DN route via ueTun0).
- **Book**: new "One VRF, both directions — the single-N6 UPF" section in ch-02-35 with the full validated configuration, live `show bgp mup` output (both STs under one RD), what the one VRF table holds with `dataplane gtp`, per-direction lifecycle, and the Kubernetes/Multus guidance (N6 needs no XDP so macvlan is fine; N3 does the XDP GTP decap so keep it on a native-XDP device). Stale one-direction-per-VRF statements reconciled; the `MUP VRFs:` show example gained its missing `dataplane=` field.

## Test plan

- Live-validated end-to-end on the collapsed topology against real free5GC v4.0.1 + free-ran-ue: SMF association, one PFCP session originating both STs under rd 65000:1, UE ping 5/5 at 0% loss, iperf3 uplink ~1.86 Gbit/s / downlink ~2.65 Gbit/s (single box, debug builds).
- The distilled regression (round-trip ICMP + iperf3 through one N6 port) lands in cradle-rs as `@cradle_mup_gtp_single_n6`; the two-leg `@cradle_mup_gtp_roundtrip` / `@cradle_mup_gtp_zebra` features still pass with the #2038 zebra binary.
- `mdbook build` clean; section anchors verified.

Part of #1947.

Generated with [Claude Code](https://claude.com/claude-code)