### PR TITLE
bgp: sweep dynamic peers when their listen-range is revoked

### DIFF
--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
@@ -1,0 +1,38 @@
+# z1 — DUT whose listen-range group SENDERS binds an inbound DENY-ALL
+# route policy. A peer materialized from 192.168.0.0/24 must inherit
+# it: the session establishes, z1 still advertises 10.0.1.1/32, but
+# nothing the client sends may enter z1's Loc-RIB.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      policy:
+        in: DENY-ALL
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
@@ -1,0 +1,37 @@
+# Identical to z1-deny.yaml except SENDERS carries no policy binding.
+# `vtyctl apply -f` is a declarative whole-config replace, so the file
+# restates the full config — the commit diff against z1-deny.yaml is
+# exactly the deletion of the group's `policy in` leaf. The DENY-ALL
+# definition itself stays: an unreferenced policy filters nothing.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client. Ordinary static eBGP session toward the DUT;
+# originates 10.0.2.2/32, the route the DUT's inherited DENY-ALL must
+# stop (and the policy-less rebind must readmit).
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1-norange.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1-norange.yaml
@@ -1,0 +1,35 @@
+# Identical to z1.yaml except the whole `dynamic-neighbors` block is
+# gone. `vtyctl apply -f` is a declarative whole-config replace, so the
+# commit diff against z1.yaml is exactly the listen-range deletion —
+# which must revoke the peer that range materialized (session down,
+# peer removed, listen-limit slot returned).
+#
+# SENDERS is kept: the group outliving the range is the realistic
+# operator shape, and it proves the sweep keys off the range binding
+# rather than off group existence.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -4,6 +4,13 @@
 # z3 connects from 192.168.1.3 — outside the range — and must be
 # refused at accept time. Originates 10.0.1.1/32 so the dynamic
 # session carries a route in the DUT->client direction too.
+#
+# `listen-limit: 1` is deliberate, not arbitrary: with exactly one
+# in-range client the cap is saturated the moment z2 is materialized,
+# so every re-establishment in this feature only succeeds if the slot
+# was actually released. A leaked `dynamic_peer_count` (missing GC on
+# session end, or a range-delete sweep that forgot to decrement) shows
+# up as a session that never comes back.
 interface:
 - if-name: i1
   ipv4:
@@ -27,7 +34,7 @@ router:
       - name: ipv4
         enabled: true
     dynamic-neighbors:
-      listen-limit: 10
+      listen-limit: 1
       listen-range:
       - prefix: 192.168.0.0/24
         neighbor-group: SENDERS

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -1,0 +1,37 @@
+# z1 — the DUT. No static neighbors: every session must arrive via the
+# dynamic-neighbors listen-range 192.168.0.0/24, which materializes a
+# passive peer inheriting SENDERS (remote-as 65002, ipv4 enabled).
+# z3 connects from 192.168.1.3 — outside the range — and must be
+# refused at accept time. Originates 10.0.1.1/32 so the dynamic
+# session carries a route in the DUT->client direction too.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-limit: 10
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,6 +1,14 @@
 # z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
 # of view this is an ordinary static eBGP session toward the DUT; only
 # z1's side is dynamic. Originates 10.0.2.2/32.
+#
+# `connect-retry-time: 3` is required, not cosmetic. When the DUT
+# revokes a dynamic peer (listen-range delete) or refuses a connect,
+# the TCP dies after the handshake — z2's FSM lands in Active, where
+# the redial is paced by the ConnectRetryTimer and NOT by the 5s
+# idle-hold. At the 120s default the client would not redial within
+# any sane scenario timeout, and "session never came back" would look
+# like a slot leak instead of a sleeping timer.
 interface:
 - if-name: i1
   ipv4:
@@ -18,6 +26,7 @@ router:
     - remote-address: 192.168.0.1
       enabled: true
       remote-as: 65001
+      timers: {connect-retry-time: 3}
       afi-safi:
       - name: ipv4
         enabled: true

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
+# of view this is an ordinary static eBGP session toward the DUT; only
+# z1's side is dynamic. Originates 10.0.2.2/32.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
@@ -1,0 +1,29 @@
+# z3 — out-of-range client (192.168.1.3, matched by NO listen-range).
+# Identical client shape to z2; the only difference is the source
+# subnet, so any session it ever establishes means the listen-range
+# authorization leaked. Originates 10.0.3.3/32 — that prefix showing
+# up on z1 is the failure signal.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.3.3/32

