### PR TITLE
bgp: authenticate dynamic neighbors with prefix-scoped TCP-AO

### DIFF
--- a/bdd/tests/configs/bgp_dynamic_nbr_ao/z1-noao.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_ao/z1-noao.yaml
@@ -1,0 +1,44 @@
+# Identical to z1.yaml except SENDERS carries no tcp-ao. The commit
+# diff is exactly the deletion of the group's tcp-ao container, which
+# must retract the prefix MKT from the listening socket.
+#
+# The chain definition itself stays: an unreferenced key-chain
+# authenticates nothing. The client keeps signing, so with the MKT gone
+# the handshake cannot complete.
+key-chains:
+  key-chain:
+  - name: BGP-AO
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "dyn-ao-secret"
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_ao/z1-rotated.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_ao/z1-rotated.yaml
@@ -1,0 +1,46 @@
+# Identical to z1.yaml except the BGP-AO chain's key-string is rotated
+# while key-id / send-id / recv-id stay put. The kernel identifies an
+# MKT by (address, prefixlen, send-id, recv-id) and answers EEXIST on a
+# duplicate add, so the reconciler must DELETE the old prefix MKT
+# before adding the rotated one — otherwise the listener keeps serving
+# the stale key and the now-mismatched client still gets in.
+key-chains:
+  key-chain:
+  - name: BGP-AO
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "rotated-ao-secret"
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      tcp-ao:
+        key-chain: BGP-AO
+        include-tcp-options: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_ao/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_ao/z1.yaml
@@ -1,0 +1,45 @@
+# z1 — DUT. The listen-range's group carries the TCP-AO key-chain, so
+# the whole 192.168.0.0/24 prefix is authenticated by one prefix-scoped
+# MKT on the listening socket (TCP_AO_ADD_KEY with a non-host prefix).
+# A per-address MKT cannot work: the peer is materialized only after
+# accept(), while the kernel verifies the AO MAC during the handshake.
+key-chains:
+  key-chain:
+  - name: BGP-AO
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "dyn-ao-secret"
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      tcp-ao:
+        key-chain: BGP-AO
+        include-tcp-options: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_ao/z2-wrong.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_ao/z2-wrong.yaml
@@ -1,0 +1,42 @@
+# Identical to z2.yaml except the key-string does not match the DUT's
+# chain. Same chain name and same send-id/recv-id, so the mismatch is
+# purely in the MAC — the DUT's kernel drops the signed SYN during the
+# handshake and no peer is ever materialized.
+key-chains:
+  key-chain:
+  - name: BGP-AO
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "WRONG-ao-secret"
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      tcp-ao:
+        key-chain: BGP-AO
+        include-tcp-options: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_ao/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_ao/z2.yaml
@@ -1,0 +1,43 @@
+# z2 — client with the matching TCP-AO key-chain. From z2's side this
+# is an ordinary static, AO-protected eBGP session; only z1's side is
+# dynamic. `connect-retry-time: 3` keeps the redial prompt — a dropped
+# SYN leaves the FSM in Active, where the retry is paced by the
+# ConnectRetryTimer (120s default), not the 5s idle-hold.
+key-chains:
+  key-chain:
+  - name: BGP-AO
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "dyn-ao-secret"
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      tcp-ao:
+        key-chain: BGP-AO
+        include-tcp-options: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z1-nopass.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z1-nopass.yaml
@@ -1,0 +1,35 @@
+# Identical to z1.yaml except SENDERS carries no password. `vtyctl
+# apply -f` is a declarative whole-config replace, so the commit diff
+# is exactly the deletion of the group's `password` leaf — which must
+# retract the prefix key from the listening socket.
+#
+# The client keeps signing its SYNs, so with the key gone the handshake
+# cannot complete: an unauthenticated listener drops MD5-signed SYNs
+# just as surely as a mismatched key does.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z1.yaml
@@ -1,0 +1,34 @@
+# z1 — DUT. The listen-range's group carries the TCP MD5 password, so
+# the whole 192.168.0.0/24 prefix is authenticated by one key installed
+# on the listening socket (TCP_MD5SIG_EXT + TCP_MD5SIG_FLAG_PREFIX).
+# A per-address key cannot work here: the peer is only materialized
+# after accept(), while the kernel checks the MD5 option during the
+# handshake.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      password: "dyn-md5-secret"
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z2-wrong.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z2-wrong.yaml
@@ -1,0 +1,33 @@
+# Identical to z2.yaml except the secret does not match the DUT's
+# group password. The DUT's kernel drops the signed SYN during the
+# handshake, so the failure is invisible at the BGP layer: no OPEN, no
+# NOTIFICATION, and — the assertion that matters — no peer entry ever
+# materialized on the DUT.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      tcp-md5:
+        encoding: clear
+        password: "WRONG-md5-secret"
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_md5/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_md5/z2.yaml
@@ -1,0 +1,33 @@
+# z2 — client with the matching TCP MD5 secret. From z2's side this is
+# an ordinary static, MD5-protected eBGP session; only z1's side is
+# dynamic. `connect-retry-time: 3` keeps the redial prompt — a dropped
+# SYN leaves the FSM in Active, where the retry is paced by the
+# ConnectRetryTimer (120s default), not the 5s idle-hold.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      tcp-md5:
+        encoding: clear
+        password: "dyn-md5-secret"
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-deny.yaml
@@ -1,0 +1,38 @@
+# z1 — DUT whose listen-range group SENDERS binds an inbound DENY-ALL
+# route policy. A peer materialized from 192.168.0.0/24 must inherit
+# it: the session establishes, z1 still advertises 10.0.1.1/32, but
+# nothing the client sends may enter z1's Loc-RIB.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      policy:
+        in: DENY-ALL
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z1-open.yaml
@@ -1,0 +1,37 @@
+# Identical to z1-deny.yaml except SENDERS carries no policy binding.
+# `vtyctl apply -f` is a declarative whole-config replace, so the file
+# restates the full config — the commit diff against z1-deny.yaml is
+# exactly the deletion of the group's `policy in` leaf. The DENY-ALL
+# definition itself stays: an unreferenced policy filters nothing.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_nbr_policy/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client. Ordinary static eBGP session toward the DUT;
+# originates 10.0.2.2/32, the route the DUT's inherited DENY-ALL must
+# stop (and the policy-less rebind must readmit).
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1-norange.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1-norange.yaml
@@ -1,0 +1,35 @@
+# Identical to z1.yaml except the whole `dynamic-neighbors` block is
+# gone. `vtyctl apply -f` is a declarative whole-config replace, so the
+# commit diff against z1.yaml is exactly the listen-range deletion —
+# which must revoke the peer that range materialized (session down,
+# peer removed, listen-limit slot returned).
+#
+# SENDERS is kept: the group outliving the range is the realistic
+# operator shape, and it proves the sweep keys off the range binding
+# rather than off group existence.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -4,6 +4,13 @@
 # z3 connects from 192.168.1.3 — outside the range — and must be
 # refused at accept time. Originates 10.0.1.1/32 so the dynamic
 # session carries a route in the DUT->client direction too.
+#
+# `listen-limit: 1` is deliberate, not arbitrary: with exactly one
+# in-range client the cap is saturated the moment z2 is materialized,
+# so every re-establishment in this feature only succeeds if the slot
+# was actually released. A leaked `dynamic_peer_count` (missing GC on
+# session end, or a range-delete sweep that forgot to decrement) shows
+# up as a session that never comes back.
 interface:
 - if-name: i1
   ipv4:
@@ -27,7 +34,7 @@ router:
       - name: ipv4
         enabled: true
     dynamic-neighbors:
-      listen-limit: 10
+      listen-limit: 1
       listen-range:
       - prefix: 192.168.0.0/24
         neighbor-group: SENDERS

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z1.yaml
@@ -1,0 +1,37 @@
+# z1 — the DUT. No static neighbors: every session must arrive via the
+# dynamic-neighbors listen-range 192.168.0.0/24, which materializes a
+# passive peer inheriting SENDERS (remote-as 65002, ipv4 enabled).
+# z3 connects from 192.168.1.3 — outside the range — and must be
+# refused at accept time. Originates 10.0.1.1/32 so the dynamic
+# session carries a route in the DUT->client direction too.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor-group:
+    - name: SENDERS
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    dynamic-neighbors:
+      listen-limit: 10
+      listen-range:
+      - prefix: 192.168.0.0/24
+        neighbor-group: SENDERS
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,6 +1,14 @@
 # z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
 # of view this is an ordinary static eBGP session toward the DUT; only
 # z1's side is dynamic. Originates 10.0.2.2/32.
+#
+# `connect-retry-time: 3` is required, not cosmetic. When the DUT
+# revokes a dynamic peer (listen-range delete) or refuses a connect,
+# the TCP dies after the handshake — z2's FSM lands in Active, where
+# the redial is paced by the ConnectRetryTimer and NOT by the 5s
+# idle-hold. At the 120s default the client would not redial within
+# any sane scenario timeout, and "session never came back" would look
+# like a slot leak instead of a sleeping timer.
 interface:
 - if-name: i1
   ipv4:
@@ -18,6 +26,7 @@ router:
     - remote-address: 192.168.0.1
       enabled: true
       remote-as: 65001
+      timers: {connect-retry-time: 3}
       afi-safi:
       - name: ipv4
         enabled: true

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — in-range client (192.168.0.2 ∈ 192.168.0.0/24). From z2's point
+# of view this is an ordinary static eBGP session toward the DUT; only
+# z1's side is dynamic. Originates 10.0.2.2/32.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.2.2/32

--- a/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
+++ b/bdd/tests/configs/bgp_dynamic_neighbors/z3.yaml
@@ -1,0 +1,29 @@
+# z3 — out-of-range client (192.168.1.3, matched by NO listen-range).
+# Identical client shape to z2; the only difference is the source
+# subnet, so any session it ever establishes means the listen-range
+# authorization leaked. Originates 10.0.3.3/32 — that prefix showing
+# up on z1 is the failure signal.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.3.3/32

