### PR TITLE
isis: purge pseudonode LSP when a DIS loses its circuit

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -158,6 +158,13 @@ isis_lan_dis_reelection:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_lan_dis_reelection"
 
+# A DIS that loses its circuit must purge the pseudonode LSP it originated
+# rather than leave it to age out over MaxAge (~20 min). Slow by nature:
+# the purged copy has to outlive ZeroAgeLifetime (60s) before eviction.
+isis_lan_dis_pseudonode_purge:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_lan_dis_pseudonode_purge"
+
 isis_topology_output:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_topology_output"

--- a/bdd/tests/configs/isis_lan_dis_pseudonode_purge/a1.yaml
+++ b/bdd/tests/configs/isis_lan_dis_pseudonode_purge/a1.yaml
@@ -1,0 +1,23 @@
+# a1: L2 IS-IS router on broadcast LAN br0 (iface va1ns, IP
+# 192.168.100.1/24 assigned by the topology step). Loopback 10.0.0.1/32.
+# LAN priority 200 makes a1 the DIS deterministically (a2/a3 sit at the
+# default 64), so a1 is the node whose pseudonode LSP must be purged when
+# its circuit goes down.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: a1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+    - if-name: va1ns
+      metric: 10
+      priority: 200
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_dis_pseudonode_purge/a2.yaml
+++ b/bdd/tests/configs/isis_lan_dis_pseudonode_purge/a2.yaml
@@ -1,0 +1,21 @@
+# a2: L2 IS-IS router on broadcast LAN br0 (iface va2ns, IP
+# 192.168.100.2/24 assigned by the topology step). Loopback 10.0.0.2/32.
+# Default LAN priority (64) so a1 (200) wins DIS; a2 is a plain LAN member
+# and is used to confirm which pseudonode the LAN points at.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: a2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+    - if-name: va2ns
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_dis_pseudonode_purge/a3.yaml
+++ b/bdd/tests/configs/isis_lan_dis_pseudonode_purge/a3.yaml
@@ -1,0 +1,21 @@
+# a3: L2 IS-IS router on broadcast LAN br0 (iface va3ns, IP
+# 192.168.100.3/24 assigned by the topology step). Loopback 10.0.0.3/32.
+# Default LAN priority (64) so a1 (200) wins DIS. a3 keeps the LAN quorum
+# at three members so a DIS election actually happens.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    is-type: level-2-only
+    hostname: a3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+    - if-name: va3ns
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1514,6 +1514,93 @@ async fn show_command_eventually_contains(
     );
 }
 
