### PR TITLE
bgp: authenticate dynamic neighbors with prefix-scoped TCP MD5

### DIFF
--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z1-nopass.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z1-nopass.yaml
@@ -1,0 +1,35 @@
+# Identical to z1.yaml except SENDERS carries no password. `vtyctl
+# apply -f` is a declarative whole-config replace, so the commit diff
+# is exactly the deletion of the group's `password` leaf — which must
+# retract the prefix key from the listening socket.
+#
+# The client keeps signing its SYNs, so with the key gone the handshake
+# cannot complete: an unauthenticated listener drops MD5-signed SYNs
+# just as surely as a mismatched key does.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z1.yaml
@@ -1,0 +1,34 @@
+# z1 — DUT. The listen-range's group carries the TCP MD5 password, so
+# the whole 192.168.0.0/24 prefix is authenticated by one key installed
+# on the listening socket (TCP_MD5SIG_EXT + TCP_MD5SIG_FLAG_PREFIX).
+# A per-address key cannot work here: the peer is only materialized
+# after accept(), while the kernel checks the MD5 option during the
+# handshake.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      password: "dyn-md5-secret"
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z2-wrong.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z2-wrong.yaml
@@ -1,0 +1,33 @@
+# Identical to z2.yaml except the secret does not match the DUT's
+# group password. The DUT's kernel drops the signed SYN during the
+# handshake, so the failure is invisible at the BGP layer: no OPEN, no
+# NOTIFICATION, and — the assertion that matters — no peer entry ever
+# materialized on the DUT.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      tcp-md5:
+        encoding: clear
+        password: "WRONG-md5-secret"
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z2.yaml
@@ -1,0 +1,33 @@
+# z2 — client with the matching TCP MD5 secret. From z2's side this is
+# an ordinary static, MD5-protected eBGP session; only z1's side is
+# dynamic. `connect-retry-time: 3` keeps the redial prompt — a dropped
+# SYN leaves the FSM in Active, where the retry is paced by the
+# ConnectRetryTimer (120s default), not the 5s idle-hold.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      tcp-md5:
+        encoding: clear
+        password: "dyn-md5-secret"
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
@@ -1,0 +1,38 @@
+# z1 — DUT whose listen-range group SENDERS binds an inbound DENY-ALL
+# route policy. A peer materialized from 192.168.0.0/24 must inherit
+# it: the session establishes, z1 still advertises 10.0.1.1/32, but
+# nothing the client sends may enter z1's Loc-RIB.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      policy:
+        in: DENY-ALL
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
@@ -1,0 +1,37 @@
+# Identical to z1-deny.yaml except SENDERS carries no policy binding.
+# `vtyctl apply -f` is a declarative whole-config replace, so the file
+# restates the full config — the commit diff against z1-deny.yaml is
+# exactly the deletion of the group's `policy in` leaf. The DENY-ALL
+# definition itself stays: an unreferenced policy filters nothing.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client. Ordinary static eBGP session toward the DUT;
+# originates 10.0.2.2/32, the route the DUT's inherited DENY-ALL must
+# stop (and the policy-less rebind must readmit).
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1-norange.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1-norange.yaml
@@ -1,0 +1,35 @@
+# Identical to z1.yaml except the whole `dynamic-neighbors` block is
+# gone. `vtyctl apply -f` is a declarative whole-config replace, so the
+# commit diff against z1.yaml is exactly the listen-range deletion —
+# which must revoke the peer that range materialized (session down,
+# peer removed, listen-limit slot returned).
+#
+# SENDERS is kept: the group outliving the range is the realistic
+# operator shape, and it proves the sweep keys off the range binding
+# rather than off group existence.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -4,6 +4,13 @@
 # z3 connects from 192.168.1.3 — outside the range — and must be
 # refused at accept time. Originates 10.0.1.1/32 so the dynamic
 # session carries a route in the DUT->client direction too.
+#
+# `listen-limit: 1` is deliberate, not arbitrary: with exactly one
+# in-range client the cap is saturated the moment z2 is materialized,
+# so every re-establishment in this feature only succeeds if the slot
+# was actually released. A leaked `dynamic_peer_count` (missing GC on
+# session end, or a range-delete sweep that forgot to decrement) shows
+# up as a session that never comes back.
 interface:
 - if-name: i1
   ipv4:
@@ -27,7 +34,7 @@ router:
       - name: ipv4
         enabled: true
     dynamic-neighbors:
-      listen-limit: 10
+      listen-limit: 1
       listen-range:
       - prefix: 192.168.0.0/24
         neighbor-group: SENDERS

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -1,0 +1,37 @@
+# z1 — the DUT. No static neighbors: every session must arrive via the
+# dynamic-neighbors listen-range 192.168.0.0/24, which materializes a
+# passive peer inheriting SENDERS (remote-as 65002, ipv4 enabled).
+# z3 connects from 192.168.1.3 — outside the range — and must be
+# refused at accept time. Originates 10.0.1.1/32 so the dynamic
+# session carries a route in the DUT->client direction too.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-limit: 10
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,6 +1,14 @@
 # z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
 # of view this is an ordinary static eBGP session toward the DUT; only
 # z1's side is dynamic. Originates 10.0.2.2/32.
+#
+# `connect-retry-time: 3` is required, not cosmetic. When the DUT
+# revokes a dynamic peer (listen-range delete) or refuses a connect,
+# the TCP dies after the handshake — z2's FSM lands in Active, where
+# the redial is paced by the ConnectRetryTimer and NOT by the 5s
+# idle-hold. At the 120s default the client would not redial within
+# any sane scenario timeout, and "session never came back" would look
+# like a slot leak instead of a sleeping timer.
 interface:
 - if-name: i1
   ipv4:
@@ -18,6 +26,7 @@ router:
     - remote-address: 192.168.0.1
       enabled: true
       remote-as: 65001
+      timers: {connect-retry-time: 3}
       afi-safi:
       - name: ipv4
         enabled: true

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
+# of view this is an ordinary static eBGP session toward the DUT; only
+# z1's side is dynamic. Originates 10.0.2.2/32.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
@@ -1,0 +1,29 @@
+# z3 — out-of-range client (192.168.1.3, matched by NO listen-range).
+# Identical client shape to z2; the only difference is the source
+# subnet, so any session it ever establishes means the listen-range
+# authorization leaked. Originates 10.0.3.3/32 — that prefix showing
+# up on z1 is the failure signal.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.3.3/32

