### PR TITLE
bgp: accept IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop

### DIFF
--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -539,11 +539,11 @@ pub fn parse_bgp_update_attribute(
                         nhop,
                         updates,
                     } => {
-                        // RFC 8950 IPv4-over-IPv6: the next-hop is an
-                        // IPv6 address that `BgpNexthop` has no variant
-                        // for, so leave `bgp_attr.nexthop` unset — the
-                        // consumer in `bgp/route.rs` reads `nhop` off
-                        // the mp_update variant directly.
+                        // IPv4 unicast over MP_REACH carries either a v4
+                        // next-hop (plain RFC 4760) or a v6 one (RFC 8950
+                        // IPv4-over-IPv6), so leave `bgp_attr.nexthop`
+                        // unset — the consumer in `bgp/route.rs` reads
+                        // `nhop` off the mp_update variant directly.
                         mp_update = Some(MpReachAttr::Ipv4 {
                             snpa,
                             nhop,
@@ -725,6 +725,45 @@ mod tests {
                 assert_eq!(parsed, updates);
             }
             other => panic!("Flowspec MP_REACH must surface as mp_update, got {other:?}"),
+        }
+    }
+
+    /// Regression: plain IPv4 unicast carried in MP_REACH (RFC 4760 §3,
+    /// AFI=1/SAFI=1 with a v4 next-hop) used to be dropped at ingestion —
+    /// the `bgp/route.rs` consumer only matched the RFC 8950 v6-next-hop
+    /// shape. The attribute layer must surface it as `mp_update` with the
+    /// v4 next-hop intact and `bgp_attr.nexthop` left for the consumer to
+    /// stamp from the variant.
+    #[test]
+    fn mp_reach_ipv4_unicast_v4_nexthop_surfaces_as_mp_update() {
+        use crate::MpReachAttr;
+        use std::net::IpAddr;
+
+        let mut block = vec![0x40, 0x01, 0x01, 0x00]; // ORIGIN = IGP
+        // MP_REACH: AFI=1, SAFI=1, nhop_len=4, 192.0.2.1, SNPA=0,
+        // NLRI 10.0.0.0/24.
+        let value = [0x00u8, 0x01, 0x01, 0x04, 192, 0, 2, 1, 0x00, 24, 10, 0, 0];
+        block.push(0x80); // optional
+        block.push(14); // type = MP_REACH_NLRI
+        block.push(value.len() as u8);
+        block.extend_from_slice(&value);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, mp_update, _mp_withdraw, treat_as_withdraw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("attrs must parse");
+        assert!(!treat_as_withdraw);
+        let bgp_attr = bgp_attr.expect("attrs parsed");
+        assert!(
+            bgp_attr.nexthop.is_none(),
+            "the consumer stamps the next-hop from the mp_update variant"
+        );
+        match mp_update {
+            Some(MpReachAttr::Ipv4 { nhop, updates, .. }) => {
+                assert_eq!(nhop, IpAddr::V4("192.0.2.1".parse().unwrap()));
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].prefix.to_string(), "10.0.0.0/24");
+            }
+            other => panic!("IPv4-unicast MP_REACH must surface as mp_update, got {other:?}"),
         }
     }
 

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -795,6 +795,48 @@ mod tests {
         }
     }
 
