### PR TITLE
bgp: add per-neighbor timers under router bgp vrf

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -222,5 +222,8 @@
 /router/bgp/vrf/neighbor/description
 /router/bgp/vrf/neighbor/peer-group
 /router/bgp/vrf/neighbor/remote-as
+/router/bgp/vrf/neighbor/timers/connect-retry-time
+/router/bgp/vrf/neighbor/timers/hold-time
+/router/bgp/vrf/neighbor/timers/idle-hold-time
 /router/bgp/vrf/rd
 /router/bgp/vrf/router-id

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -21,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 278
-Handled: 265
+Total settable schema nodes: 281
+Handled: 268
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -40,6 +40,21 @@ handled above. The tracing subtrees (/router/bgp/tracing and
 /router/bgp/neighbor/tracing) have no per-node callbacks; the whole
 subtree is handled by config_tracing_dispatch in src/bgp/tracing.rs, so
 they count as handled above.
+
+Note: /router/bgp/vrf/neighbor/timers exposes only connect-retry-time,
+hold-time and idle-hold-time — the three leaves crate::bgp::timer::Config
+is actually read for. It deliberately does NOT `uses neighbor-group-timers`
+the way the global neighbor's timers container does, because three leaves
+of that grouping (advertisement-interval, originate-interval,
+delay-open-time) are staged onto PeerConfig::timer and never consumed by
+any timer-arming path. They are counted as handled orphans-by-another-name
+on the global neighbor (they have callbacks, they just do nothing); adding
+them under the VRF neighbor would have shipped three more knobs that
+silently no-op. Note also that the advertisement interval (MRAI) is NOT in
+this container on either neighbor: it comes from the AdvInterval snapshot
+configured under /router/bgp/timer/adv-interval, which has no per-VRF
+plumbing, so a per-VRF session always runs the stock 30s eBGP / 5s iBGP
+cadence.
 
 == Handler paths with no schema node (stale/other) ==
   /community-list

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -306,5 +306,9 @@
 /router/bgp/vrf/neighbor/description	leaf
 /router/bgp/vrf/neighbor/peer-group	leaf
 /router/bgp/vrf/neighbor/remote-as	leaf
