### PR TITLE
bdd: cover dynamic-neighbors listen-range, incl. group policy inheritance

### DIFF
--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
@@ -1,0 +1,38 @@
+# z1 — DUT whose listen-range group SENDERS binds an inbound DENY-ALL
+# route policy. A peer materialized from 192.168.0.0/24 must inherit
+# it: the session establishes, z1 still advertises 10.0.1.1/32, but
+# nothing the client sends may enter z1's Loc-RIB.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      policy:
+        in: DENY-ALL
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
@@ -1,0 +1,37 @@
+# Identical to z1-deny.yaml except SENDERS carries no policy binding.
+# `vtyctl apply -f` is a declarative whole-config replace, so the file
+# restates the full config — the commit diff against z1-deny.yaml is
+# exactly the deletion of the group's `policy in` leaf. The DENY-ALL
+# definition itself stays: an unreferenced policy filters nothing.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client. Ordinary static eBGP session toward the DUT;
+# originates 10.0.2.2/32, the route the DUT's inherited DENY-ALL must
+# stop (and the policy-less rebind must readmit).
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -1,0 +1,37 @@
+# z1 — the DUT. No static neighbors: every session must arrive via the
+# dynamic-neighbors listen-range 192.168.0.0/24, which materializes a
+# passive peer inheriting SENDERS (remote-as 65002, ipv4 enabled).
+# z3 connects from 192.168.1.3 — outside the range — and must be
+# refused at accept time. Originates 10.0.1.1/32 so the dynamic
+# session carries a route in the DUT->client direction too.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-limit: 10
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
+# of view this is an ordinary static eBGP session toward the DUT; only
+# z1's side is dynamic. Originates 10.0.2.2/32.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
@@ -1,0 +1,29 @@
+# z3 — out-of-range client (192.168.1.3, matched by NO listen-range).
+# Identical client shape to z2; the only difference is the source
+# subnet, so any session it ever establishes means the listen-range
+# authorization leaked. Originates 10.0.3.3/32 — that prefix showing
+# up on z1 is the failure signal.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.3.3/32

