### PR TITLE
isis: algorithm-aware SR-MPLS TI-LFA repairs

### DIFF
--- a/playset/isis-flexalgo/README.md
+++ b/playset/isis-flexalgo/README.md
@@ -493,7 +493,7 @@ The effective state per algorithm is visible in `show isis flex-algo`:
 tk>show isis flex-algo
 Local Flex-Algorithms:
   Algo  Metric                 Priority Adv FRR       Constraints
-  128   igp                    -        no  n/a       exclude-any=trans-pacific
+  128   igp                    -        no  off       exclude-any=trans-pacific
 ```
 
 | FRR | meaning |
@@ -501,16 +501,39 @@ Local Flex-Algorithms:
 | `on` | inherited from the instance and computed |
 | `off` | instance-level TI-LFA is not enabled |
 | `disabled` | this algorithm opted out with `fast-reroute disable` |
-| `n/a` | inherited, but this dataplane has no per-algorithm repair yet |
 
-**This lab reads `n/a`, because per-algorithm TI-LFA is implemented for
-SRv6 only.** SR-MPLS is deliberately gated off: the repair-label resolver
-(`repair_segments_to_mpls_labels` in `zebra-rs/src/isis/tilfa.rs`) takes no
-algorithm argument and returns the first Prefix-SID it finds — the
-algorithm-0 one. A repair list built that way could steer traffic back over
-a link the FAD excluded, which is worse than leaving the algorithm
-unprotected, so it is not computed at all until the resolver is made
-algorithm-aware. The SRv6 segment resolvers in the same file already are.
+This lab reads `off` because no node enables `fast-reroute ti-lfa` by
+default. Enable it and the repairs show up per algorithm — and they are *not* the
+algorithm-0 repairs. Add `fast-reroute: {ti-lfa: {}}` under `router isis`
+in `se.yaml`, then compare:
+
+``` shell
+se>show isis repair-list
+Level AFI   Prefix          Primary via    Repair via     Segments
+L2    ipv4  10.0.0.5/32     192.168.2.2    192.168.0.2    [16800, 15001, 16500]
+
+se>show isis flex-algo 128 repair-list
+Level AFI   Prefix          Primary via    Repair via     Segments
+L2    ipv4  10.0.0.5/32     192.168.2.2    192.168.1.2    [18600, 15000, 18500]
+```
+
+Both protect the same prefix, but the algorithm-0 repair leaves over
+`192.168.0.2` — that is `se-sg`, **the trans-Pacific link algorithm 128
+exists to avoid** — carrying algorithm-0 labels (`16xxx`). The
+algorithm-128 repair leaves over `192.168.1.2` (`se-sj`) with
+algorithm-128 labels (`18xxx`).
+
+That difference is the whole point: a repair must be computed in the
+algorithm's own topology *and* expressed with its own SIDs, or the backup
+path silently violates the constraint the algorithm was created to
+enforce. Adjacency segments (`15xxx`) are shared — an Adj-SID means "pop
+and forward over this link" regardless of algorithm, and the link is
+already known to be in the algorithm's topology.
+
+When a node on the repair path advertises no Prefix-SID for this
+algorithm, the whole repair is dropped rather than approximated with an
+algorithm-0 label, so the destination is simply unprotected under that
+algorithm.
 
 ## Appendix: Loopbacks and Prefix-SIDs
 

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -190,7 +190,10 @@ impl IsisRibFamily for V4 {
         level: Level,
         repair: &spf::RepairPath,
     ) -> Option<RepairPathMpls> {
-        build_repair_path_mpls(top, level, repair)
+        // Algo-0 (legacy) repair: node segments resolve to base
+        // Prefix-SIDs. Per-algo repairs go through
+        // `build_rib_from_flex_algo`, which passes `Some(algo)`.
+        build_repair_path_mpls(top, level, None, repair)
     }
 
     fn trunc_prefix(p: Ipv4Net) -> Ipv4Net {
@@ -1161,10 +1164,10 @@ struct FlexAlgoInput {
     graph: spf::Graph,
     source: Option<usize>,
     /// Run per-algo TI-LFA in this algo's constrained graph. Set for
-    /// SRv6-dataplane algos that inherit the instance-level TI-LFA
-    /// toggle and have not opted out with `fast-reroute disable`.
-    /// SR-MPLS algos are excluded until the repair-label resolver is
-    /// algorithm-aware — see the gate in [`build_spf_input`].
+    /// any algo that inherits the instance-level TI-LFA toggle and has
+    /// not opted out with `fast-reroute disable`. Both dataplanes are
+    /// algorithm-aware: node segments resolve to this algorithm's
+    /// Prefix-SID (SR-MPLS) or End SID (SRv6).
     ti_lfa: bool,
 }
 
@@ -1275,22 +1278,17 @@ pub(super) fn build_spf_input(top: &mut IsisTop, level: Level) -> Option<SpfInpu
             algo: *algo,
             graph: algo_graph,
             source: algo_source,
-            // Per-algorithm TI-LFA now *inherits* the instance-level
-            // toggle (IOS-XR / Juniper / FRR all protect every algorithm
-            // once TI-LFA is on); `fast-reroute disable` opts one
-            // algorithm out.
+            // Per-algorithm TI-LFA inherits the instance-level toggle
+            // (IOS-XR / Juniper / FRR all protect every algorithm once
+            // TI-LFA is on); `fast-reroute disable` opts one algorithm
+            // out. Both dataplanes are algorithm-aware now: node
+            // segments resolve to this algorithm's Prefix-SID (SR-MPLS)
+            // or End SID (SRv6), so a repair cannot silently fall back
+            // to algorithm-0 segments and cross a link the FAD excluded.
             //
-            // Still SRv6-only. An SR-MPLS repair list is resolved by
-            // `tilfa::repair_segments_to_mpls_labels`, which takes no
-            // algorithm and returns the first Prefix-SID it finds — the
-            // algorithm-0 one. Computing SR-MPLS repairs here would
-            // therefore emit segment lists that can traverse a link the
-            // FAD excluded, which is worse than leaving the algorithm
-            // unprotected. Lift this gate only together with an
-            // algorithm-aware label resolver.
-            ti_lfa: top.config.ti_lfa_enabled
-                && !entry.fast_reroute_disable
-                && entry.dataplane_srv6 == Some(true),
+            // An algorithm with no dataplane flag at all keeps the
+            // historical SR-MPLS default, matching the RIB build below.
+            ti_lfa: top.config.ti_lfa_enabled && !entry.fast_reroute_disable,
         });
     }
 
@@ -1937,7 +1935,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
         // (if empty) snapshot.
         let algo_rib = match (mpls_on, algo_source, algo_spf.as_ref()) {
             (true, Some(src), Some(spf_res)) => {
-                let r = build_rib_from_flex_algo(top, level, algo, src, spf_res);
+                let r = build_rib_from_flex_algo(top, level, algo, src, spf_res, &algo_tilfa);
                 mpls_route(&r, &mut ilm, srgb);
                 r
             }
@@ -2239,6 +2237,7 @@ fn build_rib_from_flex_algo(
     algo: u8,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
+    tilfa: &BTreeMap<usize, Vec<spf::RepairPath>>,
 ) -> PrefixMap<Ipv4Net, SpfRoute<V4>> {
     let mut rib = PrefixMap::<Ipv4Net, SpfRoute<V4>>::new();
 
@@ -2311,9 +2310,35 @@ fn build_rib_from_flex_algo(
             };
             let prefix_sid = label_block.as_ref().map(|b| (algo_sid.clone(), b.clone()));
 
+            let mut nhops_for_route = spf_nhops.clone();
+
+            // Per-algo TI-LFA backup, mirroring the SRv6 sibling. Single
+            // nexthop only — an ECMP route's surviving legs already
+            // protect it. `Some(algo)` makes every node segment resolve
+            // to an algorithm-`algo` Prefix-SID, so the repair stays
+            // inside this algorithm's topology; a repair whose segments
+            // cannot all resolve is dropped rather than approximated
+            // with algorithm-0 labels.
+            if nhops_for_route.len() == 1
+                && let Some(repair) = tilfa.get(node).and_then(|paths| paths.first())
+                && let Some(mut backup) = build_repair_path_mpls(top, level, Some(algo), repair)
+            {
+                // Close the repair into a full SR path to the
+                // destination: the segment list only steers as far as
+                // its release point, and traffic tunneled through this
+                // route carries an inner destination that point may not
+                // know. Uses this algorithm's SID, not algo-0's.
+                if let Some(sid) = sid {
+                    V4::backup_append_prefix_sid(&mut backup, sid);
+                }
+                if let Some(nhop) = nhops_for_route.values_mut().next() {
+                    nhop.backup = Some(backup);
+                }
+            }
+
             let route = SpfRoute {
                 metric: nhops.cost + entry.metric,
-                nhops: spf_nhops.clone(),
+                nhops: nhops_for_route,
                 sid,
                 prefix_sid,
                 // `peer_algo_sid` stores only the SID value, not the

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -87,6 +87,8 @@ impl Isis {
             .set(show_isis_flex_algo_spf)
             .path("/show/isis/flex-algo/algorithm/graph")
             .set(show_isis_flex_algo_graph)
+            .path("/show/isis/flex-algo/algorithm/repair-list")
+            .set(show_isis_flex_algo_repair_list)
             .map();
     }
 }
@@ -3147,7 +3149,21 @@ where
     F::Prefix: std::fmt::Display,
     F::Addr: std::fmt::Display,
 {
-    for (prefix, route) in F::rib(isis, level).iter() {
+    collect_repair_rows_from::<F>(F::rib(isis, level), level, rows)
+}
+
+/// Row collector parameterized by RIB source, so the algorithm-0 view
+/// and the per-Flex-Algorithm view share one implementation.
+fn collect_repair_rows_from<F>(
+    rib: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    level: &Level,
+    rows: &mut Vec<RepairRowJson>,
+) where
+    F: IsisRibFamilyShow,
+    F::Prefix: std::fmt::Display,
+    F::Addr: std::fmt::Display,
+{
+    for (prefix, route) in rib.iter() {
         for (addr, nhop) in route.nhops.iter() {
             let Some(backup) = nhop.backup.as_ref() else {
                 continue;
@@ -3166,6 +3182,70 @@ where
             });
         }
     }
+}
+
+/// Repair rows for one Flex-Algorithm, from the per-algo RIBs.
+fn collect_repair_rows_flex_algo(isis: &Isis, algo: u8) -> Vec<RepairRowJson> {
+    let mut rows = Vec::new();
+    for level in [Level::L1, Level::L2] {
+        if let Some(rib) = isis.rib_flex_algo.get(&level).get(&algo) {
+            collect_repair_rows_from::<V4>(rib, &level, &mut rows);
+        }
+        if let Some(rib6) = isis.rib6_flex_algo.get(&level).get(&algo) {
+            collect_repair_rows_from::<V6>(rib6, &level, &mut rows);
+        }
+    }
+    rows
+}
+
+/// `show isis flex-algo <n> repair-list` — TI-LFA repairs computed in
+/// this algorithm's constrained topology. Node segments are this
+/// algorithm's Prefix-SIDs / End SIDs, so a repair listed here cannot
+/// traverse a link the FAD excluded.
+fn show_isis_flex_algo_repair_list(
+    isis: &Isis,
+    mut args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let algo = match flex_algo_arg(&mut args, json) {
+        Ok(a) => a,
+        Err(msg) => return Ok(msg),
+    };
+    let rows = collect_repair_rows_flex_algo(isis, algo);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListJson { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    if rows.is_empty() {
+        writeln!(
+            buf,
+            "(no TI-LFA repair-list entries for algorithm {})",
+            algo
+        )?;
+        return Ok(buf);
+    }
+    writeln!(
+        buf,
+        "{:<5} {:<5} {:<22} {:<22} {:<22} Segments",
+        "Level", "AFI", "Prefix", "Primary via", "Repair via",
+    )?;
+    for row in &rows {
+        let segs: Vec<String> = row.segments.iter().map(|s| s.value.clone()).collect();
+        writeln!(
+            buf,
+            "{:<5} {:<5} {:<22} {:<22} {:<22} [{}]",
+            row.level,
+            row.family,
+            row.prefix,
+            row.primary_nexthop,
+            row.repair_nexthop,
+            segs.join(", "),
+        )?;
+    }
+    Ok(buf)
 }
 
 fn collect_repair_rows(isis: &Isis) -> Vec<RepairRowJson> {
@@ -3941,10 +4021,13 @@ fn flex_algo_frr_state(isis: &Isis, entry: &crate::flex_algo::FlexAlgoEntry) -> 
         "disabled" // explicit per-algo opt-out
     } else if !isis.config.ti_lfa_enabled {
         "off" // instance-level TI-LFA is off; nothing to inherit
-    } else if entry.dataplane_srv6 == Some(true) {
-        "on" // inherited and computed
     } else {
-        "n/a" // inherited, but no algo-aware SR-MPLS repair yet
+        // Inherited and computed. Both dataplanes are algorithm-aware:
+        // node segments resolve to this algorithm's Prefix-SID (SR-MPLS)
+        // or End SID (SRv6). An algorithm with no dataplane flag at all
+        // still gets the historical SR-MPLS build, so it is protected
+        // too — mirroring `mpls_on` in `rib.rs`.
+        "on"
     }
 }
 

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -72,9 +72,10 @@ pub(super) fn first_router_hop_id(lsp_map: &LspMap, path: &[usize]) -> Option<us
 pub(super) fn build_repair_path_mpls(
     top: &IsisTop,
     level: Level,
+    algo: Option<u8>,
     rp: &spf::RepairPath,
 ) -> Option<RepairPathMpls> {
-    let labels = repair_segments_to_mpls_labels(top, level, &rp.segs)?;
+    let labels = repair_segments_to_mpls_labels(top, level, algo, &rp.segs)?;
 
     let ifindex = (rp.first_hop_link_id != 0).then_some(rp.first_hop_link_id)?;
     let link = top.links.get(&ifindex)?;
@@ -365,10 +366,27 @@ fn resolve_sid_to_label(
 }
 
 /// Look up `vertex`'s prefix-SID (NodeSID) as an absolute MPLS label.
-/// Walks the vertex's IPv4 reach entries (typically the loopback)
-/// for the first prefix-SID sub-TLV, then resolves Index against the
-/// originator's SRGB.
-fn node_sid_label_for_vertex(top: &IsisTop, level: Level, vertex: usize) -> Option<u32> {
+/// Walks the vertex's IPv4 reach entries (typically the loopback) and
+/// resolves the SID Index against the originator's SRGB.
+///
+/// `algo` selects which Prefix-SID: `None` takes the algo-0 sub-TLV off
+/// the reach entry; `Some(n)` takes the Algorithm-`n` SID from
+/// `peer_algo_sid`, keyed on the same (untruncated) prefix so the entry
+/// chosen is identical either way — only the SID differs.
+///
+/// There is deliberately **no fallback to the algo-0 SID** when a peer
+/// advertises no Algorithm-`n` Prefix-SID. Algorithm-0 segments steer
+/// along algorithm-0 paths, which may cross a link the FAD excluded —
+/// exactly the constraint the algorithm exists to enforce. Returning
+/// `None` drops the whole repair stack (see
+/// `repair_segments_to_mpls_labels`), leaving the destination
+/// unprotected under algorithm `n`, which is the safe failure.
+fn node_sid_label_for_vertex(
+    top: &IsisTop,
+    level: Level,
+    vertex: usize,
+    algo: Option<u8>,
+) -> Option<u32> {
     let Some(sys_id) = top.lsp_map.get(&level).resolve(vertex).copied() else {
         tracing::debug!(
             "[tilfa] node_sid {level:?} vertex={vertex}: no sys_id in lsp_map (vertex not in LSDB?)"
@@ -384,28 +402,35 @@ fn node_sid_label_for_vertex(top: &IsisTop, level: Level, vertex: usize) -> Opti
     };
     let mut saw_prefix_sid = false;
     for entry in entries.iter() {
-        let Some(prefix_sid) = entry.prefix_sid() else {
+        let sid = match algo {
+            None => entry.prefix_sid().map(|ps| ps.sid.clone()),
+            Some(n) => top
+                .peer_algo_sid
+                .get(&level)
+                .get(&sys_id)
+                .and_then(|m| m.get(&(n, entry.prefix)))
+                .cloned(),
+        };
+        let Some(sid) = sid else {
             continue;
         };
         saw_prefix_sid = true;
-        if let Some(label) =
-            resolve_sid_to_label(top, level, &sys_id, &prefix_sid.sid, SrBlockKind::Global)
-        {
+        if let Some(label) = resolve_sid_to_label(top, level, &sys_id, &sid, SrBlockKind::Global) {
             return Some(label);
         }
         tracing::debug!(
-            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id}: \
+            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id} algo={algo:?}: \
              prefix={:?} prefix_sid={:?} could not resolve against SRGB \
              (peer's label_map block missing or index out of range)",
             entry.prefix,
-            prefix_sid.sid,
+            sid,
         );
     }
     if !saw_prefix_sid {
         tracing::debug!(
-            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id}: \
-             {} IPv4 reach entries scanned, none carry a Prefix-SID sub-TLV \
-             (peer not advertising prefix-SID for any loopback?)",
+            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id} algo={algo:?}: \
+             {} IPv4 reach entries scanned, none carry a Prefix-SID for this algorithm \
+             (peer not participating, or advertising no per-algo SID for its loopback?)",
             entries.len(),
         );
     }
@@ -495,15 +520,23 @@ fn adj_sid_label_for_link(
 /// — we refuse to install a partial stack since the resulting label
 /// path would diverge from the post-convergence path the algorithm
 /// computed.
+/// `algo` is threaded to the NodeSid resolver so an algorithm-N repair
+/// is expressed with algorithm-N node segments. Adjacency segments are
+/// algorithm-agnostic by definition (RFC 9350 §6.2: an Adj-SID means
+/// "pop and forward over this link" regardless of algorithm), and the
+/// link is already known to be in algorithm N's topology because the
+/// repair was computed on that algorithm's pruned graph — so they need
+/// no per-algo lookup.
 fn repair_segments_to_mpls_labels(
     top: &IsisTop,
     level: Level,
+    algo: Option<u8>,
     segments: &[spf::SrSegment],
 ) -> Option<Vec<rib::Label>> {
     let mut labels = Vec::with_capacity(segments.len());
     for (idx, seg) in segments.iter().enumerate() {
         let resolved = match seg {
-            spf::SrSegment::NodeSid(v) => node_sid_label_for_vertex(top, level, *v),
+            spf::SrSegment::NodeSid(v) => node_sid_label_for_vertex(top, level, *v, algo),
             spf::SrSegment::AdjSid(from, to, via) => {
                 adj_sid_label_for_link(top, level, *from, *to, *via)
             }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -902,6 +902,10 @@ module exec {
             ext:help "Constrained topology graph for this algorithm";
             type empty;
           }
+          leaf repair-list {
+            ext:help "TI-LFA repair paths computed for this algorithm";
+            type empty;
+          }
         }
 
         container route {


### PR DESCRIPTION
Per-algorithm TI-LFA worked on SRv6 but was deliberately gated off for SR-MPLS: `repair_segments_to_mpls_labels` took no algorithm and `node_sid_label_for_vertex` returned the first Prefix-SID it found — the algorithm-0 one. A repair built that way can leave over a link the FAD excluded, so computing it would have been worse than leaving the algorithm unprotected. This makes the resolver algorithm-aware and lifts the gate.

## The failure mode was real, not theoretical

On `se` in `playset/isis-flexalgo`, both algorithms protecting the same prefix:

```
algo 0    10.0.0.5/32  repair via 192.168.0.2  [16800, 15001, 16500]
algo 128  10.0.0.5/32  repair via 192.168.1.2  [18600, 15000, 18500]
```

`192.168.0.2` is **`se-sg` — the trans-Pacific link algorithm 128 exists to avoid**. Reusing algorithm-0 repairs would have steered algorithm-128 backup traffic straight across it. The algorithm-128 repair leaves over `se-sj` with algorithm-128 labels instead.

## The gap was wider than the resolver

`build_rib_from_flex_algo` also set `backup: None` unconditionally, so the per-algo SR-MPLS RIB never carried repairs at all — the label resolver was only half of it.

* `node_sid_label_for_vertex` takes `algo: Option<u8>`; `Some(n)` resolves through `peer_algo_sid`, keyed on the same untruncated prefix so the reach entry chosen is identical — only the SID differs.
* **No fallback to the algo-0 SID.** A missing per-algo SID drops the whole repair stack, leaving that destination unprotected under the algorithm. Silent approximation is what created the hazard in the first place.
* Threaded through `repair_segments_to_mpls_labels` / `build_repair_path_mpls`, matching `build_repair_path_srv6`'s existing `Option<u8>` shape. Adjacency segments stay algorithm-agnostic (RFC 9350 §6.2 — an Adj-SID means "pop and forward over this link"), and the link is already known to be in the algorithm's topology because the repair was computed on its pruned graph.
* Added the TI-LFA stamping pass to `build_rib_from_flex_algo` (the SRv6 sibling already had one) and lifted the SRv6-only gate in `build_spf_input`.
* `show isis flex-algo` FRR column loses the now-impossible `n/a` state.
* New `show isis flex-algo <n> repair-list`, sharing the row collector with the algorithm-0 view via a RIB-source parameter.

## Test plan

- [x] verified live on the 11-node lab — the algo-0 vs algo-128 contrast above
- [x] `show isis flex-algo <n> repair-list` renders; FRR column moves `off` → `on` when instance TI-LFA is enabled
- [x] algorithm-0 repairs unchanged (`show isis repair-list` still resolves `16xxx`)
- [x] `cargo test -p zebra-rs` — 1676 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (full workspace incl. `bdd`)
- [x] `cargo fmt --all --check` — clean
- [x] `make -C packaging playset` — OK
- [x] README sample verified against live output; all temporary debug instrumentation removed

## Note for whoever tests this next

`ch` is a poor test node and looks like a broken fix: it yields **5 TI-LFA targets and 0 repairs**, because its only non-ECMP algorithm-128 destinations are its own *direct neighbours*, and node protection for an adjacent destination is empty by design (`d == x` → no post-convergence path). Pick a node with a single-nexthop **non-adjacent** destination — `se` works. When debugging "no repairs", probe `tilfa_targets(...).len()` and the ECMP count before suspecting the resolver.

Generated with [Claude Code](https://claude.com/claude-code)