### PR TITLE
bgp: import per-AFI neighbor knobs into the per-VRF neighbor

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -218,7 +218,13 @@
 /router/bgp/vrf/inter-as-hybrid
 /router/bgp/vrf/label-mode
 /router/bgp/vrf/neighbor
+/router/bgp/vrf/neighbor/afi-safi/add-path
 /router/bgp/vrf/neighbor/afi-safi/enabled
+/router/bgp/vrf/neighbor/afi-safi/encapsulation-type
+/router/bgp/vrf/neighbor/afi-safi/graceful-restart/enabled
+/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/enabled
+/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time
+/router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged
 /router/bgp/vrf/neighbor/description
 /router/bgp/vrf/neighbor/peer-group
 /router/bgp/vrf/neighbor/remote-as

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -21,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 281
-Handled: 268
+Total settable schema nodes: 287
+Handled: 274
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -40,6 +40,18 @@ handled above. The tracing subtrees (/router/bgp/tracing and
 /router/bgp/neighbor/tracing) have no per-node callbacks; the whole
 subtree is handled by config_tracing_dispatch in src/bgp/tracing.rs, so
 they count as handled above.
+
+Note: /router/bgp/vrf/neighbor/afi-safi mirrors the global neighbor's
+per-AFI knob set (add-path, graceful-restart, long-lived-graceful-restart,
+next-hop-unchanged, encapsulation-type), sharing one setter per knob from
+src/bgp/afi_knob.rs so the two subtrees cannot diverge in meaning. The
+`vrf_afi_knob_parity` test pins the knob *set*: importing a knob to the
+global neighbor without a per-VRF counterpart fails unless it is listed in
+VRF_AFI_KNOB_EXCLUSIONS with a reason. Currently excluded there:
+next-hop-self (needs neighbor-group precedence resolution) and
+policy/prefix-set in+out (need a policy-actor Register, which BgpVrf has no
+channel for). Unlike the global neighbor these are staged and applied by
+materialize_peers, so an edit takes effect on the next VRF respawn.
 
 Note: /router/bgp/vrf/neighbor/timers exposes only connect-retry-time,
 hold-time and idle-hold-time — the three leaves crate::bgp::timer::Config

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -302,7 +302,15 @@
 /router/bgp/vrf/label-mode	leaf
 /router/bgp/vrf/neighbor	list keys=remote-address
 /router/bgp/vrf/neighbor/afi-safi	list keys=name
+/router/bgp/vrf/neighbor/afi-safi/add-path	leaf
 /router/bgp/vrf/neighbor/afi-safi/enabled	leaf
+/router/bgp/vrf/neighbor/afi-safi/encapsulation-type	leaf
+/router/bgp/vrf/neighbor/afi-safi/graceful-restart	container
+/router/bgp/vrf/neighbor/afi-safi/graceful-restart/enabled	leaf
+/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart	container
+/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/enabled	leaf
+/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time	leaf
+/router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged	leaf
 /router/bgp/vrf/neighbor/description	leaf
 /router/bgp/vrf/neighbor/peer-group	leaf
 /router/bgp/vrf/neighbor/remote-as	leaf

