### PR TITLE
flex-algo: per-algorithm fast-reroute becomes an opt-out

### DIFF
--- a/playset/isis-flexalgo/README.md
+++ b/playset/isis-flexalgo/README.md
@@ -474,19 +474,43 @@ $ sudo ip netns exec se ip route flush table 100
 
 ## A note on TI-LFA
 
-The instance-level `fast-reroute ti-lfa` knob protects algorithm 0 and works
-here; the YANG also exposes a per-algorithm
-`router isis flex-algo <n> fast-reroute ti-lfa`. As of this writing that
-per-algorithm knob does **not** produce repair paths on the SR-MPLS
-dataplane: enabling it yields no backup entries in the algorithm-128 RIB,
-and `show isis ti-lfa` reports no per-algorithm section. The repair-label
-resolver (`repair_segments_to_mpls_labels` in `zebra-rs/src/isis/tilfa.rs`)
-takes no algorithm argument and resolves the algorithm-0 Prefix-SID, so a
-repair list computed for algorithm 128 would in any case be built from
-algorithm-0 segments and could steer traffic back onto an excluded link.
-The SRv6 segment resolvers in the same file *are* algorithm-aware.
+TI-LFA is enabled once, at the instance level, with `fast-reroute ti-lfa`.
+Every algorithm the router participates in inherits it — there is no
+per-algorithm *enable* — and each algorithm's repair is computed inside its
+own constrained topology. This matches IOS-XR, Juniper and FRR. To exclude
+one algorithm, opt it out:
 
-Treat per-algorithm TI-LFA over SR-MPLS as not yet implemented.
+``` yaml
+    flex-algo:
+    - algo: 128
+      fast-reroute:
+        disable: null
+```
+
+The effective state per algorithm is visible in `show isis flex-algo`:
+
+``` shell
+tk>show isis flex-algo
+Local Flex-Algorithms:
+  Algo  Metric                 Priority Adv FRR       Constraints
+  128   igp                    -        no  n/a       exclude-any=trans-pacific
+```
+
+| FRR | meaning |
+|:---|:---|
+| `on` | inherited from the instance and computed |
+| `off` | instance-level TI-LFA is not enabled |
+| `disabled` | this algorithm opted out with `fast-reroute disable` |
+| `n/a` | inherited, but this dataplane has no per-algorithm repair yet |
+
+**This lab reads `n/a`, because per-algorithm TI-LFA is implemented for
+SRv6 only.** SR-MPLS is deliberately gated off: the repair-label resolver
+(`repair_segments_to_mpls_labels` in `zebra-rs/src/isis/tilfa.rs`) takes no
+algorithm argument and returns the first Prefix-SID it finds — the
+algorithm-0 one. A repair list built that way could steer traffic back over
+a link the FAD excluded, which is worse than leaving the algorithm
+unprotected, so it is not computed at all until the resolver is made
+algorithm-aware. The SRv6 segment resolvers in the same file already are.
 
 ## Appendix: Loopbacks and Prefix-SIDs
 

--- a/zebra-rs/src/flex_algo/config.rs
+++ b/zebra-rs/src/flex_algo/config.rs
@@ -302,15 +302,15 @@ fn config_builder(prefix: &str) -> ConfigBuilder {
             }
             Ok(())
         })
-        .path(&format!("{prefix}/fast-reroute/ti-lfa"))
+        .path(&format!("{prefix}/fast-reroute/disable"))
         .set(|config, cache, algo, _args| {
             let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
-            e.ti_lfa = true;
+            e.fast_reroute_disable = true;
             Ok(())
         })
         .del(|config, cache, algo, _args| {
             let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
-            e.ti_lfa = false;
+            e.fast_reroute_disable = false;
             Ok(())
         })
 }

--- a/zebra-rs/src/flex_algo/entry.rs
+++ b/zebra-rs/src/flex_algo/entry.rs
@@ -57,5 +57,10 @@ pub struct FlexAlgoEntry {
     pub include_all: BTreeSet<String>,
     pub exclude_any: BTreeSet<String>,
     pub srlg_exclude: BTreeSet<String>,
-    pub ti_lfa: bool,
+    /// Per-algorithm fast-reroute OPT-OUT (`flex-algo <n> fast-reroute
+    /// disable`). Default `false` means this algorithm inherits the
+    /// instance-level TI-LFA setting, matching IOS-XR / Juniper / FRR,
+    /// where enabling TI-LFA protects every algorithm the router
+    /// participates in rather than algorithm 0 alone.
+    pub fast_reroute_disable: bool,
 }