--- a/bdd/tests/features/bgp_dynamic_nbr_md5.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_md5.feature
@@ -1,0 +1,93 @@
+@serial
+@bgp_dynamic_nbr_md5
+Feature: A dynamic (listen-range) peer authenticates with TCP MD5 (RFC 2385)
+  As a network operator
+  I want the password on a listen-range's neighbor-group to protect the range
+  So unconfigured sources cannot open a session just by being in the prefix.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  The DUT (z1) has no static neighbors: z2 arrives through the
+  listen-range and inherits SENDERS, which carries the password.
+
+  This needs a listener key scoped to the whole *prefix*, not to a peer
+  address: a dynamic peer does not exist until its SYN is accepted, but
+  the kernel validates the MD5 option during the handshake — so the
+  per-address key used for static peers can never be installed in time.
+  A mismatch is therefore invisible at the BGP layer: the kernel drops
+  the SYN, no peer is ever materialized, and the DUT logs nothing.
+
+  Config files:
+  - z1.yaml:        DUT — SENDERS carries `password`, listen-range 192.168.0.0/24
+  - z1-nopass.yaml: same DUT with the group password removed
+  - z2.yaml:        client, matching tcp-md5 password
+  - z2-wrong.yaml:  client, mismatched tcp-md5 password
+
+  Scenario: Establish an MD5-authenticated dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A mismatched password never materializes a peer
+    Given the test topology exists
+    # The kernel drops the SYN before accept(), so this is not a
+    # rejected session — it is no session at all: the DUT must not
+    # even have a peer entry for the client.
+    When I apply config "z2-wrong.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Restoring the matching password re-establishes the session
+    Given the test topology exists
+    When I apply config "z2.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+
+  Scenario: Clearing the group password retracts the prefix key
+    Given the test topology exists
+    # With the DUT no longer expecting MD5 and the client still signing,
+    # the handshake cannot complete — proving the key was really
+    # retracted from the listener rather than lingering.
+    When I apply config "z1-nopass.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+
+  Scenario: Restoring the group password re-installs the prefix key
+    Given the test topology exists
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_nbr_policy.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_policy.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_dynamic_nbr_policy
+Feature: A dynamic (listen-range) peer inherits its neighbor-group's route policy
+  As a network operator
+  I want the `policy` bound on a listen-range's neighbor-group
+  So every peer materialized from that range is filtered like a static member.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  z1 (the DUT) has no static neighbors; z2 arrives via the listen-range
+  and inherits SENDERS. With SENDERS carrying `policy in DENY-ALL` the
+  session must still establish, z1's own route must still flow out —
+  but z2's route must be denied on ingress. Rebinding the group without
+  the policy and re-materializing the peer readmits the route, proving
+  the policy is resolved from the group at accept time, not baked in.
+
+  Config files:
+  - z1-deny.yaml: DUT — SENDERS has `policy in DENY-ALL`, originates 10.0.1.1/32
+  - z1-open.yaml: identical but the group carries no policy binding
+  - z2.yaml:      client, static neighbor to .0.1, originates 10.0.2.2/32
+
+  Scenario: Establish with an inbound deny-all policy inherited from the group
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-deny.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    # Policy filters routes, not the session: outbound is untouched...
+    And BGP route in "z2" has "10.0.1.1/32"
+    # ...while the inherited inbound DENY-ALL drops the client's route.
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Unbinding the group policy readmits the route on re-materialization
+    Given the test topology exists
+    When I apply config "z1-open.yaml" to namespace "z1"
+    And I wait 10 seconds
+    # Hard-reset from the client: z1's dynamic peer is torn down and the
+    # reconnect materializes a fresh peer that resolves the group's
+    # CURRENT (policy-less) state through the same accept-time ritual.
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -1,0 +1,97 @@
+@serial
+@bgp_dynamic_neighbors
+Feature: BGP dynamic neighbors materialize passive peers from a listen-range
+  As a network operator
+  I want `router bgp dynamic-neighbors listen-range <prefix> neighbor-group <G>`
+  So sessions from an authorized source prefix establish without per-peer config.
+
+  Test Topology (z1 is the DUT; only z2's subnet is range-authorized):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │ i2────────────i1 │   z3    │
+   │ AS65002 │   (in range)     │ AS65001 │  (out of range)  │ AS65002 │
+   │ .0.2    │                  │.0.1 .1.1│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 has NO static neighbors. Its listen-range 192.168.0.0/24 binds
+  neighbor-group SENDERS (remote-as 65002, ipv4 enabled), so z2's inbound
+  connection materializes a passive peer that must reach Established and
+  exchange routes in both directions (regression pin for PR #2044, where
+  the materialized peer was left in Idle and every connection was
+  dropped). z3 runs the same client config from 192.168.1.3 — outside
+  the range — and must be refused at accept time with no peer state.
+
+  Config files:
+  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+
+  Scenario: Setup topology and establish the dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I connect namespace "z1" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And show command "show bgp summary" in namespace "z1" should contain "192.168.0.2"
+
+  Scenario: Routes flow in both directions over the dynamic session
+    Given the test topology exists
+    Then BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A source outside every listen-range is refused without peer state
+    Given the test topology exists
+    # z3's TCP connect is accepted by the kernel, but the LPM miss makes
+    # z1 drop the stream before any OPEN exchange — z3 never leaves the
+    # connect/retry cycle, and z1 materializes nothing for 192.168.1.3.
+    Then BGP session in "z3" to "192.168.1.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.1.3"
+    And BGP route in "z1" does not have "10.0.3.3/32"
+
+  Scenario: The client can hard-reset and re-establish the dynamic session
+    Given the test topology exists
+    # Pre-#2044 every reconnect was dropped: the very first inbound
+    # stream materialized the peer, then died in Idle forever.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A DUT-side clear frees the peer and the next connect re-materializes it
+    Given the test topology exists
+    # Clearing on z1 ends the session of a Dynamic-origin peer, which
+    # the instance GCs (freeing its listen-limit slot); z2's redial then
+    # re-materializes a fresh peer through the same accept path.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -22,10 +22,15 @@ Feature: BGP dynamic neighbors materialize passive peers from a listen-range
   dropped). z3 runs the same client config from 192.168.1.3 — outside
   the range — and must be refused at accept time with no peer state.
 
