### PR TITLE
vtyctl: fail loudly when a show command yields no output

### DIFF
--- a/vtyctl/src/show.rs
+++ b/vtyctl/src/show.rs
@@ -9,6 +9,47 @@ pub mod vty {
     tonic::include_proto!("vty");
 }
 
+/// Inspect the phase-1 ExecReply. Parse failures (and codes we don't
+/// know) must stop the client here: proceeding to the Show RPC with the
+/// unresolved paths used to end in a silent empty stream and exit 0.
+/// Returns the stderr message, or None when phase 2 may proceed.
+fn exec_reply_error(code: i32, lines: &str) -> Option<String> {
+    use vty::ExecCode;
+    match ExecCode::try_from(code) {
+        Ok(ExecCode::Success | ExecCode::Show | ExecCode::Redirect | ExecCode::RedirectShow) => {
+            None
+        }
+        Ok(ExecCode::Nomatch | ExecCode::Incomplete | ExecCode::Ambiguous) => {
+            let reason = lines.trim();
+            let reason = if reason.is_empty() {
+                match ExecCode::try_from(code) {
+                    Ok(ExecCode::Incomplete) => "Incomplete",
+                    Ok(ExecCode::Ambiguous) => "Ambiguous",
+                    _ => "NoMatch",
+                }
+            } else {
+                reason
+            };
+            Some(format!("command rejected: {reason}"))
+        }
+        Err(_) => Some(format!("unexpected exec code {code} from daemon")),
+    }
+}
+
+/// When the Show stream yields nothing, fmap-backed commands (help,
+/// candidate/running-config on older daemons) already carry their full
+/// output in the phase-1 `lines` — fall back to it instead of erroring.
+fn exec_show_fallback(code: i32, lines: &str) -> Option<&str> {
+    (code == vty::ExecCode::Show as i32 && !lines.is_empty()).then_some(lines)
+}
+
+fn print_show_output(text: &str, last_ended_with_newline: &mut bool) {
+    print!("{text}");
+    if !text.is_empty() {
+        *last_ended_with_newline = text.ends_with('\n');
+    }
+}
+
 pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
     if command.is_empty() {
         eprintln!("vtyctl show: command argument is required");
@@ -40,6 +81,11 @@ pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
     let exec_reply = exec_client.do_exec(Request::new(exec_request)).await?;
     let reply = exec_reply.into_inner();
 
+    if let Some(msg) = exec_reply_error(reply.code, &reply.lines) {
+        eprintln!("vtyctl show: {msg}");
+        exit(1);
+    }
+
     // Phase 2: Use the paths from exec_reply in ShowRequest
     let mut show_client = ShowClient::new(channel);
 
@@ -53,11 +99,36 @@ pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
 
     let mut stream = response.into_inner();
 
+    let mut got_any = false;
     let mut last_ended_with_newline = true;
-    while let Some(reply) = stream.message().await? {
-        print!("{}", reply.str);
-        if !reply.str.is_empty() {
-            last_ended_with_newline = reply.str.ends_with('\n');
+    loop {
+        match stream.message().await {
+            Ok(Some(reply)) => {
+                got_any = true;
+                print_show_output(&reply.str, &mut last_ended_with_newline);
+            }
+            Ok(None) => break,
+            // The daemon reports an unanswered command (or another
+            // stream failure). Never turn that into empty-and-success.
+            Err(status) => {
+                if !got_any && let Some(lines) = exec_show_fallback(reply.code, &reply.lines) {
+                    got_any = true;
+                    print_show_output(lines, &mut last_ended_with_newline);
+                    break;
+                }
+                eprintln!("vtyctl show: {}", status.message());
+                exit(1);
+            }
+        }
+    }
+    if !got_any {
+        if let Some(lines) = exec_show_fallback(reply.code, &reply.lines) {
+            print_show_output(lines, &mut last_ended_with_newline);
+        } else {
+            eprintln!(
+                "vtyctl show: no output produced for '{command}' (command not handled by any daemon)"
+            );
+            exit(1);
         }
     }
     if !last_ended_with_newline {
@@ -65,4 +136,50 @@ pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::vty::ExecCode;
+    use super::*;
+
+    #[test]
+    fn exec_reply_error_rejects_parse_failures() {
+        let msg = exec_reply_error(ExecCode::Nomatch as i32, "NoMatch\n").unwrap();
+        assert_eq!(msg, "command rejected: NoMatch");
+        let msg = exec_reply_error(ExecCode::Incomplete as i32, "").unwrap();
+        assert_eq!(msg, "command rejected: Incomplete");
+        let msg = exec_reply_error(ExecCode::Ambiguous as i32, "Ambiguous\n").unwrap();
+        assert_eq!(msg, "command rejected: Ambiguous");
+    }
+
+    #[test]
+    fn exec_reply_error_rejects_unknown_codes() {
+        assert!(exec_reply_error(42, "").unwrap().contains("42"));
+    }
+
+    #[test]
+    fn exec_reply_error_passes_showable_codes() {
+        for code in [
+            ExecCode::Success,
+            ExecCode::Show,
+            ExecCode::Redirect,
+            ExecCode::RedirectShow,
+        ] {
+            assert_eq!(exec_reply_error(code as i32, ""), None);
+        }
+    }
+
+    #[test]
+    fn exec_show_fallback_only_for_show_with_output() {
+        assert_eq!(
+            exec_show_fallback(ExecCode::Show as i32, "config\n"),
+            Some("config\n")
+        );
+        assert_eq!(exec_show_fallback(ExecCode::Show as i32, ""), None);
+        assert_eq!(
+            exec_show_fallback(ExecCode::RedirectShow as i32, "output\n"),
+            None
+        );
+    }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1159,6 +1159,36 @@ impl ConfigManager {
                     reply_static_show(req, text, json);
                     return;
                 }
+                // `show candidate-config [formal|json|yaml]` — same story as
+                // running-config above: the candidate store lives here, and
+                // without this arm the request would fall through to the rib
+                // task, which has no handler for it.
+                if req.paths.iter().any(|p| p.name == "candidate-config") {
+                    let candidate = || self.store.candidate.borrow();
+                    let render_json = || {
+                        let mut compact = String::new();
+                        candidate().json(&mut compact);
+                        super::commands::prettify_json(compact)
+                    };
+                    let text = if req.paths.iter().any(|p| p.name == "formal") {
+                        let mut out = String::new();
+                        candidate().list(&mut out);
+                        out
+                    } else if req.paths.iter().any(|p| p.name == "yaml") {
+                        let mut out = String::new();
+                        candidate().yaml(&mut out);
+                        out
+                    } else if req.paths.iter().any(|p| p.name == "json") {
+                        render_json()
+                    } else {
+                        let mut out = String::new();
+                        candidate().format(&mut out);
+                        out
+                    };
+                    let json = render_json();
+                    reply_static_show(req, text, json);
+                    return;
+                }
                 // Generic per-VRF instance redirect: `show <proto> vrf
                 // <name> …` is rewritten to `show <proto> …` and routed
                 // to the instance task's show channel when that instance

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -448,7 +448,7 @@ impl Show for ShowService {
         };
         self.tx.send(Message::DisplayTx(query)).await.unwrap();
         let serve = rx.await.unwrap();
-        let (bus_tx, mut bus_rx) = mpsc::channel::<String>(4);
+        let (bus_tx, bus_rx) = mpsc::channel::<String>(4);
         // The manager may rewrite the command (e.g. stripping a
         // `vrf <name>` selector to redirect into an instance task); use
         // its rewritten paths when present.
@@ -460,17 +460,36 @@ impl Show for ShowService {
         serve.tx.send(req).unwrap();
 
         let (tx, rx) = mpsc::channel(4);
-        tokio::spawn(async move {
-            while let Some(item) = bus_rx.recv().await {
-                match tx.send(Ok(ShowReply { str: item })).await {
-                    Ok(_) => {}
-                    Err(_) => {
-                        break;
-                    }
-                }
-            }
-        });
+        tokio::spawn(forward_show_stream(bus_rx, tx, request.line.clone()));
         Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+/// Forward protocol-task show output to the gRPC response stream.
+///
+/// Show handlers that answer always send at least one item (an empty
+/// string for legitimately-empty output), so a bus that closes without
+/// a single item means no handler picked the command up. Surface that
+/// as a NotFound status instead of a clean empty stream, which clients
+/// would otherwise render as empty-output-and-success.
+async fn forward_show_stream(
+    mut bus_rx: mpsc::Receiver<String>,
+    tx: mpsc::Sender<Result<ShowReply, tonic::Status>>,
+    line: String,
+) {
+    let mut sent_any = false;
+    while let Some(item) = bus_rx.recv().await {
+        sent_any = true;
+        if tx.send(Ok(ShowReply { str: item })).await.is_err() {
+            return;
+        }
+    }
+    if !sent_any {
+        let _ = tx
+            .send(Err(tonic::Status::not_found(format!(
+                "no show handler produced output for '{line}'"
+            ))))
+            .await;
     }
 }
 
@@ -814,4 +833,38 @@ fn bind_abstract_uds(name: &str) -> anyhow::Result<tokio_stream::wrappers::UnixL
     let listener = UnixListener::from_std(std_listener)
         .map_err(|e| anyhow::anyhow!("register abstract VTY socket '@{name}' with tokio: {e}"))?;
     Ok(UnixListenerStream::new(listener))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn forward_show_stream_passes_items_through() {
+        let (bus_tx, bus_rx) = mpsc::channel::<String>(4);
+        let (tx, mut rx) = mpsc::channel(4);
+        bus_tx.send("line one\n".to_string()).await.unwrap();
+        bus_tx.send(String::new()).await.unwrap();
+        drop(bus_tx);
+
+        forward_show_stream(bus_rx, tx, "show version".to_string()).await;
+
+        assert_eq!(rx.recv().await.unwrap().unwrap().str, "line one\n");
+        assert_eq!(rx.recv().await.unwrap().unwrap().str, "");
+        assert!(rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn forward_show_stream_reports_unanswered_command() {
+        let (bus_tx, bus_rx) = mpsc::channel::<String>(4);
+        let (tx, mut rx) = mpsc::channel(4);
+        drop(bus_tx);
+
+        forward_show_stream(bus_rx, tx, "show nosuch".to_string()).await;
+
+        let status = rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+        assert!(status.message().contains("show nosuch"));
+        assert!(rx.recv().await.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

`vtyctl show ...` can print nothing and exit 0 when nothing on the
daemon side actually answered the command. An operator cannot
distinguish this from a legitimately empty running config; while
debugging (zebra-rs 26.7.7 as a DUT with xk6-bgp) this masked whether
configuration had been committed at all, and we had to fall back to
tcpdump to observe daemon state.

## Cause / fix

Two paths lead to the silent-empty result:

1. The client ignores the phase-1 `ExecReply` code, so parse failures
   (NoMatch/Incomplete/Ambiguous) proceed to the Show RPC with
   unresolved paths.
2. Every protocol task's `process_show_msg` silently drops a
   `DisplayRequest` whose path has no registered callback, closing the
   stream with zero messages.

Handlers that do answer always send at least one item (an empty string
for genuinely empty output), so a zero-item stream reliably means "no
handler answered". Make that visible end to end:

- serve: when the show bus closes without a single item, emit a
  NotFound status instead of a clean empty stream, so every client
  (vtyctl, MCP) sees a hard error rather than empty-and-success.
- vtyctl show: reject phase-1 parse failures with a stderr message and
  exit 1; on an unanswered stream, fall back to the phase-1 Show
  output when present (help, config shows against older daemons),
  otherwise report the error and exit 1.
- manager: answer `show candidate-config [formal|json|yaml]` directly
  like running-config; it previously fell through to the rib task,
  which has no handler for it, and was dropped silently.

Unit tests cover the stream forwarder and the new client-side checks.
Smoke-tested against a live daemon: `show version` / `show ip route`
unchanged, `show nosuchcmd` now reports the rejection and exits 1,
`show running-config` on an empty config still prints empty + exit 0
(legitimately empty).