--- a/zebra-rs/src/bgp/afi_knob.rs
+++ b/zebra-rs/src/bgp/afi_knob.rs
@@ -1,0 +1,161 @@
+//! Shared per-AFI neighbor knob setters.
+//!
+//! Every `neighbor <addr> afi-safi <name> <knob>` statement has exactly
+//! one definition of its semantics, living here as a pure function of
+//! `(&mut PeerConfig, AfiSafi, ConfigOp, &mut Args)`. Two callers use
+//! each one:
+//!
+//!   * the **global** neighbor (`/router/bgp/neighbor/afi-safi/…`),
+//!     which looks up a live [`super::peer::Peer`] and then runs
+//!     whatever side effects the knob needs (a session bounce, an
+//!     update-group refresh, a policy-actor registration);
+//!   * the **per-VRF** neighbor (`/router/bgp/vrf/neighbor/afi-safi/…`),
+//!     which stages onto
+//!     [`super::vrf_config::BgpVrfNeighborConfig::config`] — itself a
+//!     `PeerConfig` — and relies on the VRF respawn to apply it, because
+//!     a CE peer lives in a separate task the config callback cannot
+//!     reach.
+//!
+//! Keeping the mutation pure is what makes the second caller possible at
+//! all: the global callbacks take `&mut Bgp` and a live peer, neither of
+//! which exists while staging. It also means the two subtrees cannot
+//! drift in *meaning* — only in which knobs they expose, which
+//! `vrf_afi_knob_parity` in `config::manager` pins.
+//!
+//! ## What belongs here
+//!
+//! Only knobs that are a pure function of the config. A knob that must
+//! talk to another actor (`policy` / `prefix-set`, which register with
+//! the policy actor to resolve a name) does **not** fit this shape and
+//! is deliberately absent — see the module docs on
+//! [`super::vrf_config`].
+
+use bgp_packet::{AddPathSendReceive, AddPathValue, AfiSafi};
+
+use super::peer::{AfiSafiEncapType, PeerConfig};
+use crate::config::{Args, ConfigOp};
+
+/// `afi-safi <name> add-path <send|receive|send-receive>`.
+pub(super) fn set_add_path(
+    cfg: &mut PeerConfig,
+    afi_safi: AfiSafi,
+    op: ConfigOp,
+    args: &mut Args,
+) -> Option<()> {
+    if op.is_set() {
+        let send_receive: AddPathSendReceive = args.string()?.parse().ok()?;
+        cfg.addpath.insert(
+            afi_safi,
+            AddPathValue {
+                afi: afi_safi.afi,
+                safi: afi_safi.safi,
+                send_receive,
+            },
+        );
+    } else {
+        cfg.addpath.remove(&afi_safi);
+    }
+    Some(())
+}
+
+/// `afi-safi <name> graceful-restart enabled <bool>` (RFC 4724).
+///
+/// `enabled` is a boolean leaf, so the value is honoured — `enabled
+/// false` must not enable GR. On enable the *default Restart Time in
+/// seconds* is stored, not a bare `1`: the OPEN advertises this value
+/// verbatim, and a 1-second restart time makes the peer's helper flush
+/// retained routes almost immediately, defeating the feature.
+pub(super) fn set_graceful_restart(
+    cfg: &mut PeerConfig,
+    afi_safi: AfiSafi,
+    op: ConfigOp,
+    args: &mut Args,
+) -> Option<()> {
+    let enable = op.is_set() && args.boolean()?;
+    cfg.sub.entry(afi_safi).or_default().graceful_restart =
+        enable.then_some(super::peer::GR_RESTART_TIME_DEFAULT);
+    Some(())
+}
+
+/// `afi-safi <name> long-lived-graceful-restart enabled`.
+pub(super) fn set_llgr(cfg: &mut PeerConfig, afi_safi: AfiSafi, op: ConfigOp) -> Option<()> {
+    cfg.sub.entry(afi_safi).or_default().llgr = op.is_set().then_some(1);
+    Some(())
+}
+
+/// `afi-safi <name> long-lived-graceful-restart restart-time <SECS>`.
+///
+/// Delete restores the bare enabled marker (`1`) rather than clearing
+/// LLGR outright — dropping just the restart-time leaf must not also
+/// turn the feature off.
+pub(super) fn set_llgr_restart_time(
+    cfg: &mut PeerConfig,
+    afi_safi: AfiSafi,
+    op: ConfigOp,
+    args: &mut Args,
+) -> Option<()> {
+    let time = args.u32()?;
+    cfg.sub.entry(afi_safi).or_default().llgr = if op.is_set() { Some(time) } else { Some(1) };
+    Some(())
+}
+
+/// `afi-safi <name> encapsulation-type <srv6|srv6-relax>`.
+///
+/// Both this leaf and the global neighbor's carry a YANG `when "../name
+/// = 'ipv6'"`, but that guard is **not enforced** by the config engine —
+/// verified live: `… afi-safi ipv4 encapsulation-type srv6` commits
+/// successfully on the global neighbor and on a VRF neighbor alike. So
+/// do not assume `afi_safi` is IPv6 unicast here; the value is keyed by
+/// whatever family the operator typed, and the advertise/accept paths
+/// look it up per family anyway.
+pub(super) fn set_encapsulation_type(
+    cfg: &mut PeerConfig,
+    afi_safi: AfiSafi,
+    op: ConfigOp,
+    args: &mut Args,
+) -> Option<()> {
+    let encap = if op.is_set() {
+        Some(AfiSafiEncapType::parse(&args.string()?)?)
+    } else {
+        None
+    };
+    cfg.sub.entry(afi_safi).or_default().encapsulation_type = encap;
+    Some(())
+}
+
+/// `afi-safi <name> next-hop-unchanged <bool>`.
+pub(super) fn set_next_hop_unchanged(
+    cfg: &mut PeerConfig,
+    afi_safi: AfiSafi,
+    op: ConfigOp,
+    args: &mut Args,
+) -> Option<()> {
+    let value = op.is_set() && args.boolean()?;
+    cfg.sub.entry(afi_safi).or_default().next_hop_unchanged = value;
+    Some(())
+}
+
+/// `afi-safi <name> next-hop-self <bool>` — records the verbatim
+/// statement only.
+///
+/// The *effective* value is resolved through neighbor-group precedence
+/// by the caller, which is the one thing this knob needs beyond its own
+/// config: the global path calls
+/// `neighbor_group::resolve_next_hop_self` against `Bgp::neighbor_groups`,
+/// and `materialize_peers` resolves it against the `groups` map it is
+/// already handed. Splitting it this way keeps the verbatim record
+/// shared while letting each caller supply its own group source.
+pub(super) fn set_next_hop_self_explicit(
+    cfg: &mut PeerConfig,
+    afi_safi: AfiSafi,
+    op: ConfigOp,
+    args: &mut Args,
+) -> Option<()> {
+    if op.is_set() {
+        let value = args.boolean()?;
+        cfg.nhs_explicit.insert(afi_safi, value);
+    } else {
+        cfg.nhs_explicit.remove(&afi_safi);
+    }
+    Some(())
+}

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -13,7 +13,7 @@ use crate::policy::com_list::*;
 use crate::rib::api::FdbEntry;
 
 use super::auth::AoConfig;