+  `listen-limit` is 1 on the DUT, so every re-establishment below also
+  proves the freed slot was actually returned — a leaked slot saturates
+  the cap and the client can never reconnect.
+
   Config files:
-  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
-  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
-  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+  - z1.yaml:         DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z1-norange.yaml: same DUT with the listen-range deleted (group kept)
+  - z2.yaml:         in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml:         out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
 
   Scenario: Setup topology and establish the dynamic session
     Given a clean test environment
@@ -81,6 +86,30 @@ Feature: BGP dynamic neighbors materialize passive peers from a listen-range
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: Deleting the listen-range revokes the peers it materialized
+    Given the test topology exists
+    # Revoking the authorization must not leave the session it
+    # authorized running: the sweep tears the dynamic peer down and
+    # returns its listen-limit slot.
+    When I wait 10 seconds
+    And I apply config "z1-norange.yaml" to namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Restoring the listen-range re-materializes the peer in the freed slot
+    Given the test topology exists
+    # `listen-limit` is 1, so this only succeeds if the sweep decremented
+    # `dynamic_peer_count` — a leaked slot leaves the cap saturated and
+    # the client's connect is refused forever.
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP route in "z1" has "10.0.2.2/32"
     And BGP route in "z2" has "10.0.1.1/32"
 

--- a/zebra-rs/src/bgp/auth.rs
+++ b/zebra-rs/src/bgp/auth.rs
@@ -23,6 +23,13 @@ struct TcpMd5Sig {
     tcpm_key: [u8; libc::TCP_MD5SIG_MAXKEYLEN],
 }
 
+/// `TCP_MD5SIG_FLAG_PREFIX` from `<linux/tcp.h>`: interpret
+/// `tcpm_prefixlen` so the key covers a whole prefix instead of the
+/// single address in `tcpm_addr`. Not exposed by the `libc` crate for
+/// linux targets (only for hurd), so it is spelled out here.
+#[cfg(target_os = "linux")]
+const TCP_MD5SIG_FLAG_PREFIX: u8 = 0x1;
+
 /// Install a TCP MD5 shared secret on `fd` keyed by `peer_ip`.
 ///
 /// Must be called:
