### PR TITLE
bgp: accept IPv4 unicast withdrawals in MP_UNREACH_NLRI (RFC 4760 §4)

### DIFF
--- a/bdd/docs/bgp_mp_reach_ipv4.md
+++ b/bdd/docs/bgp_mp_reach_ipv4.md
@@ -1,18 +1,21 @@
-# BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
+# BGP IPv4 unicast carried in MP_REACH_NLRI / MP_UNREACH_NLRI
 
 ## Overview
 
 As a network operator
-I want IPv4 unicast reachability encoded in an MP_REACH_NLRI attribute
-(RFC 4760 §3, AFI=1/SAFI=1 with the next-hop inside the attribute) to be
-treated identically to the traditional NLRI field, because RFC 4760
-senders such as xk6-bgp encode it that way while zebra-rs, FRR and GoBGP
-emit traditional NLRI — so only a scripted speaker can produce this shape.
-Regression for the issue fixed by PR #2045: such UPDATEs were accepted
-without error but had no effect — no Loc-RIB entry, no FIB install, no
-re-advertisement, no log line. The scripted speaker also sends a decoy
-NEXT_HOP attribute; per RFC 4760 the next-hop inside MP_REACH supersedes
-it, which the next-hop assertions pin down.
+I want IPv4 unicast encoded in the RFC 4760 multiprotocol attributes
+(AFI=1/SAFI=1 — reachability in MP_REACH_NLRI §3 with the next-hop inside
+the attribute, withdrawals in MP_UNREACH_NLRI §4) to be treated
+identically to the traditional NLRI and Withdrawn Routes fields, because
+RFC 4760 senders such as xk6-bgp encode it that way while zebra-rs, FRR
+and GoBGP use the traditional fields — so only a scripted speaker can
+produce these shapes.
+Both directions were broken, and both failure modes are covered here:
+- MP_REACH (fixed by PR #2045): the UPDATE was accepted without error but
+- MP_UNREACH: AFI=1/SAFI=1 had no arm in the parser at all, so the whole
+The scripted speaker also sends a decoy NEXT_HOP attribute; per RFC 4760
+the next-hop inside MP_REACH supersedes it, which the next-hop assertions
+pin down.
 
 ## Test Topology
 
@@ -33,9 +36,9 @@ it, which the next-hop assertions pin down.
 
 h1 runs tests/scripts/bgp_mp_reach_send.py: it announces 10.99.0.0/24
 inside MP_REACH_NLRI (next-hop 192.168.30.2, decoy NEXT_HOP attribute
-192.168.30.99), holds the session with keepalives, and withdraws the
-prefix through the traditional withdrawn-routes field when the trigger
-file /tmp/bgp_mp_reach_ipv4_withdraw appears.
+192.168.30.99) and then acts on trigger files, each consumed when it
+fires so re-touching re-triggers:
+/tmp/bgp_mp_reach_ipv4.announce, .withdraw_traditional, .withdraw_mp.
 
 ## Test Scenarios
 
@@ -44,5 +47,6 @@ file /tmp/bgp_mp_reach_ipv4_withdraw appears.
 | Setup topology and establish sessions | |
 | MP_REACH-encoded IPv4 unicast enters the Loc-RIB with the MP_REACH next-hop | |
 | The MP_REACH-learned route is re-advertised to a traditional peer | |
-| A traditional withdraw removes the MP_REACH-announced route | |
+| An MP_UNREACH withdraw removes the route without resetting the session | |
+| A traditional withdraw also removes the MP_REACH-announced route | |
 | Teardown topology | |

--- a/bdd/tests/features/bgp_mp_reach_ipv4.feature
+++ b/bdd/tests/features/bgp_mp_reach_ipv4.feature
@@ -1,18 +1,27 @@
 @serial
 @bgp_mp_reach_ipv4
-Feature: BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
+Feature: BGP IPv4 unicast carried in MP_REACH_NLRI / MP_UNREACH_NLRI
   As a network operator
-  I want IPv4 unicast reachability encoded in an MP_REACH_NLRI attribute
-  (RFC 4760 §3, AFI=1/SAFI=1 with the next-hop inside the attribute) to be
-  treated identically to the traditional NLRI field, because RFC 4760
-  senders such as xk6-bgp encode it that way while zebra-rs, FRR and GoBGP
-  emit traditional NLRI — so only a scripted speaker can produce this shape.
+  I want IPv4 unicast encoded in the RFC 4760 multiprotocol attributes
+  (AFI=1/SAFI=1 — reachability in MP_REACH_NLRI §3 with the next-hop inside
+  the attribute, withdrawals in MP_UNREACH_NLRI §4) to be treated
+  identically to the traditional NLRI and Withdrawn Routes fields, because
+  RFC 4760 senders such as xk6-bgp encode it that way while zebra-rs, FRR
+  and GoBGP use the traditional fields — so only a scripted speaker can
+  produce these shapes.
 
