### PR TITLE
bdd: cover IPv4 unicast carried in MP_REACH_NLRI (RFC 4760 §3)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -15,6 +15,13 @@ rr:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_basic_rr"
 
+# IPv4 unicast announced inside MP_REACH_NLRI (RFC 4760 §3) by a scripted
+# speaker (tests/scripts/bgp_mp_reach_send.py) — zebra-rs/FRR/GoBGP all
+# emit traditional NLRI, so only the script can produce this encoding.
+bgp_mp_reach_ipv4:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mp_reach_ipv4"
+
 bgp_srv6_redistribute:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_srv6_redistribute"
@@ -469,4 +476,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover bgp_mp_reach_ipv4 generate open docs FORCE

--- a/bdd/docs/bgp_mp_reach_ipv4.md
+++ b/bdd/docs/bgp_mp_reach_ipv4.md
@@ -1,0 +1,48 @@
+# BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
+
+## Overview
+
+As a network operator
+I want IPv4 unicast reachability encoded in an MP_REACH_NLRI attribute
+(RFC 4760 §3, AFI=1/SAFI=1 with the next-hop inside the attribute) to be
+treated identically to the traditional NLRI field, because RFC 4760
+senders such as xk6-bgp encode it that way while zebra-rs, FRR and GoBGP
+emit traditional NLRI — so only a scripted speaker can produce this shape.
+Regression for the issue fixed by PR #2045: such UPDATEs were accepted
+without error but had no effect — no Loc-RIB entry, no FIB install, no
+re-advertisement, no log line. The scripted speaker also sends a decoy
+NEXT_HOP attribute; per RFC 4760 the next-hop inside MP_REACH supersedes
+it, which the next-hop assertions pin down.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────────────────────┐
+  │                          br0                            │
+  └───────┬────────────────────┬────────────────────┬───────┘
+     ┌────┴────┐          ┌────┴────┐          ┌────┴────┐
+     │   h1    │          │   z1    │          │   z2    │
+     │ scripted│          │  (DUT)  │          │ zebra-rs│
+     │ RFC4760 │─eBGP────▶│ AS65030 │◀────eBGP─│ AS65032 │
+     │ AS65031 │          │192.168. │          │192.168. │
+     │ .30.2/24│          │ 30.1/24 │          │ 30.3/24 │
+     └─────────┘          └─────────┘          └─────────┘
+```
+
+## Notes
+
+h1 runs tests/scripts/bgp_mp_reach_send.py: it announces 10.99.0.0/24
+inside MP_REACH_NLRI (next-hop 192.168.30.2, decoy NEXT_HOP attribute
+192.168.30.99), holds the session with keepalives, and withdraws the
+prefix through the traditional withdrawn-routes field when the trigger
+file /tmp/bgp_mp_reach_ipv4_withdraw appears.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish sessions | |
+| MP_REACH-encoded IPv4 unicast enters the Loc-RIB with the MP_REACH next-hop | |
+| The MP_REACH-learned route is re-advertised to a traditional peer | |
+| A traditional withdraw removes the MP_REACH-announced route | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_mp_reach_ipv4/z1.yaml
+++ b/bdd/tests/configs/bgp_mp_reach_ipv4/z1.yaml
@@ -1,0 +1,24 @@
+router:
+  bgp:
+    global:
+      as: 65030
+      router-id: 192.168.30.1
+    neighbor:
+    # The scripted RFC 4760 speaker on h1 never listens on 179, so
+    # dialing it just cycles this peer Idle -> Connect -> Idle, and Idle
+    # refuses the inbound connection. Passive parks the peer in Active
+    # listening so the script's connect is always accepted.
+    - remote-address: 192.168.30.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65031
+      transport:
+        passive-mode: true
+    - remote-address: 192.168.30.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65032

--- a/bdd/tests/configs/bgp_mp_reach_ipv4/z2.yaml
+++ b/bdd/tests/configs/bgp_mp_reach_ipv4/z2.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65032
+      router-id: 192.168.30.3
+    neighbor:
+    - remote-address: 192.168.30.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65030

--- a/bdd/tests/features/bgp_mp_reach_ipv4.feature
+++ b/bdd/tests/features/bgp_mp_reach_ipv4.feature
@@ -1,0 +1,80 @@
+@serial
+@bgp_mp_reach_ipv4
+Feature: BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
+  As a network operator
+  I want IPv4 unicast reachability encoded in an MP_REACH_NLRI attribute
+  (RFC 4760 §3, AFI=1/SAFI=1 with the next-hop inside the attribute) to be
+  treated identically to the traditional NLRI field, because RFC 4760
+  senders such as xk6-bgp encode it that way while zebra-rs, FRR and GoBGP
+  emit traditional NLRI — so only a scripted speaker can produce this shape.
+
+  Regression for the issue fixed by PR #2045: such UPDATEs were accepted
+  without error but had no effect — no Loc-RIB entry, no FIB install, no
+  re-advertisement, no log line. The scripted speaker also sends a decoy
+  NEXT_HOP attribute; per RFC 4760 the next-hop inside MP_REACH supersedes
+  it, which the next-hop assertions pin down.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────────────────────┐
+  │                          br0                            │
+  └───────┬────────────────────┬────────────────────┬───────┘
+     ┌────┴────┐          ┌────┴────┐          ┌────┴────┐
+     │   h1    │          │   z1    │          │   z2    │
+     │ scripted│          │  (DUT)  │          │ zebra-rs│
+     │ RFC4760 │─eBGP────▶│ AS65030 │◀────eBGP─│ AS65032 │
+     │ AS65031 │          │192.168. │          │192.168. │
+     │ .30.2/24│          │ 30.1/24 │          │ 30.3/24 │
+     └─────────┘          └─────────┘          └─────────┘
+  ```
+
+  h1 runs tests/scripts/bgp_mp_reach_send.py: it announces 10.99.0.0/24
+  inside MP_REACH_NLRI (next-hop 192.168.30.2, decoy NEXT_HOP attribute
+  192.168.30.99), holds the session with keepalives, and withdraws the
+  prefix through the traditional withdrawn-routes field when the trigger
+  file /tmp/bgp_mp_reach_ipv4_withdraw appears.
+
+  Scenario: Setup topology and establish sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.30.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.30.3/24" on bridge "br0"
+    And I create namespace "h1" with IP "192.168.30.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    Then BGP session in "z1" to "192.168.30.3" should eventually be "Established"
+    When I spawn "timeout 600 python3 tests/scripts/bgp_mp_reach_send.py 192.168.30.1 65031 192.168.30.2 10.99.0.0/24 192.168.30.2 192.168.30.99 /tmp/bgp_mp_reach_ipv4_withdraw" in namespace "h1"
+    Then BGP session in "z1" to "192.168.30.2" should eventually be "Established"
+
+  Scenario: MP_REACH-encoded IPv4 unicast enters the Loc-RIB with the MP_REACH next-hop
+    Given the test topology exists
+    Then show command "show bgp" in namespace "z1" should eventually contain "10.99.0.0/24"
+    And BGP route in "z1" has "10.99.0.0/24" with "next_hop" value "192.168.30.2"
+    And BGP route in "z1" has "10.99.0.0/24" with "as_path" value "65031"
+    And kernel route "10.99.0.0/24" in namespace "z1" should eventually contain "192.168.30.2"
+
+  Scenario: The MP_REACH-learned route is re-advertised to a traditional peer
+    Given the test topology exists
+    Then show command "show bgp" in namespace "z2" should eventually contain "10.99.0.0/24"
+    And BGP route in "z2" has "10.99.0.0/24" with "next_hop" value "192.168.30.1"
+    And BGP route in "z2" has "10.99.0.0/24" with "as_path" value "65030 65031"
+
+  Scenario: A traditional withdraw removes the MP_REACH-announced route
+    Given the test topology exists
+    When I execute "touch /tmp/bgp_mp_reach_ipv4_withdraw" in namespace "h1"
+    Then show command "show bgp" in namespace "z1" should eventually not contain "10.99.0.0/24"
+    And show command "show bgp" in namespace "z2" should eventually not contain "10.99.0.0/24"
+    And kernel route "10.99.0.0/24" in namespace "z1" should eventually be gone
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I execute "rm -f /tmp/bgp_mp_reach_ipv4_withdraw" in namespace "h1"
+    And I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "h1"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/scripts/bgp_mp_reach_send.py
+++ b/bdd/tests/scripts/bgp_mp_reach_send.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Minimal scripted BGP speaker announcing IPv4 unicast inside MP_REACH_NLRI.
+
+zebra-rs, FRR and GoBGP all emit plain IPv4 unicast in the traditional
+NLRI field, so a router-to-router topology can never produce the RFC 4760
+S3 encoding (AFI=1/SAFI=1 reachability inside the MP_REACH_NLRI attribute
+with the next-hop carried in the attribute). This script plays that
+sender -- the shape xk6-bgp and other MP-first stacks emit -- against a
+zebra-rs DUT (issue fixed by PR #2045).
+
+Flow:
+  1. TCP-connect to the DUT, send OPEN with capabilities MP(1/1) and
+     4-octet AS, answer its OPEN with a KEEPALIVE, wait for its KEEPALIVE.
+  2. Send ONE UPDATE whose only reachability is an MP_REACH_NLRI
+     attribute (v4 next-hop inside the attribute, no traditional NLRI).
+     A decoy NEXT_HOP attribute rides along; per RFC 4760 the MP_REACH
+     next-hop must win, so the DUT installing the decoy is a bug the
+     feature would catch.
+  3. Keep the session alive with keepalives. When TRIGGER_FILE appears
+     (touched by a later scenario), send a traditional withdrawn-routes
+     UPDATE for the same prefix -- withdraws are prefix-keyed, so mixing
+     encodings is legal and proves the MP_REACH-announced route went into
+     the ordinary Loc-RIB.
+  4. Exit when the peer closes the connection (feature teardown stops the
+     DUT). The feature wraps the script in `timeout N` as a backstop.
+
+Usage:
+  bgp_mp_reach_send.py DUT_IP LOCAL_AS ROUTER_ID PREFIX MP_NEXTHOP \
+      DECOY_NEXTHOP TRIGGER_FILE
+"""
+
+import ipaddress
+import os
+import socket
+import struct
+import sys
+import time
+
+MARKER = b"\xff" * 16
+MSG_OPEN, MSG_UPDATE, MSG_NOTIFICATION, MSG_KEEPALIVE = 1, 2, 3, 4
+CAP_MP, CAP_AS4 = 1, 65
+HOLDTIME = 90
+
+
+def bgp_msg(msg_type, body):
+    return MARKER + struct.pack("!HB", 19 + len(body), msg_type) + body
+
+
+def open_msg(local_as, router_id):
+    caps = bytes([CAP_MP, 4]) + struct.pack("!HBB", 1, 0, 1)  # AFI=1/SAFI=1
+    caps += bytes([CAP_AS4, 4]) + struct.pack("!I", local_as)
+    opt = bytes([2, len(caps)]) + caps  # one Capabilities optional parameter
+    my_as2 = local_as if local_as < 65536 else 23456  # AS_TRANS
+    body = struct.pack("!BHH4sB", 4, my_as2, HOLDTIME,
+                       socket.inet_aton(router_id), len(opt)) + opt
+    return bgp_msg(MSG_OPEN, body)
+
+
+def peer_open_has_as4(body):
+    """Scan the OPEN's optional parameters for the 4-octet-AS capability."""
+    opt_len = body[9]
+    opts = body[10:10 + opt_len]
+    while len(opts) >= 2:
+        ptype, plen = opts[0], opts[1]
+        pval, opts = opts[2:2 + plen], opts[2 + plen:]
+        if ptype != 2:
+            continue
+        while len(pval) >= 2:
+            code, clen = pval[0], pval[1]
+            if code == CAP_AS4:
+                return True
+            pval = pval[2 + clen:]
+    return False
+
+
+def nlri_bytes(prefix):
+    net = ipaddress.ip_network(prefix)
+    nbytes = (net.prefixlen + 7) // 8
+    return bytes([net.prefixlen]) + net.network_address.packed[:nbytes]
+
+
+def update_announce(local_as, prefix, mp_nexthop, decoy_nexthop, as4):
+    attrs = b"\x40\x01\x01\x00"  # ORIGIN = IGP
+    fmt = "!BBI" if as4 else "!BBH"
+    seg = struct.pack(fmt, 2, 1, local_as)  # one AS_SEQUENCE of local AS
+    attrs += bytes([0x40, 2, len(seg)]) + seg  # AS_PATH
+    attrs += b"\x40\x03\x04" + socket.inet_aton(decoy_nexthop)  # NEXT_HOP
+    val = (struct.pack("!HBB", 1, 1, 4) + socket.inet_aton(mp_nexthop)
+           + b"\x00" + nlri_bytes(prefix))  # AFI/SAFI/nhlen/nh/SNPA=0/NLRI
+    attrs += bytes([0x80, 14, len(val)]) + val  # MP_REACH_NLRI
+    body = struct.pack("!H", 0) + struct.pack("!H", len(attrs)) + attrs
+    return bgp_msg(MSG_UPDATE, body)
+
+
+def update_withdraw(prefix):
+    w = nlri_bytes(prefix)
+    return bgp_msg(MSG_UPDATE, struct.pack("!H", len(w)) + w + b"\x00\x00")
+
+
+def recv_exact(sock, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def read_msg(sock):
+    hdr = recv_exact(sock, 19)
+    if hdr is None:
+        return None
+    length, msg_type = struct.unpack("!HB", hdr[16:19])
+    body = recv_exact(sock, length - 19) if length > 19 else b""
+    if length > 19 and body is None:
+        return None
+    return msg_type, body
+
+
+def session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, trigger):
+    sock = socket.create_connection((dut_ip, 179), timeout=10)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.settimeout(30)
+    sock.sendall(open_msg(local_as, router_id))
+    peer_as4 = False
+    got_open = False
+    while True:
+        m = read_msg(sock)
+        if m is None:
+            raise ConnectionError("peer closed during handshake")
+        msg_type, body = m
+        if msg_type == MSG_OPEN:
+            peer_as4 = peer_open_has_as4(body)
+            got_open = True
+            sock.sendall(bgp_msg(MSG_KEEPALIVE, b""))
+        elif msg_type == MSG_KEEPALIVE and got_open:
+            break  # Established
+        elif msg_type == MSG_NOTIFICATION:
+            raise ConnectionError(f"NOTIFICATION in handshake: {body.hex()}")
+    print(f"established (peer as4={peer_as4}); announcing {prefix} "
+          f"via MP_REACH next-hop {mp_nexthop}", flush=True)
+    sock.sendall(update_announce(local_as, prefix, mp_nexthop, decoy, peer_as4))
+
+    sock.settimeout(1)
+    last_keepalive = time.time()
+    withdrawn = False
+    while True:
+        try:
+            m = read_msg(sock)
+            if m is None:
+                print("peer closed; exiting", flush=True)
+                return
+            if m[0] == MSG_NOTIFICATION:
+                print(f"NOTIFICATION: {m[1].hex()}; exiting", flush=True)
+                return
+        except socket.timeout:
+            pass
+        if time.time() - last_keepalive > 20:
+            sock.sendall(bgp_msg(MSG_KEEPALIVE, b""))
+            last_keepalive = time.time()
+        if not withdrawn and os.path.exists(trigger):
+            print(f"trigger file seen; withdrawing {prefix} via the "
+                  "traditional withdrawn-routes field", flush=True)
+            sock.sendall(update_withdraw(prefix))
+            withdrawn = True
+
+
+def main():
+    dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, trigger = (
+        sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4],
+        sys.argv[5], sys.argv[6], sys.argv[7])
+    # A stale trigger from a crashed prior run would withdraw immediately.
+    try:
+        os.unlink(trigger)
+    except FileNotFoundError:
+        pass
+    # The DUT's neighbor config may not be applied yet when we are spawned
+    # (it closes/refuses until then) -- retry the whole handshake.
+    deadline = time.time() + 120
+    while True:
+        try:
+            session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy,
+                    trigger)
+            return
+        except (ConnectionError, OSError) as e:
+            if time.time() > deadline:
+                print(f"giving up: {e}", file=sys.stderr, flush=True)
+                sys.exit(1)
+            print(f"session attempt failed ({e}); retrying", flush=True)
+            time.sleep(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds live BDD coverage for the bug fixed by #2045: IPv4 unicast
reachability carried in an MP_REACH_NLRI attribute (AFI=1/SAFI=1 with
the next-hop inside the attribute) was accepted without error but had no
effect — no Loc-RIB entry, no FIB install, no re-advertisement.

zebra-rs, FRR and GoBGP all emit plain IPv4 unicast in the traditional
NLRI field, so a router-to-router topology can never produce this
encoding. The feature therefore adds a scripted BGP speaker,
`bdd/tests/scripts/bgp_mp_reach_send.py` (stdlib only), that plays the
RFC 4760 sender — the shape xk6-bgp and other MP-first stacks emit.

## Topology

h1 runs the script, z1 is the DUT, z2 is an ordinary zebra-rs peer, all
on one bridge. The script announces `10.99.0.0/24` inside MP_REACH with
next-hop `192.168.30.2`, holds the session with keepalives, and
withdraws on a trigger file.

## What it asserts

- The prefix enters z1's Loc-RIB **with the MP_REACH next-hop**. A decoy
  `NEXT_HOP` attribute (`192.168.30.99`) rides along and must lose, per
  RFC 4760 §3 — this pins the precedence rule that lives in `route.rs`
  and that the unit tests in #2045 could not reach.
- It reaches the kernel FIB.
- It is re-advertised to z2 with the AS path extended (`65030 65031`).
- A **traditional** withdrawn-routes UPDATE removes it. Mixing encodings
  is deliberate: that only works if the MP_REACH-announced route landed
  in the ordinary Loc-RIB rather than a side path.

## Verification

Proven to be a real regression gate — built both binaries and ran the
feature against each:

| | main before #2045 | with #2045 |
|---|---|---|
| session to 192.168.30.2 Established | **fail** | pass |
| `show bgp` in z1 has 10.99.0.0/24 | **fail** | pass |
| `show bgp` in z2 has 10.99.0.0/24 | **fail** | pass |

All 5 scenarios pass on current `main` (which now includes #2045).

## Notes

- The DUT peers **passively** toward h1: the script never listens on
  179, so dialing it would cycle that peer Idle -> Connect -> Idle, and
  Idle refuses the inbound connection.
- CI excludes the `bdd` crate, so this is a local/nightly gate. Run it
  with `make -C bdd bgp_mp_reach_ipv4`.

Follow-up worth filing separately: `MpUnreachAttr` still has no
IPv4-unicast variant, so an MP_UNREACH 1/1 withdrawal fails to parse and
resets the session. A sender that announces via MP_REACH will typically
withdraw the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)