### PR TITLE
bgp: start per-VRF peers after assigning their identity

### DIFF
--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -451,8 +451,16 @@ fn materialize_peers(
         peer.config.mp = mp;
         peer.config.mp_explicit = nbr_cfg.mp_explicit.clone();
 
-        peer.start();
         vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
+        // `PeerMap::insert_with_key` assigns the stable ident used in every
+        // timer/FSM message. Starting before insertion leaves every peer at
+        // Peer::new's ident 0, so a second neighbor's Start events are
+        // delivered to the first neighbor and the second session never
+        // leaves Idle/Active.
+        vrf.peers
+            .get_mut(addr)
+            .expect("peer was just inserted")
+            .start();
         count += 1;
     }
     count


### PR DESCRIPTION
## Problem

`Peer::start()` queues FSM events containing the peer identity.

During per-VRF peer materialization, a peer was started before
`PeerMap::insert_with_key()` assigned its stable index. Newly constructed
peers therefore emitted their initial events with identity `0`.

When multiple neighbors were created, a later peer's `Start` event could be
delivered to the first peer, leaving the intended peer in the Idle or Active
state.

## Change

- Insert each peer into `PeerMap` before starting it.
- Retrieve the inserted peer by address.
- Call `Peer::start()` only after the map has assigned its stable identity.