-use super::peer::{AfiSafiEncapType, BgpTop};
+use super::peer::BgpTop;
 use super::route_clean;
 use super::{
     AssistedReplicationRole, BGP_PORT, Bgp, EvpnBumTunnel,
@@ -2937,20 +2937,7 @@ fn config_add_path(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
     let peer = bgp.peers.get_mut(&addr)?;
-    let add_path_str: String = args.string()?;
-    let send_receive: AddPathSendReceive = add_path_str.parse().ok()?;
-
-    if op.is_set() {
-        let add_path = AddPathValue {
-            afi: afi_safi.afi,
-            safi: afi_safi.safi,
-            send_receive,
-        };
-        peer.config.addpath.insert(afi_safi, add_path);
-    } else {
-        peer.config.addpath.remove(&afi_safi);
-    }
-    Some(())
+    super::afi_knob::set_add_path(&mut peer.config, afi_safi, op, &mut args)
 }
 
 /// `set/delete router bgp neighbor <addr> afi-safi <name>
@@ -2964,11 +2951,8 @@ fn config_add_path(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 fn config_restart(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
-    let enable = op.is_set() && args.boolean()?;
     let peer = bgp.peers.get_mut(&addr)?;
-    let config = peer.config.sub.entry(afi_safi).or_default();
-    config.graceful_restart = enable.then_some(super::peer::GR_RESTART_TIME_DEFAULT);
-    Some(())
+    super::afi_knob::set_graceful_restart(&mut peer.config, afi_safi, op, &mut args)
 }
 
 /// `set/delete router bgp neighbor <addr> afi-safi <name> encapsulation-type
@@ -2981,16 +2965,7 @@ fn config_encapsulation_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
     let peer = bgp.peers.get_mut(&addr)?;
-
-    if op.is_set() {
-        let encap = AfiSafiEncapType::parse(&args.string()?)?;
-        let config = peer.config.sub.entry(afi_safi).or_default();
-        config.encapsulation_type = Some(encap);
-    } else {
-        let config = peer.config.sub.entry(afi_safi).or_default();
-        config.encapsulation_type = None;
-    }
-    Some(())
+    super::afi_knob::set_encapsulation_type(&mut peer.config, afi_safi, op, &mut args)
 }
 
 /// `set/delete router bgp neighbor <addr> afi-safi <name> next-hop-self
@@ -3011,12 +2986,7 @@ fn config_next_hop_self(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
     // Record the verbatim statement, then resolve through the
     // neighbor-group precedence — a Delete falls back to the group's
     // per-family opinion (or the off default).
-    if op.is_set() {
-        let value = args.boolean()?;
-        peer.config.nhs_explicit.insert(afi_safi, value);
-    } else {
-        peer.config.nhs_explicit.remove(&afi_safi);
-    }
+    super::afi_knob::set_next_hop_self_explicit(&mut peer.config, afi_safi, op, &mut args)?;
     let value =
         super::neighbor_group::resolve_next_hop_self(&bgp.neighbor_groups, &peer.config, afi_safi);
     peer.config.sub.entry(afi_safi).or_default().next_hop_self = value;
@@ -3027,46 +2997,21 @@ fn config_next_hop_unchanged(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
     let peer = bgp.peers.get_mut(&addr)?;
-
-    let value = op.is_set() && args.boolean()?;
-    peer.config
-        .sub
-        .entry(afi_safi)
-        .or_default()
-        .next_hop_unchanged = value;
-    Some(())
+    super::afi_knob::set_next_hop_unchanged(&mut peer.config, afi_safi, op, &mut args)
 }
 
 fn config_llgr(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
     let peer = bgp.peers.get_mut(&addr)?;
-
-    if op.is_set() {
-        let config = peer.config.sub.entry(afi_safi).or_default();
-        config.llgr = Some(1);
-    } else {
-        let config = peer.config.sub.entry(afi_safi).or_default();
-        config.llgr = None;
-    }
-    Some(())
+    super::afi_knob::set_llgr(&mut peer.config, afi_safi, op)
 }
 
 fn config_llgr_restart_time(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
     let peer = bgp.peers.get_mut(&addr)?;
-    let time = args.u32()?;
-
-    if op.is_set() {
-        let config = peer.config.sub.entry(afi_safi).or_default();
-        config.llgr = Some(time);
-    } else {
-        let config = peer.config.sub.entry(afi_safi).or_default();
-        config.llgr = Some(1);
-    }
-
-    Some(())
+    super::afi_knob::set_llgr_restart_time(&mut peer.config, afi_safi, op, &mut args)
 }
 
 fn config_local_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -4427,6 +4372,33 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/neighbor/afi-safi/enabled",
             super::vrf_config::config_vrf_neighbor_afi_safi_enabled,
+        );
+        // Per-AFI knobs imported from the global neighbor. Each shares
+        // its setter with the `/router/bgp/neighbor/afi-safi/…`
+        // registration above; `vrf_afi_knob_parity` pins the set.
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/add-path",
+            super::vrf_config::config_vrf_neighbor_afi_safi_add_path,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/graceful-restart/enabled",
+            super::vrf_config::config_vrf_neighbor_afi_safi_graceful_restart,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/enabled",
+            super::vrf_config::config_vrf_neighbor_afi_safi_llgr,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time",
+            super::vrf_config::config_vrf_neighbor_afi_safi_llgr_restart_time,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged",
+            super::vrf_config::config_vrf_neighbor_afi_safi_next_hop_unchanged,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/encapsulation-type",
+            super::vrf_config::config_vrf_neighbor_afi_safi_encapsulation_type,
         );
         self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv4",

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -4,6 +4,7 @@ pub use inst::{AssistedReplicationRole, Bgp, EvpnBumTunnel, Message};
 pub mod constant;
 pub use constant::*;
 
+pub mod afi_knob;
 pub mod auth;
 pub mod config;
 pub mod connected;

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -349,10 +349,7 @@ fn materialize_peers(
         // group is resolved here at materialization (and re-resolved on the
         // next respawn) rather than swept live, because the group lives on
         // the global `Bgp` and these peers run in a separate per-VRF task.
-        let group = nbr_cfg
-            .peer_group
-            .as_ref()
-            .and_then(|name| groups.get(name));
+        let group = nbr_cfg.peer_group().and_then(|name| groups.get(name));
 
         // `Peer::start()` gates on `remote_as != 0` already, but
         // skipping the insert entirely keeps the per-VRF peer map
@@ -399,26 +396,32 @@ fn materialize_peers(
         } else {
             PeerType::EBGP
         };
-        // Record the group binding so `show bgp vrf` reflects it. The
-        // inheritance below is resolved eagerly (the global group sweep
-        // doesn't reach per-VRF tasks); a later edit to the group's
-        // opinions takes effect when the VRF task next respawns or the
-        // session is cleared.
-        peer.config.neighbor_group = nbr_cfg.peer_group.clone();
-
-        // Session timers (`neighbor <addr> timers { … }`). Copied before
-        // `start()` below so the very first idle-hold timer this peer
-        // arms already honours a configured `idle-hold-time` — arming it
-        // from the default and fixing it up afterwards would leave the
-        // first dial on the wrong cadence. Unset leaves stay `None` and
-        // fall through to `timer::Config`'s defaults, so a VRF neighbor
-        // with no `timers` block behaves exactly as before.
+        // Adopt the staged config wholesale. `BgpVrfNeighborConfig::config`
+        // IS a `PeerConfig`, so every knob the per-VRF schema stages —
+        // description, peer-group binding, `timers`, and the per-family
+        // `afi-safi` knobs — lands here in one move, and importing another
+        // knob from the global neighbor needs no line of its own.
         //
-        // This does NOT cover MRAI: advertisement pacing comes from the
-        // `AdvInterval` snapshot on the peer, which per-VRF tasks have no
-        // plumbing for — a CE session still advertises on the stock 30s
-        // eBGP / 5s iBGP cadence regardless of what is set here.
-        peer.config.timer = nbr_cfg.timer.clone();
+        // Anything the schema doesn't expose keeps its
+        // `PeerConfig::default()` value, which is exactly what `Peer::new`
+        // had just installed, so this is behaviour-preserving for
+        // unconfigured fields.
+        //
+        // Done before `start()` below so the first idle-hold timer a peer
+        // arms already honours a configured `idle-hold-time`; arming from
+        // the default and fixing up afterwards would leave the first dial
+        // on the wrong cadence.
+        //
+        // Two things this deliberately does NOT carry:
+        //   - MRAI. Advertisement pacing comes from the `AdvInterval`
+        //     snapshot on the peer, which per-VRF tasks have no plumbing
+        //     for, so a CE session still runs the stock 30s eBGP / 5s iBGP
+        //     cadence.
+        //   - Policy / prefix-set names. Those need a policy-actor
+        //     Register to resolve, and `BgpVrf` holds no `policy_tx`; a
+        //     staged name would sit inert. They stay out of the schema
+        //     until that plumbing exists.
+        peer.config = nbr_cfg.config.clone();
 
         // Derive the negotiated address-family set for this CE peer.
         // `Peer::new` defaults to IPv4 unicast only, which is wrong for
@@ -455,15 +458,17 @@ fn materialize_peers(
                 }
             }
         }