+/router/bgp/vrf/neighbor/timers	container
+/router/bgp/vrf/neighbor/timers/connect-retry-time	leaf
+/router/bgp/vrf/neighbor/timers/hold-time	leaf
+/router/bgp/vrf/neighbor/timers/idle-hold-time	leaf
 /router/bgp/vrf/rd	leaf
 /router/bgp/vrf/router-id	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4413,6 +4413,18 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_description,
         );
         self.callback_add(
+            "/router/bgp/vrf/neighbor/timers/connect-retry-time",
+            super::vrf_config::config_vrf_neighbor_connect_retry_time,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/timers/hold-time",
+            super::vrf_config::config_vrf_neighbor_hold_time,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/timers/idle-hold-time",
+            super::vrf_config::config_vrf_neighbor_idle_hold_time,
+        );
+        self.callback_add(
             "/router/bgp/vrf/neighbor/afi-safi/enabled",
             super::vrf_config::config_vrf_neighbor_afi_safi_enabled,
         );

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -406,6 +406,20 @@ fn materialize_peers(
         // session is cleared.
         peer.config.neighbor_group = nbr_cfg.peer_group.clone();
 
+        // Session timers (`neighbor <addr> timers { … }`). Copied before
+        // `start()` below so the very first idle-hold timer this peer
+        // arms already honours a configured `idle-hold-time` — arming it
+        // from the default and fixing it up afterwards would leave the
+        // first dial on the wrong cadence. Unset leaves stay `None` and
+        // fall through to `timer::Config`'s defaults, so a VRF neighbor
+        // with no `timers` block behaves exactly as before.
+        //
+        // This does NOT cover MRAI: advertisement pacing comes from the
+        // `AdvInterval` snapshot on the peer, which per-VRF tasks have no
+        // plumbing for — a CE session still advertises on the stock 30s
+        // eBGP / 5s iBGP cadence regardless of what is set here.
+        peer.config.timer = nbr_cfg.timer.clone();
+
         // Derive the negotiated address-family set for this CE peer.
         // `Peer::new` defaults to IPv4 unicast only, which is wrong for
         // an IPv6 CE peer — so resolve the family set in three layers,
@@ -699,6 +713,75 @@ mod tests {
             vrf.peers.get(&no_as).is_none(),
             "neighbor without remote-as skipped"
         );
+    }
+
+    /// `neighbor <addr> timers { … }` must reach the peer that
+    /// `materialize_peers` builds — the per-VRF equivalent of the global
+    /// neighbor's `timer::config::*` callbacks, which mutate a live peer
+    /// directly. Here the staged config is the only carrier: nothing
+    /// re-applies it after the peer exists, so if the copy is dropped the
+    /// session silently runs the stock cadence and the operator's
+    /// `timers` block does nothing at all.
+    #[tokio::test]
+    async fn materialize_peers_applies_configured_timers() {
+        use super::super::super::vrf_config::{BgpVrfConfig, BgpVrfNeighborConfig};
+        use super::super::inst::BgpVrf;
+        use crate::context::ProtoContext;
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "v1".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let mut cfg = BgpVrfConfig::default();
+        let tuned: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let bare: std::net::IpAddr = "192.0.2.2".parse().unwrap();
+
+        let mut nbr = BgpVrfNeighborConfig {
+            remote_as: Some(65001),
+            ..Default::default()
+        };
+        nbr.timer.connect_retry_time = Some(3);
+        nbr.timer.hold_time = Some(9);
+        nbr.timer.idle_hold_time = Some(1);
+        cfg.neighbors.insert(tuned, nbr);
+
+        cfg.neighbors.insert(
+            bare,
+            BgpVrfNeighborConfig {
+                remote_as: Some(65002),
+                ..Default::default()
+            },
+        );
+
+        materialize_peers(&mut vrf, &cfg, &BTreeMap::new());
+
+        let peer = vrf.peers.get(&tuned).expect("tuned peer inserted");
+        assert_eq!(peer.config.timer.connect_retry_time, Some(3));
+        assert_eq!(peer.config.timer.hold_time, Some(9));
+        assert_eq!(peer.config.timer.idle_hold_time, Some(1));
+        // Read back through the accessors the timer code actually calls,
+        // so the test pins the effective value and not just the field.
+        assert_eq!(peer.config.timer.connect_retry_time(), 3);
+        assert_eq!(peer.config.timer.hold_time(), 9);
+        assert_eq!(peer.config.timer.idle_hold_time(), 1);
+
+        // A neighbor with no `timers` block is untouched: all three fall
+        // through to the documented defaults (RFC 4271 §10 suggests 120s
+        // ConnectRetry; hold-time 180s; idle-hold 5s).
+        let peer = vrf.peers.get(&bare).expect("bare peer inserted");
+        assert!(peer.config.timer.connect_retry_time.is_none());
+        assert_eq!(peer.config.timer.connect_retry_time(), 120);
+        assert_eq!(peer.config.timer.hold_time(), 180);
+        assert_eq!(peer.config.timer.idle_hold_time(), 5);
     }
 
     /// A CE peer's negotiated MP family set is derived from its own

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -103,6 +103,17 @@ pub struct BgpVrfNeighborConfig {
     /// stored `peer_group` is not resolved at materialization), so this
     /// map is the only override layer.
     pub mp_explicit: BTreeMap<AfiSafi, bool>,
+    /// Staged `timers { … }` for this CE peer, copied verbatim onto
+    /// [`super::peer::PeerConfig::timer`] by `materialize_peers`.
+    ///
+    /// Deliberately the *same* type the peer holds rather than a
+    /// narrower struct: the schema only exposes the three leaves the
+    /// timer code actually consumes (connect-retry-time, hold-time,
+    /// idle-hold-time), so the rest stay `None` — which is what they
+    /// would be anyway, since nothing reads them even on the global
+    /// neighbor. Sharing the type means wiring one of those up later
+    /// is a schema-only change here.
+    pub timer: super::timer::Config,
 }
 
 /// Per-AFI knobs under `router bgp vrf X afi-safi {ipv4,ipv6}-unicast`.
