### PR TITLE
bgp: gate every unconditional tracing::info! behind a tracing category

### DIFF
--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -433,7 +433,10 @@ pub(super) fn sweep_range_peers(bgp: &mut Bgp, prefix: &IpNet) {
     for addr in victims {
         if super::config::remove_peer_full(bgp, addr).is_some() {
             bgp.dynamic_peer_count = bgp.dynamic_peer_count.saturating_sub(1);
-            tracing::info!(
+            // Debug, matching the rest of this module's lifecycle
+            // logging: the peer is already gone, so there is no `Peer`
+            // left to read a tracing gate from.
+            tracing::debug!(
                 peer = %addr,
                 range = %prefix,
                 "bgp: dynamic peer removed by listen-range sweep",

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -124,7 +124,10 @@ impl GroupEgressTask {
     /// (the group emptied).
     pub fn spawn(id: UpdateGroupId) -> Self {
         let (delta_tx, mut delta_rx) = mpsc::unbounded_channel::<GroupEgressDeltaV4>();
-        tracing::info!("BGP egress group task: spawned (group {id:?})");
+        // Debug, matching the "exited" line below: `spawn` is a plain
+        // constructor with no `BgpTracing` in reach, and it fires once
+        // per update-group.
+        tracing::debug!("BGP egress group task: spawned (group {id:?})");
         let task = Task::spawn(async move {
             let mut engine = Engine::default();
             while let Some(delta) = delta_rx.recv().await {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -511,7 +511,9 @@ pub fn init_shard_count(config_shards: Option<usize>) -> usize {
         "default"
     };
     if n > 1 {
-        tracing::info!("BGP RIB sharding: {n} shards (from {source})");
+        // Debug, not info: this runs inside `spawn_bgp`, before any
+        // `BgpTracing` exists to gate it against.
+        tracing::debug!("BGP RIB sharding: {n} shards (from {source})");
     } else {
         // Disable default logging.
         // tracing::info!("BGP RIB sharding: 1 shard, synchronous (from {source})");
@@ -1833,6 +1835,7 @@ impl Bgp {
             kernel,
             &self.rib_subscriber,
             srv6,
+            self.tracing.clone(),
             self.vrf_global_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
@@ -2019,13 +2022,32 @@ impl Bgp {
             }
             let depth = peer.egress_depth.load(std::sync::atomic::Ordering::Relaxed);
             let over = depth >= sync_egress_high_water();
+            // Read the gate and the peer address before taking the
+            // `&mut` on the cursor — `bgp_adj_out_trace!` needs `&peer`,
+            // which `sync_v4.as_mut()` would conflict with.
+            let trace = peer.trace_adj_out();
+            let address = peer.address;
             if let Some(cursor) = peer.sync_v4.as_mut() {
-                if over && !cursor.parked {
+                let transition = if over && !cursor.parked {
                     cursor.parked = true;
-                    tracing::info!(ident, depth, "bgp: v4 sync parked (egress backpressure)");
+                    Some("bgp: v4 sync parked (egress backpressure)")
                 } else if !over && cursor.parked {
                     cursor.parked = false;
-                    tracing::info!(ident, depth, "bgp: v4 sync resumed");
+                    Some("bgp: v4 sync resumed")
+                } else {
+                    None
+                };
+                if let Some(msg) = transition
+                    && trace
+                {
+                    tracing::info!(
+                        proto = "bgp",
+                        category = "adj-out",
+                        peer = %address,
+                        ident,
+                        depth,
+                        "{msg}"
+                    );
                 }
             }
             over
@@ -2535,6 +2557,7 @@ impl Bgp {
                 kernel,
                 &self.rib_subscriber,
                 srv6,
+                self.tracing.clone(),
                 self.vrf_global_tx.clone(),
             );
             self.register_vrf_show(&name, &handle);
@@ -2889,6 +2912,7 @@ impl Bgp {
             Some(kernel),
             &self.rib_subscriber,
             srv6,
+            self.tracing.clone(),
             self.vrf_global_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
@@ -3411,11 +3435,14 @@ impl Bgp {
         self.listen_fd_v4 = None;
         self.listen_fd_v6 = None;
         self.listen_err = None;
+        // Debug, not info: listener churn is operator-driven (a `listen
+        // port` edit) and has no tracing category of its own. A failure
+        // to reopen still surfaces through `self.listen_err`.
         if self.port == 0 {
-            tracing::info!("bgp: listen port set to 0 — BGP listener disabled");
+            tracing::debug!("bgp: listen port set to 0 — BGP listener disabled");
             return;
         }
-        tracing::info!(port = self.port, "bgp: reopening BGP listener");
+        tracing::debug!(port = self.port, "bgp: reopening BGP listener");
         if let Err(err) = self.listen().await {
             self.listen_err = Some(err);
         }
@@ -3763,6 +3790,21 @@ impl Bgp {
                     color_policy: self.color_policy.clone(),
                     srv6_shadow: self.flex_algo_srv6_routes.clone(),
                 });
+        }
+    }
+
+    /// Push the instance-wide `router bgp tracing { … }` config to every
+    /// per-VRF task. A per-VRF `ConfigChannel` only receives
+    /// `/router/bgp/vrf/<name>/…`, so the instance-scoped tracing path
+    /// can't reach those tasks by config dispatch — same reason
+    /// [`Self::broadcast_colour_steering`] exists. Called from
+    /// `propagate_instance_tracing`, which already re-snapshots the
+    /// global peers; spawn-time seeding goes through `spawn_bgp_vrf`.
+    pub fn broadcast_tracing(&self) {
+        for handle in self.vrf_registry.values() {
+            let _ = handle
+                .inbox
+                .send(super::vrf::msg::BgpVrfMsg::Tracing(self.tracing.clone()));
         }
     }
 
@@ -4178,6 +4220,7 @@ impl Bgp {
             kernel,
             &self.rib_subscriber,
             srv6,
+            self.tracing.clone(),
             self.vrf_global_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -26,9 +26,9 @@ use crate::bgp::route::{route_clean, route_sync};
 use crate::bgp::tracing::{Direction, PacketKind};
 use crate::bgp::{AdjRib, MainAdjIn, Out};
 use crate::bgp::{stale_route_withdraw, timer};
-use crate::bgp_packet_trace;
 use crate::config::Args;
 use crate::context::task::*;
+use crate::{bgp_fsm_trace, bgp_packet_trace};
 
 use super::cap::{CapAfiMap, cap_addpath_recv, cap_register_send};
 use super::inst::Message;
@@ -1727,13 +1727,11 @@ fn resolve_conn(peer: &Peer, id: ConnId) -> Option<ConnTag> {
     } else if peer.collision.as_ref().map(|c| c.conn_id) == Some(id) {
         Some(ConnTag::Collision)
     } else {
-        if peer.trace_fsm() {
-            tracing::info!(
-                peer = %peer.address,
-                conn_id = id,
-                "bgp: ignoring event from a superseded connection",
-            );
-        }
+        bgp_fsm_trace!(
+            peer,
+            conn_id = id,
+            "bgp: ignoring event from a superseded connection",
+        );
         None
     }
 }
@@ -1989,12 +1987,10 @@ pub fn fsm_start(peer: &mut Peer) -> State {
     // peer through its callback — so the connect-retry tick is only a
     // backstop.
     if !peer.connected_check_ok() {
-        if peer.trace_fsm() {
-            tracing::info!(
-                peer = %peer.address,
-                "bgp: holding eBGP session — neighbor is not on a connected network and disable-connected-check is off",
-            );
-        }
+        bgp_fsm_trace!(
+            peer,
+            "bgp: holding eBGP session — neighbor is not on a connected network and disable-connected-check is off",
+        );
         peer.timer.connect_retry = Some(timer::start_connect_retry_timer(peer));
         return State::Active;
     }
@@ -2237,13 +2233,16 @@ pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State
 
 pub fn fsm_bgp_notification(peer: &mut Peer, conn: ConnTag, packet: NotificationPacket) -> State {
     peer.counter[BgpType::Notification as usize].rcvd += 1;
-    // A NOTIFICATION is the peer telling us why it is tearing the session down,
-    // and it was never surfaced anywhere: the only log here was the Bad Peer AS
-    // case below. Record it, including any RFC 9003 shutdown communication —
-    // an operator's "maintenance window, back at 03:00" is worth exactly as much
-    // as the numeric subcode next to it.
-    tracing::info!(
-        peer = %peer.display_name(),
+    // A NOTIFICATION is the peer telling us why it is tearing the session down.
+    // The dispatch-level `recv NOTIFICATION` in `Bgp::process_msg` only records
+    // that one arrived; this is the decoded reason, including any RFC 9003
+    // shutdown communication — an operator's "maintenance window, back at 03:00"
+    // is worth exactly as much as the numeric subcode next to it. Same
+    // `tracing packet notification` gate as its sibling.
+    bgp_packet_trace!(
+        peer,
+        PacketKind::Notification,
+        Direction::Recv,
         "bgp: NOTIFICATION received: {} / {}{}",
         packet.code,
         bgp_packet::notify_sub_code_str(packet.code, packet.sub_code),
@@ -2261,8 +2260,8 @@ pub fn fsm_bgp_notification(peer: &mut Peer, conn: ConnTag, packet: Notification
         && peer.config.local_as.is_some_and(|la| la.dual_as)
     {
         peer.local_as_dual_fallback = !peer.local_as_dual_fallback;
-        tracing::info!(
-            peer = %peer.display_name(),
+        bgp_fsm_trace!(
+            peer,
             "bgp: Bad Peer AS with local-as dual-as — next OPEN presents AS {}",
             peer.open_local_as(),
         );

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -67,7 +67,9 @@ pub fn init_peer_task(config: Option<bool>) -> bool {
         "default"
     };
     if on {
-        tracing::info!("BGP per-peer egress task: enabled (from {source})");
+        // Debug, not info: this runs inside `spawn_bgp`, before any
+        // `BgpTracing` exists to gate it against.
+        tracing::debug!("BGP per-peer egress task: enabled (from {source})");
     } else {
         // Disable default logging.
         // tracing::info!("BGP per-peer egress task: disabled (from {source})");

--- a/zebra-rs/src/bgp/tracing.rs
+++ b/zebra-rs/src/bgp/tracing.rs
@@ -471,12 +471,17 @@ pub fn config_tracing_dispatch(
 }
 
 /// Copy the instance tracing config onto every peer's snapshot, so each
-/// peer's effective (additive) config picks up an instance-level change.
+/// peer's effective (additive) config picks up an instance-level change,
+/// and mirror it to every per-VRF task. Both are copies rather than
+/// shared reads: the trace sites see only a `Peer` (global) or a
+/// `BgpVrf` (per-VRF task, a different `!Send` runtime), never the
+/// instance.
 pub fn propagate_instance_tracing(bgp: &mut Bgp) {
     let snapshot = bgp.tracing.clone();
     for (_, peer) in bgp.peers.iter_mut_all() {
         peer.tracing_instance = snapshot.clone();
     }
+    bgp.broadcast_tracing();
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -13,6 +13,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::config::{ConfigChannel, ShowChannel};
 use crate::context::{ProtoContext, Task};
+use crate::{bgp_vpn_trace, bgp_vrf_trace};
 
 use super::super::Message;
 use super::super::config::BgpRedistSource;
@@ -48,6 +49,15 @@ pub struct BgpVrf {
     /// Shard-scope Loc-RIB tables (unicast/LU/VPN) — the per-VRF
     /// twin of [`crate::bgp::shard::BgpShard`] on the global task.
     pub shard: BgpShard,
+    /// Mirror of the instance-wide `router bgp tracing { … }` config,
+    /// seeded at spawn by `spawn_bgp_vrf` and refreshed on every edit
+    /// via [`BgpVrfMsg::Tracing`] (the per-VRF `ConfigChannel` never
+    /// sees the instance-scoped path). Read by this task's gated trace
+    /// sites — `bgp_vpn_trace!` for the import/withdraw pipeline,
+    /// `bgp_vrf_trace!` for task lifecycle. There is no per-neighbor
+    /// overlay here: the CE peers in a VRF are traced through the
+    /// instance config only.
+    pub tracing: super::super::tracing::BgpTracing,
     /// Per-VRF BGP router-id. Defaults to the global router-id at
     /// spawn time; the operator may override via
     /// `set router bgp vrf <name> router-id <addr>`, in which case
@@ -707,6 +717,9 @@ impl BgpVrf {
             peers: PeerMap::new(),
             local_rib: LocalRib::default(),
             shard: BgpShard::default(),
+            // Default all-off; `spawn_bgp_vrf` seeds it from the
+            // instance config and `BgpVrfMsg::Tracing` refreshes it.
+            tracing: Default::default(),
             router_id,
             // Default unset; `spawn_bgp_vrf` sets it from the VRF config.
             rd: None,
@@ -1151,14 +1164,15 @@ impl BgpVrf {
                 msg = self.global_rx.recv() => {
                     match msg {
                         Some(BgpVrfMsg::Shutdown) => {
-                            tracing::info!(vrf = %self.name, "bgp vrf: shutdown");
+                            bgp_vrf_trace!(&self.tracing, vrf = %self.name, "bgp vrf: shutdown");
                             break;
                         }
                         Some(other) => self.process_global_msg(other),
                         None => {
                             // All senders dropped — the global task
                             // exited without sending Shutdown.
-                            tracing::info!(
+                            bgp_vrf_trace!(
+                                &self.tracing,
                                 vrf = %self.name,
                                 "bgp vrf: inbound channel closed; exiting",
                             );
@@ -1554,7 +1568,8 @@ impl BgpVrf {
             }
         }
 
-        tracing::info!(
+        bgp_vpn_trace!(
+            &self.tracing,
             vrf = %self.name,
             %prefix,
             rd = %rd,
@@ -1576,7 +1591,8 @@ impl BgpVrf {
         // imported from has nothing to remove — and must not touch a
         // sibling RD's row (the aliasing this fixes).
         let Some(&import_id) = self.import_ids.get(&rd) else {
-            tracing::info!(
+            bgp_vpn_trace!(
+                &self.tracing,
                 vrf = %self.name,
                 %prefix,
                 rd = %rd,
@@ -1653,7 +1669,8 @@ impl BgpVrf {
             }
         }
 
-        tracing::info!(
+        bgp_vpn_trace!(
+            &self.tracing,
             vrf = %self.name,
             %prefix,
             rd = %rd,
@@ -1796,7 +1813,8 @@ impl BgpVrf {
             }
         }
 
-        tracing::info!(
+        bgp_vpn_trace!(
+            &self.tracing,
             vrf = %self.name,
             %prefix,
             rd = %rd,
@@ -1814,7 +1832,8 @@ impl BgpVrf {
     ) {
         // See `handle_withdraw_import`: only the withdrawing RD's row.
         let Some(&import_id) = self.import_ids.get(&rd) else {
-            tracing::info!(
+            bgp_vpn_trace!(
+                &self.tracing,
                 vrf = %self.name,
                 %prefix,
                 rd = %rd,
@@ -1879,7 +1898,8 @@ impl BgpVrf {
             }
         }
 
-        tracing::info!(
+        bgp_vpn_trace!(
+            &self.tracing,
             vrf = %self.name,
             %prefix,
             rd = %rd,
@@ -2187,6 +2207,11 @@ impl BgpVrf {
                 // routes refresh on the SPF that changed the shadow.
                 self.color_policy = color_policy;
                 self.flex_algo_srv6_routes = srv6_shadow;
+            }
+            BgpVrfMsg::Tracing(tracing) => {
+                // Instance-wide tracing config changed. Purely a
+                // logging switch — nothing to re-run.
+                self.tracing = tracing;
             }
             BgpVrfMsg::Accept(stream, sockaddr) => {
                 // Passive accept for the per-VRF PE-CE session. The global

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -216,6 +216,17 @@ pub enum BgpVrfMsg {
         srv6_shadow: crate::bgp::color_policy::FlexAlgoSrv6Shadow,
     },
 
+    /// Snapshot of the instance-wide `router bgp tracing { … }` config,
+    /// so the per-VRF task's gated trace sites (`bgp_vpn_trace!`,
+    /// `bgp_vrf_trace!`) can read it. The per-VRF `ConfigChannel` only
+    /// receives `/router/bgp/vrf/<name>/…` paths, so an instance-scoped
+    /// `/router/bgp/tracing/…` edit can't reach the task by config
+    /// dispatch — the global task mirrors it here on every change, the
+    /// same way `ColourSteering` mirrors the colour shadow. Spawn-time
+    /// initialisation goes through `spawn_bgp_vrf` instead, so a VRF
+    /// task never runs a single event with a stale snapshot.
+    Tracing(crate::bgp::tracing::BgpTracing),
+
     /// Tear the VRF task down cleanly. The event loop exits on the
     /// next select iteration after receiving this. Used by
     /// `despawn_bgp_vrf` and during daemon shutdown.

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -134,6 +134,7 @@ pub fn spawn_bgp_vrf(
     kernel: Option<RibKnownVrf>,
     rib_subscriber: &RibSubscriber,
     srv6: Option<Srv6VrfSid>,
+    tracing_cfg: crate::bgp::tracing::BgpTracing,
     global_tx: UnboundedSender<BgpGlobalMsg>,
 ) -> BgpVrfHandle {
     // Snapshot for logging + ILM install so we can move
@@ -192,6 +193,11 @@ pub fn spawn_bgp_vrf(
     // The MUP forwarding-plane mode (End.DT46 stand-in vs cradle GTP-U).
     // Spawn-time capture like `rd`; a live `dataplane` edit respawns the VRF.
     vrf.dataplane = cfg.mobile_uplane.dataplane;
+    // Seed the instance-wide tracing snapshot so the task's gated trace
+    // sites are live from its first event. Unlike `rd`/`dataplane` this
+    // is *not* a spawn-time capture — `Bgp::broadcast_tracing` refreshes
+    // it via `BgpVrfMsg::Tracing` on every edit, no respawn needed.
+    vrf.tracing = tracing_cfg;
 
     // Materialise per-VRF peers from the BgpVrfConfig snapshot.
     // `peer.start()`'s timer events get logged at debug and
@@ -607,6 +613,7 @@ mod tests {
             None,
             &subscriber,
             /* srv6 */ None,
+            /* tracing */ Default::default(),
             global_tx,
         )
     }


### PR DESCRIPTION
## Summary

`zebra-rs/src/bgp/` had 18 `tracing::info!` sites that fired regardless of `router bgp tracing { … }`, so a default-level daemon log carried BGP chatter no operator asked for — worst of all the per-VRF VPN import/withdraw pipeline, which logs **once per imported prefix**.

Each site is routed to the category that already describes it:

| Sites | Gate |
|---|---|
| `vrf/inst.rs` ImportV4/V6, WithdrawImport(V6) — per prefix | `bgp_vpn_trace!` |
| `vrf/inst.rs` task shutdown / inbox closed | `bgp_vrf_trace!` |
| `peer.rs` decoded NOTIFICATION reason | `bgp_packet_trace!` (notification, recv) |
| `peer.rs` local-as dual-as AS flip | `bgp_fsm_trace!` |
| `inst.rs` v4 sync park / resume | adj-out gate |

### Per-VRF plumbing

The per-VRF task had no `BgpTracing` to gate against: its `ConfigChannel` only receives `/router/bgp/vrf/<name>/…`, so an instance-scoped `/router/bgp/tracing/…` edit can never reach it by config dispatch. `BgpVrf` now carries a mirrored snapshot following the existing `BgpVrfMsg::ColourSteering` pattern — seeded by `spawn_bgp_vrf` so the task is never live with a stale value, refreshed by a new `BgpVrfMsg::Tracing` from `propagate_instance_tracing`.

### Sites that dropped to `debug!` instead

Five have no category to sit under *and* no config object in reach: `init_shard_count` / `init_peer_task` run inside `spawn_bgp` before any `BgpTracing` exists, `GroupEgressTask::spawn` is a plain constructor, the listen-port edit has no matching knob, and the dynamic-neighbor sweep logs a peer it has already removed.

Also converts two hand-rolled `if peer.trace_fsm()` blocks in `peer.rs` to `bgp_fsm_trace!` so they carry the `proto` / `category` / `peer` fields the macro adds.

No YANG changes — every gate reuses an existing category.

## Test plan

- [x] `cargo build -p zebra-rs` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --exclude bdd --all-targets` — no warnings
- [x] `cargo test --workspace --exclude bdd` — all pass, 0 failures
- [x] **Live run** (debug binary under sudo, unreachable peer to force FSM churn): with no tracing config the entire log is one INFO line, `zebra-rs started` — **zero** from `src/bgp/`. Adding `tracing { fsm; }` brings the FSM transitions back:
      ```
      INFO zebra-rs/src/bgp/inst.rs:2196: FSM transition proto="bgp" category="fsm" peer=127.0.0.9 from="Idle" to="Connect"
      ```
- [ ] BDD L3VPN features (exercise the changed VPN import path) — not run locally; relying on CI

Generated with [Claude Code](https://claude.com/claude-code)