### PR TITLE
bdd: cover two BGP CE neighbors under a single VRF

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -271,6 +271,10 @@ vrf_connected_route:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_connected_route"
 
+l3vpn_dual_ce:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@l3vpn_dual_ce"
+
 bgp_vrf_redistribute:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_redistribute"
@@ -483,4 +487,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover bgp_mp_reach_ipv4 generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover bgp_mp_reach_ipv4 l3vpn_dual_ce generate open docs FORCE

--- a/bdd/tests/configs/l3vpn_dual_ce/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_dual_ce/ce1.yaml
@@ -1,0 +1,39 @@
+# CE1 — customer edge 1 (AS 65001), the FIRST neighbor in PE1's VRF
+# (10.1.0.2 sorts below 10.2.0.2). This session came up even with the
+# ident bug, because the first peer's accidental ident 0 was correct;
+# it is here as the control against which CE2 is compared.
+#
+# `redistribute connected` puts both the loopback (the ping target) and
+# the PE-facing /30 into BGP. The /30 matters: the CE-to-CE ping picks
+# its source from the egress interface, so the far CE needs a route back
+# to this /30 for the reply.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.1.1
+    # Cut the default 30s eBGP MRAI: the CE-PE-CE chain cascades one
+    # advertisement interval per eBGP hop per direction, which would
+    # otherwise push convergence past the ping step's 60s budget.
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.1.0.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/l3vpn_dual_ce/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_dual_ce/ce2.yaml
@@ -1,0 +1,34 @@
+# CE2 — customer edge 2 (AS 65002), the SECOND neighbor in PE1's VRF
+# (10.2.0.2 sorts above 10.1.0.2). This is the peer the ident bug broke:
+# PE1 armed its idle-hold timer under ident 0, so the Start landed on
+# CE1's peer instead and this one sat in Idle forever — never dialling,
+# and (because `handle_peer_connection` drops inbound streams for an
+# Idle peer) never accepting CE2's dial either.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: pe1
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.2.1
+    # Cut the default 30s eBGP MRAI — see ce1.yaml.
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.2.0.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/l3vpn_dual_ce/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_dual_ce/pe1.yaml
@@ -1,0 +1,53 @@
+# PE1 — the router under test (AS 65000). A single VRF (vrf-cust) holds
+# *two* eBGP PE-CE sessions, one per CE. This is the shape issue #2077
+# found to have zero coverage: every other BDD config puts at most one
+# neighbor under a `router bgp vrf` block, so nothing exercised the
+# ident assignment that `materialize_peers` performs per peer.
+#
+# There is no VPNv4 core here on purpose — the second CE *is* the far
+# end. PE1 puts both CE-learned prefixes in vrf-cust's Loc-RIB and
+# re-advertises each to the other CE, so a CE-to-CE ping proves both
+# sessions carry routes rather than merely reaching Established.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      # Both CE peers live under the one VRF. Peer ordering matters to
+      # the bug this guards: `materialize_peers` walks `cfg.neighbors`
+      # (a BTreeMap, so ascending address order) and every peer past the
+      # first is the one that used to be mis-identified.
+      - remote-address: 10.1.0.2
+        remote-as: 65001
+        afi-safi:
+        - name: ipv4
+          enabled: true
+      - remote-address: 10.2.0.2
+        remote-as: 65002
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/features/l3vpn_dual_ce.feature
+++ b/bdd/tests/features/l3vpn_dual_ce.feature
@@ -1,0 +1,103 @@
+@serial
+@l3vpn_dual_ce
+Feature: Two BGP CE neighbors under a single VRF
+  As a service provider attaching more than one customer edge to the
+  same VRF on a PE
+  I want every neighbor under `router bgp vrf <name>` to establish and
+  carry routes, not just the first one
+  So that a multi-CE VRF converges instead of silently wedging one
+  session in Idle.
+
+  Regression guard for issue #2077 / PR #2071. `materialize_peers`
+  used to call `Peer::start()` *before* `PeerMap::insert_with_key`
+  assigned the peer's stable ident. `start_timer!` captures
+  `peer.ident` by value when it arms the idle-hold timer, and the
+  per-VRF loop dispatches `Message::Event(ident, …)` purely on that
+  value, so every peer past the first armed its timer under ident 0
+  and its `Event::Start` was delivered to the *first* peer instead.
+
+  The wedged peer stays in Idle, which blocks the session from both
+  directions: it never dials, and `handle_peer_connection` drops
+  inbound streams for an Idle peer, so the CE's own dial is refused
+  too. Before the fix CE2 below never leaves Idle.
+
+  Every pre-existing BDD config puts at most one neighbor under a
+  `router bgp vrf` block (106 such blocks, zero with two), which is
+  why nothing caught this. The second neighbor is the entire point of
+  this topology.
+
+  Test Topology (3 namespaces):
+  ```
+   ce1 ────────── pe1 ────────── ce2
+   AS 65001    AS 65000        AS 65002
+   lo          vrf-cust        lo
+   10.0.1.1/32 RD 65000:1      10.0.2.1/32
+        .2 ── .1        .1 ── .2
+       10.1.0.0/30    10.2.0.0/30
+  ```
+  Both PE-CE sessions are eBGP and both live inside vrf-cust. There is
+  no VPNv4 core: PE1 re-advertises each CE's prefixes to the other CE
+  out of the same VRF Loc-RIB, so the CE-to-CE ping proves both
+  sessions carry routes rather than merely reaching Established.
+
+  Scenario: Build the dual-CE VRF topology
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "ce2"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "ce2" to namespace "ce2" interface "pe1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "ce2"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp vrf" in namespace "pe1" should contain "vrf-cust"
+    And show command "show bgp vrf" in namespace "pe1" should contain "running"
+
+  Scenario: Both PE-CE sessions in the VRF reach Established
+    # The assertion that actually catches the regression. It is made
+    # from the CE side deliberately: `BGP session in …` queries the
+    # global instance, and each CE's peer *is* a global neighbor, so
+    # this needs no per-VRF show plumbing to be trustworthy.
+    #
+    # CE1 is the control — it established even with the bug, because
+    # the first peer's accidental ident 0 happened to be correct. CE2
+    # is the regression guard.
+    Given the test topology exists
+    Then BGP session in "ce1" to "10.1.0.1" should eventually be "Established"
+    And BGP session in "ce2" to "10.2.0.1" should eventually be "Established"
+
+  Scenario: The VRF Loc-RIB holds both CE's prefixes
+    # Proves the second session is not merely up but actually
+    # exchanging NLRI into the shared VRF table.
+    Given the test topology exists
+    Then show command "show bgp vrf vrf-cust" in namespace "pe1" should eventually contain "10.0.1.1/32"
+    And show command "show bgp vrf vrf-cust" in namespace "pe1" should eventually contain "10.0.2.1/32"
+
+  Scenario: CE-to-CE reachability across the shared VRF
+    # End-to-end: PE1 re-advertises each CE's routes to the other CE
+    # and forwards between them in vrf-cust's kernel table.
+    #
+    # Expect ~25-30s before the first reply, and don't "fix" that by
+    # trimming the wait above: the CE-side `adv-interval ebgp 3` does
+    # not apply to PE1's half of the session. Per-VRF peers are built
+    # by `materialize_peers` from the `router bgp vrf` subtree, which
+    # carries no timer plumbing at all, so they run the default 30s
+    # eBGP MRAI on the PE-to-CE direction. The step's own budget
+    # (60 attempts) covers it with room to spare.
+    Given the test topology exists
+    Then ping from "ce1" to "10.0.2.1" should eventually succeed
+    And ping from "ce2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "ce2"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "ce2"
+    Then the test environment should be clean


