### PR TITLE
config: skip '#' comment lines in set/delete config documents

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -836,14 +836,7 @@ impl ConfigManager {
             ConfigFormat::Cli => (load_config_file(config.to_string()), Vec::new()),
             ConfigFormat::Json => json_read(entry, config),
             ConfigFormat::Yaml => yaml_read(entry, config),
-            ConfigFormat::SetDelete => (
-                config
-                    .lines()
-                    .filter(|l| !l.trim().is_empty())
-                    .map(str::to_string)
-                    .collect(),
-                Vec::new(),
-            ),
+            ConfigFormat::SetDelete => (set_delete_commands(config), Vec::new()),
         };
         if !doc_errors.is_empty() {
             return Err(doc_errors);
@@ -1528,6 +1521,23 @@ pub fn config_format_type(config_str: &str) -> ConfigFormat {
     }
 }
 
+/// Split a set/delete document into one command per line, dropping
+/// blank lines and `#` comments. The book documents comment-only
+/// files as loading an empty configuration, and the format sniffer
+/// already skips comments — without this filter a `#` line reached
+/// the parser and the whole document was rejected. Free function so
+/// the filtering is unit-testable without a full `ConfigManager`.
+fn set_delete_commands(config: &str) -> Vec<String> {
+    config
+        .lines()
+        .filter(|l| {
+            let line = l.trim();
+            !line.is_empty() && !line.starts_with('#')
+        })
+        .map(str::to_string)
+        .collect()
+}
+
 /// Extract the `system hostname` leaf value from a config tree, or
 /// `None` when the leaf is absent or empty. Free function so the
 /// lookup is unit-testable without a full `ConfigManager`.
@@ -1616,6 +1626,22 @@ mod config_format_tests {
             config_format_type("delete vrf N3\n"),
             ConfigFormat::SetDelete
         );
+    }
+
+    /// Regression: a `#` comment line in a set/delete document used to
+    /// be passed to the parser as a command, rejecting the whole
+    /// document (`vtyctl apply -f` echoed the comment as the error).
+    #[test]
+    fn set_delete_skips_comments() {
+        assert_eq!(
+            set_delete_commands("# base\nset router bgp global as 65000\n"),
+            vec!["set router bgp global as 65000"]
+        );
+        assert_eq!(
+            set_delete_commands("  # indented comment\n\n   \ndelete vrf N3\n"),
+            vec!["delete vrf N3"]
+        );
+        assert!(set_delete_commands("# only\n# comments\n").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A set/delete-format config file containing a `#` comment line fails to
apply as a whole via `vtyctl apply -f` — the error reply echoes the
comment line as the offending input. The book's command-line options
chapter says "an empty (or comment-only) file is loaded as an empty
configuration", implying comments are expected to be skipped. Found
while benchmarking zebra-rs 26.7.7 as a DUT with xk6-bgp.

## Steps to reproduce

```sh
cat > /tmp/a.conf <<'CONF'
# base
set router bgp global as 65000
CONF
vtyctl apply -f /tmp/a.conf
```

Expected: comment skipped, `set` line applied.
Actual: `error reply: # base` and nothing is applied (whole-file
rejection).

## Cause / fix

`config_to_commands()` only filtered blank lines in the `SetDelete`
branch, so the `#` line reached the parser as a command and the whole
document was rejected. The format sniffer (`config_format_type`)
already skips `#` lines, and the CLI brace format tolerates comments
via its tokenizer — `SetDelete` was the only format that did not. The
startup config load shares the same branch, so a set/delete startup
file with comments hit the same rejection.

The fix extracts the line filtering into `set_delete_commands()` and
drops `#`-prefixed lines (after trim) alongside blank ones, with a
regression test.