--- a/bdd/tests/features/bgp_dynamic_nbr_ao.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_ao.feature
@@ -1,0 +1,104 @@
+@serial
+@bgp_dynamic_nbr_ao
+Feature: A dynamic (listen-range) peer authenticates with TCP-AO (RFC 5925)
+  As a network operator
+  I want the tcp-ao key-chain on a listen-range's neighbor-group to protect the range
+  So unconfigured sources cannot open a session just by being in the prefix.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  Requires Linux kernel >= 6.7 on both peers.
+
+  The DUT (z1) has no static neighbors: z2 arrives through the
+  listen-range and inherits SENDERS, which carries the tcp-ao
+  key-chain. Like the MD5 case, the MKT must be scoped to the whole
+  prefix — the peer is materialized only after its SYN is accepted,
+  while the kernel verifies the AO MAC during the handshake.
+
+  Config files:
+  - z1.yaml:        DUT — SENDERS carries `tcp-ao key-chain BGP-AO`, listen-range 192.168.0.0/24
+  - z1-noao.yaml:   same DUT with the group's tcp-ao removed
+  - z1-rotated.yaml: DUT whose BGP-AO chain holds a rotated key-string (same IDs)
+  - z2.yaml:        client, matching key-chain
+  - z2-wrong.yaml:  client, mismatched key-string
+
+  Scenario: Establish a TCP-AO authenticated dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A mismatched key-string never materializes a peer
+    Given the test topology exists
+    # The kernel drops the SYN before accept(), so there is no session
+    # to reject — and no peer entry on the DUT at all.
+    When I apply config "z2-wrong.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Restoring the matching key-string re-establishes the session
+    Given the test topology exists
+    When I apply config "z2.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+
+  Scenario: Rotating the key-string on the DUT re-keys the prefix MKT
+    Given the test topology exists
+    # Same chain name and the same send-id/recv-id, new key-string. The
+    # kernel identifies an MKT by (address, prefixlen, send-id, recv-id)
+    # and refuses a duplicate with EEXIST, so the reconciler must delete
+    # the old MKT before adding the rotated one. If it did not, the
+    # listener would keep serving the old key and the now-mismatched
+    # client would still get in.
+    When I apply config "z1-rotated.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+
+  Scenario: Clearing the group tcp-ao retracts the prefix MKT
+    Given the test topology exists
+    # With the DUT no longer expecting AO and the client still signing,
+    # the handshake cannot complete — proving the MKT was really removed
+    # from the listener rather than lingering.
+    When I apply config "z1-noao.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+
+  Scenario: Restoring the group tcp-ao re-installs the prefix MKT
+    Given the test topology exists
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_nbr_md5.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_md5.feature
@@ -1,0 +1,93 @@
+@serial
+@bgp_dynamic_nbr_md5
+Feature: A dynamic (listen-range) peer authenticates with TCP MD5 (RFC 2385)
+  As a network operator
+  I want the password on a listen-range's neighbor-group to protect the range
+  So unconfigured sources cannot open a session just by being in the prefix.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  The DUT (z1) has no static neighbors: z2 arrives through the
+  listen-range and inherits SENDERS, which carries the password.
+
+  This needs a listener key scoped to the whole *prefix*, not to a peer
+  address: a dynamic peer does not exist until its SYN is accepted, but
+  the kernel validates the MD5 option during the handshake — so the
+  per-address key used for static peers can never be installed in time.
+  A mismatch is therefore invisible at the BGP layer: the kernel drops
+  the SYN, no peer is ever materialized, and the DUT logs nothing.
+
+  Config files:
+  - z1.yaml:        DUT — SENDERS carries `password`, listen-range 192.168.0.0/24
+  - z1-nopass.yaml: same DUT with the group password removed
+  - z2.yaml:        client, matching tcp-md5 password
+  - z2-wrong.yaml:  client, mismatched tcp-md5 password
+
+  Scenario: Establish an MD5-authenticated dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A mismatched password never materializes a peer
+    Given the test topology exists
+    # The kernel drops the SYN before accept(), so this is not a
+    # rejected session — it is no session at all: the DUT must not
+    # even have a peer entry for the client.
+    When I apply config "z2-wrong.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Restoring the matching password re-establishes the session
+    Given the test topology exists
+    When I apply config "z2.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+
+  Scenario: Clearing the group password retracts the prefix key
+    Given the test topology exists
+    # With the DUT no longer expecting MD5 and the client still signing,
+    # the handshake cannot complete — proving the key was really
+    # retracted from the listener rather than lingering.
+    When I apply config "z1-nopass.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+
+  Scenario: Restoring the group password re-installs the prefix key
+    Given the test topology exists
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_nbr_policy.feature
+++ b/bdd/tests/features/bgp_dynamic_nbr_policy.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_dynamic_nbr_policy
+Feature: A dynamic (listen-range) peer inherits its neighbor-group's route policy
+  As a network operator
+  I want the `policy` bound on a listen-range's neighbor-group
+  So every peer materialized from that range is filtered like a static member.
+
+  Test Topology:
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+  ```
+
+  z1 (the DUT) has no static neighbors; z2 arrives via the listen-range
+  and inherits SENDERS. With SENDERS carrying `policy in DENY-ALL` the
+  session must still establish, z1's own route must still flow out —
+  but z2's route must be denied on ingress. Rebinding the group without
+  the policy and re-materializing the peer readmits the route, proving
+  the policy is resolved from the group at accept time, not baked in.
+
+  Config files:
+  - z1-deny.yaml: DUT — SENDERS has `policy in DENY-ALL`, originates 10.0.1.1/32
+  - z1-open.yaml: identical but the group carries no policy binding
+  - z2.yaml:      client, static neighbor to .0.1, originates 10.0.2.2/32
+
+  Scenario: Establish with an inbound deny-all policy inherited from the group
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-deny.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    # Policy filters routes, not the session: outbound is untouched...
+    And BGP route in "z2" has "10.0.1.1/32"
+    # ...while the inherited inbound DENY-ALL drops the client's route.
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Unbinding the group policy readmits the route on re-materialization
+    Given the test topology exists
+    When I apply config "z1-open.yaml" to namespace "z1"
+    And I wait 10 seconds
+    # Hard-reset from the client: z1's dynamic peer is torn down and the
+    # reconnect materializes a fresh peer that resolves the group's
+    # CURRENT (policy-less) state through the same accept-time ritual.
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -1,0 +1,97 @@
+@serial
+@bgp_dynamic_neighbors
+Feature: BGP dynamic neighbors materialize passive peers from a listen-range
+  As a network operator
+  I want `router bgp dynamic-neighbors listen-range <prefix> neighbor-group <G>`
+  So sessions from an authorized source prefix establish without per-peer config.
+
+  Test Topology (z1 is the DUT; only z2's subnet is range-authorized):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │ i2────────────i1 │   z3    │
+   │ AS65002 │   (in range)     │ AS65001 │  (out of range)  │ AS65002 │
+   │ .0.2    │                  │.0.1 .1.1│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 has NO static neighbors. Its listen-range 192.168.0.0/24 binds
+  neighbor-group SENDERS (remote-as 65002, ipv4 enabled), so z2's inbound
+  connection materializes a passive peer that must reach Established and
+  exchange routes in both directions (regression pin for PR #2044, where
+  the materialized peer was left in Idle and every connection was
+  dropped). z3 runs the same client config from 192.168.1.3 — outside
+  the range — and must be refused at accept time with no peer state.
+
+  Config files:
+  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+
+  Scenario: Setup topology and establish the dynamic session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z2" interface "i1" to namespace "z1" interface "i1"
+    And I connect namespace "z1" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And show command "show bgp summary" in namespace "z1" should contain "192.168.0.2"
+
+  Scenario: Routes flow in both directions over the dynamic session
+    Given the test topology exists
+    Then BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A source outside every listen-range is refused without peer state
+    Given the test topology exists
+    # z3's TCP connect is accepted by the kernel, but the LPM miss makes
+    # z1 drop the stream before any OPEN exchange — z3 never leaves the
+    # connect/retry cycle, and z1 materializes nothing for 192.168.1.3.
+    Then BGP session in "z3" to "192.168.1.1" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.1.3"
+    And BGP route in "z1" does not have "10.0.3.3/32"
+
+  Scenario: The client can hard-reset and re-establish the dynamic session
+    Given the test topology exists
+    # Pre-#2044 every reconnect was dropped: the very first inbound
+    # stream materialized the peer, then died in Idle forever.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: A DUT-side clear frees the peer and the next connect re-materializes it
+    Given the test topology exists
+    # Clearing on z1 ends the session of a Dynamic-origin peer, which
+    # the instance GCs (freeing its listen-limit slot); z2's redial then
+    # re-materializes a fresh peer through the same accept path.
+    When I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_dynamic_neighbors.feature
+++ b/bdd/tests/features/bgp_dynamic_neighbors.feature
@@ -22,10 +22,15 @@ Feature: BGP dynamic neighbors materialize passive peers from a listen-range
   dropped). z3 runs the same client config from 192.168.1.3 — outside
   the range — and must be refused at accept time with no peer state.
 
+  `listen-limit` is 1 on the DUT, so every re-establishment below also
+  proves the freed slot was actually returned — a leaked slot saturates
+  the cap and the client can never reconnect.
+
   Config files:
-  - z1.yaml: DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
-  - z2.yaml: in-range client, static neighbor to .0.1, originates 10.0.2.2/32
-  - z3.yaml: out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+  - z1.yaml:         DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+  - z1-norange.yaml: same DUT with the listen-range deleted (group kept)
+  - z2.yaml:         in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+  - z3.yaml:         out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
 
   Scenario: Setup topology and establish the dynamic session
     Given a clean test environment
@@ -81,6 +86,30 @@ Feature: BGP dynamic neighbors materialize passive peers from a listen-range
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z1" has "10.0.2.2/32"
+    And BGP route in "z2" has "10.0.1.1/32"
+
+  Scenario: Deleting the listen-range revokes the peers it materialized
+    Given the test topology exists
+    # Revoking the authorization must not leave the session it
+    # authorized running: the sweep tears the dynamic peer down and
+    # returns its listen-limit slot.
+    When I wait 10 seconds
+    And I apply config "z1-norange.yaml" to namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "192.168.0.2"
+    And BGP route in "z1" does not have "10.0.2.2/32"
+
+  Scenario: Restoring the listen-range re-materializes the peer in the freed slot
+    Given the test topology exists
+    # `listen-limit` is 1, so this only succeeds if the sweep decremented
+    # `dynamic_peer_count` — a leaked slot leaves the cap saturated and
+    # the client's connect is refused forever.
+    When I apply config "z1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP route in "z1" has "10.0.2.2/32"
     And BGP route in "z2" has "10.0.1.1/32"
 

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -105,6 +105,8 @@
 /router/bgp/neighbor-group/remove-private-as/all
 /router/bgp/neighbor-group/remove-private-as/replace-as
 /router/bgp/neighbor-group/route-reflector/client
+/router/bgp/neighbor-group/tcp-ao/include-tcp-options
+/router/bgp/neighbor-group/tcp-ao/key-chain
 /router/bgp/neighbor-group/tcp-mss
 /router/bgp/neighbor-group/ttl-security
 /router/bgp/neighbor-group/update-source

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -10,6 +10,7 @@ ORPHAN leaf         /router/bgp/sharding/peer-sharding
   /router/bgp/neighbor/afi-safi  [list]
   /router/bgp/neighbor/tcp-md5  [p-container]
   /router/bgp/neighbor/tcp-ao  [p-container]
+  /router/bgp/neighbor-group/tcp-ao  [p-container]
   /router/bgp/color-policy  [p-container]
   /router/bgp/sr-policy  [p-container]
   /router/bgp/vrf/neighbor/afi-safi  [list]
@@ -20,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 275
-Handled: 263
+Total settable schema nodes: 278
+Handled: 265
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -107,6 +107,9 @@
 /router/bgp/neighbor-group/remove-private-as/replace-as	leaf
 /router/bgp/neighbor-group/route-reflector	container
 /router/bgp/neighbor-group/route-reflector/client	leaf
+/router/bgp/neighbor-group/tcp-ao	p-container
+/router/bgp/neighbor-group/tcp-ao/include-tcp-options	leaf
+/router/bgp/neighbor-group/tcp-ao/key-chain	leaf
 /router/bgp/neighbor-group/tcp-mss	leaf
 /router/bgp/neighbor-group/ttl-security	p-container
 /router/bgp/neighbor-group/update-source	leaf

--- a/zebra-rs/src/bgp/auth.rs
+++ b/zebra-rs/src/bgp/auth.rs
@@ -227,6 +227,65 @@ pub fn set_tcp_ao_key(
     recv_id: u8,
     include_tcp_options: bool,
 ) -> io::Result<()> {
+    set_ao(
+        fd,
+        peer_ip,
+        None,
+        alg_name,
+        key,
+        send_id,
+        recv_id,
+        include_tcp_options,
+    )
+}
+
+/// Prefix-scoped variant: one MKT authenticates every source inside
+/// `prefix`. The dynamic-neighbors counterpart of
+/// [`set_tcp_md5_key_prefix`] — a listen-range peer is materialized
+/// only after its SYN is accepted, but the kernel verifies the AO MAC
+/// during the handshake, so a per-address MKT can never be installed
+/// in time.
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+pub fn set_tcp_ao_key_prefix(
+    fd: RawFd,
+    prefix: ipnet::IpNet,
+    alg_name: &str,
+    key: &[u8],
+    send_id: u8,
+    recv_id: u8,
+    include_tcp_options: bool,
+) -> io::Result<()> {
+    // Masked, for the same reason as MD5: the kernel matches the
+    // inbound source against the masked network.
+    set_ao(
+        fd,
+        prefix.network(),
+        Some(prefix.prefix_len()),
+        alg_name,
+        key,
+        send_id,
+        recv_id,
+        include_tcp_options,
+    )
+}
+
+/// Shared core. `prefixlen` of `None` keys the MKT on the exact
+/// address (host prefix, the static-peer case); `Some(len)` scopes it
+/// to a whole prefix.
+#[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
+fn set_ao(
+    fd: RawFd,
+    addr: IpAddr,
+    prefixlen: Option<u8>,
+    alg_name: &str,
+    key: &[u8],
+    send_id: u8,
+    recv_id: u8,
+    include_tcp_options: bool,
+) -> io::Result<()> {
+    let peer_ip = addr;
     if key.len() > TCP_AO_MAXKEYLEN {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -247,7 +306,7 @@ pub fn set_tcp_ao_key(
     let mut add: TcpAoAdd = unsafe { mem::zeroed() };
     fill_sockaddr(&mut add.addr, peer_ip);
     add.alg_name[..alg_name.len()].copy_from_slice(alg_name.as_bytes());
-    add.prefix = if peer_ip.is_ipv4() { 32 } else { 128 };
+    add.prefix = prefixlen.unwrap_or(if peer_ip.is_ipv4() { 32 } else { 128 });
     add.sndid = send_id;
     add.rcvid = recv_id;
     add.maclen = 12; // RFC 5926 default 96-bit MAC
@@ -275,9 +334,40 @@ pub fn set_tcp_ao_key(
 /// Remove the TCP-AO MKT for `peer_ip` from `fd`.
 #[cfg(target_os = "linux")]
 pub fn del_tcp_ao_key(fd: RawFd, peer_ip: IpAddr, send_id: u8, recv_id: u8) -> io::Result<()> {
+    del_ao(fd, peer_ip, None, send_id, recv_id)
+}
+
+/// Remove a prefix-scoped MKT. The kernel keys MKTs by
+/// (address, prefixlen, send_id, recv_id), so a prefix entry must be
+/// deleted with the same prefix length it was added under — deleting
+/// it as a host route silently leaves it installed.
+#[cfg(target_os = "linux")]
+pub fn del_tcp_ao_key_prefix(
+    fd: RawFd,
+    prefix: ipnet::IpNet,
+    send_id: u8,
+    recv_id: u8,
+) -> io::Result<()> {
+    del_ao(
+        fd,
+        prefix.network(),
+        Some(prefix.prefix_len()),
+        send_id,
+        recv_id,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn del_ao(
+    fd: RawFd,
+    peer_ip: IpAddr,
+    prefixlen: Option<u8>,
+    send_id: u8,
+    recv_id: u8,
+) -> io::Result<()> {
     let mut del: TcpAoDel = unsafe { mem::zeroed() };
     fill_sockaddr(&mut del.addr, peer_ip);
-    del.prefix = if peer_ip.is_ipv4() { 32 } else { 128 };
+    del.prefix = prefixlen.unwrap_or(if peer_ip.is_ipv4() { 32 } else { 128 });
     del.sndid = send_id;
     del.rcvid = recv_id;
 
@@ -315,6 +405,31 @@ pub fn del_tcp_ao_key(_fd: i32, _peer_ip: IpAddr, _send_id: u8, _recv_id: u8) ->
     Ok(())
 }
 
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
+pub fn set_tcp_ao_key_prefix(
+    _fd: i32,
+    _prefix: ipnet::IpNet,
+    _alg_name: &str,
+    _key: &[u8],
+    _send_id: u8,
+    _recv_id: u8,
+    _include_tcp_options: bool,
+) -> io::Result<()> {
+    tracing::warn!("TCP-AO authentication not supported on this platform; no-op");
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn del_tcp_ao_key_prefix(
+    _fd: i32,
+    _prefix: ipnet::IpNet,
+    _send_id: u8,
+    _recv_id: u8,
+) -> io::Result<()> {
+    Ok(())
+}
+
 // =========================================================
 // TCP-AO key-chain resolution.
 //
@@ -344,7 +459,7 @@ pub fn tcp_ao_alg_from_policy(a: crate::policy::CryptoAlgorithm) -> Option<&'sta
 
 /// Per-neighbor TCP-AO configuration (zebra-bgp-auth.yang `tcp-ao`
 /// presence container).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AoConfig {
     /// Name of a configured key chain under `/key-chains`.
     pub key_chain: String,

--- a/zebra-rs/src/bgp/auth.rs
+++ b/zebra-rs/src/bgp/auth.rs
@@ -23,6 +23,13 @@ struct TcpMd5Sig {
     tcpm_key: [u8; libc::TCP_MD5SIG_MAXKEYLEN],
 }
 
+/// `TCP_MD5SIG_FLAG_PREFIX` from `<linux/tcp.h>`: interpret
+/// `tcpm_prefixlen` so the key covers a whole prefix instead of the
+/// single address in `tcpm_addr`. Not exposed by the `libc` crate for
+/// linux targets (only for hurd), so it is spelled out here.
+#[cfg(target_os = "linux")]
+const TCP_MD5SIG_FLAG_PREFIX: u8 = 0x1;
+
 /// Install a TCP MD5 shared secret on `fd` keyed by `peer_ip`.
 ///
 /// Must be called:
@@ -34,6 +41,31 @@ struct TcpMd5Sig {
 /// An empty `key` removes the entry for that peer on the socket.
 #[cfg(target_os = "linux")]
 pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()> {
+    set_md5(fd, peer_ip, None, key)
+}
+
+/// Prefix-scoped variant: one key authenticates every source inside
+/// `prefix`. This is what makes TCP MD5 usable with
+/// `dynamic-neighbors` — the listener must validate the MD5 option on
+/// a SYN whose source has no peer entry yet (the peer is only
+/// materialized *after* the handshake completes), so a per-address key
+/// can never be installed in time.
+///
+/// Requires `TCP_MD5SIG_EXT` (Linux 4.13+). An empty `key` removes the
+/// prefix entry.
+#[cfg(target_os = "linux")]
+pub fn set_tcp_md5_key_prefix(fd: RawFd, prefix: ipnet::IpNet, key: &[u8]) -> io::Result<()> {
+    // `network()` truncates host bits: the kernel matches on the
+    // masked address, and a key installed under an unmasked one would
+    // silently never match an inbound SYN.
+    set_md5(fd, prefix.network(), Some(prefix.prefix_len()), key)
+}
+
+/// Shared core for both scopes. `prefixlen` of `None` keys the entry
+/// on the exact address (classic `TCP_MD5SIG`); `Some(len)` switches
+/// to the extended request that carries the prefix length.
+#[cfg(target_os = "linux")]
+fn set_md5(fd: RawFd, addr: IpAddr, prefixlen: Option<u8>, key: &[u8]) -> io::Result<()> {
     if key.len() > libc::TCP_MD5SIG_MAXKEYLEN {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -46,7 +78,7 @@ pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()>
     }
 
     let mut sig: TcpMd5Sig = unsafe { mem::zeroed() };
-    match peer_ip {
+    match addr {
         IpAddr::V4(a) => {
             let sa = unsafe {
                 &mut *(&mut sig.tcpm_addr as *mut libc::sockaddr_storage as *mut libc::sockaddr_in)
@@ -67,11 +99,20 @@ pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()>
     sig.tcpm_keylen = key.len() as u16;
     sig.tcpm_key[..key.len()].copy_from_slice(key);
 
+    let optname = match prefixlen {
+        Some(len) => {
+            sig.tcpm_flags = TCP_MD5SIG_FLAG_PREFIX;
+            sig.tcpm_prefixlen = len;
+            libc::TCP_MD5SIG_EXT
+        }
+        None => libc::TCP_MD5SIG,
+    };
+
     let ret = unsafe {
         libc::setsockopt(
             fd,
             libc::IPPROTO_TCP,
-            libc::TCP_MD5SIG,
+            optname,
             &sig as *const TcpMd5Sig as *const libc::c_void,
             mem::size_of::<TcpMd5Sig>() as libc::socklen_t,
         )
@@ -84,6 +125,12 @@ pub fn set_tcp_md5_key(fd: RawFd, peer_ip: IpAddr, key: &[u8]) -> io::Result<()>
 
 #[cfg(not(target_os = "linux"))]
 pub fn set_tcp_md5_key(_fd: i32, _peer_ip: IpAddr, _key: &[u8]) -> io::Result<()> {
+    tracing::warn!("TCP MD5 authentication not supported on this platform; no-op");
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_tcp_md5_key_prefix(_fd: i32, _prefix: ipnet::IpNet, _key: &[u8]) -> io::Result<()> {
     tracing::warn!("TCP MD5 authentication not supported on this platform; no-op");
     Ok(())
 }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -335,46 +335,59 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // dialing yet, so no kick fires here.
         bgp.refresh_connected();
     } else {
-        let peer_idx = {
-            let peer = bgp.peers.get(&addr)?;
-            peer.ident
-        };
-
-        // Defensively clear any listener auth entries associated with
-        // this peer before removing it, in case the per-leaf delete
-        // callbacks didn't fire (e.g., whole-neighbor delete without
-        // explicit tcp-md5 / tcp-ao deletions first).
-        clear_peer_listener_auth(bgp, &addr);
-
-        let mut bgp_ref = BgpTop {
-            router_id: &bgp.router_id,
-            srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
-            local_rib: &mut bgp.local_rib,
-            shard: &mut bgp.shard,
-            tx: &bgp.tx,
-            rib_client: &bgp.ctx.rib,
-            attr_store: &mut bgp.attr_store,
-            update_groups: &mut bgp.update_groups,
-            interface_addrs: &bgp.interface_addrs,
-            vrf_export: None,
-            color_policy: Some(&bgp.color_policy),
-            flex_algo_routes: Some(&bgp.flex_algo_routes),
-            flex_algo_srv6_routes: Some(&bgp.flex_algo_srv6_routes),
-            vrf_import: None,
-            nexthop_cache: None,
-            vrf_transport_v4: None,
-            vrf_transport_v6: None,
-            central_label_alloc: None,
-            as_sets_withdraw: bgp.as_sets_withdraw,
-        };
-        route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
-        // Update-groups live outside `PeerMap`: removal below purges
-        // the membership index by construction, but the group member
-        // sets must be detached explicitly or the freed ident lingers
-        // and a future slot reuse inherits the group.
-        super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
-        bgp.peers.remove(&addr);
+        remove_peer_full(bgp, addr)?;
     }
+    Some(())
+}
+
+/// The full peer-removal ritual: listener auth cleanup, Loc-RIB route
+/// withdrawal, update-group detach, map removal, and the listener-wide
+/// TCP-MSS / IP_TRANSPARENT reconciliations. Shared by the static
+/// `delete router bgp neighbor <addr>` path above and the
+/// dynamic-neighbors range sweep
+/// (`super::dynamic_neighbors::sweep_range_peers`); the sweep owns the
+/// `dynamic_peer_count` decrement, since only it knows the peer was
+/// slot-counted.
+pub(super) fn remove_peer_full(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
+    let peer_idx = {
+        let peer = bgp.peers.get(&addr)?;
+        peer.ident
+    };
+
+    // Defensively clear any listener auth entries associated with
+    // this peer before removing it, in case the per-leaf delete
+    // callbacks didn't fire (e.g., whole-neighbor delete without
+    // explicit tcp-md5 / tcp-ao deletions first).
+    clear_peer_listener_auth(bgp, &addr);
+
+    let mut bgp_ref = BgpTop {
+        router_id: &bgp.router_id,
+        srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
+        local_rib: &mut bgp.local_rib,
+        shard: &mut bgp.shard,
+        tx: &bgp.tx,
+        rib_client: &bgp.ctx.rib,
+        attr_store: &mut bgp.attr_store,
+        update_groups: &mut bgp.update_groups,
+        interface_addrs: &bgp.interface_addrs,
+        vrf_export: None,
+        color_policy: Some(&bgp.color_policy),
+        flex_algo_routes: Some(&bgp.flex_algo_routes),
+        flex_algo_srv6_routes: Some(&bgp.flex_algo_srv6_routes),
+        vrf_import: None,
+        nexthop_cache: None,
+        vrf_transport_v4: None,
+        vrf_transport_v6: None,
+        central_label_alloc: None,
+        as_sets_withdraw: bgp.as_sets_withdraw,
+    };
+    route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
+    // Update-groups live outside `PeerMap`: removal below purges
+    // the membership index by construction, but the group member
+    // sets must be detached explicitly or the freed ident lingers
+    // and a future slot reuse inherits the group.
+    super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
+    bgp.peers.remove(&addr);
     // Keep the shared listener's TCP MSS minimum in step with the peer
     // set: a whole-neighbor delete may drop the peer that owned the
     // current minimum without the per-leaf `/tcp-mss` delete firing (the

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -544,6 +544,9 @@ fn config_peer_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
     if outcome.md5_refresh {
         apply_md5_refresh_for(bgp, addr);
     }
+    if outcome.ao_refresh {
+        apply_ao_refresh_all(bgp);
+    }
     if outcome.bfd_reapply {
         let _ = bfd_apply(bgp, addr);
     }
@@ -600,7 +603,7 @@ fn config_remote_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 /// previously occurred when the operator switched a peer from
 /// `policy in hoge` to `policy in fuga` — the "hoge"
 /// watcher would otherwise stay registered forever.
-fn policy_attach_msgs(
+pub(super) fn policy_attach_msgs(
     policy_tx: &tokio::sync::mpsc::UnboundedSender<policy::Message>,
     ident: usize,
     policy_type: policy::PolicyType,
@@ -3741,6 +3744,19 @@ pub(super) fn apply_md5_password(peer: &mut Peer, want: Option<String>) -> bool 
     true
 }
 
+/// Adopt an inherited TCP-AO config onto a peer. An explicit
+/// per-neighbor `tcp-ao` always wins: `resolve_knob` has already
+/// preferred the peer's own statement, so `want` is what should be in
+/// effect. Returns whether anything changed, so the caller can
+/// re-run the listener sweep and bounce a live session.
+pub(super) fn apply_ao_config(peer: &mut Peer, want: Option<super::auth::AoConfig>) -> bool {
+    if peer.config.transport.ao_config == want {
+        return false;
+    }
+    peer.config.transport.ao_config = want;
+    true
+}
+
 /// Reconcile the listener TCP MD5 key for a single peer. Reads
 /// `peer.config.transport.md5_password` and installs (or removes,
 /// with an empty key) on the appropriate listening socket. Silent
@@ -4259,6 +4275,14 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/neighbor-group/password",
             super::neighbor_group::config_neighbor_group_password,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/tcp-ao/key-chain",
+            super::neighbor_group::config_neighbor_group_tcp_ao_key_chain,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/tcp-ao/include-tcp-options",
+            super::neighbor_group::config_neighbor_group_tcp_ao_include_tcp_options,
         );
         self.callback_add(
             "/router/bgp/neighbor-group/policy/in",

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -3,8 +3,9 @@
 //! Stores the configured `listen-range` prefixes and `listen-limit`,
 //! and exposes `lpm_match` for the accept-path. Materialization of
 //! the synthesized [`super::peer::Peer`] lives in
-//! [`super::peer::try_dynamic_accept`] — this module is just state
-//! + config callbacks.
+//! [`super::peer::try_dynamic_accept`] — this module holds the state,
+//! the config callbacks, and the revocation sweep
+//! ([`sweep_range_peers`]) that tears those peers back down.
 
 use std::collections::BTreeMap;
 use std::net::IpAddr;
@@ -90,8 +91,8 @@ pub fn config_listen_limit(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 }
 
 /// `set router bgp dynamic-neighbors listen-range <prefix>` —
-/// list-key callback. Creates the entry on `Set` and removes it on
-/// `Delete`.
+/// list-key callback. Creates the entry on `Set`; removes it on
+/// `Delete` and sweeps the peers it materialized.
 pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let prefix: IpNet = args.string()?.parse().ok()?;
     match op {
@@ -100,6 +101,7 @@ pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         }
         ConfigOp::Delete => {
             bgp.dynamic_neighbors.ranges.remove(&prefix);
+            sweep_range_peers(bgp, &prefix);
         }
         _ => {}
     }
@@ -113,13 +115,68 @@ pub fn config_listen_range_neighbor_group(
     op: ConfigOp,
 ) -> Option<()> {
     let prefix: IpNet = args.string()?.parse().ok()?;
-    let entry = bgp.dynamic_neighbors.ranges.entry(prefix).or_default();
     match op {
-        ConfigOp::Set => entry.neighbor_group = Some(args.string()?),
-        ConfigOp::Delete => entry.neighbor_group = None,
+        ConfigOp::Set => {
+            bgp.dynamic_neighbors
+                .ranges
+                .entry(prefix)
+                .or_default()
+                .neighbor_group = Some(args.string()?);
+        }
+        ConfigOp::Delete => {
+            // `get_mut`, not `entry().or_default()`: when the whole
+            // listen-range entry is deleted, this leaf's Delete may fire
+            // after the list-key's — an `or_default` here would
+            // resurrect the just-removed range as a ghost entry.
+            if let Some(entry) = bgp.dynamic_neighbors.ranges.get_mut(&prefix) {
+                entry.neighbor_group = None;
+            }
+            // A group-less range can materialize nothing, and the peers
+            // it already materialized just lost the source of their
+            // session attributes — revoke them like a range delete.
+            sweep_range_peers(bgp, &prefix);
+        }
         _ => {}
     }
     Some(())
+}
+
+/// Tear down and remove every `PeerOrigin::Dynamic` peer materialized
+/// from `prefix`, freeing their `listen-limit` slots. Deleting a
+/// listen-range (or unbinding its neighbor-group) revokes the
+/// authorization those peers were accepted under, so their sessions
+/// must not outlive it — mirroring FRR's `no bgp listen range`.
+///
+/// Peers are matched by their provenance stamp (the `range_prefix`
+/// recorded at materialization), not by re-running LPM: if an
+/// overlapping range still covers a swept client, its next connect
+/// re-materializes under that range — with that range's group, which
+/// is the correct attribute source from then on.
+pub(super) fn sweep_range_peers(bgp: &mut Bgp, prefix: &IpNet) {
+    use super::peer_key::PeerOrigin;
+
+    let victims: Vec<IpAddr> = bgp
+        .peers
+        .idents()
+        .into_iter()
+        .filter_map(|ident| bgp.peers.get_by_idx(ident))
+        .filter(|peer| {
+            matches!(&peer.origin,
+                PeerOrigin::Dynamic { range_prefix } if range_prefix == prefix)
+        })
+        .map(|peer| peer.address)
+        .collect();
+
+    for addr in victims {
+        if super::config::remove_peer_full(bgp, addr).is_some() {
+            bgp.dynamic_peer_count = bgp.dynamic_peer_count.saturating_sub(1);
+            tracing::info!(
+                peer = %addr,
+                range = %prefix,
+                "bgp: dynamic peer removed by listen-range sweep",
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -188,5 +245,226 @@ mod tests {
     fn default_listen_limit_is_one_hundred() {
         let dn = DynamicNeighbors::default();
         assert_eq!(dn.listen_limit, 100);
+    }
+}
+
+/// Revocation sweep: deleting a listen-range (or unbinding its
+/// neighbor-group) must tear down the peers that range materialized
+/// and give their `listen-limit` slots back.
+#[cfg(test)]
+mod sweep_tests {
+    use std::collections::VecDeque;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::bgp::peer::Peer;
+    use crate::bgp::peer_key::PeerOrigin;
+
+    fn net(s: &str) -> IpNet {
+        s.parse().unwrap()
+    }
+
+    fn addr(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    fn arg_words(parts: &[&str]) -> Args {
+        Args(
+            parts
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<VecDeque<_>>(),
+        )
+    }
+
+    fn test_ctx() -> (
+        crate::context::ProtoContext,
+        mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
+    ) {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        // Leak the inbound rx: a dropped receiver turns every send
+        // through the client into a SendError, which BGP unwraps.
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+        (ctx, rib_rx)
+    }
+
+    fn test_rib_subscriber() -> crate::config::RibSubscriber {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_inbound_rx));
+        // Starts at 1 so it never collides with the
+        // `ProtoId::from_raw(0)` baked into `test_ctx`.
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id)
+    }
+
+    fn fresh_bgp() -> Bgp {
+        let (ctx, rib_rx) = test_ctx();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    /// Stand in for `try_dynamic_accept`'s materialization without a
+    /// socket: insert a Dynamic-origin peer stamped with `range` and
+    /// take its `listen-limit` slot, exactly as the accept path does.
+    fn materialize(bgp: &mut Bgp, peer_addr: &str, range: &str) {
+        let address = addr(peer_addr);
+        let mut peer = Peer::new(
+            0,
+            bgp.asn,
+            bgp.router_id,
+            65001,
+            address,
+            bgp.hostname(),
+            bgp.tx.clone(),
+            bgp.ctx.clone(),
+        );
+        peer.origin = PeerOrigin::Dynamic {
+            range_prefix: net(range),
+        };
+        peer.config.transport.passive = true;
+        bgp.peers.insert(address, peer);
+        bgp.dynamic_peer_count += 1;
+    }
+
+    /// Config a range bound to a group, the way an operator would.
+    fn configure_range(bgp: &mut Bgp, prefix: &str, group: &str) {
+        config_listen_range(bgp, arg_words(&[prefix]), ConfigOp::Set).unwrap();
+        config_listen_range_neighbor_group(bgp, arg_words(&[prefix, group]), ConfigOp::Set)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn range_delete_sweeps_only_its_own_peers() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        configure_range(&mut bgp, "10.2.0.0/24", "B");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+        materialize(&mut bgp, "10.1.0.8", "10.1.0.0/24");
+        materialize(&mut bgp, "10.2.0.9", "10.2.0.0/24");
+        assert_eq!(bgp.dynamic_peer_count, 3);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert!(bgp.peers.get(&addr("10.1.0.7")).is_none());
+        assert!(bgp.peers.get(&addr("10.1.0.8")).is_none());
+        assert!(
+            bgp.peers.get(&addr("10.2.0.9")).is_some(),
+            "a peer from a still-configured range must survive"
+        );
+        assert_eq!(
+            bgp.dynamic_peer_count, 1,
+            "both swept peers must return their listen-limit slots"
+        );
+    }
+
+    /// The slot accounting has to be exact, not merely non-negative:
+    /// a sweep that forgot to decrement would wedge a `listen-limit`
+    /// speaker forever (the pre-existing worry that motivated this).
+    #[tokio::test]
+    async fn swept_slots_are_reusable_up_to_the_limit() {
+        let mut bgp = fresh_bgp();
+        bgp.dynamic_neighbors.listen_limit = 2;
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+        materialize(&mut bgp, "10.1.0.8", "10.1.0.0/24");
+        assert_eq!(bgp.dynamic_peer_count, bgp.dynamic_neighbors.listen_limit);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert_eq!(bgp.dynamic_peer_count, 0, "the cap must be fully released");
+    }
+
+    /// Unbinding the group leaves the range unable to supply session
+    /// attributes, so its peers go too.
+    #[tokio::test]
+    async fn group_unbind_sweeps_range_peers() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        materialize(&mut bgp, "10.1.0.7", "10.1.0.0/24");
+
+        config_listen_range_neighbor_group(
+            &mut bgp,
+            arg_words(&["10.1.0.0/24", "A"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(bgp.peers.get(&addr("10.1.0.7")).is_none());
+        assert_eq!(bgp.dynamic_peer_count, 0);
+    }
+
+    /// A statically configured peer whose address happens to fall
+    /// inside the range is NOT dynamic — provenance, not address
+    /// containment, decides. Sweeping it would delete operator config.
+    #[tokio::test]
+    async fn sweep_spares_static_peers_inside_the_prefix() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+        let static_addr = addr("10.1.0.5");
+        let peer = Peer::new(
+            0,
+            bgp.asn,
+            bgp.router_id,
+            65001,
+            static_addr,
+            bgp.hostname(),
+            bgp.tx.clone(),
+            bgp.ctx.clone(),
+        );
+        bgp.peers.insert(static_addr, peer);
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+
+        assert!(
+            bgp.peers.get(&static_addr).is_some(),
+            "a PeerOrigin::Static peer must survive a range delete"
+        );
+        assert_eq!(
+            bgp.dynamic_peer_count, 0,
+            "a static peer never held a slot, so none is released"
+        );
+    }
+
+    /// Deleting a whole listen-range fires the list-key callback and
+    /// the child-leaf callback. Whichever order they arrive in, the
+    /// range must stay gone — an `entry().or_default()` in the leaf's
+    /// Delete arm would resurrect it as a group-less ghost that
+    /// `lpm_match` then hits on every inbound connection.
+    #[tokio::test]
+    async fn leaf_delete_after_key_delete_does_not_resurrect_the_range() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "A");
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        config_listen_range_neighbor_group(
+            &mut bgp,
+            arg_words(&["10.1.0.0/24", "A"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(
+            bgp.dynamic_neighbors.ranges.is_empty(),
+            "trailing leaf delete must not re-create the range entry"
+        );
+        assert!(bgp.dynamic_neighbors.lpm_match(&addr("10.1.0.7")).is_none());
     }
 }

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -34,6 +34,13 @@ pub struct DynamicNeighbors {
     /// put there: the desired set is recomputed from config, but the
     /// *removal* set can only be known from what was installed before.
     installed_md5: BTreeMap<IpNet, String>,
+    /// Same shadow for prefix-scoped TCP-AO MKTs. The stored value is
+    /// the full resolved key, because the kernel identifies an MKT by
+    /// `(address, prefixlen, send_id, recv_id)` — a rotation that
+    /// keeps both IDs but changes the material still has to be
+    /// deleted before it can be re-added (`TCP_AO_ADD_KEY` answers
+    /// EEXIST otherwise), so the IDs alone are not enough state.
+    installed_ao: BTreeMap<IpNet, super::auth::ResolvedAoKey>,
 }
 
 /// RFC-style operator default — IOS-XR ships 100, FRR ships 100,
@@ -47,6 +54,7 @@ impl Default for DynamicNeighbors {
             listen_limit: DEFAULT_LISTEN_LIMIT,
             ranges: BTreeMap::new(),
             installed_md5: BTreeMap::new(),
+            installed_ao: BTreeMap::new(),
         }
     }
 }
@@ -60,6 +68,12 @@ impl DynamicNeighbors {
     /// installed" and skips every key on the new fd.
     pub fn forget_installed_md5(&mut self) {
         self.installed_md5.clear();
+    }
+
+    /// TCP-AO twin of [`Self::forget_installed_md5`], for the same
+    /// fd-replacement reason.
+    pub fn forget_installed_ao(&mut self) {
+        self.installed_ao.clear();
     }
 
     /// Longest-prefix match against the configured ranges. Returns
@@ -123,6 +137,7 @@ pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         _ => {}
     }
     reconcile_listener_md5(bgp);
+    reconcile_listener_ao(bgp);
     Some(())
 }
 
@@ -157,6 +172,7 @@ pub fn config_listen_range_neighbor_group(
         _ => {}
     }
     reconcile_listener_md5(bgp);
+    reconcile_listener_ao(bgp);
     Some(())
 }
 
@@ -263,6 +279,125 @@ fn md5_prefix_apply(bgp: &Bgp, prefix: &IpNet, key: &[u8]) -> bool {
                 error = %e,
                 "TCP MD5 prefix setsockopt on listener failed; \
                  authenticated SYNs from this range will be dropped"
+            );
+            false
+        }
+    }
+}
+
+/// TCP-AO twin of [`reconcile_listener_md5`]: keep the listener's
+/// prefix-scoped MKTs in step with `listen-range × neighbor-group
+/// tcp-ao`, resolved against the current key-chain table.
+///
+/// Same rationale — a listen-range peer is materialized only after its
+/// SYN is accepted, but the kernel verifies the AO MAC during the
+/// handshake — and the same diff-gating. The extra wrinkle is that the
+/// kernel identifies an MKT by `(address, prefixlen, send_id,
+/// recv_id)` and refuses a duplicate with EEXIST, so any change to a
+/// range's key must delete the *previously installed* IDs before
+/// adding, including a rotation that keeps both IDs.
+pub(super) fn reconcile_listener_ao(bgp: &mut Bgp) {
+    let desired = desired_listener_ao(bgp);
+
+    if desired == bgp.dynamic_neighbors.installed_ao {
+        return;
+    }
+
+    let stale: Vec<(IpNet, super::auth::ResolvedAoKey)> = bgp
+        .dynamic_neighbors
+        .installed_ao
+        .iter()
+        .filter(|(prefix, installed)| desired.get(*prefix) != Some(*installed))
+        .map(|(prefix, installed)| (*prefix, installed.clone()))
+        .collect();
+    for (prefix, installed) in stale {
+        if ao_prefix_del(bgp, &prefix, installed.send_id, installed.recv_id) {
+            bgp.dynamic_neighbors.installed_ao.remove(&prefix);
+        }
+    }
+
+    for (prefix, key) in desired {
+        if bgp.dynamic_neighbors.installed_ao.get(&prefix) == Some(&key) {
+            continue;
+        }
+        if ao_prefix_add(bgp, &prefix, &key) {
+            bgp.dynamic_neighbors.installed_ao.insert(prefix, key);
+        }
+    }
+}
+
+/// The MKTs the listener *should* be carrying: every listen-range
+/// bound to a group whose `tcp-ao` resolves against the current
+/// key-chain table. An unresolvable chain (missing, no usable key)
+/// contributes nothing, exactly as for a static peer.
+fn desired_listener_ao(bgp: &Bgp) -> BTreeMap<IpNet, super::auth::ResolvedAoKey> {
+    bgp.dynamic_neighbors
+        .ranges
+        .iter()
+        .filter_map(|(prefix, range)| {
+            let group = range.neighbor_group.as_ref()?;
+            let ao = bgp.neighbor_groups.get(group)?.knobs.ao_config.as_ref()?;
+            Some((*prefix, ao.resolve(&bgp.key_chains)?))
+        })
+        .collect()
+}
+
+fn listen_fd_for(bgp: &Bgp, prefix: &IpNet) -> Option<std::os::fd::RawFd> {
+    match prefix {
+        IpNet::V4(_) => bgp.listen_fd_v4,
+        IpNet::V6(_) => bgp.listen_fd_v6,
+    }
+}
+
+fn ao_prefix_add(bgp: &Bgp, prefix: &IpNet, key: &super::auth::ResolvedAoKey) -> bool {
+    let Some(fd) = listen_fd_for(bgp, prefix) else {
+        return false;
+    };
+    match super::auth::set_tcp_ao_key_prefix(
+        fd,
+        *prefix,
+        key.alg_name,
+        &key.key_material,
+        key.send_id,
+        key.recv_id,
+        key.include_tcp_options,
+    ) {
+        Ok(()) => {
+            tracing::debug!(
+                range = %prefix,
+                send_id = key.send_id,
+                recv_id = key.recv_id,
+                "bgp: TCP-AO prefix MKT installed on listener for listen-range",
+            );
+            true
+        }
+        Err(e) => {
+            tracing::warn!(
+                range = %prefix,
+                error = %e,
+                "TCP-AO prefix setsockopt on listener failed; \
+                 authenticated SYNs from this range will be dropped"
+            );
+            false
+        }
+    }
+}
+
+fn ao_prefix_del(bgp: &Bgp, prefix: &IpNet, send_id: u8, recv_id: u8) -> bool {
+    let Some(fd) = listen_fd_for(bgp, prefix) else {
+        return false;
+    };
+    match super::auth::del_tcp_ao_key_prefix(fd, *prefix, send_id, recv_id) {
+        Ok(()) => true,
+        // Already absent is the desired end state, not a failure.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            tracing::warn!(
+                range = %prefix,
+                send_id,
+                recv_id,
+                error = %e,
+                "TCP-AO prefix del on listener failed; MKT may be stale",
             );
             false
         }