### PR DESCRIPTION
Closes #2077.

## Problem

Every pre-existing BDD config puts **at most one** neighbor under a
`router bgp vrf` block — 106 such blocks across `bdd/tests/configs/`, none
with two. So nothing exercised the per-peer ident assignment that
`materialize_peers` performs, and that is how the bug fixed in #2071 reached
main: a peer started before `PeerMap::insert_with_key` assigned its ident
armed its idle-hold timer under ident `0`, and every peer past the first had
its `Event::Start` delivered to the *first* peer instead.

## Change

Adds `@l3vpn_dual_ce`: one PE whose `vrf-cust` holds two eBGP PE-CE sessions,
with a CE on each.

```
 ce1 ────────── pe1 ────────── ce2
 AS 65001    AS 65000        AS 65002
 lo          vrf-cust        lo
 10.0.1.1/32 RD 65000:1      10.0.2.1/32
      .2 ── .1        .1 ── .2
     10.1.0.0/30    10.2.0.0/30
```

There is no VPNv4 core on purpose — the second CE *is* the far end. PE1
re-advertises each CE's prefixes to the other out of the same VRF Loc-RIB, so
the CE-to-CE ping proves both sessions carry routes rather than merely
reaching Established.

Run it with `make -C bdd l3vpn_dual_ce`.

## Verification

Checked in **both** directions on a local host, since a regression test that
was never observed failing proves nothing:

| assertion | main without #2071 | main with #2071 |
|---|---|---|
| `BGP session ce2 → 10.2.0.1` | **fails** — stuck in `Active` | Established |
| `show bgp vrf vrf-cust` has `10.0.2.1/32` | **fails** — only CE1's prefixes | present |
| `ping ce1 → 10.0.2.1` | **fails** — 60 attempts | succeeds |
| total | 5 scenarios, **3 steps failed** | **5 scenarios / 32 steps pass** |

The observed failure matched the mechanism exactly: PE1's second VRF peer sat
in `Idle`, so it never dialled *and* `handle_peer_connection`'s
`State::Idle => drop(stream)` arm refused CE2's own dial — the session was
blocked from both directions.

The final run above is against merged `main` (i.e. with #2071 in), not a
locally-patched tree.

## Notes for reviewers

Two deliberate choices worth knowing about:

- **The session assertions are made from the CE side.** `BGP session in …`
  queries the global instance, and each CE's peer *is* a global neighbor, so
  the check needs no per-VRF show plumbing to be trustworthy. (`l3vpn_bgp_v4`
  notes the same limitation and works around it via VPNv4 route asserts.)

- **The ping takes ~25-30s, and that is expected.** Per-VRF peers are built by
  `materialize_peers` from the `router bgp vrf` subtree, which carries no timer
  plumbing at all, so PE1's direction runs the default 30s eBGP MRAI regardless
  of the CEs' `adv-interval ebgp 3`. There is a comment in the feature saying so,
  so the waits don't get "optimized" into a flake later. The step's own 60-attempt
  budget covers it with room to spare.

Also worth recording from #2077: a **unit** test could not have caught this. The
*stored* ident was always correct — only the value already baked into the armed
timer closure was stale, and no unit-level seam can observe that. The guard has
to be behavioral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