--- a/bdd/tests/features/bgp_dynamic_nbr_policy.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_policy.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_dynamic_nbr_policy
+Feature: A dynamic (listen-range) peer inherits its neighbor-group's route policy
+  As a network operator
+  I want the `policy` bound on a listen-range's neighbor-group
+  So every peer materialized from that range is filtered like a static member.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  z1 (the DUT) has no static neighbors; z2 arrives via the listen-range
+  and inherits SENDERS. With SENDERS carrying `policy in DENY-ALL` the
+  session must still establish, z1's own route must still flow out —
+  but z2's route must be denied on ingress. Rebinding the group without
+  the policy and re-materializing the peer readmits the route, proving
+  the policy is resolved from the group at accept time, not baked in.
+
+  Config files:
+  - z1-deny.yaml: DUT — SENDERS has `policy in DENY-ALL`, originates 10.0.1.1/32
+  - z1-open.yaml: identical but the group carries no policy binding
+  - z2.yaml:      client, static neighbor to .0.1, originates 10.0.2.2/32
+
+  Scenario: Establish with an inbound deny-all policy inherited from the group
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-deny.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    # Policy filters routes, not the session: outbound is untouched...
+    And BGP route in "z2" has "10.0.1.1/32"
+    # ...while the inherited inbound DENY-ALL drops the client's route.
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Unbinding the group policy readmits the route on re-materialization
+    Given the test topology exists
+    When I apply config "z1-open.yaml" to namespace "z1"
+    And I wait 10 seconds
+    # Hard-reset from the client: z1's dynamic peer is torn down and the
+    # reconnect materializes a fresh peer that resolves the group's
+    # CURRENT (policy-less) state through the same accept-time ritual.
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -1,0 +1,97 @@
+@serial
+@bgp_dynamic_neighbors
+Feature: BGP dynamic neighbors materialize passive peers from a listen-range
+  As a network operator
+  I want `router bgp dynamic-neighbors listen-range <prefix> neighbor-group <G>`
+  So sessions from an authorized source prefix establish without per-peer config.
+
+  Test Topology (z1 is the DUT; only z2's subnet is range-authorized):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │ i2────────────i1 │   z3    │
+   │ AS65002 │   (in range)     │ AS65001 │  (out of range)  │ AS65002 │
+   │ .0.2    │                  │.0.1 .1.1│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 has NO static neighbors. Its listen-range 192.168.0.0/24 binds
+  neighbor-group SENDERS (remote-as 65002, ipv4 enabled), so z2's inbound
+  connection materializes a passive peer that must reach Established and
+  exchange routes in both directions (regression pin for PR #2044, where
+  the materialized peer was left in Idle and every connection was
+  dropped). z3 runs the same client config from 192.168.1.3 — outside
+  the range — and must be refused at accept time with no peer state.
+
+  Config files:
+  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+
+  Scenario: Setup topology and establish the dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I connect namespace "z1" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And show command "show bgp summary" in namespace "z1" should contain "192.168.0.2"
+
+  Scenario: Routes flow in both directions over the dynamic session
+    Given the test topology exists
+    Then BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A source outside every listen-range is refused without peer state
+    Given the test topology exists
+    # z3's TCP connect is accepted by the kernel, but the LPM miss makes
+    # z1 drop the stream before any OPEN exchange — z3 never leaves the
+    # connect/retry cycle, and z1 materializes nothing for 192.168.1.3.
+    Then BGP session in "z3" to "192.168.1.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.1.3"
+    And BGP route in "z1" does not have "10.0.3.3/32"
+
+  Scenario: The client can hard-reset and re-establish the dynamic session
+    Given the test topology exists
+    # Pre-#2044 every reconnect was dropped: the very first inbound
+    # stream materialized the peer, then died in Idle forever.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A DUT-side clear frees the peer and the next connect re-materializes it
+    Given the test topology exists
+    # Clearing on z1 ends the session of a Dynamic-origin peer, which
+    # the instance GCs (freeing its listen-limit slot); z2's redial then
+    # re-materializes a fresh peer through the same accept path.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -22,10 +22,15 @@ Feature: BGP dynamic neighbors materialize passive peers from a listen-range
   dropped). z3 runs the same client config from 192.168.1.3 — outside
   the range — and must be refused at accept time with no peer state.
 