+    /// Issue repro: a full UPDATE that carries IPv4 unicast only inside
+    /// MP_REACH (RFC 4760 §3) with a v4 next-hop — no traditional NLRI —
+    /// alongside the usual ORIGIN / AS_PATH / NEXT_HOP attributes. It
+    /// must decode to an `MpReachAttr::Ipv4` mp_update carrying the v4
+    /// next-hop so ingestion can treat it like traditional NLRI.
+    #[test]
+    fn ipv4_unicast_mp_reach_with_v4_nexthop_full_packet_decodes() {
+        let mut attrs = vec![0x40u8, 0x01, 0x01, 0x00]; // ORIGIN = IGP
+        // AS_PATH: one AS_SEQUENCE of AS 65001 (4-octet, as4 session).
+        attrs.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfd, 0xe9]);
+        // A NEXT_HOP attribute rides along too (the issue's sender set
+        // both); MP_REACH's next-hop must win at ingestion.
+        attrs.extend_from_slice(&[0x40, 0x03, 0x04, 192, 0, 2, 254]);
+        // MP_REACH: AFI=1/SAFI=1, nhop_len=4, 192.0.2.1, SNPA=0,
+        // NLRI 10.0.0.0/24.
+        let value = [0x00u8, 0x01, 0x01, 0x04, 192, 0, 2, 1, 0x00, 24, 10, 0, 0];
+        attrs.push(0x80); // optional
+        attrs.push(14); // type = MP_REACH_NLRI
+        attrs.push(value.len() as u8);
+        attrs.extend_from_slice(&value);
+
+        let mut buf = vec![0xffu8; 16];
+        let total = BGP_HEADER_LEN as usize + 2 + 2 + attrs.len();
+        buf.extend_from_slice(&(total as u16).to_be_bytes());
+        buf.push(2); // type = UPDATE
+        buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn routes length
+        buf.extend_from_slice(&(attrs.len() as u16).to_be_bytes());
+        buf.extend_from_slice(&attrs);
+
+        let (_, parsed) = UpdatePacket::parse_packet(&buf, true, None).expect("must decode");
+        assert!(parsed.ipv4_update.is_empty(), "no traditional NLRI");
+        assert!(!parsed.treat_as_withdraw);
+        match parsed.mp_update {
+            Some(MpReachAttr::Ipv4 { nhop, updates, .. }) => {
+                assert_eq!(nhop, IpAddr::V4("192.0.2.1".parse().unwrap()));
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].prefix.to_string(), "10.0.0.0/24");
+            }
+            other => panic!("expected MpReachAttr::Ipv4 with v4 next-hop, got {other:?}"),
+        }
+    }
+
     #[test]
     fn many_prefixes_round_trip_into_one_packet() {
         let ll: Ipv6Addr = "fe80::abcd".parse().unwrap();

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9849,40 +9849,55 @@ pub fn route_from_peer(
                     snpa: _,
                     nhop,
                     updates,
-                } => {
+                } => match nhop {
+                    // Plain IPv4 unicast in MP_REACH (RFC 4760 §3): valid
+                    // whenever capability 1/1 was negotiated, and must be
+                    // treated identically to the traditional NLRI field.
+                    // The next-hop inside MP_REACH supersedes any NEXT_HOP
+                    // attribute; stamp it and go through the same batch
+                    // path as traditional NLRI.
+                    IpAddr::V4(nh4) => {
+                        let mut attr_v4 = bgp_attr.clone();
+                        attr_v4.nexthop = Some(BgpNexthop::Ipv4(nh4));
+                        route_ipv4_update_batch(
+                            peer_id, &updates, &attr_v4, bgp, peers, shards, false,
+                        );
+                    }
                     // RFC 8950 IPv4-over-IPv6: install the prefix into
                     // Loc-RIB and the FIB with the v6 next-hop from
                     // MP_REACH (the remote's link-local) as the gateway,
                     // pinned to the egress ifindex of the peer that
                     // delivered the UPDATE (a link-local needs its
-                    // interface). ENHE on a non-interface peer or with a
-                    // v4-shaped next-hop is unexpected — ENHE is currently
-                    // only negotiated by unnumbered peers; log and drop in
-                    // that case rather than fall back to a bogus install.
-                    let egress_ifindex = peers.get_by_idx(peer_id).and_then(|p| p.scope_id);
-                    if let (IpAddr::V6(nh6), Some(ifindex)) = (nhop, egress_ifindex) {
-                        for update in updates.iter() {
-                            route_ipv4_update(
+                    // interface). ENHE on a non-interface peer is
+                    // unexpected — ENHE is currently only negotiated by
+                    // unnumbered peers; log and drop in that case rather
+                    // than fall back to a bogus install.
+                    IpAddr::V6(nh6) => {
+                        let egress_ifindex = peers.get_by_idx(peer_id).and_then(|p| p.scope_id);
+                        if let Some(ifindex) = egress_ifindex {
+                            for update in updates.iter() {
+                                route_ipv4_update(
+                                    peer_id,
+                                    update,
+                                    None,
+                                    None,
+                                    bgp_attr,
+                                    None,
+                                    Some((nh6, ifindex)),
+                                    bgp,
+                                    peers,
+                                    false,
+                                );
+                            }
+                        } else {
+                            tracing::warn!(
+                                "RFC 8950: dropping IPv4 routes from peer {} via next-hop {} — need an egress ifindex",
                                 peer_id,
-                                update,
-                                None,
-                                None,
-                                bgp_attr,
-                                None,
-                                Some((nh6, ifindex)),
-                                bgp,
-                                peers,
-                                false,
+                                nhop,
                             );
                         }
-                    } else {
-                        tracing::warn!(
-                            "RFC 8950: dropping IPv4 routes from peer {} via next-hop {} — need a v6 next-hop and an egress ifindex",
-                            peer_id,
-                            nhop,
-                        );
                     }
-                }
+                },
                 MpReachAttr::Ipv6 {
                     snpa: _,
                     nhop,


### PR DESCRIPTION
## Summary

UPDATEs carrying IPv4 unicast reachability in an MP_REACH_NLRI
attribute (AFI=1/SAFI=1, RFC 4760) with a conventional IPv4 next-hop
are accepted without error but have no effect: no routes are
installed, nothing is re-advertised, and no NOTIFICATION or log line
is produced. The same prefixes sent in the traditional NLRI field work
normally. gobgpd, RustyBGP and FRR treat the two encodings
identically. Found while benchmarking zebra-rs 26.7.7 as a DUT with
xk6-bgp (its MP_REACH encoding mode produced zero routes).

## Steps to reproduce

1. Two eBGP passive neighbors (sender AS 65001, receiver AS 65002),
   IPv4 unicast, MP capability (1/1) negotiated on both sessions.
2. Sender announces prefixes encoded as MP_REACH_NLRI with the
   next-hop inside the attribute (RFC 4760 §3).

Expected: prefixes enter the Loc-RIB and are re-advertised.
Actual: sessions stay Established but the receiver gets zero prefixes.

## Cause / fix

Parsing is fine — the attribute decodes into `MpReachAttr::Ipv4`. The
`MpReachAttr::Ipv4` arm in `route_from_peer` only matched the RFC 8950
IPv4-over-IPv6 shape (v6 next-hop plus egress ifindex) and discarded
everything else with a warning.

Split the arm on the next-hop family: a v4 next-hop (RFC 4760 §3,
superseding any NEXT_HOP attribute) is stamped into the path
attributes and the prefixes go through `route_ipv4_update_batch`, the
same path traditional NLRI takes, so the two encodings behave
identically (inbound policy included). The RFC 8950 v6-next-hop path
is unchanged.

Regression tests added at the attribute-block level (attr.rs) and the
full-UPDATE level (update.rs) for the v4-next-hop MP_REACH form.
