### PR TITLE
bdd: zero rp_filter in every created namespace

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -79,6 +79,25 @@ pub async fn create_netns(netns: &str) -> Result<()> {
 
     // Bring up loopback
     exec_in_netns(netns, "ip", &["link", "set", "lo", "up"]).await?;
+
+    // Neutralize host-inherited IPv4 reverse-path filtering. A new
+    // namespace inherits the host's conf/{all,default} IPv4 devconf
+    // (devconf_inherit_init_net=0), so a hardened host's rp_filter=2
+    // leaks in and silently drops test traffic whose source has no
+    // return route — e.g. multicast payloads at a PIM receiver host
+    // that only has its own subnet. Both all and default must be 0:
+    // the effective value is max(all, iface) and later-created
+    // interfaces start from default.
+    exec_in_netns(
+        netns,
+        "sysctl",
+        &[
+            "-qw",
+            "net.ipv4.conf.all.rp_filter=0",
+            "net.ipv4.conf.default.rp_filter=0",
+        ],
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Makes the BDD suite hermetic against host-level IPv4 reverse-path-filter hardening. `create_netns` now sets `net.ipv4.conf.{all,default}.rp_filter=0` inside every namespace it creates.

**Root cause chased down from a full-suite regression run:** all five IPv4 PIM data-plane features (`pim_asm`, `pim_assert`, `pim_bsr`, `pim_ssm`, `pim_vrf`) failed deterministically (c=8, c=3, and solo) on their final "payload reaches the receiver" assert, while every control-plane and kernel-MFC assert passed. Live tracing on a kept `pim_ssm` topology showed the kernel MFC forwarding all 90 sender packets with zero loss and tcpdump capturing them on the receiver's interface — but the joined UDP socket never saw them. The drop is the IPv4 multicast source RPF check: a new namespace inherits the host's `conf/{all,default}` IPv4 devconf (`devconf_inherit_init_net=0`), the host hardens `rp_filter=2`, and the receiver-host namespace has no route back to the source's subnet, so loose RPF fails and IP drops the payload before UDP. Setting `rp_filter=0` in the namespace made the payload flow instantly.

**Why it only bit now:** the host rebooted 2026-07-20 23:52, restoring `/etc/sysctl.d/10-network-security.conf`'s `rp_filter=2` that earlier lab work had relaxed at runtime — the same features were green the day before on the same code. IPv6 twins (`pim6_*`) passed throughout because `rp_filter` is IPv4-only, corroborating the mechanism.

## Test plan

- The five failing features pass 5/5 at `--concurrency=3` with the fix, host still at `rp_filter=2`.
- Full suite regression context: 241 features ran, 234 passed; besides the five PIM features, the only failures were `ospfv2_spf_interval` / `ospfv2_virtual_link`, both in the documented c=8 roaming load-flake set and both green on the c=3 re-run.

Generated with [Claude Code](https://claude.com/claude-code)