+  `listen-limit` is 1 on the DUT, so every re-establishment below also
+  proves the freed slot was actually returned — a leaked slot saturates
+  the cap and the client can never reconnect.
+
   Config files:
-  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
-  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
-  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+  - z1.yaml:         DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z1-norange.yaml: same DUT with the listen-range deleted (group kept)
+  - z2.yaml:         in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml:         out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
 
   Scenario: Setup topology and establish the dynamic session
     Given a clean test environment
@@ -81,6 +86,30 @@ Feature: BGP dynamic neighbors materialize passive peers from a listen-range
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: Deleting the listen-range revokes the peers it materialized
+    Given the test topology exists
+    # Revoking the authorization must not leave the session it
+    # authorized running: the sweep tears the dynamic peer down and
+    # returns its listen-limit slot.
+    When I wait 10 seconds
+    And I apply config "z1-norange.yaml" to namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Restoring the listen-range re-materializes the peer in the freed slot
+    Given the test topology exists
+    # `listen-limit` is 1, so this only succeeds if the sweep decremented
+    # `dynamic_peer_count` — a leaked slot leaves the cap saturated and
+    # the client's connect is refused forever.
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP route in "z1" has "10.0.2.2/32"
     And BGP route in "z2" has "10.0.1.1/32"
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -335,46 +335,59 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // dialing yet, so no kick fires here.
         bgp.refresh_connected();
     } else {
-        let peer_idx = {
-            let peer = bgp.peers.get(&addr)?;
-            peer.ident
-        };
-
-        // Defensively clear any listener auth entries associated with
-        // this peer before removing it, in case the per-leaf delete
-        // callbacks didn't fire (e.g., whole-neighbor delete without
-        // explicit tcp-md5 / tcp-ao deletions first).
-        clear_peer_listener_auth(bgp, &addr);
-
-        let mut bgp_ref = BgpTop {
-            router_id: &bgp.router_id,
-            srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
-            local_rib: &mut bgp.local_rib,
-            shard: &mut bgp.shard,
-            tx: &bgp.tx,
-            rib_client: &bgp.ctx.rib,
-            attr_store: &mut bgp.attr_store,
-            update_groups: &mut bgp.update_groups,
-            interface_addrs: &bgp.interface_addrs,
-            vrf_export: None,
-            color_policy: Some(&bgp.color_policy),
-            flex_algo_routes: Some(&bgp.flex_algo_routes),
-            flex_algo_srv6_routes: Some(&bgp.flex_algo_srv6_routes),
-            vrf_import: None,
-            nexthop_cache: None,
-            vrf_transport_v4: None,
-            vrf_transport_v6: None,
-            central_label_alloc: None,
-            as_sets_withdraw: bgp.as_sets_withdraw,
-        };
-        route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
-        // Update-groups live outside `PeerMap`: removal below purges
-        // the membership index by construction, but the group member
-        // sets must be detached explicitly or the freed ident lingers
-        // and a future slot reuse inherits the group.
-        super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
-        bgp.peers.remove(&addr);
+        remove_peer_full(bgp, addr)?;
     }