@@ -750,5 +885,145 @@ mod sweep_tests {
         // And it really is on the new socket, not just in the shadow.
         crate::bgp::auth::set_tcp_md5_key_prefix(second.as_raw_fd(), net("10.1.0.0/24"), &[])
             .expect("key must be present on the new listener");
+    }
+    // ===================================================
+    // Listener prefix-TCP-AO reconciliation
+    // ===================================================
+
+    fn seed_key_chain(bgp: &mut Bgp, name: &str, material: &str) {
+        use crate::policy::keychain::set::{Key, KeyChain};
+        let mut keys = std::collections::BTreeMap::new();
+        keys.insert(
+            100u64,
+            Key {
+                algo: Some(crate::policy::keychain::CryptoAlgorithm::HmacSha1),
+                key_material: material.as_bytes().to_vec(),
+                send_id: Some(100),
+                recv_id: Some(100),
+                ..Default::default()
+            },
+        );
+        bgp.key_chains.insert(
+            name.to_string(),
+            KeyChain {
+                description: None,
+                keys,
+                delete: false,
+            },
+        );
+    }
+
+    fn set_group_ao(bgp: &mut Bgp, group: &str, chain: &str) {
+        crate::bgp::neighbor_group::config_neighbor_group_tcp_ao_key_chain(
+            bgp,
+            arg_words(&[group, chain]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+    }
+
+    /// The whole wiring, end to end: chain + group tcp-ao + range must
+    /// put a prefix MKT on the listener.
+    #[tokio::test]
+    async fn range_group_tcp_ao_installs_a_prefix_mkt() {
+        use std::os::fd::AsRawFd;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(listener.as_raw_fd());
+        seed_key_chain(&mut bgp, "BGP-AO", "dyn-ao-secret");
+
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_ao(&mut bgp, "SECURE", "BGP-AO");
+
+        let installed = bgp.dynamic_neighbors.installed_ao.get(&net("10.1.0.0/24"));
+        assert!(
+            installed.is_some(),
+            "a range whose group carries tcp-ao must get a prefix MKT"
+        );
+        assert_eq!(installed.unwrap().key_material, b"dyn-ao-secret".to_vec());
+    }
+
+    /// The key-chain usually arrives from the policy actor *after* the
+    /// BGP config that references it, so the group callback resolves
+    /// nothing. The reconcile driven from the KeyChain message is what
+    /// installs the MKT — without it the listener stays unauthenticated
+    /// and every SYN from the range is dropped.
+    #[tokio::test]
+    async fn late_key_chain_arrival_still_installs_the_mkt() {
+        use std::os::fd::AsRawFd;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(listener.as_raw_fd());
+
+        // Config first, chain still unknown.
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_ao(&mut bgp, "SECURE", "BGP-AO");
+        assert!(
+            bgp.dynamic_neighbors.installed_ao.is_empty(),
+            "precondition: nothing resolvable yet"
+        );
+
+        // Chain lands later; this is what `PolicyRx::KeyChain` does.
+        seed_key_chain(&mut bgp, "BGP-AO", "dyn-ao-secret");
+        reconcile_listener_ao(&mut bgp);
+
+        assert!(
+            bgp.dynamic_neighbors
+                .installed_ao
+                .contains_key(&net("10.1.0.0/24")),
+            "a late key-chain must still reach the listener"
+        );
+    }
+
+    /// A rotation that keeps send-id/recv-id must delete before adding:
+    /// the kernel keys MKTs by (addr, prefixlen, send_id, recv_id) and
+    /// answers EEXIST on a duplicate, so a naive add would leave the
+    /// stale key serving the range.
+    #[tokio::test]
+    async fn same_id_rotation_replaces_the_prefix_mkt() {
+        use std::os::fd::AsRawFd;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(listener.as_raw_fd());
+        seed_key_chain(&mut bgp, "BGP-AO", "dyn-ao-secret");
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_ao(&mut bgp, "SECURE", "BGP-AO");
+
+        seed_key_chain(&mut bgp, "BGP-AO", "rotated-ao-secret");
+        reconcile_listener_ao(&mut bgp);
+
+        assert_eq!(
+            bgp.dynamic_neighbors
+                .installed_ao
+                .get(&net("10.1.0.0/24"))
+                .map(|k| k.key_material.clone()),
+            Some(b"rotated-ao-secret".to_vec()),
+            "the rotated material must replace the old MKT"
+        );
+    }
+
+    /// Clearing the group's tcp-ao retracts the MKT from the socket.
+    #[tokio::test]
+    async fn clearing_group_ao_retracts_the_prefix_mkt() {
+        use std::os::fd::AsRawFd;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(listener.as_raw_fd());
+        seed_key_chain(&mut bgp, "BGP-AO", "dyn-ao-secret");
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_ao(&mut bgp, "SECURE", "BGP-AO");
+        assert_eq!(bgp.dynamic_neighbors.installed_ao.len(), 1);
+
+        crate::bgp::neighbor_group::config_neighbor_group_tcp_ao_key_chain(
+            &mut bgp,
+            arg_words(&["SECURE", "BGP-AO"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+
+        assert!(
+            bgp.dynamic_neighbors.installed_ao.is_empty(),
+            "deleting the group's tcp-ao must remove the MKT"
+        );
     }
 }

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -28,6 +28,12 @@ pub struct ListenRange {
 pub struct DynamicNeighbors {
     pub listen_limit: u32,
     pub ranges: BTreeMap<IpNet, ListenRange>,
+    /// Prefix-scoped TCP MD5 keys currently installed on the listening
+    /// socket, keyed by range. Mirrors kernel state so
+    /// [`reconcile_listener_md5`] can remove or re-key exactly what it
+    /// put there: the desired set is recomputed from config, but the
+    /// *removal* set can only be known from what was installed before.
+    installed_md5: BTreeMap<IpNet, String>,
 }
 
 /// RFC-style operator default — IOS-XR ships 100, FRR ships 100,
@@ -40,11 +46,22 @@ impl Default for DynamicNeighbors {
         Self {
             listen_limit: DEFAULT_LISTEN_LIMIT,
             ranges: BTreeMap::new(),
+            installed_md5: BTreeMap::new(),
         }
     }
 }
 
 impl DynamicNeighbors {
+    /// Drop the record of which prefix MD5 keys are installed, without
+    /// touching the socket. Called when the listener fd is replaced (a
+    /// fresh bind or a `relisten`): the keys were attached to the old
+    /// socket and died with it, so the shadow must be cleared before
+    /// [`reconcile_listener_md5`] diffs — otherwise it sees "already
+    /// installed" and skips every key on the new fd.
+    pub fn forget_installed_md5(&mut self) {
+        self.installed_md5.clear();
+    }
+
     /// Longest-prefix match against the configured ranges. Returns
     /// the matched `(prefix, range)` so the caller can record the
     /// prefix on the synthesized peer's `PeerOrigin::Dynamic`.
@@ -105,6 +122,7 @@ pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         }
         _ => {}
     }
+    reconcile_listener_md5(bgp);
     Some(())
 }
 
@@ -138,7 +156,117 @@ pub fn config_listen_range_neighbor_group(
         }
         _ => {}
     }
+    reconcile_listener_md5(bgp);
     Some(())
+}
+
+/// Reconcile the listener's prefix-scoped TCP MD5 keys against the
+/// configured listen-ranges.
+///
+/// A dynamic peer does not exist until its SYN has been accepted, but
+/// the kernel validates the MD5 option *during* the handshake — so a
+/// per-address key (the static-peer mechanism) can never be installed
+/// in time, and an authenticated inbound connection is dropped before
+/// `accept()` ever sees it. The fix is a key scoped to the whole
+/// listen-range, installed as soon as the range and its group's
+/// password are both known.
+///
+/// Idempotent and diff-gated: the desired set is recomputed from
+/// config on every call, compared against what this function last
+/// installed, and only genuine adds / re-keys / removals reach the
+/// kernel. Safe to call from any config callback that could change the
+/// mapping, and from `listen()` once the fd exists.
+pub(super) fn reconcile_listener_md5(bgp: &mut Bgp) {
+    let desired = desired_listener_md5(bgp);
+
+    if desired == bgp.dynamic_neighbors.installed_md5 {
+        return;
+    }
+
+    // Ranges that lost their key (range deleted, group unbound or
+    // deleted, password cleared) must be removed from the socket
+    // first, so a re-key of the same prefix can never race its own
+    // removal.
+    let stale: Vec<IpNet> = bgp
+        .dynamic_neighbors
+        .installed_md5
+        .keys()
+        .filter(|prefix| !desired.contains_key(*prefix))
+        .copied()
+        .collect();
+    for prefix in stale {
+        if md5_prefix_apply(bgp, &prefix, &[]) {
+            bgp.dynamic_neighbors.installed_md5.remove(&prefix);
+        }
+    }
+
+    for (prefix, password) in desired {
+        if bgp.dynamic_neighbors.installed_md5.get(&prefix) == Some(&password) {
+            continue;
+        }
+        if md5_prefix_apply(bgp, &prefix, password.as_bytes()) {
+            bgp.dynamic_neighbors.installed_md5.insert(prefix, password);
+        }
+    }
+}
+
+/// The prefix keys the listener *should* be carrying: every
+/// listen-range bound to a group that defines a password. A range with
+/// no group, a group that does not exist, or a group with no password
+/// contributes nothing — an unauthenticated range still accepts plain
+/// connections, exactly as before.
+fn desired_listener_md5(bgp: &Bgp) -> BTreeMap<IpNet, String> {
+    bgp.dynamic_neighbors
+        .ranges
+        .iter()
+        .filter_map(|(prefix, range)| {
+            let group = range.neighbor_group.as_ref()?;
+            let password = bgp.neighbor_groups.get(group)?.knobs.password.clone()?;
+            Some((*prefix, password))
+        })
+        .collect()
+}
+
+/// Install (empty `key` ⇒ remove) one prefix key on the listener of
+/// the matching address family. Returns whether the shadow state
+/// should be updated: `false` when there is no listener yet, so the
+/// post-bind sweep in `listen()` retries rather than believing a key
+/// is installed that never was.
+fn md5_prefix_apply(bgp: &Bgp, prefix: &IpNet, key: &[u8]) -> bool {
+    let listen_fd = match prefix {
+        IpNet::V4(_) => bgp.listen_fd_v4,
+        IpNet::V6(_) => bgp.listen_fd_v6,
+    };
+    let Some(fd) = listen_fd else {
+        return false;
+    };
+    match super::auth::set_tcp_md5_key_prefix(fd, *prefix, key) {
+        Ok(()) => {
+            if !key.is_empty() {
+                tracing::debug!(
+                    range = %prefix,
+                    keylen = key.len(),
+                    "bgp: TCP MD5 prefix key installed on listener for listen-range",
+                );
+            }
+            true
+        }
+        Err(e) => {
+            // Removing a key the kernel does not have is a no-op, not a
+            // failure — it answers ENOENT. Treat it as success so the
+            // shadow state still clears.
+            if key.is_empty() && e.kind() == std::io::ErrorKind::NotFound {
+                return true;
+            }
+            tracing::warn!(
+                range = %prefix,
+                error = %e,
+                "TCP MD5 prefix setsockopt on listener failed; \
+                 authenticated SYNs from this range will be dropped"
+            );
+            false
+        }
+    }
 }
 
 /// Tear down and remove every `PeerOrigin::Dynamic` peer materialized
