### PR TITLE
ospf-packet: length-stamp guard + auth-gated raw_body copy

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -39,9 +39,11 @@ pub struct Ospfv2Packet {
     pub auth_trailer: Vec<u8>,
     /// On-wire bytes covered by the cryptographic-auth digest:
     /// header (with the Crypto auth overlay) + body, i.e.
-    /// `input[..pkt_len]`. Populated by `parse()` for every packet
-    /// so receive-side verification can re-hash exactly what the
-    /// sender hashed. Empty for packets built via `new()`.
+    /// `input[..pkt_len]`. Populated by `parse()` only for
+    /// cryptographic auth (type 2) — digest verification is its
+    /// sole consumer — so receive-side verification can re-hash
+    /// exactly what the sender hashed. Empty for Null/Simple auth
+    /// and for packets built via `new()`.
     #[nom(Ignore)]
     pub raw_body: Vec<u8>,
 }
@@ -85,7 +87,12 @@ impl Ospfv2Packet {
         // RFC 2328 §D.4: the cryptographic-auth digest follows the
         // body but is not counted in this length, so finalize the
         // length and checksum before appending the trailer.
-        let len = buf.len() as u16;
+        debug_assert!(
+            buf.len() <= u16::MAX as usize,
+            "OSPFv2 packet overflows its 16-bit length field: {} bytes",
+            buf.len()
+        );
+        let len = buf.len().min(u16::MAX as usize) as u16;
         BigEndian::write_u16(&mut buf[2..4], len);
 
         // Update checksum. RFC 2328 §D.4.1-D.4.3: the checksum is
@@ -2724,16 +2731,17 @@ pub fn parse(input: &[u8]) -> IResult<&[u8], Ospfv2Packet> {
         return Err(Err::Error(make_error(input, ErrorKind::Verify)));
     }
     let (_, mut packet) = Ospfv2Packet::parse_be(&input[..pkt_len])?;
-    // Cache the on-wire bytes covered by the cryptographic-auth
-    // digest — receive-side verification recomputes MD5 over this
-    // exact slice + the padded key (RFC 2328 §D.4.3).
-    packet.raw_body = input[..pkt_len].to_vec();
 
     // RFC 2328 §D.4: a cryptographic-auth (type 2) packet carries
     // the digest as a trailer after the OSPF body; `auth_data_len`
     // in the header overlay says how many bytes to consume.
     let mut consumed = pkt_len;
     if let Ospfv2Auth::Crypto(ref c) = packet.auth {
+        // Cache the on-wire bytes covered by the digest —
+        // receive-side verification recomputes MD5 over this exact
+        // slice + the padded key (RFC 2328 §D.4.3). Null/Simple
+        // auth never re-hashes, so skip the per-packet copy there.
+        packet.raw_body = input[..pkt_len].to_vec();
         let trailer_len = c.auth_data_len as usize;
         let trailer_end = pkt_len + trailer_len;
         if input.len() < trailer_end {
@@ -2767,6 +2775,25 @@ mod tests {
         )
     }
 
+    /// Emitting a >64 KB packet is a local packing bug — the debug
+    /// assert trips instead of the 16-bit length field silently
+    /// wrapping on the wire.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "OSPFv2 packet overflows its 16-bit length field")]
+    fn v2_packet_length_overflow_asserts() {
+        let packet = Ospfv2Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::new(0, 0, 0, 0),
+            Ospfv2Payload::Unknown(OspfUnknown {
+                typ: OspfType::Unknown(9),
+                payload: vec![0; (u16::MAX as usize) + 1],
+            }),
+        );
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+    }
+
     #[test]
     fn null_auth_roundtrip() {
         let pkt = null_hello_packet();
@@ -2778,6 +2805,8 @@ mod tests {
         assert_eq!(parsed.auth_type, 0);
         assert!(matches!(parsed.auth, Ospfv2Auth::Null(_)));
         assert!(parsed.auth_trailer.is_empty());
+        // Non-crypto packets skip the digest-covered byte cache.
+        assert!(parsed.raw_body.is_empty());
     }
 
     #[test]

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -113,10 +113,10 @@ pub fn ospfv3_verify_checksum(src: &Ipv6Addr, dst: &Ipv6Addr, packet_bytes: &[u8
 ///
 /// Slices to the header `len` before parsing so a RFC 7166 trailer
 /// (when present) is read out separately into `auth_trailer`
-/// rather than feeding into the payload parser. `raw_body` is
-/// populated with the exact slice covered by the cryptographic
-/// digest so receive-side verification can re-hash without
-/// re-emitting.
+/// rather than feeding into the payload parser. When a trailer is
+/// captured, `raw_body` is populated with the exact slice covered
+/// by the cryptographic digest so receive-side verification can
+/// re-hash without re-emitting; without a trailer it stays empty.
 pub fn parse_v3(input: &[u8]) -> IResult<&[u8], Ospfv3Packet> {
     use nom::Err;
     use nom::error::{ErrorKind, make_error};
@@ -130,7 +130,6 @@ pub fn parse_v3(input: &[u8]) -> IResult<&[u8], Ospfv3Packet> {
         return Err(Err::Error(make_error(input, ErrorKind::Verify)));
     }
     let (_, mut packet) = Ospfv3Packet::parse_be(&input[..pkt_len])?;
-    packet.raw_body = input[..pkt_len].to_vec();
 
     // RFC 7166: once the AT-bit is negotiated (advertised in the
     // Hello/DBD Options), EVERY subsequent OSPF packet carries the
@@ -151,6 +150,11 @@ pub fn parse_v3(input: &[u8]) -> IResult<&[u8], Ospfv3Packet> {
         // obviously-bogus lengths so we don't allocate gigabytes.
         if (16..=1024).contains(&trailer_len) && input.len() >= pkt_len + trailer_len {
             packet.auth_trailer = input[pkt_len..pkt_len + trailer_len].to_vec();
+            // Cache the digest-covered bytes only when a trailer is
+            // actually present — trailer verification is raw_body's
+            // sole consumer, so the unauthenticated hot path skips
+            // the per-packet copy.
+            packet.raw_body = input[..pkt_len].to_vec();
             consumed = pkt_len + trailer_len;
         }
     }
@@ -258,10 +262,11 @@ pub struct Ospfv3Packet {
     pub auth_trailer: Vec<u8>,
     /// On-wire bytes covered by the cryptographic-auth digest —
     /// the OSPF header (with AT-bit set) + body, i.e.
-    /// `input[..pkt_len]`. Populated by `parse_v3()` for every
-    /// packet so receive-side verification can re-hash exactly
-    /// what the sender hashed. Empty for packets built via
-    /// `new()`.
+    /// `input[..pkt_len]`. Populated by `parse_v3()` only when an
+    /// authentication trailer is present — trailer verification is
+    /// its sole consumer — so receive-side verification can re-hash
+    /// exactly what the sender hashed. Empty for unauthenticated
+    /// packets and for packets built via `new()`.
     #[nom(Ignore)]
     pub raw_body: Vec<u8>,
 }
@@ -321,7 +326,12 @@ impl Ospfv3Packet {
         buf.put_u8(self.instance_id);
         buf.put_u8(self.reserved);
         self.payload.emit(buf);
-        let len = buf.len() as u16;
+        debug_assert!(
+            buf.len() <= u16::MAX as usize,
+            "OSPFv3 packet overflows its 16-bit length field: {} bytes",
+            buf.len()
+        );
+        let len = buf.len().min(u16::MAX as usize) as u16;
         BigEndian::write_u16(&mut buf[2..4], len);
     }
 }
@@ -3395,6 +3405,67 @@ fn parse_ipv6_sid(input: &[u8]) -> IResult<&[u8], Ipv6Addr> {
 mod tests {
     use super::*;
     use crate::OspfType;
+
+    /// Emitting a >64 KB packet is a local packing bug — the debug
+    /// assert trips instead of the 16-bit length field silently
+    /// wrapping on the wire.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "OSPFv3 packet overflows its 16-bit length field")]
+    fn v3_packet_length_overflow_asserts() {
+        let packet = Ospfv3Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::new(0, 0, 0, 0),
+            0,
+            Ospfv3Payload::Unknown(vec![0; (u16::MAX as usize) + 1]),
+        );
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+    }
+
+    /// Without an RFC 7166 trailer, `raw_body` stays empty — the
+    /// digest-covered byte cache exists only for trailer
+    /// verification.
+    #[test]
+    fn v3_parse_without_trailer_skips_raw_body() {
+        let packet = Ospfv3Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::new(0, 0, 0, 0),
+            0,
+            Ospfv3Payload::Unknown(vec![0xAB; 8]),
+        );
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+        let (rest, parsed) = parse_v3(&buf).expect("parse must succeed");
+        assert!(rest.is_empty());
+        assert!(parsed.auth_trailer.is_empty());
+        assert!(parsed.raw_body.is_empty());
+    }
+
+    /// With a trailer appended, `raw_body` caches exactly the
+    /// digest-covered packet bytes alongside the captured trailer.
+    #[test]
+    fn v3_parse_with_trailer_populates_raw_body() {
+        let packet = Ospfv3Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::new(0, 0, 0, 0),
+            0,
+            Ospfv3Payload::Unknown(vec![0xAB; 8]),
+        );
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+        let pkt_len = buf.len();
+        let trailer = Ospfv3AuthTrailer {
+            auth_type: Ospfv3AuthTrailer::AUTH_TYPE_HMAC,
+            auth_data_len: Ospfv3AuthTrailer::PREFIX_LEN as u16,
+            ..Default::default()
+        };
+        trailer.emit(&mut buf);
+        let (rest, parsed) = parse_v3(&buf).expect("parse must succeed");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.auth_trailer, buf[pkt_len..].to_vec());
+        assert_eq!(parsed.raw_body, buf[..pkt_len].to_vec());
+    }
 
     #[test]
     fn srv6_locator_tlv_rejects_oversized_locator_length() {

--- a/docs/design/ospf-packet-code-review.md
+++ b/docs/design/ospf-packet-code-review.md
@@ -101,16 +101,18 @@ opportunistic ideas surfaced during the review, not review findings.
 
 **Additional notes (below the top 15)** — opportunistic; state re-checked
 2026-07-21:
-- ⏳ `parser.rs:88` / `v3.rs:324` emit: stamp packet length via
-  `try_into`/`checked` so a >64 KB serialization fails loudly instead of
-  silently wrapping the `u16`. Still open.
+- ✅ `parser.rs:88` / `v3.rs:324` emit length stamp — **fixed in
+  [#2042](https://github.com/zebra-rs/zebra-rs/pull/2042)**: `debug_assert` +
+  release-mode clamp instead of the silently wrapping `as u16`, with
+  `#[should_panic]` overflow tests for v2 and v3.
 - ⏳ Non-bijective `From<u8>` for link types (`parser.rs:747`, `v3.rs:695`;
   unknown → `Stub`/`PointToPoint`). Its `verify_checksum` consequence is gone
   since #1993 verifies received LSAs over `raw`; what remains is cosmetic.
-- ⏳/✅ Efficiency: `raw_body` eager copy on every received packet
-  (`parser.rs:2730`, `v3.rs:133`) still open; the `Ospfv3Lsa::update` double
-  serialization is **already fixed** — it now emits the body once and reuses
-  the buffer (also invalidating `raw` on mutation).
+- ✅ Efficiency — **fixed**: the `raw_body` eager copy is now gated on
+  digest verification actually consuming it (v2: Crypto auth; v3: trailer
+  present) in [#2042](https://github.com/zebra-rs/zebra-rs/pull/2042); the
+  `Ospfv3Lsa::update` double serialization had already been fixed (single
+  emit, buffer reused, `raw` invalidated on mutation).
 - ⏳ `Ospfv3IntraAreaPrefixTlv` (`v3.rs:1941`, RFC 8362 E-Intra-Area-Prefix
   TLV) — verify the 16-bit-metric + referenced-LSA-triple layout against
   RFC 8362 §3.9; internal round-trips pass (zebra-to-zebra) but it was never
@@ -456,21 +458,27 @@ real `parse_tlv` into finding 8's fix first).
 
 State re-checked against the tree on 2026-07-21; line numbers refreshed.
 
-- ⏳ **`parser.rs:88` / `v3.rs:324`** — packet length stamped via
-  `buf.len() as u16` truncates for a serialized packet > 64 KB. Latent: OSPF
-  packet length is a 16-bit field and the daemon keeps LSUs under MTU, but a
-  `checked`/`try_into` would fail loudly instead of silently wrapping.
+- ✅ **`parser.rs:88` / `v3.rs:324`** — packet length stamped via
+  `buf.len() as u16` truncated silently for a serialized packet > 64 KB.
+  **Fixed in [#2042](https://github.com/zebra-rs/zebra-rs/pull/2042)**:
+  `debug_assert` + release-mode clamp to `u16::MAX`, mirroring the
+  isis-packet sub-TLV overflow guard, with `#[should_panic]` emit tests for
+  both versions.
 - ⏳ **`parser.rs:747` / `v3.rs:695`** — `From<u8>` for link types maps every
   unknown value to `Stub` / `PointToPoint` (non-bijective). Originally listed
   as contributing to the finding-10 `verify_checksum` false-reject; since
   #1993 verifies received LSAs over `raw`, that consequence is gone and only
   the cosmetic non-bijectivity remains.
-- ⏳ **Efficiency** — `raw_body` is eagerly copied for every received packet
-  even when no cryptographic auth is configured (`parser.rs:2730`,
-  `v3.rs:133`); prefer zero-copy `Bytes::slice`. Still open. The second half
-  of this note — `Ospfv3Lsa::update` serializing the body twice — is ✅
-  **already fixed** (`v3.rs:2784` now emits the body once into `body_buf` and
-  reuses it for the checksum pass, and sets `raw = None` on mutation).
+- ✅ **Efficiency** — `raw_body` was eagerly copied for every received packet
+  even when no cryptographic auth is configured. **Fixed in
+  [#2042](https://github.com/zebra-rs/zebra-rs/pull/2042)**: the copy is
+  gated on digest verification being able to consume it — v2 populates it
+  only under `Ospfv2Auth::Crypto`, v3 only when an RFC 7166 trailer is
+  captured — so the unauthenticated receive hot path makes no copy at all.
+  The second half of this note — `Ospfv3Lsa::update` serializing the body
+  twice — was already fixed earlier (`v3.rs:2784` emits the body once into
+  `body_buf` and reuses it for the checksum pass, and sets `raw = None` on
+  mutation).
 - ⏳ **`v3.rs:1941`** — `Ospfv3IntraAreaPrefixTlv` (RFC 8362
   E-Intra-Area-Prefix TLV) uses a 16-bit metric and an embedded referenced-LSA
   triple. Worth double-checking the field layout against RFC 8362 §3.9;


### PR DESCRIPTION
## Summary

Closes items 1 and 3 of the post-review opportunistic notes in `docs/design/ospf-packet-code-review.md`.

**Item 1 — checked packet-length stamping** (`parser.rs`, `v3.rs` emit): the OSPF packet length was stamped with a silently wrapping `buf.len() as u16`. A >64 KB serialization now trips a `debug_assert` (mirroring the isis-packet sub-TLV overflow guard) and clamps to `u16::MAX` in release builds instead of wrapping to a bogus small length on the wire.

**Item 3 — `raw_body` eager copy** (`parse()` / `parse_v3()`): every received packet copied its digest-covered bytes into `raw_body`, but the only consumer is cryptographic-auth digest verification. The copy is now gated on that path actually existing — v2: `Ospfv2Auth::Crypto`; v3: an RFC 7166 trailer being captured — removing a per-packet `Vec` allocation+copy from the unauthenticated receive hot path. Field/API docs updated to match.

## Test plan

- New `#[should_panic]` overflow tests for the v2 and v3 emit guards (debug builds).
- New v3 tests: no trailer → `raw_body` empty; trailer appended → `raw_body` caches exactly `input[..pkt_len]` alongside the trailer.
- Existing v2 crypto-auth parse test still asserts `raw_body` holds the hashed bytes; null-auth test now also asserts it stays empty.
- Daemon HMAC-SHA1/256/512 round-trips (`packet_v3.rs`) go through `parse_v3` and lock the trailer-present path end-to-end.
- `cargo test --workspace --exclude bdd` and workspace clippy: green.

Generated with [Claude Code](https://claude.com/claude-code)