-  Regression for the issue fixed by PR #2045: such UPDATEs were accepted
-  without error but had no effect — no Loc-RIB entry, no FIB install, no
-  re-advertisement, no log line. The scripted speaker also sends a decoy
-  NEXT_HOP attribute; per RFC 4760 the next-hop inside MP_REACH supersedes
-  it, which the next-hop assertions pin down.
+  Both directions were broken, and both failure modes are covered here:
+  - MP_REACH (fixed by PR #2045): the UPDATE was accepted without error but
+    had no effect — no Loc-RIB entry, no FIB install, no re-advertisement,
+    no log line.
+  - MP_UNREACH: AFI=1/SAFI=1 had no arm in the parser at all, so the whole
+    UPDATE failed to parse. That error is not on the RFC 7606 recoverable
+    lists, so the peer reader **tore the session down** — a sender that
+    announced via MP_REACH reset the session on its first withdrawal.
+
+  The scripted speaker also sends a decoy NEXT_HOP attribute; per RFC 4760
+  the next-hop inside MP_REACH supersedes it, which the next-hop assertions
+  pin down.
 
   Test Topology:
   ```
@@ -30,9 +39,9 @@ Feature: BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
 
   h1 runs tests/scripts/bgp_mp_reach_send.py: it announces 10.99.0.0/24
   inside MP_REACH_NLRI (next-hop 192.168.30.2, decoy NEXT_HOP attribute
-  192.168.30.99), holds the session with keepalives, and withdraws the
-  prefix through the traditional withdrawn-routes field when the trigger
-  file /tmp/bgp_mp_reach_ipv4_withdraw appears.
+  192.168.30.99) and then acts on trigger files, each consumed when it
+  fires so re-touching re-triggers:
+  /tmp/bgp_mp_reach_ipv4.announce, .withdraw_traditional, .withdraw_mp.
 
   Scenario: Setup topology and establish sessions
     Given a clean test environment
@@ -45,7 +54,7 @@ Feature: BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
     And I apply config "z1.yaml" to namespace "z1"
     And I apply config "z2.yaml" to namespace "z2"
     Then BGP session in "z1" to "192.168.30.3" should eventually be "Established"
-    When I spawn "timeout 600 python3 tests/scripts/bgp_mp_reach_send.py 192.168.30.1 65031 192.168.30.2 10.99.0.0/24 192.168.30.2 192.168.30.99 /tmp/bgp_mp_reach_ipv4_withdraw" in namespace "h1"
+    When I spawn "timeout 600 python3 tests/scripts/bgp_mp_reach_send.py 192.168.30.1 65031 192.168.30.2 10.99.0.0/24 192.168.30.2 192.168.30.99 /tmp/bgp_mp_reach_ipv4" in namespace "h1"
     Then BGP session in "z1" to "192.168.30.2" should eventually be "Established"
 
   Scenario: MP_REACH-encoded IPv4 unicast enters the Loc-RIB with the MP_REACH next-hop
@@ -61,16 +70,28 @@ Feature: BGP IPv4 unicast carried in MP_REACH_NLRI with an IPv4 next-hop
     And BGP route in "z2" has "10.99.0.0/24" with "next_hop" value "192.168.30.1"
     And BGP route in "z2" has "10.99.0.0/24" with "as_path" value "65030 65031"
 
-  Scenario: A traditional withdraw removes the MP_REACH-announced route
+  # The session assertion is the real regression gate: an unparsable
+  # MP_UNREACH does not just fail to withdraw, it resets the session.
+  Scenario: An MP_UNREACH withdraw removes the route without resetting the session
     Given the test topology exists
-    When I execute "touch /tmp/bgp_mp_reach_ipv4_withdraw" in namespace "h1"
+    When I execute "touch /tmp/bgp_mp_reach_ipv4.withdraw_mp" in namespace "h1"
     Then show command "show bgp" in namespace "z1" should eventually not contain "10.99.0.0/24"
     And show command "show bgp" in namespace "z2" should eventually not contain "10.99.0.0/24"
     And kernel route "10.99.0.0/24" in namespace "z1" should eventually be gone
+    And BGP session in "z1" to "192.168.30.2" should be "Established"
+
+  Scenario: A traditional withdraw also removes the MP_REACH-announced route
+    Given the test topology exists
+    When I execute "touch /tmp/bgp_mp_reach_ipv4.announce" in namespace "h1"
+    Then show command "show bgp" in namespace "z1" should eventually contain "10.99.0.0/24"
+    When I execute "touch /tmp/bgp_mp_reach_ipv4.withdraw_traditional" in namespace "h1"
+    Then show command "show bgp" in namespace "z1" should eventually not contain "10.99.0.0/24"
+    And show command "show bgp" in namespace "z2" should eventually not contain "10.99.0.0/24"
+    And BGP session in "z1" to "192.168.30.2" should be "Established"
 
   Scenario: Teardown topology
     Given the test topology exists
-    When I execute "rm -f /tmp/bgp_mp_reach_ipv4_withdraw" in namespace "h1"
+    When I execute "rm -f /tmp/bgp_mp_reach_ipv4.announce /tmp/bgp_mp_reach_ipv4.withdraw_traditional /tmp/bgp_mp_reach_ipv4.withdraw_mp" in namespace "h1"
     And I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I delete namespace "z1"

--- a/bdd/tests/scripts/bgp_mp_reach_send.py
+++ b/bdd/tests/scripts/bgp_mp_reach_send.py
@@ -1,32 +1,37 @@
 #!/usr/bin/env python3
-"""Minimal scripted BGP speaker announcing IPv4 unicast inside MP_REACH_NLRI.
+"""Minimal scripted BGP speaker for the RFC 4760 MP-encoded IPv4 unicast forms.
 
-zebra-rs, FRR and GoBGP all emit plain IPv4 unicast in the traditional
-NLRI field, so a router-to-router topology can never produce the RFC 4760
-S3 encoding (AFI=1/SAFI=1 reachability inside the MP_REACH_NLRI attribute
-with the next-hop carried in the attribute). This script plays that
-sender -- the shape xk6-bgp and other MP-first stacks emit -- against a
-zebra-rs DUT (issue fixed by PR #2045).
+zebra-rs, FRR and GoBGP all put plain IPv4 unicast in the traditional
+NLRI / Withdrawn Routes fields, so a router-to-router topology can never
+produce the RFC 4760 encodings for AFI=1/SAFI=1 -- reachability inside
+MP_REACH_NLRI (S3) and withdrawals inside MP_UNREACH_NLRI (S4). This
+script plays that sender, the shape xk6-bgp and other MP-first stacks
+emit. Both encodings were broken in zebra-rs: MP_REACH was accepted and
+silently dropped (fixed by PR #2045), MP_UNREACH failed to parse and
+reset the session.
 
 Flow:
   1. TCP-connect to the DUT, send OPEN with capabilities MP(1/1) and
      4-octet AS, answer its OPEN with a KEEPALIVE, wait for its KEEPALIVE.
-  2. Send ONE UPDATE whose only reachability is an MP_REACH_NLRI
-     attribute (v4 next-hop inside the attribute, no traditional NLRI).
-     A decoy NEXT_HOP attribute rides along; per RFC 4760 the MP_REACH
-     next-hop must win, so the DUT installing the decoy is a bug the
-     feature would catch.
-  3. Keep the session alive with keepalives. When TRIGGER_FILE appears
-     (touched by a later scenario), send a traditional withdrawn-routes
-     UPDATE for the same prefix -- withdraws are prefix-keyed, so mixing
-     encodings is legal and proves the MP_REACH-announced route went into
-     the ordinary Loc-RIB.
+  2. Announce PREFIX in an MP_REACH_NLRI attribute (v4 next-hop inside
+     the attribute, no traditional NLRI). A decoy NEXT_HOP attribute
+     rides along; per RFC 4760 the MP_REACH next-hop must win, so a DUT
+     installing the decoy is a bug the feature would catch.
+  3. Keep the session alive with keepalives and act on trigger files,
+     each consumed (unlinked) when it fires so re-touching re-triggers:
+       <TRIGGER_BASE>.announce               re-announce via MP_REACH
+       <TRIGGER_BASE>.withdraw_traditional   withdraw via the legacy
+                                             Withdrawn Routes field
+       <TRIGGER_BASE>.withdraw_mp            withdraw via MP_UNREACH
+     Mixing encodings is deliberate: a traditional withdraw of an
+     MP_REACH-announced prefix only works if the route went into the
+     ordinary Loc-RIB rather than a side path.
   4. Exit when the peer closes the connection (feature teardown stops the
      DUT). The feature wraps the script in `timeout N` as a backstop.
 
 Usage:
   bgp_mp_reach_send.py DUT_IP LOCAL_AS ROUTER_ID PREFIX MP_NEXTHOP \
-      DECOY_NEXTHOP TRIGGER_FILE
+      DECOY_NEXTHOP TRIGGER_BASE
 """
 
 import ipaddress
@@ -39,7 +44,10 @@ import time
 MARKER = b"\xff" * 16
 MSG_OPEN, MSG_UPDATE, MSG_NOTIFICATION, MSG_KEEPALIVE = 1, 2, 3, 4
 CAP_MP, CAP_AS4 = 1, 65
+ATTR_MP_REACH, ATTR_MP_UNREACH = 14, 15
+AFI_IP, SAFI_UNICAST = 1, 1
 HOLDTIME = 90
+TRIGGERS = ("announce", "withdraw_traditional", "withdraw_mp")
 
 
 def bgp_msg(msg_type, body):
@@ -47,7 +55,7 @@ def bgp_msg(msg_type, body):
 
 
 def open_msg(local_as, router_id):
-    caps = bytes([CAP_MP, 4]) + struct.pack("!HBB", 1, 0, 1)  # AFI=1/SAFI=1
+    caps = bytes([CAP_MP, 4]) + struct.pack("!HBB", AFI_IP, 0, SAFI_UNICAST)
     caps += bytes([CAP_AS4, 4]) + struct.pack("!I", local_as)
     opt = bytes([2, len(caps)]) + caps  # one Capabilities optional parameter
     my_as2 = local_as if local_as < 65536 else 23456  # AS_TRANS
@@ -74,27 +82,46 @@ def peer_open_has_as4(body):
 
 
 def nlri_bytes(prefix):
+    """Prefix length octet + the ceil(plen/8) significant prefix octets."""
     net = ipaddress.ip_network(prefix)
     nbytes = (net.prefixlen + 7) // 8
     return bytes([net.prefixlen]) + net.network_address.packed[:nbytes]
 
 
-def update_announce(local_as, prefix, mp_nexthop, decoy_nexthop, as4):
-    attrs = b"\x40\x01\x01\x00"  # ORIGIN = IGP
-    fmt = "!BBI" if as4 else "!BBH"
-    seg = struct.pack(fmt, 2, 1, local_as)  # one AS_SEQUENCE of local AS
-    attrs += bytes([0x40, 2, len(seg)]) + seg  # AS_PATH
-    attrs += b"\x40\x03\x04" + socket.inet_aton(decoy_nexthop)  # NEXT_HOP
-    val = (struct.pack("!HBB", 1, 1, 4) + socket.inet_aton(mp_nexthop)
-           + b"\x00" + nlri_bytes(prefix))  # AFI/SAFI/nhlen/nh/SNPA=0/NLRI
-    attrs += bytes([0x80, 14, len(val)]) + val  # MP_REACH_NLRI
-    body = struct.pack("!H", 0) + struct.pack("!H", len(attrs)) + attrs
+def attr(flags, type_code, value):
+    return bytes([flags, type_code, len(value)]) + value
+
+
+def update_msg(withdrawn, attrs, nlri=b""):
+    body = (struct.pack("!H", len(withdrawn)) + withdrawn
+            + struct.pack("!H", len(attrs)) + attrs + nlri)
     return bgp_msg(MSG_UPDATE, body)
 
 
-def update_withdraw(prefix):
-    w = nlri_bytes(prefix)
-    return bgp_msg(MSG_UPDATE, struct.pack("!H", len(w)) + w + b"\x00\x00")
+def update_announce(local_as, prefix, mp_nexthop, decoy_nexthop, as4):
+    attrs = attr(0x40, 1, b"\x00")  # ORIGIN = IGP
+    fmt = "!BBI" if as4 else "!BBH"
+    attrs += attr(0x40, 2, struct.pack(fmt, 2, 1, local_as))  # AS_PATH
+    attrs += attr(0x40, 3, socket.inet_aton(decoy_nexthop))  # NEXT_HOP
+    # MP_REACH: AFI/SAFI, next-hop length + address, SNPA=0, NLRI.
+    value = (struct.pack("!HBB", AFI_IP, SAFI_UNICAST, 4)
+             + socket.inet_aton(mp_nexthop) + b"\x00" + nlri_bytes(prefix))
+    attrs += attr(0x80, ATTR_MP_REACH, value)
+    return update_msg(b"", attrs)
+
+
+def update_withdraw_traditional(prefix):
+    return update_msg(nlri_bytes(prefix), b"")
+
+
+def update_withdraw_mp(prefix):
+    """RFC 4760 §4 withdrawal: MP_UNREACH is the UPDATE's only attribute.
+
+    A withdraw-only UPDATE carries no mandatory path attributes, so this
+    is exactly what an MP-first sender puts on the wire.
+    """
+    value = struct.pack("!HB", AFI_IP, SAFI_UNICAST) + nlri_bytes(prefix)
+    return update_msg(b"", attr(0x80, ATTR_MP_UNREACH, value))
 
 
 def recv_exact(sock, n):
@@ -118,7 +145,29 @@ def read_msg(sock):
     return msg_type, body
 
 
-def session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, trigger):
+def clear_triggers(base):
+    """Drop stale trigger files so a crashed prior run cannot fire one."""
+    for name in TRIGGERS:
+        try:
+            os.unlink(f"{base}.{name}")
+        except FileNotFoundError:
+            pass
+
+
+def take_trigger(base):
+    """Return the name of one fired trigger, consuming it, else None."""
+    for name in TRIGGERS:
+        path = f"{base}.{name}"
+        if os.path.exists(path):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            return name
+    return None
+
+
+def session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, base):
     sock = socket.create_connection((dut_ip, 179), timeout=10)
     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     sock.settimeout(30)
@@ -138,13 +187,13 @@ def session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, trigger):
             break  # Established
         elif msg_type == MSG_NOTIFICATION:
             raise ConnectionError(f"NOTIFICATION in handshake: {body.hex()}")
+    announce = update_announce(local_as, prefix, mp_nexthop, decoy, peer_as4)
     print(f"established (peer as4={peer_as4}); announcing {prefix} "
           f"via MP_REACH next-hop {mp_nexthop}", flush=True)
-    sock.sendall(update_announce(local_as, prefix, mp_nexthop, decoy, peer_as4))
+    sock.sendall(announce)
 
     sock.settimeout(1)
     last_keepalive = time.time()
-    withdrawn = False
     while True:
         try:
             m = read_msg(sock)
@@ -159,29 +208,31 @@ def session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, trigger):
         if time.time() - last_keepalive > 20:
             sock.sendall(bgp_msg(MSG_KEEPALIVE, b""))
             last_keepalive = time.time()
-        if not withdrawn and os.path.exists(trigger):
-            print(f"trigger file seen; withdrawing {prefix} via the "
-                  "traditional withdrawn-routes field", flush=True)
-            sock.sendall(update_withdraw(prefix))
-            withdrawn = True
+        fired = take_trigger(base)
+        if fired == "announce":
+            print(f"re-announcing {prefix} via MP_REACH", flush=True)
+            sock.sendall(announce)
+        elif fired == "withdraw_traditional":
+            print(f"withdrawing {prefix} via the traditional "
+                  "withdrawn-routes field", flush=True)
+            sock.sendall(update_withdraw_traditional(prefix))
+        elif fired == "withdraw_mp":
+            print(f"withdrawing {prefix} via MP_UNREACH", flush=True)
+            sock.sendall(update_withdraw_mp(prefix))
 
 
 def main():
-    dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, trigger = (
+    dut_ip, local_as, router_id, prefix, mp_nexthop, decoy, base = (
         sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4],
         sys.argv[5], sys.argv[6], sys.argv[7])
-    # A stale trigger from a crashed prior run would withdraw immediately.
-    try:
-        os.unlink(trigger)
-    except FileNotFoundError:
-        pass
+    clear_triggers(base)
     # The DUT's neighbor config may not be applied yet when we are spawned
     # (it closes/refuses until then) -- retry the whole handshake.
     deadline = time.time() + 120
     while True:
         try:
             session(dut_ip, local_as, router_id, prefix, mp_nexthop, decoy,
-                    trigger)
+                    base)
             return
         except (ConnectionError, OSError) as e:
             if time.time() > deadline:

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -5,7 +5,7 @@ use nom::error::{ErrorKind, make_error};
 use nom_derive::*;
 
 use crate::{
-    Afi, AttrFlags, AttrType, BgpLsNlri, EvpnRoute, FlowspecNlri, Ipv6Nlri, Labelv4Nlri,
+    Afi, AttrFlags, AttrType, BgpLsNlri, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, Labelv4Nlri,
     Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv4Unreach, Rtcv6,
     Rtcv6Unreach, Safi, SrPolicyNlri, Vpnv4Nlri, Vpnv6Nlri, parse_nlri_block,
 };
@@ -20,7 +20,12 @@ pub struct MpUnreachHeader {
 
 #[derive(Clone)]
 pub enum MpUnreachAttr {
-    // Ipv4Nlri(Vec<>),
+    /// IPv4 unicast withdrawals carried in MP_UNREACH (RFC 4760 §4,
+    /// AFI=1/SAFI=1). IPv4 unicast normally uses the UPDATE's legacy
+    /// Withdrawn Routes field, but a sender that announces through
+    /// MP_REACH typically withdraws through MP_UNREACH too, and
+    /// RFC 4760 permits it whenever capability 1/1 is negotiated.
+    Ipv4Nlri(Vec<Ipv4Nlri>),
     Ipv4Eor,
     Ipv6Nlri(Vec<Ipv6Nlri>),
     Ipv6Eor,
@@ -91,6 +96,12 @@ impl MpUnreachAttr {
                 let attr = Vpnv6Unreach { withdraw: vec![] };
                 attr.attr_emit(buf);
             }
+            MpUnreachAttr::Ipv4Nlri(withdraws) => {
+                ipv4_unreach_attr_emit(withdraws, buf);
+            }
+            MpUnreachAttr::Ipv4Eor => {
+                ipv4_unreach_attr_emit(&[], buf);
+            }
             MpUnreachAttr::Ipv6Nlri(withdraws) => {
                 ipv6_unreach_attr_emit(withdraws, buf);
             }
@@ -142,21 +153,38 @@ impl MpUnreachAttr {
     }
 }
 
-/// Serialize an `MpUnreachAttr::Evpn(updates)` (or `EvpnEor` when
-/// `updates` is empty) as a complete `MP_UNREACH_NLRI` path attribute
-/// (header + value).
+/// Serialize an `MpUnreachAttr::Ipv4Nlri(withdraws)` (or `Ipv4Eor` when
+/// `withdraws` is empty) as a complete MP_UNREACH_NLRI path attribute.
 ///
-/// Wire format (RFC 4760 §4):
-/// ```text
-///   AFI  (2 octets) = 25 (L2VPN)
-///   SAFI (1 octet)  = 70 (EVPN)
-///   Withdrawn Routes (one or more EvpnRoute encodings; empty for EoR)
-/// ```
-///
-/// MP_UNREACH carries neither nexthop nor SNPA — only the AFI/SAFI
-/// header and the NLRI list. The NLRI body bytes are produced by
-/// `EvpnRoute::nlri_emit`, the same encoder used by the
-/// MP_REACH advertise path.
+/// Wire format (RFC 4760 §4): AFI=1, SAFI=1, then the NLRI list (empty
+/// for end-of-RIB). zebra-rs itself withdraws IPv4 unicast through the
+/// UPDATE's legacy Withdrawn Routes field, so this is the decode-side
+/// inverse rather than something the advertise path emits.
+fn ipv4_unreach_attr_emit(withdraws: &[Ipv4Nlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip));
+    value.put_u8(u8::from(Safi::Unicast));
+    for nlri in withdraws {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
 /// Serialize an `MpUnreachAttr::Ipv6Nlri(withdraws)` (or `Ipv6Eor`
 /// when `withdraws` is empty) as a complete MP_UNREACH_NLRI path
 /// attribute. IPv6 unicast withdrawals have no legacy field, so this
@@ -189,6 +217,21 @@ fn ipv6_unreach_attr_emit(withdraws: &[Ipv6Nlri], buf: &mut BytesMut) {
     buf.put(&value[..]);
 }
 
+/// Serialize an `MpUnreachAttr::Evpn(updates)` (or `EvpnEor` when
+/// `updates` is empty) as a complete `MP_UNREACH_NLRI` path attribute
+/// (header + value).
+///
+/// Wire format (RFC 4760 §4):
+/// ```text
+///   AFI  (2 octets) = 25 (L2VPN)
+///   SAFI (1 octet)  = 70 (EVPN)
+///   Withdrawn Routes (one or more EvpnRoute encodings; empty for EoR)
+/// ```
+///
+/// MP_UNREACH carries neither nexthop nor SNPA — only the AFI/SAFI
+/// header and the NLRI list. The NLRI body bytes are produced by
+/// `EvpnRoute::nlri_emit`, the same encoder used by the
+/// MP_REACH advertise path.
 fn evpn_unreach_attr_emit(withdraw: &[EvpnRoute], buf: &mut BytesMut) {
     let mut value = BytesMut::new();
     value.put_u16(u16::from(Afi::L2vpn));
@@ -439,6 +482,19 @@ impl MpUnreachAttr {
             let mp_nlri = MpUnreachAttr::Vpnv6(withdrawal);
             return Ok((input, mp_nlri));
         }
+        if header.afi == Afi::Ip && header.safi == Safi::Unicast {
+            // RFC 4724 §2 makes the bare empty UPDATE the IPv4-unicast
+            // end-of-RIB, so an empty MP_UNREACH(1/1) is unusual — but
+            // some stacks send it, and every other family here treats an
+            // empty withdraw list as EoR. Mirror that rather than
+            // failing the parse (a parse error here resets the session).
+            if input.is_empty() {
+                return Ok((input, MpUnreachAttr::Ipv4Eor));
+            }
+            let (input, withdrawal) =
+                parse_nlri_block(input, |i| Ipv4Nlri::parse_nlri(i, add_path))?;
+            return Ok((input, MpUnreachAttr::Ipv4Nlri(withdrawal)));
+        }
         if header.afi == Afi::Ip6 && header.safi == Safi::Unicast {
             if input.is_empty() {
                 let mp_nlri = MpUnreachAttr::Ipv6Eor;
@@ -573,6 +629,12 @@ impl fmt::Display for MpUnreachAttr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use MpUnreachAttr::*;
         match self {
+            Ipv4Nlri(ipv4_nlris) => {
+                for ipv4 in ipv4_nlris.iter() {
+                    writeln!(f, " {}:{}", ipv4.id, ipv4.prefix)?;
+                }
+                Ok(())
+            }
             Ipv4Eor => {
                 writeln!(f, " EoR: {}/{}", Afi::Ip, Safi::Unicast)
             }
@@ -1029,5 +1091,80 @@ mod tests {
             }
             other => panic!("expected SrPolicy, got {other:?}"),
         }
+    }
+
+    /// Regression: AFI=1/SAFI=1 had no arm here at all, so an IPv4-unicast
+    /// MP_UNREACH fell through to the trailing `Err`. That error is not on
+    /// the RFC 7606 treat-as-withdraw or attribute-discard lists, so the
+    /// whole UPDATE failed to parse and the session was reset — the
+    /// withdraw-side counterpart of the MP_REACH gap fixed in #2045.
+    #[test]
+    fn ipv4_unicast_unreach_parses_instead_of_erroring() {
+        // AFI=1, SAFI=1, then 10.0.0.0/24 (3 prefix octets) and
+        // 192.0.2.0/25 (4 — a /25 still spans the fourth octet).
+        let value = [0x00u8, 0x01, 0x01, 24, 10, 0, 0, 25, 192, 0, 2, 0];
+        let (rest, mp) = MpUnreachAttr::parse_nlri_opt(&value, None)
+            .expect("IPv4-unicast MP_UNREACH must parse");
+        assert!(rest.is_empty());
+        match mp {
+            MpUnreachAttr::Ipv4Nlri(withdraws) => {
+                assert_eq!(withdraws.len(), 2);
+                assert_eq!(withdraws[0].prefix.to_string(), "10.0.0.0/24");
+                assert_eq!(withdraws[1].prefix.to_string(), "192.0.2.0/25");
+            }
+            other => panic!("expected Ipv4Nlri, got {other:?}"),
+        }
+    }
+
+    /// An empty IPv4-unicast MP_UNREACH is end-of-RIB. RFC 4724 §2 makes
+    /// the bare empty UPDATE the canonical v4 EoR, but some stacks send
+    /// this form and every other family here treats an empty withdraw
+    /// list the same way.
+    #[test]
+    fn ipv4_unicast_unreach_empty_is_eor() {
+        let value = [0x00u8, 0x01, 0x01];
+        let (_rest, mp) = MpUnreachAttr::parse_nlri_opt(&value, None).expect("EoR must parse");
+        assert!(matches!(mp, MpUnreachAttr::Ipv4Eor));
+    }
+
+    #[test]
+    fn ipv4_unreach_emit_round_trips() {
+        let withdraws = vec![
+            Ipv4Nlri {
+                id: 0,
+                prefix: "10.0.0.0/24".parse().unwrap(),
+            },
+            Ipv4Nlri {
+                id: 0,
+                prefix: "0.0.0.0/0".parse().unwrap(),
+            },
+        ];
+        let mut buf = BytesMut::new();
+        ipv4_unreach_attr_emit(&withdraws, &mut buf);
+        // Skip the attribute header (flags, type, 1-octet length).
+        let (_rest, mp) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("emitter must round-trip");
+        match mp {
+            MpUnreachAttr::Ipv4Nlri(parsed) => assert_eq!(parsed, withdraws),
+            other => panic!("expected Ipv4Nlri, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ipv4_unreach_emit_eor_round_trips() {
+        let mut buf = BytesMut::new();
+        ipv4_unreach_attr_emit(&[], &mut buf);
+        let (_rest, mp) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("EoR must round-trip");
+        assert!(matches!(mp, MpUnreachAttr::Ipv4Eor));
+    }
+
+    /// A malformed NLRI must fail the whole block rather than silently
+    /// truncating it, matching every other family (`parse_nlri_block`).
+    #[test]
+    fn ipv4_unicast_unreach_rejects_malformed_nlri() {
+        // 10.0.0.0/24 followed by prefix length 33, which exceeds 32.
+        let value = [0x00u8, 0x01, 0x01, 24, 10, 0, 0, 33, 1, 2, 3, 4, 5];
+        assert!(MpUnreachAttr::parse_nlri_opt(&value, None).is_err());
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_ipv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_ipv4.rs
@@ -1,5 +1,6 @@
 use std::net::Ipv4Addr;
 
+use bytes::{BufMut, BytesMut};
 use ipnet::Ipv4Net;
 use nom::IResult;
 use nom::bytes::complete::take;
@@ -13,6 +14,22 @@ use crate::{ParseNlri, nlri_psize};
 pub struct Ipv4Nlri {
     pub id: u32,
     pub prefix: Ipv4Net,
+}
+
+impl Ipv4Nlri {
+    /// Encode this NLRI into an MP_REACH / MP_UNREACH NLRI list:
+    /// an optional 4-octet AddPath ID (only when `id != 0`), the
+    /// 1-octet prefix length, then the `ceil(plen / 8)` significant
+    /// prefix octets. Inverse of [`Ipv4Nlri::parse_nlri`].
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.id != 0 {
+            buf.put_u32(self.id);
+        }
+        let plen = self.prefix.prefix_len();
+        buf.put_u8(plen);
+        let psize = nlri_psize(plen);
+        buf.put(&self.prefix.addr().octets()[0..psize]);
+    }
 }
 
 impl ParseNlri<Ipv4Nlri> for Ipv4Nlri {

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -837,6 +837,41 @@ mod tests {
         }
     }
 
+    /// The withdraw-side counterpart: a full UPDATE whose only content is
+    /// an IPv4-unicast MP_UNREACH (RFC 4760 §4). Before AFI=1/SAFI=1 was
+    /// handled there, this failed to parse, and because MP_UNREACH is not
+    /// on the RFC 7606 recoverable lists the peer reader tore the session
+    /// down — so a sender that announced via MP_REACH reset the session on
+    /// its first withdrawal.
+    #[test]
+    fn ipv4_unicast_mp_unreach_full_packet_decodes() {
+        // MP_UNREACH: AFI=1/SAFI=1, NLRI 10.0.0.0/24.
+        let value = [0x00u8, 0x01, 0x01, 24, 10, 0, 0];
+        let mut attrs = vec![0x80u8, 15, value.len() as u8];
+        attrs.extend_from_slice(&value);
+
+        let mut buf = vec![0xffu8; 16];
+        let total = BGP_HEADER_LEN as usize + 2 + 2 + attrs.len();
+        buf.extend_from_slice(&(total as u16).to_be_bytes());
+        buf.push(2); // type = UPDATE
+        buf.extend_from_slice(&0u16.to_be_bytes()); // withdrawn routes length
+        buf.extend_from_slice(&(attrs.len() as u16).to_be_bytes());
+        buf.extend_from_slice(&attrs);
+
+        let (_, parsed) = UpdatePacket::parse_packet(&buf, true, None).expect("must decode");
+        assert!(
+            parsed.ipv4_withdraw.is_empty(),
+            "no legacy withdrawn routes"
+        );
+        match parsed.mp_withdraw {
+            Some(MpUnreachAttr::Ipv4Nlri(withdraws)) => {
+                assert_eq!(withdraws.len(), 1);
+                assert_eq!(withdraws[0].prefix.to_string(), "10.0.0.0/24");
+            }
+            other => panic!("expected MpUnreachAttr::Ipv4Nlri, got {other:?}"),
+        }
+    }
+
     #[test]
     fn many_prefixes_round_trip_into_one_packet() {
         let ll: Ipv6Addr = "fe80::abcd".parse().unwrap();

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -10039,6 +10039,21 @@ pub fn route_from_peer(
                     route_mup_withdraw(peer_id, route, bgp, peers);
                 }
             }
+            MpUnreachAttr::Ipv4Nlri(withdrawals) => {
+                // RFC 4760 §4 IPv4-unicast withdrawals. A peer that
+                // announces through MP_REACH normally withdraws this
+                // way, so this must reach the same Loc-RIB the legacy
+                // Withdrawn Routes field does.
+                for withdraw in withdrawals.iter() {
+                    route_ipv4_withdraw(peer_id, withdraw, None, None, bgp, peers, shards, true);
+                }
+            }
+            MpUnreachAttr::Ipv4Eor => {
+                let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
+                let _ = bgp
+                    .tx
+                    .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
+            }
             MpUnreachAttr::Ipv6Nlri(withdrawals) => {
                 for withdraw in withdrawals.iter() {
                     route_ipv6_withdraw(peer_id, withdraw, None, bgp, peers, true);


### PR DESCRIPTION
## Summary

Closes the withdraw-side counterpart of the MP_REACH gap fixed in #2045.

`MpUnreachAttr` had no AFI=1/SAFI=1 arm — only a never-constructed
`Ipv4Eor` stub — so an IPv4-unicast MP_UNREACH fell through to the
trailing `Err` in `parse_nlri_opt`. That error is on neither the RFC 7606
treat-as-withdraw nor the attribute-discard list, so the whole UPDATE
failed to parse and `peer_packet_parse` dropped the connection: **the
peer got a session reset instead of a withdrawal.**

#2045 made this reachable in practice. A sender that announces through
MP_REACH (xk6-bgp and other MP-first stacks) normally withdraws through
MP_UNREACH, so the first withdrawal reset a session that was otherwise
carrying routes fine. RFC 4760 permits the encoding whenever capability
1/1 is negotiated, and gobgpd, RustyBGP and FRR all accept it.

## Change

- New `MpUnreachAttr::Ipv4Nlri(Vec<Ipv4Nlri>)` variant with parse, emit
  and `Display` arms, plus `Ipv4Nlri::nlri_emit` mirroring the IPv6 one.
- `route_from_peer` routes it through `route_ipv4_withdraw` — the same
  path the legacy Withdrawn Routes field takes, sharded identically.
- An empty list decodes as `Ipv4Eor` and fires the stale timer like every
  other family. RFC 4724 §2 makes the bare empty UPDATE the canonical v4
  end-of-RIB, but some stacks send this form, and tolerating it beats
  resetting the session. `Ipv4Eor` previously fell through `attr_emit`'s
  catch-all and encoded nothing, which the new emit arm also fixes.
- Drive-by: `evpn_unreach_attr_emit`'s doc comment had drifted onto
  `ipv6_unreach_attr_emit`; each now sits on its own function.

## Tests

Unit (bgp-packet): parse a two-prefix withdrawal, empty-is-EoR,
emit round-trips for both, malformed-NLRI still fails the block, and a
full-UPDATE decode that previously errored.

Live BDD: the scripted speaker gains a `.withdraw_mp` trigger and the
feature a scenario asserting the route is removed **and the session stays
Established**. The session assertion is the real gate — an unparsable
MP_UNREACH resets rather than merely failing to withdraw, and the
route-removal steps pass either way because a reset also drops the routes.

Verified as a regression gate by running the feature against a binary
built from current `main` and against this branch (md5 of
`/usr/bin/zebra-rs` checked before and after each run):

| | main | this branch |
|---|---|---|
| session Established after MP_UNREACH withdraw | **fail** | pass |
| re-announce after the withdraw | **fail** (session dead) | pass |
| all 6 scenarios | 0 passed | **6 passed** |

Local CI mirror is green: `cargo fmt`, `RUSTFLAGS="-D warnings" cargo
clippy --workspace --all-targets`, `RUSTFLAGS="-D warnings" cargo test
--workspace --exclude bdd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)