@@ -466,5 +594,161 @@ mod sweep_tests {
             "trailing leaf delete must not re-create the range entry"
         );
         assert!(bgp.dynamic_neighbors.lpm_match(&addr("10.1.0.7")).is_none());
+    }
+
+    // ===================================================
+    // Listener prefix-MD5 reconciliation
+    // ===================================================
+
+    fn set_group_password(bgp: &mut Bgp, group: &str, password: &str) {
+        crate::bgp::neighbor_group::config_neighbor_group_password(
+            bgp,
+            arg_words(&[group, password]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+    }
+
+    /// A range bound to a password-carrying group wants a prefix key;
+    /// one whose group has no password wants none.
+    #[tokio::test]
+    async fn desired_keys_follow_range_group_password() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        configure_range(&mut bgp, "10.2.0.0/24", "PLAIN");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+
+        let desired = desired_listener_md5(&bgp);
+
+        assert_eq!(
+            desired.get(&net("10.1.0.0/24")).map(String::as_str),
+            Some("s3cret")
+        );
+        assert!(
+            !desired.contains_key(&net("10.2.0.0/24")),
+            "a group without a password must not install a key"
+        );
+    }
+
+    /// Unbinding the group, deleting the range, or clearing the
+    /// password each retract the key.
+    #[tokio::test]
+    async fn desired_keys_retract_on_every_unbind_path() {
+        let mut bgp = fresh_bgp();
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        assert_eq!(desired_listener_md5(&bgp).len(), 1);
+
+        crate::bgp::neighbor_group::config_neighbor_group_password(
+            &mut bgp,
+            arg_words(&["SECURE"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            desired_listener_md5(&bgp).is_empty(),
+            "clearing the group password must retract the prefix key"
+        );
+
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        assert!(
+            desired_listener_md5(&bgp).is_empty(),
+            "deleting the range must retract the prefix key"
+        );
+    }
+
+    /// Bind a real listening socket and drive the reconciler through
+    /// install → re-key → retract, so the `TCP_MD5SIG_EXT` request
+    /// shape is exercised against the kernel rather than mocked. The
+    /// shadow map is the observable: it only advances when setsockopt
+    /// actually succeeded.
+    #[tokio::test]
+    async fn reconcile_installs_rekeys_and_retracts_on_a_real_socket() {
+        use std::os::fd::AsRawFd;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(listener.as_raw_fd());
+
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.get(&net("10.1.0.0/24")),
+            Some(&"s3cret".to_string()),
+            "install must reach the kernel and be recorded"
+        );
+
+        set_group_password(&mut bgp, "SECURE", "rotated");
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.get(&net("10.1.0.0/24")),
+            Some(&"rotated".to_string()),
+            "a password change must re-key the same prefix"
+        );
+
+        config_listen_range(&mut bgp, arg_words(&["10.1.0.0/24"]), ConfigOp::Delete).unwrap();
+        assert!(
+            bgp.dynamic_neighbors.installed_md5.is_empty(),
+            "range delete must retract the key from the socket"
+        );
+    }
+
+    /// The key must be installed under the masked network address: the
+    /// kernel matches an inbound SYN against the masked value, so a key
+    /// stored under an unmasked one silently never matches.
+    #[tokio::test]
+    async fn prefix_key_is_installed_on_the_masked_network() {
+        use std::os::fd::AsRawFd;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let fd = listener.as_raw_fd();
+        // 10.1.2.3/24 masks to 10.1.2.0/24. If `set_tcp_md5_key_prefix`
+        // forgot `network()`, the kernel would reject or misfile it.
+        let sloppy: IpNet = "10.1.2.3/24".parse().unwrap();
+        crate::bgp::auth::set_tcp_md5_key_prefix(fd, sloppy, b"s3cret")
+            .expect("prefix key install must succeed");
+        // Removing it under the canonical spelling proves that is where
+        // it actually landed.
+        crate::bgp::auth::set_tcp_md5_key_prefix(fd, net("10.1.2.0/24"), &[])
+            .expect("key must be removable under its masked network");
+    }
+
+    /// A relisten hands BGP a brand-new fd that carries none of the old
+    /// socket's keys. Without forgetting the shadow first, the diff
+    /// would conclude everything was already installed and leave the
+    /// new listener unauthenticated.
+    #[tokio::test]
+    async fn forgetting_the_shadow_forces_reinstall_after_relisten() {
+        use std::os::fd::AsRawFd;
+
+        let first = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut bgp = fresh_bgp();
+        bgp.listen_fd_v4 = Some(first.as_raw_fd());
+        configure_range(&mut bgp, "10.1.0.0/24", "SECURE");
+        set_group_password(&mut bgp, "SECURE", "s3cret");
+        assert_eq!(bgp.dynamic_neighbors.installed_md5.len(), 1);
+
+        // Rebind: new socket, no keys on it.
+        let second = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        bgp.listen_fd_v4 = Some(second.as_raw_fd());
+
+        // Without the forget, this is a no-op diff.
+        reconcile_listener_md5(&mut bgp);
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.len(),
+            1,
+            "precondition: the stale shadow still claims the key is present"
+        );
+
+        bgp.dynamic_neighbors.forget_installed_md5();
+        reconcile_listener_md5(&mut bgp);
+        assert_eq!(
+            bgp.dynamic_neighbors.installed_md5.get(&net("10.1.0.0/24")),
+            Some(&"s3cret".to_string()),
+            "after forgetting, the key must be re-installed on the new fd"
+        );
+        // And it really is on the new socket, not just in the shadow.
+        crate::bgp::auth::set_tcp_md5_key_prefix(second.as_raw_fd(), net("10.1.0.0/24"), &[])
+            .expect("key must be present on the new listener");
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -883,6 +883,15 @@ pub struct Bgp {
     /// group unbind.
     pub dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors,
     pub dynamic_peer_count: u32,
+    /// Watch idents handed to the policy actor for `neighbor-group`
+    /// TCP-AO key-chain subscriptions, allocated per group name and
+    /// never reused. A group has no `PeerMap` ident of its own, and
+    /// the actor's unregister matches on `(proto, ident,
+    /// policy_type)`, so two groups sharing one chain must not share
+    /// an ident — otherwise unbinding either would silently drop the
+    /// other's watch and stop key updates reaching the listener.
+    pub group_keychain_watch: BTreeMap<String, usize>,
+    pub group_keychain_watch_next: usize,
     /// `interface-neighbor` config — operator types
     /// `set router bgp interface-neighbor <name>`. Lookup key is the
     /// interface name; the runtime resolves to ifindex via
@@ -1203,6 +1212,8 @@ impl Bgp {
             flex_algo_srv6_routes: Default::default(),
             dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors::default(),
             dynamic_peer_count: 0,
+            group_keychain_watch: BTreeMap::new(),
+            group_keychain_watch_next: 0,
             interface_neighbors: super::interface_neighbor::empty_map(),
             vrfs: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
@@ -3367,7 +3378,9 @@ impl Bgp {
         // has none, and a diff against stale state would install
         // nothing.
         self.dynamic_neighbors.forget_installed_md5();
+        self.dynamic_neighbors.forget_installed_ao();
         super::dynamic_neighbors::reconcile_listener_md5(self);
+        super::dynamic_neighbors::reconcile_listener_ao(self);
         // Reconcile the listener TCP MSS too: a `tcp-mss` callback that
         // ran before the bind observed `listen_fd_v4/v6 = None` and could
         // not clamp the listener, so a passively-accepted peer would
@@ -5161,6 +5174,10 @@ impl Bgp {
                     self.key_chains.remove(&name);
                 }
                 super::config::apply_ao_refresh_all(self);
+                // A listen-range's MKT is resolved from the same chain
+                // but keyed on the prefix, so it needs its own
+                // reconcile — no peer exists yet to carry it.
+                super::dynamic_neighbors::reconcile_listener_ao(self);
             }
         }
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3358,6 +3358,16 @@ impl Bgp {
         // because the kernel drops the incoming SYN.
         super::config::apply_md5_refresh_all(self);
         super::config::apply_ao_refresh_all(self);
+        // Same gap for dynamic-neighbors: a listen-range whose group
+        // carries a password needs its prefix key on the fresh fd, or
+        // every authenticated SYN from that range is dropped by the
+        // kernel before `accept()` can materialize the peer. The
+        // shadow state is cleared first because the keys it records
+        // lived on the *previous* fd — after a relisten the new socket
+        // has none, and a diff against stale state would install
+        // nothing.
+        self.dynamic_neighbors.forget_installed_md5();
+        super::dynamic_neighbors::reconcile_listener_md5(self);
         // Reconcile the listener TCP MSS too: a `tcp-mss` callback that
         // ran before the bind observed `listen_fd_v4/v6 = None` and could
         // not clamp the listener, so a passively-accepted peer would

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -876,9 +876,11 @@ pub struct Bgp {
     /// `dynamic-neighbors` runtime (zebra-bgp-dynamic-neighbors.yang).
     /// Holds the configured listen-ranges and the soft cap on
     /// materialized passive peers. `dynamic_peer_count` is bumped on
-    /// successful accept-time materialization in `peer::accept`; it
-    /// is never decremented yet — session-close GC is deferred to a
-    /// follow-up so this PR stays focused on the accept path.
+    /// accept-time materialization (`peer::try_dynamic_accept`) and
+    /// decremented when a slot frees:
+    /// [`Self::gc_dynamic_peer_if_session_ended`] on session end,
+    /// `dynamic_neighbors::sweep_range_peers` on range delete /
+    /// group unbind.
     pub dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors,
     pub dynamic_peer_count: u32,
     /// `interface-neighbor` config — operator types

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -65,6 +65,11 @@ pub struct InheritableKnobs {
     pub ebgp_multihop: Option<u8>,
     pub tcp_mss: Option<u16>,
     pub password: Option<String>,
+    /// TCP-AO (RFC 5925) key-chain reference inherited by members —
+    /// and, when the group is bound to a `dynamic-neighbors`
+    /// listen-range, installed on the listener as a prefix-scoped MKT
+    /// for the whole range.
+    pub ao_config: Option<super::auth::AoConfig>,
     pub disable_connected_check: Option<bool>,
     pub ip_transparent: Option<bool>,
     pub policy_in: Option<String>,
@@ -125,6 +130,28 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
             // second pass finds peers with `remote_as_inherited =
             // false` and returns `SweepAction::Ignore`.
             sweep_peers_for_group(bgp, &name, None);
+            // Drop the group's key-chain watch with the group itself —
+            // the per-leaf delete may never fire on a whole-group
+            // delete, and a leaked watch keeps the policy actor pushing
+            // updates for a binding that no longer exists.
+            if let Some(chain) = bgp
+                .neighbor_groups
+                .get(&name)
+                .and_then(|g| g.knobs.ao_config.as_ref())
+                .map(|ao| ao.key_chain.clone())
+                .filter(|s| !s.is_empty())
+            {
+                let ident = group_keychain_ident(bgp, &name);
+                super::config::policy_attach_msgs(
+                    &bgp.policy_tx,
+                    ident,
+                    crate::policy::PolicyType::KeyChain(
+                        crate::policy::KeyChainScope::BgpNeighborGroup,
+                    ),
+                    Some(chain),
+                    None,
+                );
+            }
             bgp.neighbor_groups.remove(&name);
             // With the group gone every opinion it carried is gone
             // too: members fall back to defaults + their own explicit
@@ -134,10 +161,11 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
         }
         _ => {}
     }
-    // The group's password is the source of any listen-range prefix key
-    // bound to it — creating or deleting the group changes what the
-    // listener should be authenticating.
+    // The group's password / tcp-ao are the source of any listen-range
+    // prefix key bound to it — creating or deleting the group changes
+    // what the listener should be authenticating.
     super::dynamic_neighbors::reconcile_listener_md5(bgp);
+    super::dynamic_neighbors::reconcile_listener_ao(bgp);
     Some(())
 }
 
@@ -750,6 +778,111 @@ pub fn config_neighbor_group_tcp_mss(bgp: &mut Bgp, mut args: Args, op: ConfigOp
     Some(())
 }
 
+/// `set router bgp neighbor-group <name> tcp-ao key-chain <name>`.
+///
+/// Deleting the leaf clears the whole `tcp-ao` opinion: `key-chain` is
+/// mandatory inside the presence container, so a group with no chain
+/// has no AO to inherit.
+pub fn config_neighbor_group_tcp_ao_key_chain(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    let prior = knobs
+        .ao_config
+        .as_ref()
+        .map(|ao| ao.key_chain.clone())
+        .filter(|s| !s.is_empty());
+    let new = match op {
+        ConfigOp::Set => {
+            let key_chain = args.string()?;
+            // Preserve an `include-tcp-options` that arrived first —
+            // leaf callback order within one commit is not guaranteed.
+            let include_tcp_options = knobs
+                .ao_config
+                .as_ref()
+                .map(|ao| ao.include_tcp_options)
+                .unwrap_or(true);
+            knobs.ao_config = Some(super::auth::AoConfig {
+                key_chain: key_chain.clone(),
+                include_tcp_options,
+            });
+            Some(key_chain)
+        }
+        ConfigOp::Delete => {
+            knobs.ao_config = None;
+            None
+        }
+        _ => return Some(()),
+    };
+    // Subscribe the group's interest in the chain. Without this the
+    // policy actor never pushes the chain's content to BGP, so
+    // `resolve()` finds nothing and the listener's prefix MKT is never
+    // installed — the kernel then drops every AO-signed SYN from the
+    // range with TCPAOKeyNotFound. A group is not a peer, so it needs a
+    // watch ident of its own (see `group_keychain_watch`).
+    let ident = group_keychain_ident(bgp, &name);
+    super::config::policy_attach_msgs(
+        &bgp.policy_tx,
+        ident,
+        crate::policy::PolicyType::KeyChain(crate::policy::KeyChainScope::BgpNeighborGroup),
+        prior,
+        new,
+    );
+    sweep_members_inherit(bgp, &name);
+    super::dynamic_neighbors::reconcile_listener_ao(bgp);
+    Some(())
+}
+
+/// Stable per-group watch ident for key-chain subscriptions, minted on
+/// first use and kept for the lifetime of the process. Deliberately
+/// never recycled: a recycled ident could unregister a watch belonging
+/// to a since-deleted group that shared the chain.
+fn group_keychain_ident(bgp: &mut Bgp, name: &str) -> usize {
+    if let Some(ident) = bgp.group_keychain_watch.get(name) {
+        return *ident;
+    }
+    let ident = bgp.group_keychain_watch_next;
+    bgp.group_keychain_watch_next += 1;
+    bgp.group_keychain_watch.insert(name.to_string(), ident);
+    ident
+}
+
+/// `set router bgp neighbor-group <name> tcp-ao include-tcp-options <bool>`.
+///
+/// A no-op when the group has no `key-chain` yet: without one there is
+/// no MKT to qualify, and the value is re-derived (defaulting to true)
+/// when the chain does arrive.
+pub fn config_neighbor_group_tcp_ao_include_tcp_options(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let want = match op {
+        ConfigOp::Set => args.boolean()?,
+        // RFC 5925 §3.1 default, matching the YANG `default "true"`.
+        ConfigOp::Delete => true,
+        _ => return Some(()),
+    };
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if let Some(ao) = knobs.ao_config.as_mut() {
+        ao.include_tcp_options = want;
+    } else {
+        // Chain not configured yet: stash the opinion so a later
+        // `key-chain` in the same commit adopts it.
+        knobs.ao_config = Some(super::auth::AoConfig {
+            key_chain: String::new(),
+            include_tcp_options: want,
+        });
+    }
+    sweep_members_inherit(bgp, &name);
+    super::dynamic_neighbors::reconcile_listener_ao(bgp);
+    Some(())
+}
+
 /// `set router bgp neighbor-group <name> password <string>`.
 ///
 /// Like the per-neighbor knob: no bounce (a live session keeps its
@@ -1005,6 +1138,11 @@ pub(super) struct InheritOutcome {
     /// The MD5 password changed — run `apply_md5_refresh_for` with
     /// this peer's address to re-key the listener.
     pub md5_refresh: bool,
+    /// The inherited TCP-AO config changed — run
+    /// `apply_ao_refresh_all` so the listener MKT follows. Unlike
+    /// MD5 there is no per-peer variant: AO resolution reads the
+    /// key-chain table, which the whole-instance sweep already has.
+    pub ao_refresh: bool,
     /// `update-source` changed — run `bfd_apply` so an attached BFD
     /// session re-keys to the new local address.
     pub bfd_reapply: bool,
@@ -1030,6 +1168,7 @@ pub(super) fn apply_inherited(
         ebgp_multihop: resolve_knob(groups, &peer.config, |k| k.ebgp_multihop),
         tcp_mss: resolve_knob(groups, &peer.config, |k| k.tcp_mss),
         password: resolve_knob(groups, &peer.config, |k| k.password.clone()),
+        ao_config: resolve_knob(groups, &peer.config, |k| k.ao_config.clone()),
         disable_connected_check: resolve_knob(groups, &peer.config, |k| k.disable_connected_check),
         ip_transparent: resolve_knob(groups, &peer.config, |k| k.ip_transparent),
         policy_in: resolve_knob(groups, &peer.config, |k| k.policy_in.clone()),
@@ -1055,6 +1194,7 @@ pub(super) fn apply_inherited(
         ebgp_multihop,
         tcp_mss,
         password,
+        ao_config,
         disable_connected_check,
         ip_transparent,
         policy_in,
@@ -1103,6 +1243,11 @@ pub(super) fn apply_inherited(
     outcome.bfd_reapply = super::config::apply_update_source(peer, update_source);
     outcome.mss_refresh = super::config::apply_tcp_mss(peer, tcp_mss);
     outcome.md5_refresh = super::config::apply_md5_password(peer, password);
+    outcome.ao_refresh = super::config::apply_ao_config(peer, ao_config);
+    // Same reasoning as the password: the MKT is consulted at
+    // handshake time, so a live session under the old key must bounce
+    // to pick up the new one.
+    bounce |= outcome.ao_refresh;
     // A password change must reset the session, like the per-neighbor
     // path: the listener / connect-socket key only takes effect on a
     // fresh connection, so a live session under the old key must bounce.
@@ -1146,6 +1291,7 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
     let policy_tx = bgp.policy_tx.clone();
     let mut stops: Vec<usize> = Vec::new();
     let mut mss_refresh = false;
+    let mut ao_refresh = false;
     // Collect idents, not addresses: the MD5 / BFD reconcilers must be
     // able to reach an interface-keyed (unnumbered) member, whose
     // link-local is not a map key (`get(&peer.address)` would miss it).
@@ -1160,6 +1306,7 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
             stops.push(peer.ident);
         }
         mss_refresh |= outcome.mss_refresh;
+        ao_refresh |= outcome.ao_refresh;
         if outcome.md5_refresh {
             md5_idents.push(peer.ident);
         }
@@ -1172,6 +1319,9 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
     }
     if mss_refresh {
         super::config::apply_tcp_mss_refresh_all(bgp);
+    }
+    if ao_refresh {
+        super::config::apply_ao_refresh_all(bgp);
     }
     // Unconditional (cheap, idempotent): this sweep also serves the
     // group-delete cascade, where a deleted `ip-transparent` opinion

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -134,6 +134,10 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
         }
         _ => {}
     }
+    // The group's password is the source of any listen-range prefix key
+    // bound to it — creating or deleting the group changes what the
+    // listener should be authenticating.
+    super::dynamic_neighbors::reconcile_listener_md5(bgp);
     Some(())
 }
 
@@ -765,6 +769,10 @@ pub fn config_neighbor_group_password(bgp: &mut Bgp, mut args: Args, op: ConfigO
         .knobs
         .password = value;
     sweep_members_inherit(bgp, &name);
+    // A listen-range bound to this group authenticates its whole
+    // prefix with the group password, so the listener's prefix key
+    // has to follow the knob.
+    super::dynamic_neighbors::reconcile_listener_md5(bgp);
     Some(())
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -3291,8 +3291,10 @@ pub fn accept(bgp: &mut Bgp, stream: TcpStream, sockaddr: SocketAddr) {
 fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Option<TcpStream> {
     // Soft cap. The listen-limit guards against an attacker spamming
     // SYNs from many sources in a wide listen-range — once we hit
-    // the limit, additional matches drop silently until existing
-    // dynamic peers are GC'd (session-close GC lands in a follow-up).
+    // the limit, additional matches drop silently until a slot frees
+    // up: `gc_dynamic_peer_if_session_ended` reclaims a peer whose
+    // session ended, and `dynamic_neighbors::sweep_range_peers`
+    // reclaims every peer of a deleted (or group-unbound) range.
     if bgp.dynamic_peer_count >= bgp.dynamic_neighbors.listen_limit {
         return Some(stream);
     }

--- a/zebra-rs/src/policy/keychain/mod.rs
+++ b/zebra-rs/src/policy/keychain/mod.rs
@@ -28,6 +28,13 @@ pub enum KeyChainScope {
     OspfInterface,
     /// BGP per-neighbor `tcp-ao/key-chain <name>` leaf.
     BgpNeighbor,
+    /// BGP `neighbor-group <g> tcp-ao/key-chain <name>` leaf. Distinct
+    /// from [`Self::BgpNeighbor`] because the actor's unregister
+    /// matches on `(proto, ident, policy_type)`: a group's watch ident
+    /// comes from its own registry, not from `PeerMap`, so the two
+    /// spaces would otherwise collide and one unbind could drop the
+    /// other's watch.
+    BgpNeighborGroup,
     /// IS-IS per-interface `hello-authentication/key-chain <name>`.
     IsisIih,
     /// IS-IS `/router/isis/area-password/key-chain <name>`.

--- a/zebra-rs/yang/zebra-bgp-auth.yang
+++ b/zebra-rs/yang/zebra-bgp-auth.yang
@@ -249,6 +249,21 @@ module zebra-bgp-auth {
       }
     }
 
+    uses bgp-tcp-ao-extension;
+  }
+
+  /* =========================================================
+   * TCP-AO container, split out so it can be attached to a
+   * `neighbor-group` as well as to a neighbor. A listen-range
+   * binds its group's TCP-AO to the whole prefix.
+   * ========================================================= */
+
+  grouping bgp-tcp-ao-extension {
+    description
+      "Presence container carrying a TCP-AO key-chain reference and
+       the option-coverage knob. Shared by `neighbor` and
+       `neighbor-group`.";
+
     container tcp-ao {
       ext:help "TCP Authentication Option (RFC 5925)";
       presence "Enable TCP-AO on this neighbor";

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -36,6 +36,10 @@ module zebra-bgp-neighbor-group {
     prefix zbrpa;
   }
 
+  import zebra-bgp-auth {
+    prefix zbauth;
+  }
+
   import zebra-bgp-enforce-first-as {
     prefix zbef;
   }
@@ -153,6 +157,11 @@ module zebra-bgp-neighbor-group {
       uses zbao:bgp-neighbor-as-override-extension;
       uses zbrpa:bgp-neighbor-remove-private-as-extension;
       uses zbef:bgp-neighbor-enforce-first-as-extension;
+      /* TCP-AO for members, and — via a listen-range binding — for
+         the whole range: a dynamic peer is materialized only after
+         its SYN is accepted, so the MKT must already be on the
+         listener, scoped to the prefix. */
+      uses zbauth:bgp-tcp-ao-extension;
       container policy {
         ext:help "Route policy inherited by group members";
         description


### PR DESCRIPTION
Last in the dynamic-neighbors series, stacked in git on #2050 → #2052 → #2055. Targets `main` so CI runs; until the parents merge the diff shows their commits too — **this PR's own change is the last commit, `3f45914c`**.

## Problem

TCP-AO and `dynamic-neighbors` were mutually exclusive. Same root cause as the MD5 case — a listen-range peer is materialized only after its SYN is accepted, while the kernel verifies the AO MAC during the handshake — plus a second gap: `neighbor-group` had no `tcp-ao` at all, so there was nothing to bind a range's authentication to.

## Fix

**YANG**: the `tcp-ao` container moves into a reusable `bgp-tcp-ao-extension` grouping and is attached to `neighbor-group`. The neighbor tree is unchanged (it now `uses` the grouping).

**Runtime**: `InheritableKnobs` gains `ao_config`, so a group's TCP-AO is inherited by members like any other knob, with a new `ao_refresh` outcome driving the listener sweep and bouncing a live session whose resolved key changed. `auth::set_ao` / `del_ao` grow a prefix mode — `TcpAoAdd.prefix` / `TcpAoDel.prefix` already existed but were hard-coded to 32/128 — and `reconcile_listener_ao` keeps the listener's prefix MKTs in step with `listen-range × neighbor-group tcp-ao`.

The kernel identifies an MKT by `(address, prefixlen, send_id, recv_id)` and answers EEXIST on a duplicate, so the reconciler stores the **full resolved key** and deletes before adding — a rotation that keeps both IDs but changes the material would otherwise leave the stale key serving the range. There is a BDD scenario for exactly that.

## The bug live testing caught

A group must also **subscribe** to its key-chain. Without it the policy actor never pushes the chain's content to BGP, `resolve()` finds nothing, and the kernel drops every AO-signed SYN with `TCPAOKeyNotFound`. My unit tests all passed while this was broken, because they seed `bgp.key_chains` directly and so bypass the subscription entirely; only the live BDD run failed. I diagnosed it from `nstat` (`TCPAOKeyNotFound = 256`) plus a tcpdump showing the client's signed SYN going unanswered.

Groups have no `PeerMap` ident, and the actor's unregister matches on `(proto, ident, policy_type)` — so they get their own `KeyChainScope::BgpNeighborGroup` and a per-group ident registry. Sharing the peer ident space would let one unbind silently drop another's watch. The group-delete path unregisters too, since the per-leaf delete may never fire on a whole-group delete.

## Testing

**Unit** (4 new, 1671 total pass): full wiring (chain + group + range installs an MKT), the late-key-chain-arrival path that the live bug exposed, same-ID rotation, and retraction on `tcp-ao` delete.

**BDD** (`bgp_dynamic_nbr_ao.feature`, 7 scenarios, green locally; needs kernel ≥ 6.7): matching chain establishes; a mismatched key-string materializes no peer; rotating the DUT's key-string re-keys the MKT and locks the old client out; clearing the group's `tcp-ao` retracts the MKT; restoring it lets the session back.

**Regression** — all green locally against this build, since this touches the shared inheritance path and `auth.rs`: `bgp_dynamic_neighbors` 8/8, `bgp_dynamic_nbr_policy` 3/3, `bgp_dynamic_nbr_md5` 6/6, `bgp_tcp_ao_auth` 6/6, `bgp_tcp_md5_auth` 4/4, `bgp_neighbor_group` 6/6, `bgp_afi_safi_policy` 4/4, `bgp_unnumbered_afi_safi` 4/4. Workspace clippy and fmt clean.

Note for anyone reproducing the BDD run: the daemon reads YANG from `/usr/share/zebra-rs/yang`, so installing a rebuilt binary is not enough — the schemas must be copied too, or the new `tcp-ao` leaf is rejected at apply time with "unknown key".

🤖 Generated with [Claude Code](https://claude.com/claude-code)