-        for (fam, enabled) in &nbr_cfg.mp_explicit {
+        for (fam, enabled) in &nbr_cfg.config.mp_explicit {
             if *enabled {
                 mp.insert(*fam, true);
             } else {
                 mp.remove(fam);
             }
         }
+        // `mp` is the *resolved* set, so it is computed here rather than
+        // staged; `mp_explicit` (the verbatim statements it was resolved
+        // from) already arrived with the config adoption above.
         peer.config.mp = mp;
-        peer.config.mp_explicit = nbr_cfg.mp_explicit.clone();
 
         vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
         // `PeerMap::insert_with_key` assigns the stable ident used in every
@@ -749,9 +754,9 @@ mod tests {
             remote_as: Some(65001),
             ..Default::default()
         };
-        nbr.timer.connect_retry_time = Some(3);
-        nbr.timer.hold_time = Some(9);
-        nbr.timer.idle_hold_time = Some(1);
+        nbr.config.timer.connect_retry_time = Some(3);
+        nbr.config.timer.hold_time = Some(9);
+        nbr.config.timer.idle_hold_time = Some(1);
         cfg.neighbors.insert(tuned, nbr);
 
         cfg.neighbors.insert(
@@ -782,6 +787,89 @@ mod tests {
         assert_eq!(peer.config.timer.connect_retry_time(), 120);
         assert_eq!(peer.config.timer.hold_time(), 180);
         assert_eq!(peer.config.timer.idle_hold_time(), 5);
+    }
+
+    /// Per-AFI knobs imported from the global neighbor must survive the
+    /// staging round-trip onto the built peer. This is the payoff of
+    /// staging a real `PeerConfig`: `materialize_peers` adopts it
+    /// wholesale, so this test covers every knob at once rather than one
+    /// assertion per import.
+    #[tokio::test]
+    async fn materialize_peers_applies_per_afi_knobs() {
+        use super::super::super::vrf_config::{BgpVrfConfig, BgpVrfNeighborConfig};
+        use super::super::inst::BgpVrf;
+        use crate::context::ProtoContext;
+        use bgp_packet::{AddPathSendReceive, AddPathValue, Afi, AfiSafi, Safi};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "v1".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let v4u = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        let tuned: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let bare: std::net::IpAddr = "192.0.2.2".parse().unwrap();
+
+        let mut nbr = BgpVrfNeighborConfig {
+            remote_as: Some(65001),
+            ..Default::default()
+        };
+        nbr.config.addpath.insert(
+            v4u,
+            AddPathValue {
+                afi: v4u.afi,
+                safi: v4u.safi,
+                send_receive: AddPathSendReceive::SendReceive,
+            },
+        );
+        {
+            let sub = nbr.config.sub.entry(v4u).or_default();
+            sub.graceful_restart = Some(120);
+            sub.llgr = Some(300);
+            sub.next_hop_unchanged = true;
+        }
+
+        let mut cfg = BgpVrfConfig::default();
+        cfg.neighbors.insert(tuned, nbr);
+        cfg.neighbors.insert(
+            bare,
+            BgpVrfNeighborConfig {
+                remote_as: Some(65002),
+                ..Default::default()
+            },
+        );
+
+        materialize_peers(&mut vrf, &cfg, &BTreeMap::new());
+
+        let peer = vrf.peers.get(&tuned).expect("tuned peer inserted");
+        assert_eq!(
+            peer.config.addpath.get(&v4u).map(|v| v.send_receive),
+            Some(AddPathSendReceive::SendReceive),
+            "add-path must ride the staged config onto the peer"
+        );
+        let sub = peer.config.sub.get(&v4u).expect("per-AFI sub-config");
+        assert_eq!(sub.graceful_restart, Some(120));
+        assert_eq!(sub.llgr, Some(300));
+        assert!(sub.next_hop_unchanged);
+
+        // A neighbor that configured none of them is untouched — the
+        // wholesale adoption must not invent per-AFI state.
+        let peer = vrf.peers.get(&bare).expect("bare peer inserted");
+        assert!(peer.config.addpath.get(&v4u).is_none());
+        assert!(
+            peer.config.sub.get(&v4u).is_none_or(|s| {
+                s.graceful_restart.is_none() && s.llgr.is_none() && !s.next_hop_unchanged
+            }),
+            "an unconfigured neighbor must keep PeerConfig defaults"
+        );
     }
 
     /// A CE peer's negotiated MP family set is derived from its own
@@ -841,7 +929,7 @@ mod tests {
             remote_as: Some(65001),
             ..Default::default()
         };
-        dual.mp_explicit.insert(ipv4u, true);
+        dual.config.mp_explicit.insert(ipv4u, true);
         cfg.neighbors.insert(v6_dual, dual);
 
         materialize_peers(&mut vrf, &cfg, &BTreeMap::new());
@@ -919,19 +1007,17 @@ mod tests {
         let override_peer: std::net::IpAddr = "192.0.2.6".parse().unwrap();
 
         let mut cfg = BgpVrfConfig::default();
-        cfg.neighbors.insert(
-            inherit,
-            BgpVrfNeighborConfig {
-                peer_group: Some("g1".to_string()),
-                ..Default::default()
-            },
-        );
+        cfg.neighbors.insert(inherit, {
+            let mut n = BgpVrfNeighborConfig::default();
+            n.config.neighbor_group = Some("g1".to_string());
+            n
+        });
         let mut over = BgpVrfNeighborConfig {
             remote_as: Some(65020),
-            peer_group: Some("g1".to_string()),
             ..Default::default()
         };
-        over.mp_explicit.insert(ipv6u, false);
+        over.config.neighbor_group = Some("g1".to_string());
+        over.config.mp_explicit.insert(ipv6u, false);
         cfg.neighbors.insert(override_peer, over);
 
         let count = materialize_peers(&mut vrf, &cfg, &groups);

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -32,6 +32,7 @@ use crate::config::{Args, ConfigOp};
 
 use super::Bgp;
 use super::config::BgpRedistSource;
+use super::peer::PeerConfig;
 use super::vrf::msg::BgpVrfMsg;
 use crate::rib::RedistAfi;
 
@@ -88,32 +89,35 @@ impl BgpVrfEncapsulation {
 /// Per-peer attribute set for a CE peer configured under
 /// `router bgp vrf X neighbor <addr>`. Mirrors `bgp-vrf-neighbor` in
 /// zebra-bgp-vrf.yang.
+/// Staging is the peer's *own* [`PeerConfig`] type rather than a
+/// parallel struct that mirrors fragments of it. Every knob imported
+/// from the global neighbor then costs a YANG leaf and one shared
+/// setter — no new field here, no new line in `materialize_peers`, and
+/// no opportunity for the two representations to drift.
+///
+/// `remote_as` stays outside because it lands on [`super::peer::Peer`]
+/// itself, not on its config. Everything else the schema exposes
+/// (`description`, `peer-group`, `timers`, per-family `afi-safi`
+/// knobs) is a `PeerConfig` field already.
+///
+/// Fields the per-VRF schema does not expose simply keep their
+/// `PeerConfig::default()` values, which is exactly what a peer built
+/// by `Peer::new` would have had — so staging the whole struct is
+/// behaviour-preserving for anything unconfigured, and wiring a new
+/// knob later is a schema + setter change with no plumbing.
 #[derive(Debug, Clone, Default)]
 pub struct BgpVrfNeighborConfig {
     pub remote_as: Option<u32>,
-    pub peer_group: Option<String>,
-    pub description: Option<String>,
-    /// Verbatim per-family `afi-safi <name> enabled <bool>` statements
-    /// for this CE peer — the per-VRF equivalent of
-    /// [`super::peer::PeerConfig::mp_explicit`]. Only the IPv4 / IPv6
-    /// unicast families are reachable from the schema. Empty means "no
-    /// explicit override": the negotiated family is then derived from
-    /// the peer's own address family in `materialize_peers`. There is
-    /// no neighbor-group afi-safi inheritance for CE peers yet (the
-    /// stored `peer_group` is not resolved at materialization), so this
-    /// map is the only override layer.
-    pub mp_explicit: BTreeMap<AfiSafi, bool>,
-    /// Staged `timers { … }` for this CE peer, copied verbatim onto
-    /// [`super::peer::PeerConfig::timer`] by `materialize_peers`.
-    ///
-    /// Deliberately the *same* type the peer holds rather than a
-    /// narrower struct: the schema only exposes the three leaves the
-    /// timer code actually consumes (connect-retry-time, hold-time,
-    /// idle-hold-time), so the rest stay `None` — which is what they
-    /// would be anyway, since nothing reads them even on the global
-    /// neighbor. Sharing the type means wiring one of those up later
-    /// is a schema-only change here.
-    pub timer: super::timer::Config,
+    pub config: PeerConfig,
+}
+
+impl BgpVrfNeighborConfig {
+    /// The referenced `neighbor-group` name, if any. `materialize_peers`
+    /// resolves the group's opinions eagerly at build time (the global
+    /// group sweep doesn't reach per-VRF tasks).
+    pub fn peer_group(&self) -> Option<&String> {
+        self.config.neighbor_group.as_ref()
+    }
 }
 
 /// Per-AFI knobs under `router bgp vrf X afi-safi {ipv4,ipv6}-unicast`.
@@ -629,8 +633,8 @@ pub fn config_vrf_neighbor_peer_group(bgp: &mut Bgp, mut args: Args, op: ConfigO
     let cfg = vrf_entry(bgp, name, op)?;
     let nbr = neighbor_entry(cfg, addr, op)?;
     match op {
-        ConfigOp::Set => nbr.peer_group = Some(args.string()?),
-        ConfigOp::Delete => nbr.peer_group = None,
+        ConfigOp::Set => nbr.config.neighbor_group = Some(args.string()?),
+        ConfigOp::Delete => nbr.config.neighbor_group = None,
         _ => {}
     }
     Some(())
@@ -643,8 +647,8 @@ pub fn config_vrf_neighbor_description(bgp: &mut Bgp, mut args: Args, op: Config
     let cfg = vrf_entry(bgp, name, op)?;
     let nbr = neighbor_entry(cfg, addr, op)?;
     match op {
-        ConfigOp::Set => nbr.description = Some(args.string()?),
-        ConfigOp::Delete => nbr.description = None,
+        ConfigOp::Set => nbr.config.description = Some(args.string()?),
+        ConfigOp::Delete => nbr.config.description = None,
         _ => {}
     }
     Some(())
@@ -671,8 +675,8 @@ pub fn config_vrf_neighbor_connect_retry_time(
     let cfg = vrf_entry(bgp, name, op)?;
     let nbr = neighbor_entry(cfg, addr, op)?;
     match op {
-        ConfigOp::Set => nbr.timer.connect_retry_time = Some(args.u16()?),
-        ConfigOp::Delete => nbr.timer.connect_retry_time = None,
+        ConfigOp::Set => nbr.config.timer.connect_retry_time = Some(args.u16()?),
+        ConfigOp::Delete => nbr.config.timer.connect_retry_time = None,
         _ => {}
     }
     Some(())
@@ -685,8 +689,8 @@ pub fn config_vrf_neighbor_hold_time(bgp: &mut Bgp, mut args: Args, op: ConfigOp
     let cfg = vrf_entry(bgp, name, op)?;
     let nbr = neighbor_entry(cfg, addr, op)?;
     match op {
-        ConfigOp::Set => nbr.timer.hold_time = Some(args.u16()?),
-        ConfigOp::Delete => nbr.timer.hold_time = None,
+        ConfigOp::Set => nbr.config.timer.hold_time = Some(args.u16()?),
+        ConfigOp::Delete => nbr.config.timer.hold_time = None,
         _ => {}
     }
     Some(())
@@ -704,8 +708,8 @@ pub fn config_vrf_neighbor_idle_hold_time(
     let cfg = vrf_entry(bgp, name, op)?;
     let nbr = neighbor_entry(cfg, addr, op)?;
     match op {
-        ConfigOp::Set => nbr.timer.idle_hold_time = Some(args.u16()?),
-        ConfigOp::Delete => nbr.timer.idle_hold_time = None,
+        ConfigOp::Set => nbr.config.timer.idle_hold_time = Some(args.u16()?),
+        ConfigOp::Delete => nbr.config.timer.idle_hold_time = None,
         _ => {}
     }
     Some(())
@@ -732,14 +736,75 @@ pub fn config_vrf_neighbor_afi_safi_enabled(
     match op {
         ConfigOp::Set => {
             let enabled = args.boolean()?;
-            nbr.mp_explicit.insert(afi_safi, enabled);
+            nbr.config.mp_explicit.insert(afi_safi, enabled);
         }
         ConfigOp::Delete => {
-            nbr.mp_explicit.remove(&afi_safi);
+            nbr.config.mp_explicit.remove(&afi_safi);
         }
         _ => {}
     }
     Some(())
+}
+
+/// Generate a `router bgp vrf <NAME> neighbor <addr> afi-safi <af>
+/// <knob>` callback that stages through one of the shared
+/// [`super::afi_knob`] setters.
+///
+/// Every one of these is the same four lines — resolve the VRF, resolve
+/// the neighbor, hand the staged `PeerConfig` to the setter — which is
+/// the whole point of staging a real `PeerConfig`: importing a knob from
+/// the global neighbor is a YANG leaf plus one line here, with the
+/// knob's *meaning* defined once in `afi_knob` and shared with the
+/// global callback.
+macro_rules! vrf_afi_knob {
+    ($(#[$m:meta])* $name:ident => $setter:ident) => {
+        $(#[$m])*
+        pub fn $name(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+            let vrf = args.string()?;
+            let addr = args.addr()?;
+            let afi_safi: AfiSafi = args.afi_safi()?;
+            let cfg = vrf_entry(bgp, vrf, op)?;
+            let nbr = neighbor_entry(cfg, addr, op)?;
+            super::afi_knob::$setter(&mut nbr.config, afi_safi, op, &mut args)
+        }
+    };
+}
+
+vrf_afi_knob! {
+    /// `… afi-safi <af> add-path <send|receive|send-receive>` (RFC 7911).
+    config_vrf_neighbor_afi_safi_add_path => set_add_path
+}
+vrf_afi_knob! {
+    /// `… afi-safi <af> graceful-restart enabled <bool>` (RFC 4724).
+    config_vrf_neighbor_afi_safi_graceful_restart => set_graceful_restart
+}
+vrf_afi_knob! {
+    /// `… afi-safi <af> long-lived-graceful-restart restart-time <secs>`.
+    config_vrf_neighbor_afi_safi_llgr_restart_time => set_llgr_restart_time
+}
+vrf_afi_knob! {
+    /// `… afi-safi <af> next-hop-unchanged <bool>`.
+    config_vrf_neighbor_afi_safi_next_hop_unchanged => set_next_hop_unchanged
+}
+vrf_afi_knob! {
+    /// `… afi-safi <af> encapsulation-type <srv6|srv6-relax>`.
+    config_vrf_neighbor_afi_safi_encapsulation_type => set_encapsulation_type
+}
+
+/// `… afi-safi <af> long-lived-graceful-restart enabled` — the odd one
+/// out: [`super::afi_knob::set_llgr`] keys off presence alone and takes
+/// no value, so it doesn't fit the macro's `args`-consuming shape.
+pub fn config_vrf_neighbor_afi_safi_llgr(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    super::afi_knob::set_llgr(&mut nbr.config, afi_safi, op)
 }
 
 /// `set router bgp vrf <NAME> afi-safi ipv4` — presence container.
@@ -1246,15 +1311,15 @@ mod tests {
         // a remote-as (own or group-inherited) is known.
         let nbr = BgpVrfNeighborConfig::default();
         assert!(nbr.remote_as.is_none());
-        assert!(nbr.peer_group.is_none());
-        assert!(nbr.description.is_none());
-        assert!(nbr.mp_explicit.is_empty());
+        assert!(nbr.peer_group().is_none());
+        assert!(nbr.config.description.is_none());
+        assert!(nbr.config.mp_explicit.is_empty());
         // Every timer leaf unset — `materialize_peers` copies this
         // wholesale onto the peer, so an all-`None` default is what keeps
         // a `timers`-less VRF neighbor on the stock cadence.
-        assert!(nbr.timer.connect_retry_time.is_none());
-        assert!(nbr.timer.hold_time.is_none());
-        assert!(nbr.timer.idle_hold_time.is_none());
+        assert!(nbr.config.timer.connect_retry_time.is_none());
+        assert!(nbr.config.timer.hold_time.is_none());
+        assert!(nbr.config.timer.idle_hold_time.is_none());
     }
 
     #[test]
@@ -1263,23 +1328,28 @@ mod tests {
         let mut cfg = BgpVrfConfig::default();
 
         let nbr = neighbor_entry(&mut cfg, address, ConfigOp::Set).unwrap();
-        nbr.timer.connect_retry_time = Some(3);
-        nbr.timer.hold_time = Some(9);
-        nbr.timer.idle_hold_time = Some(1);
+        nbr.config.timer.connect_retry_time = Some(3);
+        nbr.config.timer.hold_time = Some(9);
+        nbr.config.timer.idle_hold_time = Some(1);
 
         let nbr = &cfg.neighbors[&address];
-        assert_eq!(nbr.timer.connect_retry_time, Some(3));
-        assert_eq!(nbr.timer.hold_time, Some(9));
-        assert_eq!(nbr.timer.idle_hold_time, Some(1));
+        assert_eq!(nbr.config.timer.connect_retry_time, Some(3));
+        assert_eq!(nbr.config.timer.hold_time, Some(9));
+        assert_eq!(nbr.config.timer.idle_hold_time, Some(1));
 
         // Clearing one leaf must leave the siblings alone: the three
         // callbacks share one staged `timer::Config`, so a careless
         // implementation could reset the struct instead of the field.
-        cfg.neighbors.get_mut(&address).unwrap().timer.hold_time = None;
+        cfg.neighbors
+            .get_mut(&address)
+            .unwrap()
+            .config
+            .timer
+            .hold_time = None;
         let nbr = &cfg.neighbors[&address];
-        assert!(nbr.timer.hold_time.is_none());
-        assert_eq!(nbr.timer.connect_retry_time, Some(3));
-        assert_eq!(nbr.timer.idle_hold_time, Some(1));
+        assert!(nbr.config.timer.hold_time.is_none());
+        assert_eq!(nbr.config.timer.connect_retry_time, Some(3));
+        assert_eq!(nbr.config.timer.idle_hold_time, Some(1));
     }
 
     #[test]
@@ -1294,11 +1364,11 @@ mod tests {
         let address: IpAddr = "192.0.2.1".parse().unwrap();
         let mut cfg = BgpVrfConfig::default();
         let nbr = neighbor_entry(&mut cfg, address, ConfigOp::Set).unwrap();
-        nbr.timer.connect_retry_time = Some(3);
+        nbr.config.timer.connect_retry_time = Some(3);
 
-        assert!(nbr.timer.min_adv_interval.is_none());
-        assert!(nbr.timer.orig_interval.is_none());
-        assert!(nbr.timer.delay_open_time.is_none());
+        assert!(nbr.config.timer.min_adv_interval.is_none());
+        assert!(nbr.config.timer.orig_interval.is_none());
+        assert!(nbr.config.timer.delay_open_time.is_none());
     }
 
     #[test]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4965,6 +4965,105 @@ mod bgp_config_audit_tests {
         assert_doc_matches("handler-paths.txt", &lines);
     }
 
+    /// Per-AFI neighbor knobs the per-VRF neighbor deliberately does NOT
+    /// mirror from the global neighbor, each with the reason it is out.
+    ///
+    /// Anything listed here is a decision; anything *not* listed is
+    /// expected to exist in both subtrees. Entries are the path suffix
+    /// below `afi-safi`.
+    const VRF_AFI_KNOB_EXCLUSIONS: &[(&str, &str)] = &[
+        (
+            "next-hop-self",
+            "Tier 2: needs neighbor-group precedence resolution \
+             (neighbor_group::resolve_next_hop_self) on top of the verbatim \
+             statement. materialize_peers already receives the groups map, so \
+             this is a small follow-up rather than a structural gap.",
+        ),
+        (
+            "policy/in",
+            "Needs a policy-actor Register to resolve the name; BgpVrf holds \
+             no policy_tx, and peer_policy_ident encodes an index into the \
+             GLOBAL PeerMap, so a per-VRF peer would cross-wire onto whichever \
+             global peer sits at that index. Blocked on namespacing the \
+             registration (proto \"bgp-vrf:<name>\").",
+        ),
+        ("policy/out", "See policy/in."),
+        ("prefix-set/in", "See policy/in."),
+        ("prefix-set/out", "See policy/in."),
+    ];
+
+    /// The per-VRF neighbor's `afi-safi` knob set must equal the global
+    /// neighbor's, modulo [`VRF_AFI_KNOB_EXCLUSIONS`].
+    ///
+    /// This is the drift guard for the import effort: adding a knob to
+    /// `/router/bgp/neighbor/afi-safi` without either adding the per-VRF
+    /// counterpart or recording *why* it is excluded fails here. Without
+    /// it the two subtrees silently diverge, which is precisely how the
+    /// VRF neighbor ended up with one knob against the global
+    /// neighbor's twelve.
+    ///
+    /// Compares schema shape, not handlers — a leaf present in both
+    /// subtrees but wired in only one is caught by the orphan report.
+    #[test]
+    fn vrf_afi_knob_parity() {
+        let top = configure_entry();
+        let bgp = child(&child(&child(&top, "set"), "router"), "bgp");
+        let mut map = BTreeMap::new();
+        schema_walk(&bgp, "/router/bgp", true, &mut map);
+
+        let suffixes = |prefix: &str| -> BTreeSet<String> {
+            map.keys()
+                .filter_map(|p| p.strip_prefix(prefix))
+                .filter_map(|rest| rest.strip_prefix('/'))
+                .map(str::to_string)
+                .collect()
+        };
+
+        let global = suffixes("/router/bgp/neighbor/afi-safi");
+        let vrf = suffixes("/router/bgp/vrf/neighbor/afi-safi");
+
+        let excluded: BTreeSet<&str> = VRF_AFI_KNOB_EXCLUSIONS.iter().map(|(k, _)| *k).collect();
+
+        // In the global subtree, absent from the VRF one, and not an
+        // acknowledged exclusion.
+        let unimported: Vec<&String> = global
+            .difference(&vrf)
+            .filter(|p| !excluded.contains(p.as_str()))
+            // A container whose children are all excluded is itself
+            // legitimately absent (e.g. `policy` once policy/{in,out} are).
+            .filter(|p| !excluded.iter().any(|e| e.starts_with(&format!("{p}/"))))
+            .collect();
+        assert!(
+            unimported.is_empty(),
+            "per-AFI knobs exist on the global neighbor but not on the per-VRF \
+             neighbor: {unimported:#?}\n\
+             Either mirror them under /router/bgp/vrf/neighbor/afi-safi (sharing \
+             a setter from src/bgp/afi_knob.rs) or add them to \
+             VRF_AFI_KNOB_EXCLUSIONS with the reason."
+        );
+
+        // The reverse: a VRF-only knob means the global neighbor is
+        // missing something, which is equally a divergence.
+        let vrf_only: Vec<&String> = vrf.difference(&global).collect();
+        assert!(
+            vrf_only.is_empty(),
+            "per-AFI knobs exist on the per-VRF neighbor but not on the global \
+             neighbor: {vrf_only:#?}"
+        );
+
+        // A stale exclusion (knob since imported, or renamed) is dead
+        // documentation that will mislead the next reader.
+        let stale: Vec<&&str> = excluded
+            .iter()
+            .filter(|e| vrf.contains(**e) || !global.contains(**e))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "VRF_AFI_KNOB_EXCLUSIONS entries no longer apply (imported, or gone \
+             from the global neighbor): {stale:#?}"
+        );
+    }
+
     /// The whole `/router/bgp/tracing` and `/router/bgp/neighbor/tracing`
     /// subtrees are handled by `config_tracing_dispatch`
     /// (`src/bgp/tracing.rs`) rather than per-node callbacks.

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -277,6 +277,89 @@ module zebra-bgp-vrf {
           description
             "Whether this AFI,SAFI is enabled for the CE peer.";
         }
+
+        // The knobs below mirror the global neighbor's
+        // /router/bgp/neighbor/afi-safi subtree leaf for leaf, and share
+        // its setters (src/bgp/afi_knob.rs) so the two can never diverge
+        // in meaning. `vrf_afi_knob_parity` in src/config/manager.rs
+        // pins the *set* of knobs: adding one to the global neighbor
+        // without adding it here (or listing it as a deliberate
+        // exclusion) fails that test.
+        //
+        // Unlike the global neighbor these are staged, not applied to a
+        // live peer — a CE peer runs in the per-VRF task, out of reach
+        // of a config callback — so an edit takes effect on the next VRF
+        // respawn or `clear bgp`.
+        leaf add-path {
+          ext:help "Additional-Paths send/receive mode (RFC 7911)";
+          // Must stay an enumeration, matching the global neighbor's
+          // leaf. A callback's `None` return is DISCARDED by the config
+          // dispatcher (`Bgp::process_cm_msg` calls `f(self, args, op)`
+          // and ignores the result), so an unparseable value is never
+          // reported: with a loose `type string` the commit reports
+          // "applied" while the setter silently rejects it. The schema
+          // type is the only thing that rejects bad input here.
+          type enumeration {
+            enum send;
+            enum receive;
+            enum send-receive;
+          }
+          description
+            "Negotiated in the OPEN, so a change needs the session to
+             renegotiate.";
+        }
+        container graceful-restart {
+          ext:help "Per-family Graceful Restart (RFC 4724)";
+          leaf enabled {
+            ext:help "Advertise GR forwarding-state preservation";
+            type boolean;
+          }
+        }
+        container long-lived-graceful-restart {
+          ext:help "Per-family Long-Lived Graceful Restart";
+          leaf enabled {
+            ext:help "Advertise LLGR for this family";
+            type boolean;
+          }
+          leaf restart-time {
+            ext:help "LLGR stale-route retention time (seconds)";
+            type uint32;
+            units "seconds";
+            description
+              "Deleting only this leaf leaves LLGR enabled with the
+               bare marker value — it does not turn the feature off.";
+          }
+        }
+        leaf next-hop-unchanged {
+          ext:help "Keep the received next-hop toward this CE peer";
+          type boolean;
+          description
+            "When true, routes re-advertised to this eBGP CE keep their
+             received next-hop instead of the default rewrite to self.";
+        }
+        leaf encapsulation-type {
+          ext:help "Encapsulation for advertised routes (srv6)";
+          when "../name = 'ipv6'" {
+            description
+              "SRv6 encapsulation only applies to the IPv6 unicast
+               family.";
+          }
+          // Enumeration, not string — see the note on `add-path`.
+          type enumeration {
+            enum srv6;
+            enum srv6-relax;
+          }
+          description
+            "`srv6` advertises/accepts only routes carrying an SRv6
+             service SID; `srv6-relax` allows a mixed session. Same
+             values and same `when` as the global neighbor's leaf.
+
+             Note the `when` is documentation rather than enforcement:
+             the config engine does not evaluate it, so this leaf can in
+             fact be committed under `afi-safi ipv4`. That matches the
+             global neighbor's behaviour exactly — it is not a per-VRF
+             quirk — and the setter keys the value by family regardless.";
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

A per-VRF CE neighbor exposed **one** per-AFI knob (`enabled`) against the
global neighbor's **twelve**. Porting the rest one at a time would mean a new
struct field, a new callback, a new `materialize_peers` line and a new test per
knob — and nothing to stop the two subtrees drifting again afterwards.

## Change

Adds the framework that makes each import cheap and drift-proof, then uses it
for the six knobs that are pure functions of the peer config.

**1. Stage a real `PeerConfig`.** `BgpVrfNeighborConfig` was hand-mirroring
fragments of it (`peer_group`, `description`, `mp_explicit`, `timer` — four
such). It now holds the actual `PeerConfig`, and `materialize_peers` adopts it
wholesale:

```rust
peer.config = nbr_cfg.config.clone();
```

A new knob costs a YANG leaf and one line — no field, no apply site, no way for
the two representations to disagree.

**2. One setter per knob, two callers.** `bgp/afi_knob.rs` holds each knob's
semantics as a pure function of `(&mut PeerConfig, AfiSafi, ConfigOp, &mut
Args)`. The global callback wraps it with a live peer plus its side effects; the
per-VRF callback stages it and relies on the VRF respawn. Keeping the mutation
pure is what makes the second caller possible at all — the global callbacks take
`&mut Bgp` and a live peer, neither of which exists while staging.

**3. A parity test.** `vrf_afi_knob_parity` pins the knob *set* across the two
subtrees. `VRF_AFI_KNOB_EXCLUSIONS` records each deliberate omission with its
reason:

- `next-hop-self` — needs neighbor-group precedence resolution (Tier 2; a small
  follow-up, since `materialize_peers` already receives the groups map).
- `policy/{in,out}`, `prefix-set/{in,out}` — need a policy-actor `Register`,
  and `BgpVrf` holds no `policy_tx`. Worse, `peer_policy_ident` encodes an index
  into the **global** `PeerMap`, so a per-VRF peer registering today would have
  its resolution delivered to whichever global peer sits at that index. Blocked
  on namespacing the registration.

Adding a knob to the global neighbor without a per-VRF counterpart now fails CI
unless it is listed with a reason. **Verified by deleting a knob and watching
the test fail**, then restoring it.

Imported: `add-path`, `graceful-restart`, `long-lived-graceful-restart`
(`enabled` + `restart-time`), `next-hop-unchanged`, `encapsulation-type`.

## The bug the live test caught

Unit tests cover staged-config → peer, but nothing covers YANG → staged-config.
A differential probe against the global neighbor found both new enum-valued
leaves had been hand-written as `type string`:

```
before:  VRF add-path bogus-mode  → applied      ❌
         global add-path bogus-mode → error reply
after:   VRF add-path bogus-mode  → error reply  ✅
         VRF add-path receive     → applied
```

This matters more than a loose type usually would. `Bgp::process_cm_msg` calls
`f(self, args, msg.op)` and **discards the return value**, so a setter's `None`
is never reported — the commit says "applied" while the value is silently
rejected. **The schema type is the only thing that rejects bad input on this
path.** Both leaves now use the same enumerations as the global neighbor.

Worth noting the framework did *not* prevent this: it shares the setters, so the
knobs cannot diverge in behaviour, but the YANG types were hand-copied. That is
a direct argument for the shared-grouping step, deferred to a follow-up.

## Also corrected

A claim inherited from the global neighbor's comment: the `when "../name =
'ipv6'"` guard on `encapsulation-type` is **not enforced** by the config engine.
Verified on both subtrees — `set router bgp neighbor X afi-safi ipv4
encapsulation-type srv6` commits fine on the *global* neighbor too. So it is
documentation, not validation, and a setter must not assume the family. I fixed
my copy of the claim in `afi_knob.rs`; the global's own stale comment in
`config.rs` is left alone rather than widen this diff, but it is worth a
follow-up.

## Test plan

- `cargo fmt --all --check`, workspace clippy, and the full suite (**2517
  tests**) green.
- All four `bgp_config_audit` tests pass; `docs/{handler,schema}-paths.txt`
  regenerated, `docs/orphan-report.txt` counts updated by hand as its header
  requires (settable 281 → 287, handled 268 → 274; orphans unchanged at 3).
- New unit test `materialize_peers_applies_per_afi_knobs` covers every imported
  knob at once — a payoff of wholesale adoption — plus the negative case that an
  unconfigured neighbor keeps `PeerConfig` defaults.
- Existing VRF tests pass **unchanged**, which is what makes the `PeerConfig`
  fold credible as behaviour-preserving.
- Live: config applies, bad enum values rejected identically to the global
  neighbor, valid values accepted.

Follow-ups: Tier 2 (`next-hop-self`), the shared YANG grouping, Tier 3
(policy/prefix-set, gated on the policy plumbing), and a BDD scenario on the
dual-CE topology from #2078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