--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -306,7 +306,10 @@ flex_algo_cb!(
     "/router/isis/flex-algo/affinity/exclude-any"
 );
 flex_algo_cb!(cb_srlg_exclude, "/router/isis/flex-algo/srlg-exclude");
-flex_algo_cb!(cb_ti_lfa, "/router/isis/flex-algo/fast-reroute/ti-lfa");
+flex_algo_cb!(
+    cb_frr_disable,
+    "/router/isis/flex-algo/fast-reroute/disable"
+);
 
 pub fn callback_register(isis: &mut Isis) {
     isis.callback_add("/router/isis/flex-algo", cb_entry);
@@ -333,7 +336,10 @@ pub fn callback_register(isis: &mut Isis) {
         cb_affinity_exclude_any,
     );
     isis.callback_add("/router/isis/flex-algo/srlg-exclude", cb_srlg_exclude);
-    isis.callback_add("/router/isis/flex-algo/fast-reroute/ti-lfa", cb_ti_lfa);
+    isis.callback_add(
+        "/router/isis/flex-algo/fast-reroute/disable",
+        cb_frr_disable,
+    );
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1160,9 +1160,11 @@ struct FlexAlgoInput {
     algo: u8,
     graph: spf::Graph,
     source: Option<usize>,
-    /// Run per-algo TI-LFA in this algo's constrained graph. Set only
-    /// for SRv6-dataplane algos with the per-algo `fast-reroute ti-lfa`
-    /// toggle — Flex-Algo TI-LFA is an SRv6 feature here.
+    /// Run per-algo TI-LFA in this algo's constrained graph. Set for
+    /// SRv6-dataplane algos that inherit the instance-level TI-LFA
+    /// toggle and have not opted out with `fast-reroute disable`.
+    /// SR-MPLS algos are excluded until the repair-label resolver is
+    /// algorithm-aware — see the gate in [`build_spf_input`].
     ti_lfa: bool,
 }
 
@@ -1273,11 +1275,22 @@ pub(super) fn build_spf_input(top: &mut IsisTop, level: Level) -> Option<SpfInpu
             algo: *algo,
             graph: algo_graph,
             source: algo_source,
-            // Per-algo TI-LFA is an SRv6 feature here: compute it only
-            // for SRv6-dataplane algos whose per-algo `fast-reroute
-            // ti-lfa` toggle is set, so we don't pay the cost for algos
-            // whose repair we'd never install.
-            ti_lfa: entry.ti_lfa && entry.dataplane_srv6 == Some(true),
+            // Per-algorithm TI-LFA now *inherits* the instance-level
+            // toggle (IOS-XR / Juniper / FRR all protect every algorithm
+            // once TI-LFA is on); `fast-reroute disable` opts one
+            // algorithm out.
+            //
+            // Still SRv6-only. An SR-MPLS repair list is resolved by
+            // `tilfa::repair_segments_to_mpls_labels`, which takes no
+            // algorithm and returns the first Prefix-SID it finds — the
+            // algorithm-0 one. Computing SR-MPLS repairs here would
+            // therefore emit segment lists that can traverse a link the
+            // FAD excluded, which is worse than leaving the algorithm
+            // unprotected. Lift this gate only together with an
+            // algorithm-aware label resolver.
+            ti_lfa: top.config.ti_lfa_enabled
+                && !entry.fast_reroute_disable
+                && entry.dataplane_srv6 == Some(true),
         });
     }
 

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -3648,8 +3648,8 @@ fn show_isis_flex_algo(
         writeln!(buf, "Local Flex-Algorithms:")?;
         writeln!(
             buf,
-            "  {:<5} {:<22} {:<8} {:<3} Constraints",
-            "Algo", "Metric", "Priority", "Adv"
+            "  {:<5} {:<22} {:<8} {:<3} {:<9} Constraints",
+            "Algo", "Metric", "Priority", "Adv", "FRR"
         )?;
         for (algo, entry) in &isis.flex_algo.config {
             let metric = match entry.metric_type {
@@ -3664,6 +3664,21 @@ fn show_isis_flex_algo(
                 "yes"
             } else {
                 "no"
+            };
+            // Effective fast-reroute state for this algorithm. Worth
+            // showing explicitly: the algorithm inherits the
+            // instance-level TI-LFA toggle, so without this an operator
+            // cannot tell an inherited-on algorithm from one that is
+            // silently unprotected because its dataplane has no per-algo
+            // repair yet.
+            let frr = if entry.fast_reroute_disable {
+                "disabled" // explicit per-algo opt-out
+            } else if !isis.config.ti_lfa_enabled {
+                "off" // instance-level TI-LFA is off; nothing to inherit
+            } else if entry.dataplane_srv6 == Some(true) {
+                "on" // inherited and computed
+            } else {
+                "n/a" // inherited, but no algo-aware SR-MPLS repair yet
             };
             let mut constraints = String::new();
             if !entry.include_any.is_empty() {
@@ -3719,11 +3734,12 @@ fn show_isis_flex_algo(
             }
             writeln!(
                 buf,
-                "  {:<5} {:<22} {:<8} {:<3} {}",
+                "  {:<5} {:<22} {:<8} {:<3} {:<9} {}",
                 algo,
                 metric,
                 prio,
                 adv,
+                frr,
                 constraints.trim_end()
             )?;
         }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1380,13 +1380,23 @@ module config {
           }
 
           container fast-reroute {
-            ext:help "Per-algo fast-reroute (TI-LFA)";
-            // Per-algo TI-LFA toggle. Empty container is a no-op; the
-            // child presence container turns the per-algo TI-LFA
-            // computation on (deferred — no OSPF per-algo TI-LFA yet).
-            container ti-lfa {
-              ext:help "Topology-Independent LFA for this flex-algo";
-              presence "Enable Topology-Independent LFA for this flex-algo";
+            ext:help "Per-algo fast-reroute";
+            // Per-algorithm fast-reroute OPT-OUT; same model and rationale
+            // as `router isis / flex-algo / fast-reroute`. TI-LFA
+            // enablement is instance-level
+            // (/router/ospf/fast-reroute/ti-lfa) and every algorithm this
+            // router participates in inherits it. The per-algorithm
+            // computation itself is still deferred for OSPFv2 — the leaf
+            // is accepted and stored so the schema stays uniform across
+            // IS-IS / OSPFv2 / OSPFv3, but nothing consumes it yet.
+            leaf disable {
+              ext:help "Disable fast-reroute for this flex-algo";
+              type empty;
+              description
+                "Suppress TI-LFA repair computation and installation for
+                 this Flex-Algorithm only; algorithm 0 and every other
+                 algorithm keep whatever /router/ospf/fast-reroute/ti-lfa
+                 configures.";
             }
           }
         }
@@ -2399,13 +2409,23 @@ module config {
           }
 
           container fast-reroute {
-            ext:help "Per-flex-algo fast-reroute (TI-LFA)";
-            // Per-algo TI-LFA toggle. Empty container is a no-op; the
-            // child presence container turns the per-algo TI-LFA
-            // computation on (deferred — no OSPF per-algo TI-LFA yet).
-            container ti-lfa {
-              ext:help "Topology-Independent LFA for this flex-algo";
-              presence "Enable Topology-Independent LFA for this flex-algo";
+            ext:help "Per-flex-algo fast-reroute";
+            // Per-algorithm fast-reroute OPT-OUT; same model and rationale
+            // as `router isis / flex-algo / fast-reroute`. TI-LFA
+            // enablement is instance-level
+            // (/router/ospfv3/fast-reroute/ti-lfa) and every algorithm
+            // this router participates in inherits it. The per-algorithm
+            // computation itself is still deferred for OSPFv3 — the leaf
+            // is accepted and stored so the schema stays uniform across
+            // IS-IS / OSPFv2 / OSPFv3, but nothing consumes it yet.
+            leaf disable {
+              ext:help "Disable fast-reroute for this flex-algo";
+              type empty;
+              description
+                "Suppress TI-LFA repair computation and installation for
+                 this Flex-Algorithm only; algorithm 0 and every other
+                 algorithm keep whatever /router/ospfv3/fast-reroute/ti-lfa
+                 configures.";
             }
           }
         }
@@ -2824,14 +2844,34 @@ module config {
           }
 
           container fast-reroute {
-            ext:help "Per-flex-algo fast-reroute (TI-LFA)";
-            // Per-algo override of the instance-level
-            // /router/isis/fast-reroute/ti-lfa toggle. Empty
-            // container is a no-op; the child presence container
-            // turns the per-algo TI-LFA computation on.
-            container ti-lfa {
-              ext:help "Topology-Independent LFA for this flex-algo";
-              presence "Enable Topology-Independent LFA for this flex-algo";
+            ext:help "Per-flex-algo fast-reroute";
+            // Per-algorithm fast-reroute OPT-OUT. TI-LFA enablement is an
+            // instance-level property (/router/isis/fast-reroute/ti-lfa):
+            // once on, every algorithm this router participates in is
+            // protected, with each algorithm's repair computed inside its
+            // own constrained topology and expressed with that
+            // algorithm's SIDs. That inheritance is what RFC 9350 §12
+            // requires — a repair built from algorithm-0 segments can
+            // traverse a link the FAD excluded, defeating the constraint
+            // the algorithm exists to enforce.
+            //
+            // Matches the industry model: IOS-XR enables TI-LFA per
+            // interface and offers only `flex-algo <n> fast-reroute
+            // disable`; Juniper and FRR have no per-algorithm knob at all
+            // and simply protect every slice. An opt-IN toggle here would
+            // leave an operator who configured `fast-reroute ti-lfa` with
+            // silently unprotected flex-algo traffic.
+            leaf disable {
+              ext:help "Disable fast-reroute for this flex-algo";
+              type empty;
+              description
+                "Suppress TI-LFA repair computation and installation for
+                 this Flex-Algorithm only; algorithm 0 and every other
+                 algorithm keep whatever /router/isis/fast-reroute/ti-lfa
+                 configures. Use where a repair is worse than a drop — a
+                 low-latency slice whose post-convergence repair still
+                 satisfies the FAD constraints but blows the latency
+                 budget the slice exists to guarantee.";
             }
           }
         }


### PR DESCRIPTION
TI-LFA enablement is an instance-level property, not a per-algorithm one. Once `router isis fast-reroute ti-lfa` is on, every algorithm the router participates in inherits it, with each algorithm's repair computed inside its own constrained topology. `flex-algo <n> fast-reroute disable` opts a single algorithm out.

## Why

This matches every implementation surveyed:

| | TI-LFA enablement | per-algo knob |
|:--|:--|:--|
| Cisco IOS-XR | per-interface `fast-reroute per-prefix ti-lfa` — covers all algos | **opt-out only**: `flex-algo <n> fast-reroute disable` |
| Juniper | `backup-spf-options use-post-convergence-lfa` | none — every slice protected automatically |
| FRR | per-interface `isis fast-reroute ti-lfa …` | none at all |

The previous opt-IN presence container was the inverse of all three, so an operator who configured `fast-reroute ti-lfa` got algorithm 0 protected and every flex-algo slice silently unprotected — while `show isis ti-lfa` still reported "enabled".

## Changes

**Schema**, swept across isis / ospf / ospfv3 so the three stay uniform: replace `flex-algo <n> fast-reroute ti-lfa` (presence container) with `flex-algo <n> fast-reroute disable` (empty leaf). Only IS-IS wires a callback; the OSPF leaves are accepted and stored, as before.

**Gate** is now `ti_lfa_enabled && !fast_reroute_disable && dataplane_srv6`.

**`show isis flex-algo` gains an FRR column** (`on` / `off` / `disabled` / `n/a`). Without it the opt-out is invisible and an operator cannot distinguish an inherited-on algorithm from a silently unprotected one.

```
  Algo  Metric                 Priority Adv FRR       Constraints
  128   igp                    -        no  n/a       exclude-any=trans-pacific
  129   igp                    -        no  on
  130   igp                    -        no  disabled
```

## Behaviour change — the old toggle was not inert

It gated per-algorithm TI-LFA for **SRv6**-dataplane algorithms (`isis/rib.rs`), and did so *without* consulting the instance-level setting. Under the new model:

- an SRv6 algorithm that never set the toggle now **inherits** instance TI-LFA (newly protected);
- an SRv6 algorithm whose toggle was set while instance TI-LFA was off no longer computes repairs.

Both follow directly from the opt-out model, but they are behaviour changes rather than paperwork.

## SR-MPLS stays gated off, now with the reason at the gate

`tilfa::repair_segments_to_mpls_labels` takes no algorithm and resolves the algorithm-0 Prefix-SID, so an SR-MPLS repair list computed for algorithm N could traverse a link the FAD excluded — worse than leaving the algorithm unprotected. That gate should be lifted only together with an algorithm-aware label resolver. The SRv6 segment resolvers in the same file already are algorithm-aware.

## Test plan

- [x] live in a namespace: all four FRR states render correctly (`on` SRv6-inherited, `off` instance-disabled, `disabled` opt-out, `n/a` SR-MPLS)
- [x] new `fast-reroute: disable: null` applies cleanly
- [x] old `fast-reroute: ti-lfa: {}` is now rejected — `unknown key `ti-lfa`` (schema removal confirmed at live apply, where YANG errors actually surface)
- [x] `cargo test -p zebra-rs` — 1676 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (full workspace including `bdd`)
- [x] `cargo fmt --all --check` — clean

Generated with [Claude Code](https://claude.com/claude-code)