@@ -34,6 +41,31 @@ struct TcpMd5Sig {
 /// An empty `key` removes the entry for that peer on the socket.
 #[cfg(target_os = "linux")]
 pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()> {
+    set_md5(fd, peer_ip, None, key)
+}
+
+/// Prefix-scoped variant: one key authenticates every source inside
+/// `prefix`. This is what makes TCP MD5 usable with
+/// `dynamic-neighbors` — the listener must validate the MD5 option on
+/// a SYN whose source has no peer entry yet (the peer is only
+/// materialized *after* the handshake completes), so a per-address key
+/// can never be installed in time.
+///
+/// Requires `TCP_MD5SIG_EXT` (Linux 4.13+). An empty `key` removes the
+/// prefix entry.
+#[cfg(target_os = "linux")]
+pub fn set_tcp_md5_key_prefix(fd: RawFd, prefix: ipnet::IpNet, key: &[u8]) -> io::Result<()> {
+    // `network()` truncates host bits: the kernel matches on the
+    // masked address, and a key installed under an unmasked one would
+    // silently never match an inbound SYN.
+    set_md5(fd, prefix.network(), Some(prefix.prefix_len()), key)
+}
+
+/// Shared core for both scopes. `prefixlen` of `None` keys the entry
+/// on the exact address (classic `TCP_MD5SIG`); `Some(len)` switches
+/// to the extended request that carries the prefix length.
+#[cfg(target_os = "linux")]
+fn set_md5(fd: RawFd, addr: IpAddr, prefixlen: Option<u8>, key: &[u8]) -> io::Result<()> {
     if key.len() > libc::TCP_MD5SIG_MAXKEYLEN {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -46,7 +78,7 @@ pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()>
     }
 
     let mut sig: TcpMd5Sig = unsafe { mem::zeroed() };
-    match peer_ip {
+    match addr {
         IpAddr::V4(a) => {
             let sa = unsafe {
                 &mut *(&mut sig.tcpm_addr as *mut libc::sockaddr_storage as *mut libc::sockaddr_in)
@@ -67,11 +99,20 @@ pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()>
     sig.tcpm_keylen = key.len() as u16;
     sig.tcpm_key[..key.len()].copy_from_slice(key);
 
+    let optname = match prefixlen {
+        Some(len) => {
+            sig.tcpm_flags = TCP_MD5SIG_FLAG_PREFIX;
+            sig.tcpm_prefixlen = len;
+            libc::TCP_MD5SIG_EXT
+        }
+        None => libc::TCP_MD5SIG,
+    };
+
     let ret = unsafe {
         libc::setsockopt(
             fd,
             libc::IPPROTO_TCP,
-            libc::TCP_MD5SIG,
+            optname,
             &sig as *const TcpMd5Sig as *const libc::c_void,
             mem::size_of::<TcpMd5Sig>() as libc::socklen_t,
         )
@@ -84,6 +125,12 @@ pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()>
 
 #[cfg(not(target_os = "linux"))]
 pub fn set_tcp_md5_key(_fd: i32, _peer_ip: IpAddr, _key: &[u8]) -> io::Result<()> {
+    tracing::warn!("TCP MD5 authentication not supported on this platform; no-op");
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_tcp_md5_key_prefix(_fd: i32, _prefix: ipnet::IpNet, _key: &[u8]) -> io::Result<()> {
     tracing::warn!("TCP MD5 authentication not supported on this platform; no-op");
     Ok(())
 }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -335,46 +335,59 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // dialing yet, so no kick fires here.
         bgp.refresh_connected();
     } else {
-        let peer_idx = {
-            let peer = bgp.peers.get(&addr)?;
-            peer.ident
-        };
-
-        // Defensively clear any listener auth entries associated with
-        // this peer before removing it, in case the per-leaf delete
-        // callbacks didn't fire (e.g., whole-neighbor delete without
-        // explicit tcp-md5 / tcp-ao deletions first).
-        clear_peer_listener_auth(bgp, &addr);
-
-        let mut bgp_ref = BgpTop {
-            router_id: &bgp.router_id,
-            srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
-            local_rib: &mut bgp.local_rib,
-            shard: &mut bgp.shard,
-            tx: &bgp.tx,
-            rib_client: &bgp.ctx.rib,
-            attr_store: &mut bgp.attr_store,
-            update_groups: &mut bgp.update_groups,
-            interface_addrs: &bgp.interface_addrs,
-            vrf_export: None,
-            color_policy: Some(&bgp.color_policy),
-            flex_algo_routes: Some(&bgp.flex_algo_routes),
-            flex_algo_srv6_routes: Some(&bgp.flex_algo_srv6_routes),
-            vrf_import: None,
-            nexthop_cache: None,
-            vrf_transport_v4: None,
-            vrf_transport_v6: None,
-            central_label_alloc: None,
-            as_sets_withdraw: bgp.as_sets_withdraw,
-        };
-        route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
-        // Update-groups live outside `PeerMap`: removal below purges
-        // the membership index by construction, but the group member
-        // sets must be detached explicitly or the freed ident lingers
-        // and a future slot reuse inherits the group.
-        super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
-        bgp.peers.remove(&addr);
+        remove_peer_full(bgp, addr)?;
     }
+    Some(())
+}
+
+/// The full peer-removal ritual: listener auth cleanup, Loc-RIB route
+/// withdrawal, update-group detach, map removal, and the listener-wide
+/// TCP-MSS / IP_TRANSPARENT reconciliations. Shared by the static
+/// `delete router bgp neighbor <addr>` path above and the
+/// dynamic-neighbors range sweep
+/// (`super::dynamic_neighbors::sweep_range_peers`); the sweep owns the
+/// `dynamic_peer_count` decrement, since only it knows the peer was
+/// slot-counted.
+pub(super) fn remove_peer_full(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
+    let peer_idx = {
+        let peer = bgp.peers.get(&addr)?;
+        peer.ident
+    };
+
+    // Defensively clear any listener auth entries associated with
+    // this peer before removing it, in case the per-leaf delete
+    // callbacks didn't fire (e.g., whole-neighbor delete without
+    // explicit tcp-md5 / tcp-ao deletions first).
+    clear_peer_listener_auth(bgp, &addr);
+
+    let mut bgp_ref = BgpTop {
+        router_id: &bgp.router_id,
+        srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
+        local_rib: &mut bgp.local_rib,
+        shard: &mut bgp.shard,
+        tx: &bgp.tx,
+        rib_client: &bgp.ctx.rib,
+        attr_store: &mut bgp.attr_store,
+        update_groups: &mut bgp.update_groups,
+        interface_addrs: &bgp.interface_addrs,
+        vrf_export: None,
+        color_policy: Some(&bgp.color_policy),
+        flex_algo_routes: Some(&bgp.flex_algo_routes),
+        flex_algo_srv6_routes: Some(&bgp.flex_algo_srv6_routes),
+        vrf_import: None,
+        nexthop_cache: None,
+        vrf_transport_v4: None,
+        vrf_transport_v6: None,
+        central_label_alloc: None,
+        as_sets_withdraw: bgp.as_sets_withdraw,
+    };
+    route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
+    // Update-groups live outside `PeerMap`: removal below purges
+    // the membership index by construction, but the group member
+    // sets must be detached explicitly or the freed ident lingers
+    // and a future slot reuse inherits the group.
+    super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
+    bgp.peers.remove(&addr);
     // Keep the shared listener's TCP MSS minimum in step with the peer
     // set: a whole-neighbor delete may drop the peer that owned the
     // current minimum without the per-leaf `/tcp-mss` delete firing (the

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -3,8 +3,9 @@
 //! Stores the configured `listen-range` prefixes and `listen-limit`,
 //! and exposes `lpm_match` for the accept-path. Materialization of
 //! the synthesized [`super::peer::Peer`] lives in
-//! [`super::peer::try_dynamic_accept`] — this module is just state
-//! + config callbacks.
+//! [`super::peer::try_dynamic_accept`] — this module holds the state,
+//! the config callbacks, and the revocation sweep
+//! ([`sweep_range_peers`]) that tears those peers back down.
 
 use std::collections::BTreeMap;
 use std::net::IpAddr;
@@ -90,8 +91,8 @@ pub fn config_listen_limit(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 }
 
 /// `set router bgp dynamic-neighbors listen-range <prefix>` —
-/// list-key callback. Creates the entry on `Set` and removes it on
-/// `Delete`.
+/// list-key callback. Creates the entry on `Set`; removes it on
+/// `Delete` and sweeps the peers it materialized.
 pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let prefix: IpNet = args.string()?.parse().ok()?;
     match op {
@@ -100,6 +101,7 @@ pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         }
         ConfigOp::Delete => {
             bgp.dynamic_neighbors.ranges.remove(&prefix);
+            sweep_range_peers(bgp, &prefix);
         }
         _ => {}
     }
@@ -113,13 +115,68 @@ pub fn config_listen_range_neighbor_group(
     op: ConfigOp,
 ) -> Option<()> {
     let prefix: IpNet = args.string()?.parse().ok()?;
-    let entry = bgp.dynamic_neighbors.ranges.entry(prefix).or_default();
     match op {
-        ConfigOp::Set => entry.neighbor_group = Some(args.string()?),
-        ConfigOp::Delete => entry.neighbor_group = None,
+        ConfigOp::Set => {
+            bgp.dynamic_neighbors
+                .ranges
+                .entry(prefix)
+                .or_default()
+                .neighbor_group = Some(args.string()?);
+        }
+        ConfigOp::Delete => {
+            // `get_mut`, not `entry().or_default()`: when the whole
+            // listen-range entry is deleted, this leaf's Delete may fire
+            // after the list-key's — an `or_default` here would
+            // resurrect the just-removed range as a ghost entry.
+            if let Some(entry) = bgp.dynamic_neighbors.ranges.get_mut(&prefix) {
+                entry.neighbor_group = None;
+            }
+            // A group-less range can materialize nothing, and the peers
+            // it already materialized just lost the source of their
+            // session attributes — revoke them like a range delete.
+            sweep_range_peers(bgp, &prefix);
+        }
         _ => {}
     }
     Some(())
+}
+
+/// Tear down and remove every `PeerOrigin::Dynamic` peer materialized
+/// from `prefix`, freeing their `listen-limit` slots. Deleting a
+/// listen-range (or unbinding its neighbor-group) revokes the
+/// authorization those peers were accepted under, so their sessions
+/// must not outlive it — mirroring FRR's `no bgp listen range`.
+///
+/// Peers are matched by their provenance stamp (the `range_prefix`
+/// recorded at materialization), not by re-running LPM: if an
+/// overlapping range still covers a swept client, its next connect
+/// re-materializes under that range — with that range's group, which
+/// is the correct attribute source from then on.
+pub(super) fn sweep_range_peers(bgp: &mut Bgp, prefix: &IpNet) {
+    use super::peer_key::PeerOrigin;
+
+    let victims: Vec<IpAddr> = bgp
+        .peers
+        .idents()
+        .into_iter()
+        .filter_map(|ident| bgp.peers.get_by_idx(ident))
+        .filter(|peer| {
+            matches!(&peer.origin,
+                PeerOrigin::Dynamic { range_prefix } if range_prefix == prefix)
+        })
+        .map(|peer| peer.address)
+        .collect();
+
+    for addr in victims {
+        if super::config::remove_peer_full(bgp, addr).is_some() {
+            bgp.dynamic_peer_count = bgp.dynamic_peer_count.saturating_sub(1);
+            tracing::info!(
+                peer = %addr,
+                range = %prefix,
+                "bgp: dynamic peer removed by listen-range sweep",
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -188,5 +245,226 @@ mod tests {
     fn default_listen_limit_is_one_hundred() {
         let dn = DynamicNeighbors::default();
         assert_eq!(dn.listen_limit, 100);
+    }
+}
+
+/// Revocation sweep: deleting a listen-range (or unbinding its
+/// neighbor-group) must tear down the peers that range materialized
+/// and give their `listen-limit` slots back.
+#[cfg(test)]
+mod sweep_tests {
+    use std::collections::VecDeque;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::bgp::peer::Peer;
+    use crate::bgp::peer_key::PeerOrigin;
+
+    fn net(s: &str) -> IpNet {
+        s.parse().unwrap()
+    }
+
+    fn addr(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn arg_words(parts: &[&str]) -> Args {
+        Args(
+            parts
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<VecDeque<_>>(),
+        )
+    }
+
+    fn test_ctx() -> (
+        crate::context::ProtoContext,
+        mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
+    ) {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        // Leak the inbound rx: a dropped receiver turns every send
+        // through the client into a SendError, which BGP unwraps.
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+        (ctx, rib_rx)
+    }
+
+    fn test_rib_subscriber() -> crate::config::RibSubscriber {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_inbound_rx));
+        // Starts at 1 so it never collides with the
+        // `ProtoId::from_raw(0)` baked into `test_ctx`.
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id)
+    }
+
+    fn fresh_bgp() -> Bgp {
+        let (ctx, rib_rx) = test_ctx();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    /// Stand in for `try_dynamic_accept`'s materialization without a
+    /// socket: insert a Dynamic-origin peer stamped with `range` and
+    /// take its `listen-limit` slot, exactly as the accept path does.
+    fn materialize(bgp: &mut Bgp, peer_addr: &str, range: &str) {
+        let address = addr(peer_addr);
+        let mut peer = Peer::new(
+            0,
+            bgp.asn,
+            bgp.router_id,
+            65001,
+            address,
+            bgp.hostname(),
+            bgp.tx.clone(),
+            bgp.ctx.clone(),
+        );
+        peer.origin = PeerOrigin::Dynamic {
+            range_prefix: net(range),
+        };
+        peer.config.transport.passive = true;
+        bgp.peers.insert(address, peer);
+        bgp.dynamic_peer_count += 1;
+    }
+
+    /// Config a range bound to a group, the way an operator would.
+    fn configure_range(bgp: &mut Bgp, prefix: &str, group: &str) {
+        config_listen_range(bgp, arg_words(&[prefix]), ConfigOp::Set).unwrap();
+        config_listen_range_neighbor_group(bgp, arg_words(&[prefix, group]), ConfigOp::Set)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn range_delete_sweeps_only_its_own_peers() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        configure_range(&mut bgp, "10.2.0.0/24", "B");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+        materialize(&mut bgp, "10.1.0.8", "10.1.0.0/24");
+        materialize(&mut bgp, "10.2.0.9", "10.2.0.0/24");
+        assert_eq!(bgp.dynamic_peer_count, 3);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert!(bgp.peers.get(&addr("10.1.0.7")).is_none());
+        assert!(bgp.peers.get(&addr("10.1.0.8")).is_none());
+        assert!(
+            bgp.peers.get(&addr("10.2.0.9")).is_some(),
+            "a peer from a still-configured range must survive"
+        );
+        assert_eq!(
+            bgp.dynamic_peer_count, 1,
+            "both swept peers must return their listen-limit slots"
+        );
+    }
+
+    /// The slot accounting has to be exact, not merely non-negative:
+    /// a sweep that forgot to decrement would wedge a `listen-limit`
+    /// speaker forever (the pre-existing worry that motivated this).
+    #[tokio::test]
+    async fn swept_slots_are_reusable_up_to_the_limit() {
+        let mut bgp = fresh_bgp();
+        bgp.dynamic_neighbors.listen_limit = 2;
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+        materialize(&mut bgp, "10.1.0.8", "10.1.0.0/24");
+        assert_eq!(bgp.dynamic_peer_count, bgp.dynamic_neighbors.listen_limit);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert_eq!(bgp.dynamic_peer_count, 0, "the cap must be fully released");
+    }
+
+    /// Unbinding the group leaves the range unable to supply session
+    /// attributes, so its peers go too.
+    #[tokio::test]
+    async fn group_unbind_sweeps_range_peers() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+
+        config_listen_range_neighbor_group(
+            &mut bgp,
+            arg_words(&["10.1.0.0/24", "A"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(bgp.peers.get(&addr("10.1.0.7")).is_none());
+        assert_eq!(bgp.dynamic_peer_count, 0);
+    }
+
+    /// A statically configured peer whose address happens to fall
+    /// inside the range is NOT dynamic — provenance, not address
+    /// containment, decides. Sweeping it would delete operator config.
+    #[tokio::test]
+    async fn sweep_spares_static_peers_inside_the_prefix() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        let static_addr = addr("10.1.0.5");
+        let peer = Peer::new(
+            0,
+            bgp.asn,
+            bgp.router_id,
+            65001,
+            static_addr,
+            bgp.hostname(),
+            bgp.tx.clone(),
+            bgp.ctx.clone(),
+        );
+        bgp.peers.insert(static_addr, peer);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert!(
+            bgp.peers.get(&static_addr).is_some(),
+            "a PeerOrigin::Static peer must survive a range delete"
+        );
+        assert_eq!(
+            bgp.dynamic_peer_count, 0,
+            "a static peer never held a slot, so none is released"
+        );
+    }
+
+    /// Deleting a whole listen-range fires the list-key callback and
+    /// the child-leaf callback. Whichever order they arrive in, the
+    /// range must stay gone — an `entry().or_default()` in the leaf's
+    /// Delete arm would resurrect it as a group-less ghost that
+    /// `lpm_match` then hits on every inbound connection.
+    #[tokio::test]
+    async fn leaf_delete_after_key_delete_does_not_resurrect_the_range() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        config_listen_range_neighbor_group(
+            &mut bgp,
+            arg_words(&["10.1.0.0/24", "A"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(
+            bgp.dynamic_neighbors.ranges.is_empty(),
+            "trailing leaf delete must not re-create the range entry"
+        );
+        assert!(bgp.dynamic_neighbors.lpm_match(&addr("10.1.0.7")).is_none());
     }
 }

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -28,6 +28,12 @@ pub struct ListenRange {
 pub struct DynamicNeighbors {
     pub listen_limit: u32,
     pub ranges: BTreeMap<IpNet, ListenRange>,
+    /// Prefix-scoped TCP MD5 keys currently installed on the listening
+    /// socket, keyed by range. Mirrors kernel state so
+    /// [`reconcile_listener_md5`] can remove or re-key exactly what it
+    /// put there: the desired set is recomputed from config, but the
+    /// *removal* set can only be known from what was installed before.
+    installed_md5: BTreeMap<IpNet, String>,
 }
 
 /// RFC-style operator default — IOS-XR ships 100, FRR ships 100,
@@ -40,11 +46,22 @@ impl Default for DynamicNeighbors {
         Self {
             listen_limit: DEFAULT_LISTEN_LIMIT,
             ranges: BTreeMap::new(),
+            installed_md5: BTreeMap::new(),
         }
     }
 }
 
 impl DynamicNeighbors {
+    /// Drop the record of which prefix MD5 keys are installed, without
+    /// touching the socket. Called when the listener fd is replaced (a
+    /// fresh bind or a `relisten`): the keys were attached to the old
+    /// socket and died with it, so the shadow must be cleared before
+    /// [`reconcile_listener_md5`] diffs — otherwise it sees "already
+    /// installed" and skips every key on the new fd.
+    pub fn forget_installed_md5(&mut self) {
+        self.installed_md5.clear();
+    }
+
     /// Longest-prefix match against the configured ranges. Returns
     /// the matched `(prefix, range)` so the caller can record the
     /// prefix on the synthesized peer's `PeerOrigin::Dynamic`.
@@ -105,6 +122,7 @@ pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         }
         _ => {}
     }
+    reconcile_listener_md5(bgp);
     Some(())
 }
 
@@ -138,7 +156,117 @@ pub fn config_listen_range_neighbor_group(
         }
         _ => {}
     }
+    reconcile_listener_md5(bgp);
     Some(())
+}
+
+/// Reconcile the listener's prefix-scoped TCP MD5 keys against the
+/// configured listen-ranges.
+///
+/// A dynamic peer does not exist until its SYN has been accepted, but
+/// the kernel validates the MD5 option *during* the handshake — so a
+/// per-address key (the static-peer mechanism) can never be installed
+/// in time, and an authenticated inbound connection is dropped before
+/// `accept()` ever sees it. The fix is a key scoped to the whole
+/// listen-range, installed as soon as the range and its group's
+/// password are both known.
+///
+/// Idempotent and diff-gated: the desired set is recomputed from
+/// config on every call, compared against what this function last
+/// installed, and only genuine adds / re-keys / removals reach the
+/// kernel. Safe to call from any config callback that could change the
+/// mapping, and from `listen()` once the fd exists.
+pub(super) fn reconcile_listener_md5(bgp: &mut Bgp) {
+    let desired = desired_listener_md5(bgp);
+
+    if desired == bgp.dynamic_neighbors.installed_md5 {
+        return;
+    }
+
+    // Ranges that lost their key (range deleted, group unbound or
+    // deleted, password cleared) must be removed from the socket
+    // first, so a re-key of the same prefix can never race its own
+    // removal.
+    let stale: Vec<IpNet> = bgp
+        .dynamic_neighbors
+        .installed_md5
+        .keys()
+        .filter(|prefix| !desired.contains_key(*prefix))
+        .copied()
+        .collect();
+    for prefix in stale {
+        if md5_prefix_apply(bgp, &prefix, &[]) {
+            bgp.dynamic_neighbors.installed_md5.remove(&prefix);
+        }
+    }
+
+    for (prefix, password) in desired {
+        if bgp.dynamic_neighbors.installed_md5.get(&prefix) == Some(&password) {
+            continue;
+        }
+        if md5_prefix_apply(bgp, &prefix, password.as_bytes()) {
+            bgp.dynamic_neighbors.installed_md5.insert(prefix, password);
+        }
+    }
+}
+
+/// The prefix keys the listener *should* be carrying: every
+/// listen-range bound to a group that defines a password. A range with
+/// no group, a group that does not exist, or a group with no password
+/// contributes nothing — an unauthenticated range still accepts plain
+/// connections, exactly as before.
+fn desired_listener_md5(bgp: &Bgp) -> BTreeMap<IpNet, String> {
+    bgp.dynamic_neighbors
+        .ranges
+        .iter()
+        .filter_map(|(prefix, range)| {
+            let group = range.neighbor_group.as_ref()?;
+            let password = bgp.neighbor_groups.get(group)?.knobs.password.clone()?;
+            Some((*prefix, password))
+        })
+        .collect()
+}
+
+/// Install (empty `key` ⇒ remove) one prefix key on the listener of
+/// the matching address family. Returns whether the shadow state
+/// should be updated: `false` when there is no listener yet, so the
+/// post-bind sweep in `listen()` retries rather than believing a key
+/// is installed that never was.
+fn md5_prefix_apply(bgp: &Bgp, prefix: &IpNet, key: &[u8]) -> bool {
+    let listen_fd = match prefix {
+        IpNet::V4(_) => bgp.listen_fd_v4,
+        IpNet::V6(_) => bgp.listen_fd_v6,
+    };
+    let Some(fd) = listen_fd else {
+        return false;
+    };
+    match super::auth::set_tcp_md5_key_prefix(fd, *prefix, key) {
+        Ok(()) => {
+            if !key.is_empty() {
+                tracing::debug!(
+                    range = %prefix,
+                    keylen = key.len(),
+                    "bgp: TCP MD5 prefix key installed on listener for listen-range",
+                );
+            }
+            true
+        }
+        Err(e) => {
+            // Removing a key the kernel does not have is a no-op, not a
+            // failure — it answers ENOENT. Treat it as success so the
+            // shadow state still clears.
+            if key.is_empty() && e.kind() == std::io::ErrorKind::NotFound {
+                return true;
+            }
+            tracing::warn!(
+                range = %prefix,
+                error = %e,
+                "TCP MD5 prefix setsockopt on listener failed; \
+                 authenticated SYNs from this range will be dropped"
+            );
+            false
+        }
+    }
 }
 
 /// Tear down and remove every `PeerOrigin::Dynamic` peer materialized
@@ -466,5 +594,161 @@ mod sweep_tests {
             "trailing leaf delete must not re-create the range entry"
         );
         assert!(bgp.dynamic_neighbors.lpm_match(&addr("10.1.0.7")).is_none());
+    }
+
+    // ===================================================
+    // Listener prefix-MD5 reconciliation
+    // ===================================================
+
+    fn set_group_password(bgp: &mut Bgp, group: &str, password: &str) {
+        crate::bgp::neighbor_group::config_neighbor_group_password(
+            bgp,
+            arg_words(&[group, password]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+    }
+
+    /// A range bound to a password-carrying group wants a prefix key;
+    /// one whose group has no password wants none.
+    #[tokio::test]
+    async fn desired_keys_follow_range_group_password() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        configure_range(&mut bgp, "10.2.0.0/24", "PLAIN");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+
+        let desired = desired_listener_md5(&bgp);
+
+        assert_eq!(
+            desired.get(&net("10.1.0.0/24")).map(String::as_str),
+            Some("s3cret")
+        );
+        assert!(
+            !desired.contains_key(&net("10.2.0.0/24")),
+            "a group without a password must not install a key"
+        );
+    }
+
+    /// Unbinding the group, deleting the range, or clearing the
+    /// password each retract the key.
+    #[tokio::test]
+    async fn desired_keys_retract_on_every_unbind_path() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        assert_eq!(desired_listener_md5(&bgp).len(), 1);
+
+        crate::bgp::neighbor_group::config_neighbor_group_password(
+            &mut bgp,
+            arg_words(&["SECURE"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            desired_listener_md5(&bgp).is_empty(),
+            "clearing the group password must retract the prefix key"
+        );
+
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        assert!(
+            desired_listener_md5(&bgp).is_empty(),
+            "deleting the range must retract the prefix key"
+        );
+    }
+
+    /// Bind a real listening socket and drive the reconciler through
+    /// install → re-key → retract, so the `TCP_MD5SIG_EXT` request
+    /// shape is exercised against the kernel rather than mocked. The
+    /// shadow map is the observable: it only advances when setsockopt
+    /// actually succeeded.
+    #[tokio::test]
+    async fn reconcile_installs_rekeys_and_retracts_on_a_real_socket() {
+        use std::os::fd::AsRawFd;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(listener.as_raw_fd());
+
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.get(&net("10.1.0.0/24")),
+            Some(&"s3cret".to_string()),
+            "install must reach the kernel and be recorded"
+        );
+
+        set_group_password(&mut bgp, "SECURE", "rotated");
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.get(&net("10.1.0.0/24")),
+            Some(&"rotated".to_string()),
+            "a password change must re-key the same prefix"
+        );
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        assert!(
+            bgp.dynamic_neighbors.installed_md5.is_empty(),
+            "range delete must retract the key from the socket"
+        );
+    }
+
+    /// The key must be installed under the masked network address: the
+    /// kernel matches an inbound SYN against the masked value, so a key
+    /// stored under an unmasked one silently never matches.
+    #[tokio::test]
+    async fn prefix_key_is_installed_on_the_masked_network() {
+        use std::os::fd::AsRawFd;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let fd = listener.as_raw_fd();
+        // 10.1.2.3/24 masks to 10.1.2.0/24. If `set_tcp_md5_key_prefix`
+        // forgot `network()`, the kernel would reject or misfile it.
+        let sloppy: IpNet = "10.1.2.3/24".parse().unwrap();
+        crate::bgp::auth::set_tcp_md5_key_prefix(fd, sloppy, b"s3cret")
+            .expect("prefix key install must succeed");
+        // Removing it under the canonical spelling proves that is where
+        // it actually landed.
+        crate::bgp::auth::set_tcp_md5_key_prefix(fd, net("10.1.2.0/24"), &[])
+            .expect("key must be removable under its masked network");
+    }
+
+    /// A relisten hands BGP a brand-new fd that carries none of the old
+    /// socket's keys. Without forgetting the shadow first, the diff
+    /// would conclude everything was already installed and leave the
+    /// new listener unauthenticated.
+    #[tokio::test]
+    async fn forgetting_the_shadow_forces_reinstall_after_relisten() {
+        use std::os::fd::AsRawFd;
+
+        let first = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(first.as_raw_fd());
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        assert_eq!(bgp.dynamic_neighbors.installed_md5.len(), 1);
+
+        // Rebind: new socket, no keys on it.
+        let second = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        bgp.listen_fd_v4 = Some(second.as_raw_fd());
+
+        // Without the forget, this is a no-op diff.
+        reconcile_listener_md5(&mut bgp);
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.len(),
+            1,
+            "precondition: the stale shadow still claims the key is present"
+        );
+
+        bgp.dynamic_neighbors.forget_installed_md5();
+        reconcile_listener_md5(&mut bgp);
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.get(&net("10.1.0.0/24")),
+            Some(&"s3cret".to_string()),
+            "after forgetting, the key must be re-installed on the new fd"
+        );
+        // And it really is on the new socket, not just in the shadow.
+        crate::bgp::auth::set_tcp_md5_key_prefix(second.as_raw_fd(), net("10.1.0.0/24"), &[])
+            .expect("key must be present on the new listener");
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3358,6 +3358,16 @@ impl Bgp {
         // because the kernel drops the incoming SYN.
         super::config::apply_md5_refresh_all(self);
         super::config::apply_ao_refresh_all(self);
+        // Same gap for dynamic-neighbors: a listen-range whose group
+        // carries a password needs its prefix key on the fresh fd, or
+        // every authenticated SYN from that range is dropped by the
+        // kernel before `accept()` can materialize the peer. The
+        // shadow state is cleared first because the keys it records
+        // lived on the *previous* fd — after a relisten the new socket
+        // has none, and a diff against stale state would install
+        // nothing.
+        self.dynamic_neighbors.forget_installed_md5();
+        super::dynamic_neighbors::reconcile_listener_md5(self);
         // Reconcile the listener TCP MSS too: a `tcp-mss` callback that
         // ran before the bind observed `listen_fd_v4/v6 = None` and could
         // not clamp the listener, so a passively-accepted peer would

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -876,9 +876,11 @@ pub struct Bgp {
     /// `dynamic-neighbors` runtime (zebra-bgp-dynamic-neighbors.yang).
     /// Holds the configured listen-ranges and the soft cap on
     /// materialized passive peers. `dynamic_peer_count` is bumped on
-    /// successful accept-time materialization in `peer::accept`; it
-    /// is never decremented yet — session-close GC is deferred to a
-    /// follow-up so this PR stays focused on the accept path.
+    /// accept-time materialization (`peer::try_dynamic_accept`) and
+    /// decremented when a slot frees:
+    /// [`Self::gc_dynamic_peer_if_session_ended`] on session end,
+    /// `dynamic_neighbors::sweep_range_peers` on range delete /
+    /// group unbind.
     pub dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors,
     pub dynamic_peer_count: u32,
     /// `interface-neighbor` config — operator types

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -134,6 +134,10 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
         }
         _ => {}
     }
+    // The group's password is the source of any listen-range prefix key
+    // bound to it — creating or deleting the group changes what the
+    // listener should be authenticating.
+    super::dynamic_neighbors::reconcile_listener_md5(bgp);
     Some(())
 }
 
@@ -765,6 +769,10 @@ pub fn config_neighbor_group_password(bgp: &mut Bgp, mut args: Args, op: ConfigO
         .knobs
         .password = value;
     sweep_members_inherit(bgp, &name);
+    // A listen-range bound to this group authenticates its whole
+    // prefix with the group password, so the listener's prefix key
+    // has to follow the knob.
+    super::dynamic_neighbors::reconcile_listener_md5(bgp);
     Some(())
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -3291,8 +3291,10 @@ pub fn accept(bgp: &mut Bgp, stream: TcpStream, sockaddr: SocketAddr) {
 fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Option<TcpStream> {
     // Soft cap. The listen-limit guards against an attacker spamming
     // SYNs from many sources in a wide listen-range — once we hit
-    // the limit, additional matches drop silently until existing
-    // dynamic peers are GC'd (session-close GC lands in a follow-up).
+    // the limit, additional matches drop silently until a slot frees
+    // up: `gc_dynamic_peer_if_session_ended` reclaims a peer whose
+    // session ended, and `dynamic_neighbors::sweep_range_peers`
+    // reclaims every peer of a deleted (or group-unbound) range.
     if bgp.dynamic_peer_count >= bgp.dynamic_neighbors.listen_limit {
         return Some(stream);
     }


### PR DESCRIPTION
Third in the dynamic-neighbors series, stacked in git on #2050 → #2052. Targets `main` so CI runs (the workflow only triggers on PRs to main); until the parents merge, the diff shows their commits too — **this PR's own change is the last commit, `070ed0d2`**.

## Problem

TCP MD5 and `dynamic-neighbors` could not be combined at all. The listener key is installed per peer address, but a dynamic peer does not exist until its SYN has been accepted — and the kernel validates the MD5 option *during* the handshake. The key could therefore never be installed in time: every authenticated SYN from a listen-range was dropped before `accept()` could materialize anything. No OPEN, no NOTIFICATION, nothing logged — the feature simply appeared dead.

## Fix

Key the listener on the **range** instead of the peer:

- `auth::set_md5` grows a prefix mode (`TCP_MD5SIG_EXT` + `TCP_MD5SIG_FLAG_PREFIX`, Linux 4.13+) exposed as `set_tcp_md5_key_prefix`. Keys are installed on the **masked network address** — the kernel matches inbound SYNs against the masked value, so a key stored under an unmasked prefix silently never matches.
- `dynamic_neighbors::reconcile_listener_md5` keeps the socket's prefix keys in step with `listen-range × neighbor-group password`. Diff-gated against a shadow map of what it last installed: the desired set is recomputed from config every call, but the *removal* set is only knowable from what was installed before.
- Driven from every input that can change the mapping: listen-range add/delete, neighbor-group bind/unbind, the group's `password` knob, and group create/delete.
- `listen()` runs it after binding and **forgets the shadow first** — the recorded keys lived on the previous fd and died with it, so a relisten would otherwise diff against stale state and leave the new listener unauthenticated. There is a dedicated test for exactly this.

## Testing

**Unit** (5 new): desired-set derivation (password present/absent, and each of the three retraction paths — password cleared, group unbound, range deleted), plus real-socket tests that drive install → re-key → retract through the kernel rather than mocking it, pin the masked-network requirement, and pin the relisten-forget behaviour. Full `cargo test -p zebra-rs`: 1667 passed. Workspace clippy and fmt clean.

**BDD** (`bgp_dynamic_nbr_md5.feature`, 6 scenarios, green locally):
- matching password establishes and exchanges routes;
- a **mismatched** password materializes no peer at all — asserted as absence from `show bgp summary`, because the failure is invisible at the BGP layer;
- clearing the group password retracts the key and the session dies;
- restoring it brings the session back.

Those last two are the feature's **own negative control**: the session stands only while the prefix key is installed, so the key is provably load-bearing rather than incidentally present.

Also re-ran `bgp_dynamic_neighbors` (8/8) and `bgp_dynamic_nbr_policy` (3/3) against this build — no regressions. Binary md5 verified identical before and after each BDD run.

## Next

TCP-AO for dynamic neighbors is the remaining item. It is a bigger change: `neighbor-group` has no `tcp-ao` YANG or `InheritableKnobs` entry yet, and the AO wrapper hard-codes prefix 32/128 (`TcpAoAdd.prefix` exists but is unused). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)