### PR TITLE
docs: record the IPv4-unicast MP_REACH/MP_UNREACH arc and its follow-ups

### DIFF
--- a/docs/design/bgp-multiprotocol-receive-followups.md
+++ b/docs/design/bgp-multiprotocol-receive-followups.md
@@ -5,6 +5,11 @@ merged). This series made plain IPv6 unicast work end to end and
 un-dropped every MP_REACH family on receive; the items below are the
 gaps that were deliberately left out of those small PRs.
 
+Updated 2026-07-21 with the IPv4-unicast arc (#2045 / #2051 / #2053) —
+see that section for what landed and its two remaining follow-ups. Two
+older items are annotated resolved/stale in place rather than deleted,
+so the reasoning behind them stays readable.
+
 Standing guidance still applies: recommend the smallest meaningful
 slice with its main tradeoff, let the user redirect, ship one branch /
 one PR at a time.
@@ -27,6 +32,80 @@ one PR at a time.
   Vpnv4/Evpn/Ipv4/Ipv6 into `_ => {}`; now `other => mp_update = Some`
   surfaces VPNv6, IPv4/IPv6 Labeled-Unicast, Flowspec, SR-Policy,
   RTC (v4/v6), BGP-LS, MUP for dispatch by `route_from_peer`.
+
+## 2026-07-21: IPv4 unicast over the MP attributes (#2045 / #2051 / #2053)
+
+A later arc closed the AFI=1/SAFI=1 half of this story. RFC 4760 lets a
+speaker carry plain IPv4 unicast in the MP attributes instead of the
+UPDATE's legacy NLRI / Withdrawn Routes fields, and xk6-bgp and other
+MP-first stacks do exactly that. Both directions were broken, in
+opposite ways:
+
+- **#2045** (MP_REACH, §3, external contribution) — the
+  `MpReachAttr::Ipv4` arm in `route_from_peer` only matched the RFC 8950
+  IPv4-over-IPv6 shape and warned-and-dropped everything else. An UPDATE
+  with a v4 next-hop inside MP_REACH was accepted with no error and no
+  effect: no Loc-RIB entry, no FIB install, no re-advertisement. Fixed by
+  splitting the arm on next-hop family and stamping the MP_REACH next-hop
+  (which supersedes any NEXT_HOP attribute) before the normal
+  `route_ipv4_update_batch` path.
+- **#2053** (MP_UNREACH, §4) — `MpUnreachAttr` had *no* AFI=1/SAFI=1 arm,
+  only a never-constructed `Ipv4Eor` stub, so the withdrawal fell through
+  to the trailing `Err` in `parse_nlri_opt`. That error is on neither the
+  RFC 7606 treat-as-withdraw nor the attribute-discard list, so the whole
+  UPDATE failed to parse and `peer_packet_parse` dropped the connection —
+  **a session reset, not a failed withdrawal**. #2045 is what made this
+  reachable: a peer that announces via MP_REACH withdraws the same way,
+  so the first withdrawal killed a session that was carrying routes fine.
+
+**The parsers are now symmetric.** MP_REACH and MP_UNREACH cover the same
+13 AFI/SAFI combinations, so there is no remaining family where a peer
+can announce successfully and then reset the session by withdrawing.
+Re-run that comparison (the `if header.afi == …` arms in `mp_reach.rs`
+vs `mp_unreach.rs`) whenever a family is added to one side.
+
+**#2051 added a scripted-speaker BDD harness**, which is relevant to the
+interop item below: `bdd/tests/scripts/bgp_mp_reach_send.py` is a
+stdlib-only Python BGP speaker driven by trigger files
+(`.announce` / `.withdraw_traditional` / `.withdraw_mp`), used by feature
+`bgp_mp_reach_ipv4`. It exists because a gobgp/FRR harness *cannot* cover
+these encodings — no mainstream implementation emits them. Reach for it
+for any "only a weird sender produces this" case (malformed attributes,
+unusual next-hop lengths); reach for gobgp/FRR for ordinary families.
+
+Two traps that cost time and are worth reusing:
+
+- The DUT neighbor facing the script must set
+  `transport: {passive-mode: true}`. The script never listens on 179, so
+  the DUT's dial-outs get refused and it cycles Idle → Connect → Idle,
+  and **Idle refuses inbound connections** — the script's connect is
+  RST'd forever.
+- When the failure mode is a session reset, assert the session is still
+  Established. The route-removal assertions pass either way, because a
+  reset drops the peer's routes too; without the session assertion the
+  MP_UNREACH scenario goes green against the broken build.
+
+### Follow-ups from that arc
+
+Neither is urgent; both are latent rather than user-visible today.
+
+**`MpUnreachAttr::Rtcv4` / `Rtcv6` have no `attr_emit` arm.** They fall
+through the `_ => {}` catch-all and encode *nothing*. Unreachable right
+now — zebra-rs only ever constructs the `Rtcv4Eor` / `Rtcv6Eor` forms on
+send, and those do have arms — so nothing is broken. It is a trap for
+whoever first implements RTC membership *withdrawal*, because it fails
+silently rather than loudly. This is the same latent shape #2053 fixed
+for `Ipv4Eor`, which had likewise been encoding nothing.
+
+**The canonical IPv4-unicast end-of-RIB is not detected on receive.**
+RFC 4724 §2 makes the bare empty UPDATE the v4 EoR, but `route_from_peer`
+has no empty-UPDATE check, so only the unusual empty-MP_UNREACH form
+(the `Ipv4Eor` arm #2053 added) fires the v4 stale timer. Impact is
+bounded: `start_stale_timer` still flushes on timeout, so a restarting
+peer's stale routes linger until it expires instead of clearing promptly
+on EoR. It is a graceful-restart conformance gap, not a correctness bug.
+Worth its own change rather than a tack-on, because the fix has to
+separate a genuine EoR from a merely malformed empty UPDATE.
 
 ## The big one: per-family end-to-end interop validation
 
@@ -90,6 +169,12 @@ AFI/SAFI. (RTC membership is already sent on establish; VPNv6 advertise
 is additionally gated on the peer's RTCv6 EoR — preserve that.)
 
 ### RFC 7606 treat-as-withdraw coverage for the newly-surfaced families
+**Resolved — verified 2026-07-21.** `withdraw_mp_reach` now has a branch
+for all ten families that can carry a Prefix-SID (Vpnv4, Vpnv6, Evpn,
+Ipv4, Ipv6, Labelv4, Labelv6, Flowspec, SrPolicy, LinkState). RTC falls
+into the `_ =>` catch-all deliberately — it cannot carry a Prefix-SID
+attribute, so there is nothing to withdraw. Original concern below.
+
 When `treat_as_withdraw` is set, `route_from_peer` calls
 `withdraw_mp_reach`. Confirm it has a branch for every family #1286
 now surfaces (VPNv6 / labeled / Flowspec / SR-Policy / RTC / BGP-LS)
@@ -99,10 +184,11 @@ reachable NLRI it should withdraw.
 
 ## Known gaps / not blocking
 
-- **MUP** is surfaced by #1286 but `route_from_peer` has no MUP arm
-  (falls into its own harmless `_ => {}`). If MUP receive is ever
-  wanted, add the handler + Loc-RIB; until then it's parsed and
-  ignored (no worse than before).
+- ~~**MUP** is surfaced by #1286 but `route_from_peer` has no MUP arm.~~
+  **Stale — verified 2026-07-21.** `route_from_peer` has a
+  `MpReachAttr::Mup` arm that stamps the MP_REACH next-hop and calls
+  `route_mup_update`; the MUP series built out receive, Loc-RIB and
+  dataplane since this was written (see `bgp-mup-followups.md`).
 - The explicit `MpReachAttr::Ipv4` / `Ipv6` arms in the attribute
   parser are now redundant with the `other =>` catch-all (they only
   set `mp_update`, same as the default). `Vpnv4` / `Evpn` still stamp


### PR DESCRIPTION
Docs-only. Extends `docs/design/bgp-multiprotocol-receive-followups.md`
rather than starting a new file — the IPv4-unicast arc (#2045 / #2051 /
#2053) is the same receive-path story as the IPv6-unicast series that
doc already covers.

## Added

- **What landed**, in both directions: MP_REACH §3 was
  accepted-then-silently-dropped (#2045); MP_UNREACH §4 had no
  AFI=1/SAFI=1 arm at all, so a withdrawal was unparsable and **reset the
  session** (#2053) — which #2045 is what made reachable, since a peer
  that announces via MP_REACH withdraws the same way.
- **The parsers are now symmetric** across all 13 AFI/SAFI arms, so that
  bug has no remaining siblings. Noted how to re-check when a family is
  added to one side.
- **The scripted-speaker BDD harness** (#2051) and when to reach for it
  instead of gobgp/FRR — it exists precisely because no mainstream
  implementation emits these encodings. Plus the two traps it cost to
  find: the DUT must peer `passive-mode`, and when the failure mode is a
  session reset you must assert the session survives (route-removal
  assertions pass either way, because a reset drops the routes too).

## Two follow-ups recorded

Both latent rather than user-visible, neither urgent:

1. `MpUnreachAttr::Rtcv4` / `Rtcv6` have no `attr_emit` arm and encode
   nothing through the catch-all. Unreachable today; a silent trap for
   whoever first implements RTC membership withdrawal. Same shape as the
   `Ipv4Eor` no-op that #2053 fixed.
2. The RFC 4724 §2 bare-empty-UPDATE IPv4 end-of-RIB is not detected on
   receive. Bounded by the stale-timer fallback, so it is a graceful-
   restart conformance gap rather than a correctness bug.

## Two older items annotated

Annotated in place rather than deleted, so the reasoning stays readable.
Both re-verified against `main` today:

- RFC 7606 treat-as-withdraw coverage — **resolved**: `withdraw_mp_reach`
  covers all ten Prefix-SID-capable families; RTC is excluded on purpose.
- "MUP has no `route_from_peer` arm" — **stale**: the arm exists and the
  MUP series built out receive, Loc-RIB and dataplane since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)