+    Some(())
+}
+
+/// The full peer-removal ritual: listener auth cleanup, Loc-RIB route
+/// withdrawal, update-group detach, map removal, and the listener-wide
+/// TCP-MSS / IP_TRANSPARENT reconciliations. Shared by the static
+/// `delete router bgp neighbor <addr>` path above and the
+/// dynamic-neighbors range sweep
+/// (`super::dynamic_neighbors::sweep_range_peers`); the sweep owns the
+/// `dynamic_peer_count` decrement, since only it knows the peer was
+/// slot-counted.
+pub(super) fn remove_peer_full(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
+    let peer_idx = {
+        let peer = bgp.peers.get(&addr)?;
+        peer.ident
+    };
+
+    // Defensively clear any listener auth entries associated with
+    // this peer before removing it, in case the per-leaf delete
+    // callbacks didn't fire (e.g., whole-neighbor delete without
+    // explicit tcp-md5 / tcp-ao deletions first).
+    clear_peer_listener_auth(bgp, &addr);
+
+    let mut bgp_ref = BgpTop {
+        router_id: &bgp.router_id,
+        srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
+        local_rib: &mut bgp.local_rib,
+        shard: &mut bgp.shard,
+        tx: &bgp.tx,
+        rib_client: &bgp.ctx.rib,
+        attr_store: &mut bgp.attr_store,
+        update_groups: &mut bgp.update_groups,
+        interface_addrs: &bgp.interface_addrs,
+        vrf_export: None,
+        color_policy: Some(&bgp.color_policy),
+        flex_algo_routes: Some(&bgp.flex_algo_routes),
+        flex_algo_srv6_routes: Some(&bgp.flex_algo_srv6_routes),
+        vrf_import: None,
+        nexthop_cache: None,
+        vrf_transport_v4: None,
+        vrf_transport_v6: None,
+        central_label_alloc: None,
+        as_sets_withdraw: bgp.as_sets_withdraw,
+    };
+    route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
+    // Update-groups live outside `PeerMap`: removal below purges
+    // the membership index by construction, but the group member
+    // sets must be detached explicitly or the freed ident lingers
+    // and a future slot reuse inherits the group.
+    super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
+    bgp.peers.remove(&addr);
     // Keep the shared listener's TCP MSS minimum in step with the peer
     // set: a whole-neighbor delete may drop the peer that owned the
     // current minimum without the per-leaf `/tcp-mss` delete firing (the

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -3,8 +3,9 @@
 //! Stores the configured `listen-range` prefixes and `listen-limit`,
 //! and exposes `lpm_match` for the accept-path. Materialization of
 //! the synthesized [`super::peer::Peer`] lives in
-//! [`super::peer::try_dynamic_accept`] — this module is just state
-//! + config callbacks.
+//! [`super::peer::try_dynamic_accept`] — this module holds the state,
+//! the config callbacks, and the revocation sweep
+//! ([`sweep_range_peers`]) that tears those peers back down.
 
 use std::collections::BTreeMap;
 use std::net::IpAddr;
@@ -90,8 +91,8 @@ pub fn config_listen_limit(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 }
 
 /// `set router bgp dynamic-neighbors listen-range <prefix>` —
-/// list-key callback. Creates the entry on `Set` and removes it on
-/// `Delete`.
+/// list-key callback. Creates the entry on `Set`; removes it on
+/// `Delete` and sweeps the peers it materialized.
 pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let prefix: IpNet = args.string()?.parse().ok()?;
     match op {
@@ -100,6 +101,7 @@ pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         }
         ConfigOp::Delete => {
             bgp.dynamic_neighbors.ranges.remove(&prefix);
+            sweep_range_peers(bgp, &prefix);
         }
         _ => {}
     }