--- a/bdd/tests/features/bgp_dynamic_nbr_policy.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_policy.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_dynamic_nbr_policy
+Feature: A dynamic (listen-range) peer inherits its neighbor-group's route policy
+  As a network operator
+  I want the `policy` bound on a listen-range's neighbor-group
+  So every peer materialized from that range is filtered like a static member.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  z1 (the DUT) has no static neighbors; z2 arrives via the listen-range
+  and inherits SENDERS. With SENDERS carrying `policy in DENY-ALL` the
+  session must still establish, z1's own route must still flow out —
+  but z2's route must be denied on ingress. Rebinding the group without
+  the policy and re-materializing the peer readmits the route, proving
+  the policy is resolved from the group at accept time, not baked in.
+
+  Config files:
+  - z1-deny.yaml: DUT — SENDERS has `policy in DENY-ALL`, originates 10.0.1.1/32
+  - z1-open.yaml: identical but the group carries no policy binding
+  - z2.yaml:      client, static neighbor to .0.1, originates 10.0.2.2/32
+
+  Scenario: Establish with an inbound deny-all policy inherited from the group
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-deny.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    # Policy filters routes, not the session: outbound is untouched...
+    And BGP route in "z2" has "10.0.1.1/32"
+    # ...while the inherited inbound DENY-ALL drops the client's route.
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Unbinding the group policy readmits the route on re-materialization
+    Given the test topology exists
+    When I apply config "z1-open.yaml" to namespace "z1"
+    And I wait 10 seconds
+    # Hard-reset from the client: z1's dynamic peer is torn down and the
+    # reconnect materializes a fresh peer that resolves the group's
+    # CURRENT (policy-less) state through the same accept-time ritual.
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -1,0 +1,97 @@
+@serial
+@bgp_dynamic_neighbors
+Feature: BGP dynamic neighbors materialize passive peers from a listen-range
+  As a network operator
+  I want `router bgp dynamic-neighbors listen-range <prefix> neighbor-group <G>`
+  So sessions from an authorized source prefix establish without per-peer config.
+
+  Test Topology (z1 is the DUT; only z2's subnet is range-authorized):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │ i2────────────i1 │   z3    │
+   │ AS65002 │   (in range)     │ AS65001 │  (out of range)  │ AS65002 │
+   │ .0.2    │                  │.0.1 .1.1│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 has NO static neighbors. Its listen-range 192.168.0.0/24 binds
+  neighbor-group SENDERS (remote-as 65002, ipv4 enabled), so z2's inbound
+  connection materializes a passive peer that must reach Established and
+  exchange routes in both directions (regression pin for PR #2044, where
+  the materialized peer was left in Idle and every connection was
+  dropped). z3 runs the same client config from 192.168.1.3 — outside
+  the range — and must be refused at accept time with no peer state.
+
+  Config files:
+  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+
+  Scenario: Setup topology and establish the dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I connect namespace "z1" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And show command "show bgp summary" in namespace "z1" should contain "192.168.0.2"
+
+  Scenario: Routes flow in both directions over the dynamic session
+    Given the test topology exists
+    Then BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A source outside every listen-range is refused without peer state
+    Given the test topology exists
+    # z3's TCP connect is accepted by the kernel, but the LPM miss makes
+    # z1 drop the stream before any OPEN exchange — z3 never leaves the
+    # connect/retry cycle, and z1 materializes nothing for 192.168.1.3.
+    Then BGP session in "z3" to "192.168.1.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.1.3"
+    And BGP route in "z1" does not have "10.0.3.3/32"
+
+  Scenario: The client can hard-reset and re-establish the dynamic session
+    Given the test topology exists
+    # Pre-#2044 every reconnect was dropped: the very first inbound
+    # stream materialized the peer, then died in Idle forever.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A DUT-side clear frees the peer and the next connect re-materializes it
+    Given the test topology exists
+    # Clearing on z1 ends the session of a Dynamic-origin peer, which
+    # the instance GCs (freeing its listen-limit slot); z2's redial then
+    # re-materializes a fresh peer through the same accept path.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

BDD coverage for `dynamic-neighbors` — the machinery PR #2044 just made functional had no feature coverage at all, which is how the materialize-then-drop bug shipped unnoticed.

**`bgp_dynamic_neighbors.feature`** (DUT + in-range client + out-of-range client):
- In-range client materializes a passive peer, reaches Established, and exchanges routes in both directions — the #2044 regression pin.
- Out-of-range client (same AS, same client config, different subnet) is refused at accept time: never Established, no peer state on the DUT, its route never imported.
- Hard reset from the client side re-establishes (pre-#2044 every reconnect died in Idle).
- Hard reset from the DUT side frees the dynamic peer (session-end GC) and the client's redial re-materializes it through the accept path.

**`bgp_dynamic_nbr_policy.feature`** (DUT + client):
- The listen-range group carries `policy in DENY-ALL`: the materialized peer inherits it — session establishes, the DUT's own route still flows out, the client's route is denied on ingress.
- Rebinding the group without the policy and re-materializing readmits the route, proving the group is resolved at accept time, not baked into the peer.

## Testing

CI does not run BDD; both features ran green locally against a freshly installed `main` binary (contains #2044), with 0 skipped steps, and tear down to a clean environment. `cargo test -p bdd --lib` (tag-guard prefix invariant) passes — the second feature is tagged `bgp_dynamic_nbr_policy` specifically so it does not share a prefix with `bgp_dynamic_neighbors`.

Follow-up (separate PRs): dynamic neighbors with TCP-MD5 and TCP-AO need daemon-side work before their BDD features can exist — listener keys are currently installed per peer address only, so an authenticated SYN from a not-yet-materialized peer is dropped by the kernel before accept. Plan in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)