### PR TITLE
bgp: share per-AFI neighbor knobs via one YANG grouping

### DIFF
--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -19,6 +19,10 @@ submodule ietf-bgp-neighbor {
   import extension {
     prefix ext;
   }
+
+  import zebra-bgp-afi-knobs {
+    prefix zbak;
+  }
   // Include the common submodule
 
   include ietf-bgp-common;
@@ -110,17 +114,6 @@ submodule ietf-bgp-neighbor {
              Loc-RIB";
         }
       }
-      container long-lived-graceful-restart {
-        ext:help "Per-family long-lived GR settings (RFC 9494)";
-        leaf enabled {
-          ext:help "Enable long-lived graceful-restart (RFC 9494)";
-          type boolean;
-        }
-        leaf restart-time {
-          ext:help "LLGR stale-retention time (seconds)";
-          type uint32;
-        }
-      }
       container graceful-restart {
         ext:help "Per-family graceful-restart settings";
         if-feature "bt:graceful-restart";
@@ -183,44 +176,12 @@ submodule ietf-bgp-neighbor {
         }
       }
       // uses mp-all-afi-safi-list-contents;
-      leaf add-path {
-        ext:help "Additional-Paths send/receive mode (RFC 7911)";
-        ext:sort "10";
-        type enumeration {
-          enum send;
-          enum receive;
-          enum send-receive;
-        }
-      }
-      leaf encapsulation-type {
-        ext:help "Encapsulation for advertised routes (srv6)";
-        when "../name = 'ipv6'" {
-          description
-            "SRv6 encapsulation only applies to the IPv6 unicast
-             family.";
-        }
-        ext:sort "20";
-        type enumeration {
-          enum srv6 {
-            description
-              "SRv6-only peer. Only routes carrying an SRv6 service SID
-               (BGP Prefix-SID attribute, RFC 9252) are advertised to /
-               accepted from this neighbor; routes without a SID are
-               filtered out on the session.";
-          }
-          enum srv6-relax {
-            description
-              "Mixed session. Routes with or without an SRv6 service SID
-               may be advertised to / accepted from this neighbor.";
-          }
-        }
-        description
-          "Per-neighbor SRv6 encapsulation mode for the IPv6 unicast
-           family. `srv6` makes the session SRv6-strict (SID-less routes
-           filtered), `srv6-relax` SRv6-relaxed (SID-less routes still
-           exchanged). Absent = no SRv6 encapsulation filtering for the
-           family.";
-      }
+      // Shared verbatim with the per-VRF neighbor
+      // (/router/bgp/vrf/neighbor/afi-safi) so the two subtrees are the
+      // same definition rather than two copies. See
+      // zebra-bgp-afi-knobs.yang for why graceful-restart and
+      // next-hop-self stay defined per-subtree.
+      uses zbak:bgp-neighbor-afi-knobs;
       leaf next-hop-self {
         ext:help "Advertise self as next hop to this neighbor";
         ext:sort "30";
@@ -244,27 +205,6 @@ submodule ietf-bgp-neighbor {
            and push the ASBR's swap label, not the unreachable foreign-AS
            next-hop carried across the inter-AS eBGP link. Honored on the
            Labeled-Unicast (SAFI 4) and VPNv4 (SAFI 128) advertise paths.";
-      }
-      leaf next-hop-unchanged {
-        ext:help "Keep the received next hop on eBGP advertisement";
-        ext:sort "31";
-        type boolean;
-        description
-          "Advertise routes of this address family to this eBGP neighbor
-           with their received next-hop preserved, instead of the default
-           eBGP rewrite to self. Equivalent to `neighbor X
-           next-hop-unchanged` (per address-family) in FRR / Cisco IOS.
-
-           Required on the multihop eBGP VPNv4 session between the route
-           reflectors of an RR-based Inter-AS MPLS/VPN Option C (RFC 4364
-           §10c): the RRs sit outside the forwarding path, so the
-           reflected route must keep the originating PE — the true LSP
-           endpoint — as its next-hop (and its original VPN label). The
-           receiving PE resolves that PE loopback over BGP-LU.
-
-           Honored for VPN routes on the VPNv4 (SAFI 128) advertise path;
-           locally-originated routes still advertise with self as the
-           next-hop.";
       }
       container policy {
         ext:sort "40";

--- a/zebra-rs/yang/zebra-bgp-afi-knobs.yang
+++ b/zebra-rs/yang/zebra-bgp-afi-knobs.yang
@@ -1,0 +1,161 @@
+module zebra-bgp-afi-knobs {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-afi-knobs";
+  prefix "zbak";
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Per-AFI BGP neighbor knobs shared verbatim by the two neighbor
+     subtrees:
+
+       * the global neighbor, /router/bgp/neighbor/afi-safi
+         (ietf-bgp-neighbor)
+       * the per-VRF CE neighbor, /router/bgp/vrf/neighbor/afi-safi
+         (zebra-bgp-vrf)
+
+     A single `grouping` used from both is what makes the two
+     definitions the same definition, rather than two copies that agree
+     today. The behaviour side is already unified — each knob has one
+     setter in src/bgp/afi_knob.rs, called by the global callback (live
+     peer) and the per-VRF callback (staged) — and this closes the
+     schema side.
+
+     That gap was not theoretical. When these knobs were first imported
+     into the per-VRF subtree the leaves were hand-copied, and both
+     enum-valued ones came out as `type string`. Nothing caught it in
+     review or in CI: `vrf_afi_knob_parity` compares the *set* of knob
+     paths, not their types. It surfaced only from a live differential
+     probe against the global neighbor, and it mattered because
+     `Bgp::process_cm_msg` discards a config callback's return value —
+     a setter that rejects a value cannot report it, so the schema type
+     is the only thing standing between a typo and a silently ignored
+     commit.
+
+     Two knobs are deliberately NOT here:
+
+       * `graceful-restart` — the global container takes
+         `mp-afi-safi-graceful-restart-config`, whose `enabled` leaf
+         carries `must \". = ../../../../graceful-restart/enabled\"`.
+         That path is anchored to the global neighbor's depth in the
+         tree and would be wrong under `vrf/neighbor`. The global
+         container also carries `if-feature` and three `config false`
+         state leaves the per-VRF one has no use for.
+       * `next-hop-self` — not yet imported into the per-VRF subtree at
+         all (it needs neighbor-group precedence resolution). It belongs
+         in this grouping the moment it is, and moving it here should be
+         part of that change.
+
+     Both exclusions are also recorded, with reasons, in
+     VRF_AFI_KNOB_EXCLUSIONS / docs/orphan-report.txt.";
+
+  grouping bgp-neighbor-afi-knobs {
+    description
+      "Per-address-family knobs common to the global and per-VRF BGP
+       neighbor. Semantics are identical on both; what differs is only
+       when they take effect — the global neighbor applies them to a
+       live peer, while a per-VRF CE peer lives in a separate task, so
+       its values are staged and applied when the VRF task next
+       respawns (or on `clear bgp`).";
+
+    leaf add-path {
+      ext:help "Additional-Paths send/receive mode (RFC 7911)";
+      ext:sort "10";
+      type enumeration {
+        enum send;
+        enum receive;
+        enum send-receive;
+      }
+      description
+        "Additional-Paths mode for this family. Negotiated in the OPEN,
+         so a change takes effect when the session next renegotiates
+         capabilities.";
+    }
+
+    leaf encapsulation-type {
+      ext:help "Encapsulation for advertised routes (srv6)";
+      when "../name = 'ipv6'" {
+        description
+          "SRv6 encapsulation only applies to the IPv6 unicast
+           family.
+
+           NOTE: this `when` is documentation, not enforcement — the
+           config engine does not evaluate it. `afi-safi ipv4
+           encapsulation-type srv6` commits successfully on both the
+           global and the per-VRF neighbor. Consumers must therefore
+           key the value by family and must not assume IPv6.";
+      }
+      ext:sort "20";
+      type enumeration {
+        enum srv6 {
+          description
+            "SRv6-only peer. Only routes carrying an SRv6 service SID
+             (BGP Prefix-SID attribute, RFC 9252) are advertised to /
+             accepted from this neighbor; routes without a SID are
+             filtered out on the session.";
+        }
+        enum srv6-relax {
+          description
+            "Mixed session. Routes with or without an SRv6 service SID
+             may be advertised to / accepted from this neighbor.";
+        }
+      }
+      description
+        "Per-neighbor SRv6 encapsulation mode for the IPv6 unicast
+         family. `srv6` makes the session SRv6-strict (SID-less routes
+         filtered), `srv6-relax` SRv6-relaxed (SID-less routes still
+         exchanged). Absent = no SRv6 encapsulation filtering for the
+         family.";
+    }
+
+    leaf next-hop-unchanged {
+      ext:help "Keep the received next hop on eBGP advertisement";
+      ext:sort "31";
+      type boolean;
+      description
+        "Advertise routes of this address family to this eBGP neighbor
+         with their received next-hop preserved, instead of the default
+         eBGP rewrite to self. Equivalent to `neighbor X
+         next-hop-unchanged` (per address-family) in FRR / Cisco IOS.
+
+         Required on the multihop eBGP VPNv4 session between the route
+         reflectors of an RR-based Inter-AS MPLS/VPN Option C (RFC 4364
+         §10c): the RRs sit outside the forwarding path, so the
+         reflected route must keep the originating PE — the true LSP
+         endpoint — as its next-hop (and its original VPN label). The
+         receiving PE resolves that PE loopback over BGP-LU.
+
+         Honored for VPN routes on the VPNv4 (SAFI 128) advertise path;
+         locally-originated routes still advertise with self as the
+         next-hop.";
+    }
+
+    container long-lived-graceful-restart {
+      ext:help "Per-family long-lived GR settings (RFC 9494)";
+      description
+        "Long-Lived Graceful Restart parameters for this family.";
+      leaf enabled {
+        ext:help "Enable long-lived graceful-restart (RFC 9494)";
+        type boolean;
+      }
+      leaf restart-time {
+        ext:help "LLGR stale-retention time (seconds)";
+        type uint32;
+        units "seconds";
+        description
+          "Stale-route retention time advertised for this family.
+           Deleting only this leaf leaves LLGR enabled with the bare
+           marker value — it does not turn the feature off.";
+      }
+    }
+  }
+}

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -20,6 +20,10 @@ module zebra-bgp-vrf {
     prefix zas;
   }
 
+  import zebra-bgp-afi-knobs {
+    prefix zbak;
+  }
+
   import config {
     prefix config;
   }
@@ -290,75 +294,31 @@ module zebra-bgp-vrf {
         // live peer — a CE peer runs in the per-VRF task, out of reach
         // of a config callback — so an edit takes effect on the next VRF
         // respawn or `clear bgp`.
-        leaf add-path {
-          ext:help "Additional-Paths send/receive mode (RFC 7911)";
-          // Must stay an enumeration, matching the global neighbor's
-          // leaf. A callback's `None` return is DISCARDED by the config
-          // dispatcher (`Bgp::process_cm_msg` calls `f(self, args, op)`
-          // and ignores the result), so an unparseable value is never
-          // reported: with a loose `type string` the commit reports
-          // "applied" while the setter silently rejects it. The schema
-          // type is the only thing that rejects bad input here.
-          type enumeration {
-            enum send;
-            enum receive;
-            enum send-receive;
-          }
-          description
-            "Negotiated in the OPEN, so a change needs the session to
-             renegotiate.";
-        }
+        // Per-AFI knobs shared verbatim with the global neighbor via one
+        // grouping, so the two subtrees cannot diverge in leaf TYPE the
+        // way they once did (both enum leaves were hand-copied as `type
+        // string`, which nothing caught — `vrf_afi_knob_parity` compares
+        // the knob set, not types, and a setter's rejection is never
+        // reported because `Bgp::process_cm_msg` discards the callback's
+        // return value).
+        //
+        // `graceful-restart` below stays local: the global container's
+        // `enabled` comes from mp-afi-safi-graceful-restart-config, whose
+        // `must` path is anchored to the global neighbor's tree depth and
+        // would be wrong here.
+        //
+        // Unlike the global neighbor these are staged, not applied to a
+        // live peer — a CE peer runs in the per-VRF task, out of reach of
+        // a config callback — so an edit takes effect on the next VRF
+        // respawn or `clear bgp`.
+        uses zbak:bgp-neighbor-afi-knobs;
+
         container graceful-restart {
           ext:help "Per-family Graceful Restart (RFC 4724)";
           leaf enabled {
             ext:help "Advertise GR forwarding-state preservation";
             type boolean;
           }
-        }
-        container long-lived-graceful-restart {
-          ext:help "Per-family Long-Lived Graceful Restart";
-          leaf enabled {
-            ext:help "Advertise LLGR for this family";
-            type boolean;
-          }
-          leaf restart-time {
-            ext:help "LLGR stale-route retention time (seconds)";
-            type uint32;
-            units "seconds";
-            description
-              "Deleting only this leaf leaves LLGR enabled with the
-               bare marker value — it does not turn the feature off.";
-          }
-        }
-        leaf next-hop-unchanged {
-          ext:help "Keep the received next-hop toward this CE peer";
-          type boolean;
-          description
-            "When true, routes re-advertised to this eBGP CE keep their
-             received next-hop instead of the default rewrite to self.";
-        }
-        leaf encapsulation-type {
-          ext:help "Encapsulation for advertised routes (srv6)";
-          when "../name = 'ipv6'" {
-            description
-              "SRv6 encapsulation only applies to the IPv6 unicast
-               family.";
-          }
-          // Enumeration, not string — see the note on `add-path`.
-          type enumeration {
-            enum srv6;
-            enum srv6-relax;
-          }
-          description
-            "`srv6` advertises/accepts only routes carrying an SRv6
-             service SID; `srv6-relax` allows a mixed session. Same
-             values and same `when` as the global neighbor's leaf.
-
-             Note the `when` is documentation rather than enforcement:
-             the config engine does not evaluate it, so this leaf can in
-             fact be committed under `afi-safi ipv4`. That matches the
-             global neighbor's behaviour exactly — it is not a per-VRF
-             quirk — and the setter keys the value by family regardless.";
         }
       }
     }


### PR DESCRIPTION
## Problem

The *behaviour* of the per-AFI neighbor knobs is already unified — #2080 gave
each one a single setter in `src/bgp/afi_knob.rs`, called by both the global and
the per-VRF callback. The *schema* was still two hand-copied sets of leaves.

That gap bit immediately. When the knobs were imported into the per-VRF subtree,
both enum-valued leaves came out as `type string`, and nothing caught it:

- `vrf_afi_knob_parity` compares the knob **set**, not leaf types.
- A setter's rejection is invisible anyway — `Bgp::process_cm_msg` calls
  `f(self, args, msg.op)` and **discards the return value**.

So the schema type is the only thing standing between a typo and a commit that
reports "applied" while silently doing nothing. Two copies of a leaf is two
chances to get that wrong.

## Change

Adds `zebra-bgp-afi-knobs.yang` holding `grouping bgp-neighbor-afi-knobs`, and
`uses` it from both `/router/bgp/neighbor/afi-safi` and
`/router/bgp/vrf/neighbor/afi-safi`.

`add-path`, `encapsulation-type`, `next-hop-unchanged` and
`long-lived-graceful-restart` are now **one definition**, not two copies that
happen to agree.

### Two knobs deliberately stay per-subtree

Both reasons are recorded in the new module:

- **`graceful-restart`** — the global container takes
  `mp-afi-safi-graceful-restart-config`, whose `enabled` leaf carries
  `must ". = ../../../../graceful-restart/enabled"`. That path is anchored to
  the global neighbor's **depth in the tree** and would be wrong under
  `vrf/neighbor`. The global container also carries `if-feature` and three
  `config false` state leaves the per-VRF one has no use for.
- **`next-hop-self`** — not in the per-VRF subtree at all yet (Tier 2; it needs
  neighbor-group precedence resolution). It belongs in this grouping the moment
  it is imported, and the module says so.

## Verification

**It is a pure refactor.** `docs/schema-paths.txt` regenerates **byte-identical**
to a baseline snapshotted before the change — the config tree is untouched, only
where the definitions live changed. (Hence no doc churn in this diff.)

**The sharing is real, not nominal.** A `uses` that silently failed to take
effect would look exactly like success, so this was checked directly: deleting
`enum send-receive` from the grouping and rebuilding made **both** subtrees
reject `add-path send-receive` from that one edit —

```
VRF:    error reply: ... afi-safi ipv4 add-path send-receive
GLOBAL: error reply: ... afi-safi ipv4 add-path send-receive
```

— and restoring it brought both back to `applied`.

Also re-checked live that bad enum values are rejected and valid ones accepted on
the global and per-VRF neighbor alike, and that the **global** neighbor still
works after having its leaves moved out from under it.

## Test plan

- `cargo fmt --all --check`, workspace clippy, full suite (**2517 tests**) green.
- All four `bgp_config_audit` tests pass, including `vrf_afi_knob_parity`.
- `docs/schema-paths.txt` diff against pre-change baseline: empty.
- Live: config applies; enum rejection/acceptance identical on both subtrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