@@ -634,6 +645,67 @@ pub fn config_vrf_neighbor_description(bgp: &mut Bgp, mut args: Args, op: Config
     match op {
         ConfigOp::Set => nbr.description = Some(args.string()?),
         ConfigOp::Delete => nbr.description = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> neighbor <addr> timers connect-retry-time
+/// <SECS>`.
+///
+/// The three `timers` callbacks stage onto
+/// [`BgpVrfNeighborConfig::timer`], which `materialize_peers` copies
+/// onto the peer at build time. Unlike the global neighbor's
+/// equivalents (`timer::config::*`) they do **not** re-arm anything:
+/// there is no live peer to reach from here — the CE peers live in the
+/// per-VRF task — so a change lands when the VRF next respawns or the
+/// session is cleared. That matches how every other per-VRF neighbor
+/// knob (remote-as, afi-safi) already behaves.
+pub fn config_vrf_neighbor_connect_retry_time(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, name, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    match op {
+        ConfigOp::Set => nbr.timer.connect_retry_time = Some(args.u16()?),
+        ConfigOp::Delete => nbr.timer.connect_retry_time = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> neighbor <addr> timers hold-time <SECS>`.
+pub fn config_vrf_neighbor_hold_time(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, name, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    match op {
+        ConfigOp::Set => nbr.timer.hold_time = Some(args.u16()?),
+        ConfigOp::Delete => nbr.timer.hold_time = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> neighbor <addr> timers idle-hold-time
+/// <SECS>`.
+pub fn config_vrf_neighbor_idle_hold_time(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, name, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    match op {
+        ConfigOp::Set => nbr.timer.idle_hold_time = Some(args.u16()?),
+        ConfigOp::Delete => nbr.timer.idle_hold_time = None,
         _ => {}
     }
     Some(())
@@ -1177,6 +1249,56 @@ mod tests {
         assert!(nbr.peer_group.is_none());
         assert!(nbr.description.is_none());
         assert!(nbr.mp_explicit.is_empty());
+        // Every timer leaf unset — `materialize_peers` copies this
+        // wholesale onto the peer, so an all-`None` default is what keeps
+        // a `timers`-less VRF neighbor on the stock cadence.
+        assert!(nbr.timer.connect_retry_time.is_none());
+        assert!(nbr.timer.hold_time.is_none());
+        assert!(nbr.timer.idle_hold_time.is_none());
+    }
+
+    #[test]
+    fn neighbor_timers_stage_and_clear_independently() {
+        let address: IpAddr = "192.0.2.1".parse().unwrap();
+        let mut cfg = BgpVrfConfig::default();
+
+        let nbr = neighbor_entry(&mut cfg, address, ConfigOp::Set).unwrap();
+        nbr.timer.connect_retry_time = Some(3);
+        nbr.timer.hold_time = Some(9);
+        nbr.timer.idle_hold_time = Some(1);
+
+        let nbr = &cfg.neighbors[&address];
+        assert_eq!(nbr.timer.connect_retry_time, Some(3));
+        assert_eq!(nbr.timer.hold_time, Some(9));
+        assert_eq!(nbr.timer.idle_hold_time, Some(1));
+
+        // Clearing one leaf must leave the siblings alone: the three
+        // callbacks share one staged `timer::Config`, so a careless
+        // implementation could reset the struct instead of the field.
+        cfg.neighbors.get_mut(&address).unwrap().timer.hold_time = None;
+        let nbr = &cfg.neighbors[&address];
+        assert!(nbr.timer.hold_time.is_none());
+        assert_eq!(nbr.timer.connect_retry_time, Some(3));
+        assert_eq!(nbr.timer.idle_hold_time, Some(1));
+    }
+
+    #[test]
+    fn neighbor_timers_leave_the_inert_leaves_unset() {
+        // The schema deliberately omits advertisement-interval /
+        // originate-interval / delay-open-time: they are staged onto
+        // `PeerConfig::timer` and never read by any arming path, even for
+        // a global neighbor. Sharing `timer::Config` with the peer means
+        // they exist as fields, so pin that they stay `None` — if one is
+        // ever wired up, this test should fail and prompt exposing it
+        // here too.
+        let address: IpAddr = "192.0.2.1".parse().unwrap();
+        let mut cfg = BgpVrfConfig::default();
+        let nbr = neighbor_entry(&mut cfg, address, ConfigOp::Set).unwrap();
+        nbr.timer.connect_retry_time = Some(3);
+
+        assert!(nbr.timer.min_adv_interval.is_none());
+        assert!(nbr.timer.orig_interval.is_none());
+        assert!(nbr.timer.delay_open_time.is_none());
     }
 
     #[test]

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -186,6 +186,68 @@ module zebra-bgp-vrf {
            neighbors` output. May contain spaces: the value is the
            rest of the line.";
       }
+      container timers {
+        ext:help "Per-neighbor BGP timers";
+        description
+          "Session timers for this CE peer. Deliberately NOT `uses
+           neighbor-group-timers` (the grouping the global neighbor
+           takes): three of that grouping's leaves
+           (advertisement-interval, originate-interval,
+           delay-open-time) are staged onto `PeerConfig::timer` and
+           never read by any timer-arming path, so mirroring it here
+           would expose knobs that silently do nothing. Only the three
+           leaves `crate::bgp::timer::Config` actually consumes are
+           modelled.
+
+           These are applied by `materialize_peers` when the peer is
+           built, so an edit takes effect on the next VRF respawn or
+           `clear bgp` rather than on the live session.
+
+           Note this container does NOT cover the advertisement
+           interval (MRAI): that is paced by the `AdvInterval`
+           snapshot on the peer, configured under the instance-level
+           `router bgp timer adv-interval`, which does not reach
+           per-VRF tasks. A per-VRF session therefore still runs the
+           stock 30s eBGP / 5s iBGP MRAI.";
+        leaf connect-retry-time {
+          ext:help "ConnectRetry timer (seconds)";
+          type uint16 {
+            range "1..max";
+          }
+          units "seconds";
+          description
+            "Time interval for the ConnectRetryTimer, pacing the
+             Connect/Active redial loop. Defaults to 120s (RFC 4271
+             §8.2.2) when unset.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+             Section 8.2.2.";
+        }
+        leaf hold-time {
+          ext:help "Hold timer negotiated with the peer (seconds)";
+          type uint16 {
+            range "0 | 3..65535";
+          }
+          units "seconds";
+          description
+            "Hold Time proposed in this session's OPEN; the session
+             uses the smaller of this and the peer's. Must be 0 or at
+             least 3. Defaults to 180s when unset.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+             Section 4.2.";
+        }
+        leaf idle-hold-time {
+          ext:help "IdleHold timer before reconnect (seconds)";
+          type uint16 {
+            range "0..max";
+          }
+          units "seconds";
+          description
+            "Time the FSM dwells in Idle before the automatic restart
+             re-arms the connect. Defaults to 5s when unset.";
+        }
+      }
       list afi-safi {
         ext:help "Per-address-family activation for this CE peer";
         key "name";


### PR DESCRIPTION
## Problem

A CE peer under `router bgp vrf <name> neighbor <addr>` had **no timer
plumbing at all**. `materialize_peers` builds it from a subtree whose YANG
carried no `timers` node, so every per-VRF session ran `PeerConfig::default()`
— 120s ConnectRetry, 180s hold, 5s idle-hold — with no way to change it. The
global neighbor has had `timers` since forever; the VRF neighbor was simply
missed.

Surfaced while adding the dual-CE BDD scenario in #2078, where a per-VRF
session's convergence could not be tuned from either side.

## Change

```
router bgp vrf vrf-cust
  neighbor 10.1.0.2
    timers
      connect-retry-time 3
      hold-time 9
      idle-hold-time 1
```

Staged onto `BgpVrfNeighborConfig::timer` and copied onto the peer by
`materialize_peers` **before** `start()`, so the first idle-hold timer a peer
arms already honours the configured value rather than arming at the default
and being fixed up afterwards.

Like every other per-VRF neighbor knob, an edit lands on the next VRF respawn
or `clear bgp` — there is no live peer to reach from the config callback,
since CE peers live in the per-VRF task.

## Two deliberate scope decisions

Both are recorded in `docs/orphan-report.txt` so they don't have to be
rediscovered:

**1. Deliberately not `uses neighbor-group-timers`.** Three leaves of the
grouping the global neighbor takes — `advertisement-interval`,
`originate-interval`, `delay-open-time` — are staged onto `PeerConfig::timer`
and read by *nothing*, on the global neighbor too. Mirroring the grouping
would have shipped three more knobs that silently no-op. Only the three
`timer::Config` actually consumes are modelled. A unit test pins the inert
fields at `None`, so if one is ever wired up it fails and prompts exposing it
here too.

**2. This does not make MRAI configurable.** Advertisement pacing comes from
the `AdvInterval` snapshot on the peer, set under the instance-level
`router bgp timer adv-interval`, which has no per-VRF plumbing. A CE session
still advertises on the stock 30s eBGP / 5s iBGP cadence. That is a separate
change and I'd rather not smuggle it in here — happy to follow up if wanted.

## Verification

Unit tests cover the staging and the copy onto the peer, including that unset
leaves fall through to the documented defaults and that clearing one leaf
doesn't disturb its siblings.

But a mistyped callback path **validates fine and silently does nothing**, and
no unit test reaches that. So this was also checked live: two CE peers in one
VRF, one with `connect-retry-time 3`, one left at the default.

```
t=2s    tuned_sport=49794   default_sport=37628
t=6s    tuned_sport=49798   default_sport=37628
t=8s    tuned_sport=49812   default_sport=37628
t=12s   tuned_sport=48946   default_sport=37628
t=14s   tuned_sport=48950   default_sport=37628
t=18s   tuned_sport=48960   default_sport=37628
t=20s   tuned_sport=48964   default_sport=37628
t=24s   tuned_sport=39694   default_sport=37628
```

The tuned peer redials on a fresh socket every ~3s (8 distinct source ports in
24s); the default peer holds one socket for the whole window. That exercises
YAML → YANG validation → callback dispatch → staged config →
`materialize_peers` → `start_connect_retry_timer`.

The regenerated `docs/handler-paths.txt` is an independent cross-check: all
three callbacks appear, so none of the registrations is a dead path.

`cargo fmt`, workspace clippy, and the full suite (2510 tests) are clean.
`docs/orphan-report.txt` counts updated by hand as its header requires
(settable 278 → 281, handled 265 → 268; orphans unchanged at 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
