### PR TITLE
packaging: ship playset *.json, guard asset coverage on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,3 +81,19 @@ jobs:
           components: clippy
       - name: Clippy (lua feature)
         run: cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings
+
+  playset-assets:
+    name: playset packaging assets
+    runs-on: ubuntu-22.04
+    # The .deb is built only by nightly.yaml / release.yaml (and the
+    # push-to-main build jobs) — never on a pull request. So a playset file
+    # with an extension no cargo-deb asset glob claims used to reach main
+    # unnoticed and break the packaging build there, which is exactly how
+    # `playset/isis-flexalgo/ontology.json` got in. This lane runs just the
+    # staging guard from `packaging/Makefile` — rsync + find, no Rust build —
+    # so an unpackaged file fails on the PR instead.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Playset asset coverage
+        run: make -C packaging playset

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -59,7 +59,8 @@ playset:
 	@# This guard only checks that each staged file is *claimed* by a glob; where
 	@# cargo-deb then puts it is checked after the build by verify-playset-layout.sh.
 	@bad=`find out/playset -type f ! \( \
-		-name '*.yaml' -o -name '*.md' -o -name '*.drawio' -o -name '*.png' -o -name '*.svg' \
+		-name '*.yaml' -o -name '*.json' -o -name '*.md' -o -name '*.drawio' \
+		-o -name '*.png' -o -name '*.svg' \
 		-o -name 'up.sh' -o -name 'down.sh' -o -name 'topology.sh' \
 		-o -name 'common.sh' -o -name 'netns.sh' -o -name 'playset.sh' -o -name 'zebra-rs.sh' \)`; \
 	if [ -n "$$bad" ]; then \

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -98,6 +98,7 @@ assets = [
   ["../packaging/out/playset/**/[p]layset.sh",   "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/[z]ebra-rs.sh",  "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.yaml",         "usr/share/zebra-rs/playset/",     "644"],
+  ["../packaging/out/playset/**/*.json",         "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.md",           "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.drawio",       "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.png",          "usr/share/zebra-rs/playset/",     "644"],


### PR DESCRIPTION
Fixes a packaging break currently on `main`.

## The break

`playset/isis-flexalgo/ontology.json` (merged in #2060) matches none of the cargo-deb asset globs, so `make -C packaging playset` fails:

```
playset: file(s) not covered by cargo-deb assets (add a glob in zebra-rs/Cargo.toml):
out/playset/isis-flexalgo/ontology.json
make: *** [Makefile:61: playset] Error 1
```

The globs cover `.yaml/.md/.drawio/.png/.svg` plus the named `.sh` basenames — no `.json`. The staging guard worked exactly as designed; it simply never got a chance to run before merge.

## Why it reached main

The `.deb` is built only by `nightly.yaml` / `release.yaml` and the push-to-main build jobs — **never on a pull request**. PR CI is fmt / clippy / test / lua, none of which touch packaging, so #2060 went green and broke `main` on merge. Same shape as the resolute-container tool-dependency trap already documented in `packaging/Makefile`.

## Changes

1. `**/*.json` cargo-deb asset + `-name '*.json'` in the Makefile staging allowlist. The glob keeps a wildcard in its **last** segment, so cargo-deb resolves it per file and the scenario subdirectory survives — the flattening trap documented above the `[u]p.sh` entries does not apply.
2. New `playset-assets` CI lane running just the staging guard (rsync + find, no Rust build). It would have failed #2060 on the PR rather than on main. No new external tool is invoked, so `build-debs.yaml`'s container base-tools line is unchanged.

## Test plan

- [x] reproduced the failure on the pre-fix tree (output above)
- [x] `make -C packaging playset` passes after the fix
- [x] built the package end to end rather than trusting the staging guard — that guard only proves a file is *claimed* by a glob, not where cargo-deb places it:

```
./zebra-rs_26.7.7_arm64.deb
verify-playset-layout: OK — 265 playset files packaged at their staged paths

$ dpkg -c zebra-rs_26.7.7_arm64.deb | grep ontology
-rw-r--r-- 0/0  818  ./usr/share/zebra-rs/playset/isis-flexalgo/ontology.json
```

  Correct path, mode 0644, subdirectory preserved. The only other packaged `.json` is the pre-existing `usr/share/zebra-rs/lua/sgt.json`, so the new glob sweeps nothing unintended.
- [x] `ci.yaml` parses as valid YAML (jobs: fmt, clippy, test, lua, playset-assets)

## Note

The new lane will not *block* merges until `playset packaging assets` is added to the branch-protection required checks — until then it only shows red.

Generated with [Claude Code](https://claude.com/claude-code)