+/// Does this `show isis database` line hold a *pseudonode* LSP originated
+/// by `host`? LSP IDs render as `<host>.<pseudo-id>-<fragment>`; the
+/// pseudo-id byte is zero for a router's own LSP and non-zero for a
+/// pseudonode.
+///
+/// Matching on the pseudo-id rather than a literal is deliberate: it is
+/// derived from the circuit's ifindex, so it is whatever the host handed
+/// out — 0x02 in a fresh hand-built namespace, but routinely 0xa6 under
+/// the BDD harness, which has created many veths by then. A test that
+/// hardcodes it passes vacuously on any run where the number moves.
+fn is_pseudonode_lsp_line(line: &str, host: &str) -> bool {
+    let Some(id) = line.split_whitespace().next() else {
+        return false;
+    };
+    let Some(rest) = id.strip_prefix(host).and_then(|r| r.strip_prefix('.')) else {
+        return false;
+    };
+    let Some((pseudo, _fragment)) = rest.split_once('-') else {
+        return false;
+    };
+    pseudo.len() == 2 && pseudo != "00" && pseudo.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+async fn pseudonode_lsp_present(scoped: &str, host: &str) -> (bool, String) {
+    let out = netns::exec_in_netns(scoped, "vtyctl", &["show", "show isis database"])
+        .await
+        .expect("Failed to run show isis database");
+    let present = out.lines().any(|l| is_pseudonode_lsp_line(l, host));
+    (present, out)
+}
+
+/// Precondition sibling of the "no pseudonode" assertion below: the named
+/// host must actually have originated a pseudonode LSP (i.e. it really is
+/// the DIS) before a later purge assertion means anything.
+#[then(expr = "namespace {string} should eventually have a pseudonode LSP from {string}")]
+async fn pseudonode_lsp_eventually_present(world: &mut World, namespace: String, host: String) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 60;
+    let mut last = String::new();
+    for i in 0..ATTEMPTS {
+        let (present, out) = pseudonode_lsp_present(&scoped, &host).await;
+        last = out;
+        if present {
+            println!("✓ namespace {} has a pseudonode LSP from {}", scoped, host);
+            return;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    panic!(
+        "namespace {} never showed a pseudonode LSP from {} after {} attempts\nlast LSDB:\n{}",
+        scoped, host, ATTEMPTS, last
+    );
+}
+
+/// A router that stops being DIS must purge the pseudonode LSP it
+/// originated (ISO 10589 §7.3.4.6). The purged copy lingers for
+/// ZeroAgeLifetime (60s) before eviction, so the budget here has to
+/// outlast that; a router that never purged keeps the LSP for MaxAge
+/// (~20 min) and fails.
+#[then(expr = "namespace {string} should eventually have no pseudonode LSP from {string}")]
+async fn pseudonode_lsp_eventually_absent(world: &mut World, namespace: String, host: String) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 90;
+    let mut last = String::new();
+    for i in 0..ATTEMPTS {
+        let (present, out) = pseudonode_lsp_present(&scoped, &host).await;
+        last = out;
+        if !present {
+            println!(
+                "✓ namespace {} has no pseudonode LSP from {} (purged)",
+                scoped, host
+            );
+            return;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    panic!(
+        "namespace {} still holds a pseudonode LSP from {} after {} attempts \
+         (it was left to age out instead of being purged)\nlast LSDB:\n{}",
+        scoped, host, ATTEMPTS, last
+    );
+}
+
 #[then(expr = "show command {string} in namespace {string} should not contain {string}")]
 async fn show_command_not_contains(
     world: &mut World,

--- a/bdd/tests/features/isis_lan_dis_pseudonode_purge.feature
+++ b/bdd/tests/features/isis_lan_dis_pseudonode_purge.feature
@@ -1,0 +1,72 @@
+@serial
+@isis_lan_dis_pseudonode_purge
+Feature: A resigning DIS purges the pseudonode LSP it originated
+
+  Regression for a pseudonode-LSP leak on DIS resignation.
+
+  On a broadcast LAN the Designated IS originates a pseudonode LSP. When it
+  ceases to be DIS it must purge that LSP (ISO 10589 §7.3.4.6) rather than
+  leave it to age out over MaxAge (~20 min). `dis_selection` does this via
+  `ifsm::dis_dropping`, but a circuit going down never reached that path —
+  `Isis::link_state_down` reset `adj` and `dis_status` directly, and
+  `dis_dropping` is the only caller that emits `Message::LspPurge` for a
+  pseudonode. So a DIS that lost its circuit left a zombie pseudonode LSP
+  behind, in its own LSDB and in every other LSDB in the area.
+
+  Forwarding survived it — SPF's two-way check discards a pseudonode the
+  ex-DIS's own LSP no longer references — which is exactly why a
+  reachability test cannot catch this. The assertion has to look at the
+  LSDB.
+
+  Three L2 routers (a1, a2, a3) share one broadcast LAN (br0). a1 holds LAN
+  priority 200 (a2/a3 default 64) so a1 is deterministically DIS and owns
+  the pseudonode. Dropping a1's circuit must purge it.
+
+  Note this scenario asserts on a1's *own* LSDB. With a single circuit a1
+  has nowhere to flood the purge once that circuit is down, so its peers
+  necessarily age the LSP out — unavoidable, and true of any
+  implementation. A router that still holds another circuit does flood the
+  purge to the rest of the area; the originator-side invariant asserted
+  here is what makes that possible.
+
+  Scenario: a DIS that loses its circuit purges its pseudonode LSP
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "a1" with IP "192.168.100.1/24" on bridge "br0"
+    And I create namespace "a2" with IP "192.168.100.2/24" on bridge "br0"
+    And I create namespace "a3" with IP "192.168.100.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "a1"
+    And I start zebra-rs in namespace "a2"
+    And I start zebra-rs in namespace "a3"
+    And I apply config "a1.yaml" to namespace "a1"
+    And I apply config "a2.yaml" to namespace "a2"
+    And I apply config "a3.yaml" to namespace "a3"
+    And I wait 20 seconds
+    # Preconditions: a1 must really be the elected DIS (a2 sees a1's system
+    # ID as the LAN ID) and must really have originated a pseudonode LSP.
+    # Without these the purge assertion below would pass vacuously on any
+    # run where a1 never became DIS.
+    Then show command "show isis interface" in namespace "a2" should eventually contain "0000.0000.0001."
+    And namespace "a1" should eventually have a pseudonode LSP from "a1"
+    # a1's circuit fails, so a1 is no longer DIS and must purge. The wait
+    # takes us past ZeroAgeLifetime (60s) so the purged entry is evicted
+    # outright rather than merely sitting at zero age.
+    When I bring link down in namespace "a1"
+    And I wait 45 seconds
+    Then namespace "a1" should eventually have no pseudonode LSP from "a1"
+    # a1's own non-pseudonode LSP is still present. This is what makes the
+    # assertion above specific to the pseudonode rather than "a1 emptied
+    # its LSDB" — before the fix the pseudonode sat here at its original
+    # sequence number with Holdtime counting down from ~1190.
+    And show command "show isis database" in namespace "a1" should contain "a1.00-00"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "a1"
+    And I stop zebra-rs in namespace "a2"
+    And I stop zebra-rs in namespace "a3"
+    And I delete namespace "a1"
+    And I delete namespace "a2"
+    And I delete namespace "a3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -907,6 +907,32 @@ impl Isis {
                 link.state.nbrs.get_mut(&level).remove(&sys_id);
             }
 
+            // If we were the elected DIS on this circuit, purge the
+            // pseudonode LSP we originated rather than leaving it to
+            // age out over MaxAge (~20 min). ISO 10589 §7.3.4.6: a
+            // router that ceases to be DIS purges its pseudonode LSP.
+            // `dis_selection` does this via `ifsm::dis_dropping`, but a
+            // link bounce never reaches that path — it resets the DIS
+            // state directly below — so without this the LSP lingers
+            // in every LSDB in the area. `dis_selection`'s
+            // Other -> Other handling already *assumes* an ex-DIS has
+            // purged, so leaving it is an invariant violation, not
+            // just cosmetic.
+            //
+            // Guard on `DisStatus::Myself`, NOT on `adj.is_some()`:
+            // `adj` also carries the *other* node's LAN-ID while we are
+            // a plain LAN member (`DisStatus::Other`), and purging then
+            // would destroy a different router's pseudonode LSP.
+            //
+            // Must run before `adj` is cleared just below — the LAN-ID
+            // it holds is what identifies the pseudonode.
+            if *link.state.dis_status.get(&level) == DisStatus::Myself
+                && let Some((adj, _)) = link.state.adj.get(&level)
+            {
+                let lsp_id = IsisLspId::from_neighbor_id(*adj, 0);
+                let _ = self.tx.send(Message::LspPurge(level, lsp_id));
+            }
+
             // Reset per-level Up-neighbor counter and adjacency
             // bookkeeping.
             *link.state.nbrs_up.get_mut(&level) = 0;


### PR DESCRIPTION
A router that stops being the Designated IS must purge the pseudonode LSP it originated (ISO 10589 §7.3.4.6) rather than leave it to age out over MaxAge (~20 min).

## The bug

`ifsm::dis_dropping` is the only caller that emits `Message::LspPurge` for a pseudonode, and its sole call site was the DIS-change block in `dis_selection`. `Isis::link_state_down` tore the DIS state down directly (`*adj = None`, `dis_status = NotSelected`), so a circuit going down never reached the purge. An ex-DIS left a zombie pseudonode LSP in its own LSDB and in every other LSDB reachable from it.

Reached both by a real link-down and by `config_network_type`, which deliberately bounces the link via `link_state_down` + `link_state_up`.

`dis_selection`'s `Other -> Other` handling already *assumes* an ex-DIS has purged, so this was an invariant violation rather than a cosmetic leak.

## The fix

Purge inside `link_state_down`'s per-level loop, before `adj` is cleared — the LAN-ID it holds is what identifies the pseudonode — guarded on `DisStatus::Myself`.

**The guard is deliberate.** `dis_dropping`'s own comment says `adj.is_some()` means "we were DIS", but that is not true: `dis_selection`'s `Other` arm also stores the *elected DIS's* LAN-ID in `adj` while we are a plain LAN member. Purging on `adj.is_some()` would make every bystander purge the real DIS's LSP. The pre-existing call site is safe only because it is separately gated on `old_status == Myself`.

## Test plan

Forwarding survives the bug — SPF's two-way check discards a pseudonode the ex-DIS's own LSP no longer references — so no reachability test can catch it. The new regression asserts on the LSDB.

- [x] **A/B on a live 3-node netns LAN** (DIS pinned with `priority: 200`):
  - before: pseudonode stays at its original sequence number, Holdtime counting down 1179 → 1089 → … over MaxAge
  - after: sequence bumped, PduLen 62 → 36, Holdtime 0, evicted at ZeroAgeLifetime (60s)
  - with a second circuit still up, the purge floods to the rest of the area and clears on every peer
- [x] **BDD `@isis_lan_dis_pseudonode_purge`** — fails on the pre-fix binary at the purge assertion ("left to age out instead of being purged"), passes after. Binary md5 verified on both runs.
- [x] `@isis_lan_dis_reelection` and `@isis_lan_pseudonode` still pass
- [x] `cargo test -p zebra-rs` — 1676 passed, 0 failed
- [x] cold `cargo clippy` clean, `cargo fmt --check` clean

## Note on the new BDD steps

The two new steps match the pseudo-id by *shape* (`<host>.<non-zero hex>-<frag>`) rather than a literal. It is derived from the circuit's ifindex — `0x02` in a hand-built namespace but routinely `0xa6` under the BDD harness — so a hardcoded value would pass vacuously. The first draft did exactly that and the precondition assertion caught it.

Known limitation, inherent rather than a gap: a DIS with a *single* circuit has nowhere to flood the purge once that circuit is down, so its peers still age the LSP out and only the originator's own LSDB is cleaned. The area-wide effect appears when the router retains another circuit.

Generated with [Claude Code](https://claude.com/claude-code)