@@ -113,13 +115,68 @@ pub fn config_listen_range_neighbor_group(
     op: ConfigOp,
 ) -> Option<()> {
     let prefix: IpNet = args.string()?.parse().ok()?;
-    let entry = bgp.dynamic_neighbors.ranges.entry(prefix).or_default();
     match op {
-        ConfigOp::Set => entry.neighbor_group = Some(args.string()?),
-        ConfigOp::Delete => entry.neighbor_group = None,
+        ConfigOp::Set => {
+            bgp.dynamic_neighbors
+                .ranges
+                .entry(prefix)
+                .or_default()
+                .neighbor_group = Some(args.string()?);
+        }
+        ConfigOp::Delete => {
+            // `get_mut`, not `entry().or_default()`: when the whole
+            // listen-range entry is deleted, this leaf's Delete may fire
+            // after the list-key's — an `or_default` here would
+            // resurrect the just-removed range as a ghost entry.
+            if let Some(entry) = bgp.dynamic_neighbors.ranges.get_mut(&prefix) {
+                entry.neighbor_group = None;
+            }
+            // A group-less range can materialize nothing, and the peers
+            // it already materialized just lost the source of their
+            // session attributes — revoke them like a range delete.
+            sweep_range_peers(bgp, &prefix);
+        }
         _ => {}
     }
     Some(())
+}
+
+/// Tear down and remove every `PeerOrigin::Dynamic` peer materialized
+/// from `prefix`, freeing their `listen-limit` slots. Deleting a
+/// listen-range (or unbinding its neighbor-group) revokes the
+/// authorization those peers were accepted under, so their sessions
+/// must not outlive it — mirroring FRR's `no bgp listen range`.
+///
+/// Peers are matched by their provenance stamp (the `range_prefix`
+/// recorded at materialization), not by re-running LPM: if an
+/// overlapping range still covers a swept client, its next connect
+/// re-materializes under that range — with that range's group, which
+/// is the correct attribute source from then on.
+pub(super) fn sweep_range_peers(bgp: &mut Bgp, prefix: &IpNet) {
+    use super::peer_key::PeerOrigin;
+
+    let victims: Vec<IpAddr> = bgp
+        .peers
+        .idents()
+        .into_iter()
+        .filter_map(|ident| bgp.peers.get_by_idx(ident))
+        .filter(|peer| {
+            matches!(&peer.origin,
+                PeerOrigin::Dynamic { range_prefix } if range_prefix == prefix)
+        })
+        .map(|peer| peer.address)
+        .collect();
+
+    for addr in victims {
+        if super::config::remove_peer_full(bgp, addr).is_some() {
+            bgp.dynamic_peer_count = bgp.dynamic_peer_count.saturating_sub(1);
+            tracing::info!(
+                peer = %addr,
+                range = %prefix,
+                "bgp: dynamic peer removed by listen-range sweep",
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -188,5 +245,226 @@ mod tests {
     fn default_listen_limit_is_one_hundred() {
         let dn = DynamicNeighbors::default();
         assert_eq!(dn.listen_limit, 100);
+    }
+}
+
+/// Revocation sweep: deleting a listen-range (or unbinding its
+/// neighbor-group) must tear down the peers that range materialized
+/// and give their `listen-limit` slots back.
+#[cfg(test)]
+mod sweep_tests {
+    use std::collections::VecDeque;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::bgp::peer::Peer;
+    use crate::bgp::peer_key::PeerOrigin;
+
+    fn net(s: &str) -> IpNet {
+        s.parse().unwrap()
+    }
+
+    fn addr(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn arg_words(parts: &[&str]) -> Args {
+        Args(
+            parts
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<VecDeque<_>>(),
+        )
+    }
+
+    fn test_ctx() -> (
+        crate::context::ProtoContext,
+        mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
+    ) {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        // Leak the inbound rx: a dropped receiver turns every send
+        // through the client into a SendError, which BGP unwraps.
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+        (ctx, rib_rx)
+    }
+
+    fn test_rib_subscriber() -> crate::config::RibSubscriber {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_inbound_rx));
+        // Starts at 1 so it never collides with the
+        // `ProtoId::from_raw(0)` baked into `test_ctx`.
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id)
+    }
+
+    fn fresh_bgp() -> Bgp {
+        let (ctx, rib_rx) = test_ctx();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    /// Stand in for `try_dynamic_accept`'s materialization without a
+    /// socket: insert a Dynamic-origin peer stamped with `range` and
+    /// take its `listen-limit` slot, exactly as the accept path does.
+    fn materialize(bgp: &mut Bgp, peer_addr: &str, range: &str) {
+        let address = addr(peer_addr);
+        let mut peer = Peer::new(
+            0,
+            bgp.asn,
+            bgp.router_id,
+            65001,
+            address,
+            bgp.hostname(),
+            bgp.tx.clone(),
+            bgp.ctx.clone(),
+        );
+        peer.origin = PeerOrigin::Dynamic {
+            range_prefix: net(range),
+        };
+        peer.config.transport.passive = true;
+        bgp.peers.insert(address, peer);
+        bgp.dynamic_peer_count += 1;
+    }
+
+    /// Config a range bound to a group, the way an operator would.
+    fn configure_range(bgp: &mut Bgp, prefix: &str, group: &str) {
+        config_listen_range(bgp, arg_words(&[prefix]), ConfigOp::Set).unwrap();
+        config_listen_range_neighbor_group(bgp, arg_words(&[prefix, group]), ConfigOp::Set)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn range_delete_sweeps_only_its_own_peers() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        configure_range(&mut bgp, "10.2.0.0/24", "B");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+        materialize(&mut bgp, "10.1.0.8", "10.1.0.0/24");
+        materialize(&mut bgp, "10.2.0.9", "10.2.0.0/24");
+        assert_eq!(bgp.dynamic_peer_count, 3);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert!(bgp.peers.get(&addr("10.1.0.7")).is_none());
+        assert!(bgp.peers.get(&addr("10.1.0.8")).is_none());
+        assert!(
+            bgp.peers.get(&addr("10.2.0.9")).is_some(),
+            "a peer from a still-configured range must survive"
+        );
+        assert_eq!(
+            bgp.dynamic_peer_count, 1,
+            "both swept peers must return their listen-limit slots"
+        );
+    }
+
+    /// The slot accounting has to be exact, not merely non-negative:
+    /// a sweep that forgot to decrement would wedge a `listen-limit`
+    /// speaker forever (the pre-existing worry that motivated this).
+    #[tokio::test]
+    async fn swept_slots_are_reusable_up_to_the_limit() {
+        let mut bgp = fresh_bgp();
+        bgp.dynamic_neighbors.listen_limit = 2;
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+        materialize(&mut bgp, "10.1.0.8", "10.1.0.0/24");
+        assert_eq!(bgp.dynamic_peer_count, bgp.dynamic_neighbors.listen_limit);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert_eq!(bgp.dynamic_peer_count, 0, "the cap must be fully released");
+    }
+
+    /// Unbinding the group leaves the range unable to supply session
+    /// attributes, so its peers go too.
+    #[tokio::test]
+    async fn group_unbind_sweeps_range_peers() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+
+        config_listen_range_neighbor_group(
+            &mut bgp,
+            arg_words(&["10.1.0.0/24", "A"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(bgp.peers.get(&addr("10.1.0.7")).is_none());
+        assert_eq!(bgp.dynamic_peer_count, 0);
+    }
+
+    /// A statically configured peer whose address happens to fall
+    /// inside the range is NOT dynamic — provenance, not address
+    /// containment, decides. Sweeping it would delete operator config.
+    #[tokio::test]
+    async fn sweep_spares_static_peers_inside_the_prefix() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        let static_addr = addr("10.1.0.5");
+        let peer = Peer::new(
+            0,
+            bgp.asn,
+            bgp.router_id,
+            65001,
+            static_addr,
+            bgp.hostname(),
+            bgp.tx.clone(),
+            bgp.ctx.clone(),
+        );
+        bgp.peers.insert(static_addr, peer);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert!(
+            bgp.peers.get(&static_addr).is_some(),
+            "a PeerOrigin::Static peer must survive a range delete"
+        );
+        assert_eq!(
+            bgp.dynamic_peer_count, 0,
+            "a static peer never held a slot, so none is released"
+        );
+    }
+
+    /// Deleting a whole listen-range fires the list-key callback and
+    /// the child-leaf callback. Whichever order they arrive in, the
+    /// range must stay gone — an `entry().or_default()` in the leaf's
+    /// Delete arm would resurrect it as a group-less ghost that
+    /// `lpm_match` then hits on every inbound connection.
+    #[tokio::test]
+    async fn leaf_delete_after_key_delete_does_not_resurrect_the_range() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        config_listen_range_neighbor_group(
+            &mut bgp,
+            arg_words(&["10.1.0.0/24", "A"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(
+            bgp.dynamic_neighbors.ranges.is_empty(),
+            "trailing leaf delete must not re-create the range entry"
+        );
+        assert!(bgp.dynamic_neighbors.lpm_match(&addr("10.1.0.7")).is_none());
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -876,9 +876,11 @@ pub struct Bgp {
     /// `dynamic-neighbors` runtime (zebra-bgp-dynamic-neighbors.yang).
     /// Holds the configured listen-ranges and the soft cap on
     /// materialized passive peers. `dynamic_peer_count` is bumped on
-    /// successful accept-time materialization in `peer::accept`; it
-    /// is never decremented yet — session-close GC is deferred to a
-    /// follow-up so this PR stays focused on the accept path.
+    /// accept-time materialization (`peer::try_dynamic_accept`) and
+    /// decremented when a slot frees:
+    /// [`Self::gc_dynamic_peer_if_session_ended`] on session end,
+    /// `dynamic_neighbors::sweep_range_peers` on range delete /
+    /// group unbind.
     pub dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors,
     pub dynamic_peer_count: u32,
     /// `interface-neighbor` config — operator types

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -3291,8 +3291,10 @@ pub fn accept(bgp: &mut Bgp, stream: TcpStream, sockaddr: SocketAddr) {
 fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Option<TcpStream> {
     // Soft cap. The listen-limit guards against an attacker spamming
     // SYNs from many sources in a wide listen-range — once we hit
-    // the limit, additional matches drop silently until existing
-    // dynamic peers are GC'd (session-close GC lands in a follow-up).
+    // the limit, additional matches drop silently until a slot frees
+    // up: `gc_dynamic_peer_if_session_ended` reclaims a peer whose
+    // session ended, and `dynamic_neighbors::sweep_range_peers`
+    // reclaims every peer of a deleted (or group-unbound) range.
     if bgp.dynamic_peer_count >= bgp.dynamic_neighbors.listen_limit {
         return Some(stream);
     }


### PR DESCRIPTION
Stacked on #2050 (base `bdd-dynamic-neighbors`) — review that one first; this PR's diff is the second commit only.

## Problem

Deleting a `dynamic-neighbors listen-range`, or unbinding its neighbor-group, removed the range from the lookup table but left the peers it had materialized running. Their sessions outlived the authorization that admitted them, and their `listen-limit` slots were never returned — so on a speaker near its cap, revoking a range permanently burned that capacity.

## Fix

`dynamic_neighbors::sweep_range_peers`, called from both the listen-range delete and the neighbor-group unbind. It matches peers by the `PeerOrigin::Dynamic { range_prefix }` provenance stamp rather than by address containment, so:

- a **statically configured** peer that happens to sit inside the prefix is untouched (sweeping it would delete operator config);
- a client still covered by an **overlapping** range re-materializes under that range on its next connect, picking up that range's group — the correct attribute source from then on.

Teardown reuses the static delete path: `config_peer`'s delete arm is factored out as `config::remove_peer_full` (listener auth cleanup, Loc-RIB withdrawal, update-group detach, map removal, listener TCP-MSS / IP_TRANSPARENT reconciliation), so a swept peer is torn down exactly like an operator-deleted one. The sweep owns the `dynamic_peer_count` decrement, since only it knows the peer was slot-counted.

Also fixes the `neighbor-group` leaf's Delete arm, which used `entry().or_default()` — on a whole-range delete, the child leaf's callback firing after the list-key's would resurrect the range as a group-less ghost that `lpm_match` then hits on every inbound connection.

## Stale comments corrected

Two comments claimed session-close GC was still a follow-up. It has existed since the accept path landed (`gc_dynamic_peer_if_session_ended`, called after every FSM dispatch). The stale text cost real review time on #2044 — I repeated the claim in that review before checking.

## Testing

- **Unit** (5 new): own-range peers only, exact slot accounting up to the cap, group unbind, static peers spared, and the ghost-entry ordering case. The two range-delete tests were verified to **fail** with the sweep call removed, then restored.
- **BDD** (2 new scenarios): the range delete revokes the peer — asserted gone from `show bgp summary`, so a mere bounce would not pass — and restoring the range re-materializes it. The DUT's `listen-limit` drops to **1**, which turns every re-establishment in the feature into a slot-leak check: a leaked count saturates the cap and the client can never reconnect.
- Feature runs green locally (8/8 scenarios, clean teardown), as does `bgp_dynamic_nbr_policy` (3/3). Full `cargo test -p zebra-rs` 1662 passed; workspace clippy and fmt clean.

One BDD gotcha worth recording: the client needs `connect-retry-time: 3`. A revoked peer's TCP dies *after* the handshake, so its FSM parks in **Active**, where the redial is paced by the ConnectRetryTimer (120s default) and not the 5s idle-hold — at the default the session simply never returns inside a scenario timeout, which reads exactly like a slot leak.

## Not included

Item 3 of the plan (dynamic peer parked sessionless in Active holding a slot) and the MD5/AO listener prefix-key work are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)