### PR TITLE
build: move to libyang 2

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -136,7 +136,7 @@ tonic-prost.workspace = true
 tower = { version = "0.5", default-features = false, features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 console-subscriber = "0.5"
-libyang = "1"
+libyang = "2"
 #libyang = { git = "https://github.com/zebra-rs/libyang", rev = "103b60c2d560a91d37fa26502eb3d495db1cdb99" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"


### PR DESCRIPTION
## Summary

libyang 2.0.0 is published. The upgrade needs **no source change** here —
zebra-rs only constructs a `YangStore` and calls `add_path` /
`read_with_resolve` / `identity_resolve` / `find_module` / `to_entry`,
none of which changed shape. One line in `Cargo.toml`.

## What it brings

- **`to_entry`'s child order is deterministic.** It previously depended
  on `HashMap` seeding, so the tree came out in a different order on
  every run — dumping one 3050-node tree five times produced five
  distinct orderings, same node set. The audit docs gated by
  `bgp_config_audit_tests` sort before comparing so they do not churn,
  but anything else derived from tree order is now reproducible.
- **Parse failures are actionable.** libyang used to `println!` parol's
  diagnostic to stdout and then return an opaque "YANG file parse
  error". It now returns the file plus the diagnostic (line, column,
  expected tokens), so a malformed YANG file says where it broke —
  useful for `yang_load_tests`, which is where we would hit it.
- **Malformed augments are reported, not printed.** They used to go to
  stderr from inside the library. Our 89 YANG files produce zero.

Also in 2.0: the dead `YangStore::import` field and the broken
`YangStore::read` are gone (the latter stack-overflowed on mutually
importing modules), `YangError` is `#[non_exhaustive]`, and the unused
`anyhow` / `env_logger` dependencies were dropped.

## Verification

- Full workspace suite (`--exclude bdd`) green: 39 suites, 1662 tests in
  the zebra-rs binary alone.
- `cargo clippy --workspace --all-targets -- -D warnings` clean,
  `cargo fmt --check` clean.
- Built against the published crate from crates.io, not a path
  dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)