### PR TITLE
bgp: import next-hop-self into the per-VRF neighbor

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -224,6 +224,7 @@
 /router/bgp/vrf/neighbor/afi-safi/graceful-restart/enabled
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/enabled
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time
+/router/bgp/vrf/neighbor/afi-safi/next-hop-self
 /router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged
 /router/bgp/vrf/neighbor/description
 /router/bgp/vrf/neighbor/peer-group

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -21,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 287
-Handled: 274
+Total settable schema nodes: 288
+Handled: 275
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -47,11 +47,24 @@ next-hop-unchanged, encapsulation-type), sharing one setter per knob from
 src/bgp/afi_knob.rs so the two subtrees cannot diverge in meaning. The
 `vrf_afi_knob_parity` test pins the knob *set*: importing a knob to the
 global neighbor without a per-VRF counterpart fails unless it is listed in
-VRF_AFI_KNOB_EXCLUSIONS with a reason. Currently excluded there:
-next-hop-self (needs neighbor-group precedence resolution) and
-policy/prefix-set in+out (need a policy-actor Register, which BgpVrf has no
-channel for). Unlike the global neighbor these are staged and applied by
+VRF_AFI_KNOB_EXCLUSIONS with a reason. Currently excluded there: only
+policy/prefix-set in+out, which need a policy-actor Register that BgpVrf has
+no channel for (and peer_policy_ident encodes an index into the GLOBAL
+PeerMap, so a per-VRF peer would cross-wire onto whichever global peer sits
+at that index). Unlike the global neighbor these are staged and applied by
 materialize_peers, so an edit takes effect on the next VRF respawn.
+
+next-hop-self is imported as of this change. It is the one knob that is not
+merely stored: the staged value is the verbatim statement, and the effective
+value is resolved through neighbor-group precedence
+(neighbor_group::resolve_next_hop_self) -- by the config callback on the
+global neighbor, and by materialize_peers for a per-VRF peer, using the same
+helper so the precedence rule has a single implementation.
+
+The shared leaves themselves live in zebra-bgp-afi-knobs.yang and are `uses`d
+by both subtrees, so they cannot diverge in TYPE either; graceful-restart is
+the sole knob still defined per-subtree, because the global container's
+`must` path is anchored to the global neighbor's depth in the tree.
 
 Note: /router/bgp/vrf/neighbor/timers exposes only connect-retry-time,
 hold-time and idle-hold-time — the three leaves crate::bgp::timer::Config

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -310,6 +310,7 @@
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart	container
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/enabled	leaf
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time	leaf
+/router/bgp/vrf/neighbor/afi-safi/next-hop-self	leaf
 /router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged	leaf
 /router/bgp/vrf/neighbor/description	leaf
 /router/bgp/vrf/neighbor/peer-group	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4401,6 +4401,10 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_afi_safi_encapsulation_type,
         );
         self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/next-hop-self",
+            super::vrf_config::config_vrf_neighbor_afi_safi_next_hop_self,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv4",
             super::vrf_config::config_vrf_afi_ipv4,
         );

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -470,6 +470,33 @@ fn materialize_peers(
         // from) already arrived with the config adoption above.
         peer.config.mp = mp;
 
+        // `next-hop-self` is the one imported knob that is not simply
+        // stored: like `mp`, the staged value is the *verbatim* statement
+        // and the effective value has to be resolved through
+        // neighbor-group precedence (explicit wins, else the group's
+        // per-family opinion, else off). The global neighbor does this in
+        // its config callback against `Bgp::neighbor_groups`; here the
+        // same helper runs against the `groups` map this function is
+        // already handed, so the precedence rule has one implementation.
+        //
+        // Resolve over the negotiated families plus any family carrying an
+        // explicit statement: a statement for a family that never
+        // negotiates is inert, but resolving it costs nothing and keeps
+        // the stored state honest if the family is enabled later.
+        let nhs_families: std::collections::BTreeSet<AfiSafi> = peer
+            .config
+            .mp
+            .0
+            .keys()
+            .copied()
+            .chain(peer.config.nhs_explicit.keys().copied())
+            .collect();
+        for fam in nhs_families {
+            let value =
+                super::super::neighbor_group::resolve_next_hop_self(groups, &peer.config, fam);
+            peer.config.sub.entry(fam).or_default().next_hop_self = value;
+        }
+
         vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
         // `PeerMap::insert_with_key` assigns the stable ident used in every
         // timer/FSM message. Starting before insertion leaves every peer at
@@ -953,6 +980,106 @@ mod tests {
             pd.config.mp.has(&ipv6u) && pd.config.mp.has(&ipv4u),
             "explicit afi-safi ipv4 enabled adds v4 over a v6 session"
         );
+    }
+
+    /// `next-hop-self` is the only imported knob whose staged value is
+    /// the *verbatim* statement rather than the effective one, so it is
+    /// the only one where the wholesale config adoption is not the whole
+    /// story: `materialize_peers` must additionally resolve
+    /// explicit-wins-else-group-else-off, the same precedence the global
+    /// neighbor's callback applies. All three arms are pinned here.
+    #[tokio::test]
+    async fn materialize_peers_resolves_next_hop_self_through_group_precedence() {
+        use super::super::super::neighbor_group::{GroupAfiSafi, NeighborGroup};
+        use super::super::super::vrf_config::{BgpVrfConfig, BgpVrfNeighborConfig};
+        use super::super::inst::BgpVrf;
+        use crate::context::ProtoContext;
+        use bgp_packet::{Afi, AfiSafi, Safi};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "v1".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let ipv4u = AfiSafi::new(Afi::Ip, Safi::Unicast);
+
+        // Group turns next-hop-self ON for IPv4 unicast.
+        let mut g1 = NeighborGroup::default();
+        g1.afi_safi.insert(
+            ipv4u,
+            GroupAfiSafi {
+                enabled: true,
+                next_hop_self: Some(true),
+            },
+        );
+        let mut groups = BTreeMap::new();
+        groups.insert("g1".to_string(), g1);
+
+        let inherits: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let overrides: std::net::IpAddr = "192.0.2.2".parse().unwrap();
+        let bare: std::net::IpAddr = "192.0.2.3".parse().unwrap();
+
+        let mut cfg = BgpVrfConfig::default();
+
+        // 1. No own statement, references the group → inherits `true`.
+        cfg.neighbors.insert(inherits, {
+            let mut n = BgpVrfNeighborConfig {
+                remote_as: Some(65001),
+                ..Default::default()
+            };
+            n.config.neighbor_group = Some("g1".to_string());
+            n
+        });
+
+        // 2. Explicit `false` against the group's `true` → explicit wins.
+        //    This is the arm that would silently pass if the resolution
+        //    were skipped and the group consulted directly.
+        cfg.neighbors.insert(overrides, {
+            let mut n = BgpVrfNeighborConfig {
+                remote_as: Some(65002),
+                ..Default::default()
+            };
+            n.config.neighbor_group = Some("g1".to_string());
+            n.config.nhs_explicit.insert(ipv4u, false);
+            n
+        });
+
+        // 3. Neither → off.
+        cfg.neighbors.insert(
+            bare,
+            BgpVrfNeighborConfig {
+                remote_as: Some(65003),
+                ..Default::default()
+            },
+        );
+
+        materialize_peers(&mut vrf, &cfg, &groups);
+
+        let nhs = |addr: &std::net::IpAddr| -> bool {
+            vrf.peers
+                .get(addr)
+                .expect("peer inserted")
+                .config
+                .sub
+                .get(&ipv4u)
+                .map(|s| s.next_hop_self)
+                .unwrap_or(false)
+        };
+
+        assert!(nhs(&inherits), "group's next-hop-self must be inherited");
+        assert!(
+            !nhs(&overrides),
+            "an explicit `false` must beat the group's `true`"
+        );
+        assert!(!nhs(&bare), "no statement and no group → off");
     }
 
     /// A CE neighbor that references a `neighbor-group` inherits the

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -790,6 +790,15 @@ vrf_afi_knob! {
     /// `… afi-safi <af> encapsulation-type <srv6|srv6-relax>`.
     config_vrf_neighbor_afi_safi_encapsulation_type => set_encapsulation_type
 }
+vrf_afi_knob! {
+    /// `… afi-safi <af> next-hop-self <bool>`.
+    ///
+    /// Records the verbatim statement only. The effective value is
+    /// resolved through neighbor-group precedence by `materialize_peers`,
+    /// which already holds the group map — the global neighbor does the
+    /// same resolution in its own callback against `Bgp::neighbor_groups`.
+    config_vrf_neighbor_afi_safi_next_hop_self => set_next_hop_self_explicit
+}
 
 /// `… afi-safi <af> long-lived-graceful-restart enabled` — the odd one
 /// out: [`super::afi_knob::set_llgr`] keys off presence alone and takes

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4973,13 +4973,6 @@ mod bgp_config_audit_tests {
     /// below `afi-safi`.
     const VRF_AFI_KNOB_EXCLUSIONS: &[(&str, &str)] = &[
         (
-            "next-hop-self",
-            "Tier 2: needs neighbor-group precedence resolution \
-             (neighbor_group::resolve_next_hop_self) on top of the verbatim \
-             statement. materialize_peers already receives the groups map, so \
-             this is a small follow-up rather than a structural gap.",
-        ),
-        (
             "policy/in",
             "Needs a policy-actor Register to resolve the name; BgpVrf holds \
              no policy_tx, and peer_policy_ident encodes an index into the \

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -179,33 +179,9 @@ submodule ietf-bgp-neighbor {
       // Shared verbatim with the per-VRF neighbor
       // (/router/bgp/vrf/neighbor/afi-safi) so the two subtrees are the
       // same definition rather than two copies. See
-      // zebra-bgp-afi-knobs.yang for why graceful-restart and
-      // next-hop-self stay defined per-subtree.
+      // zebra-bgp-afi-knobs.yang for why graceful-restart stays defined
+      // per-subtree.
       uses zbak:bgp-neighbor-afi-knobs;
-      leaf next-hop-self {
-        ext:help "Advertise self as next hop to this neighbor";
-        ext:sort "30";
-        type boolean;
-        description
-          "Advertise our own address as the BGP next-hop for routes sent
-           to this neighbor in this address family, even when the route
-           was learned from another peer. Equivalent to `neighbor X
-           next-hop-self` (per address-family) in FRR / Cisco IOS.
-
-           By default the next-hop is rewritten to self only for eBGP and
-           locally-originated routes; a route learned from one iBGP/eBGP
-           peer and reflected/forwarded to another keeps its received
-           next-hop. Setting this forces next-hop-self on those forwarded
-           routes too.
-
-           Required on the iBGP IPv4/IPv6 Labeled-Unicast session an
-           Inter-AS MPLS/VPN Option C ASBR runs toward its PE, and on the
-           iBGP VPNv4 session an Inter-AS Option B ASBR runs toward its PE:
-           the PE must resolve the ASBR's loopback (reachable via the IGP)
-           and push the ASBR's swap label, not the unreachable foreign-AS
-           next-hop carried across the inter-AS eBGP link. Honored on the
-           Labeled-Unicast (SAFI 4) and VPNv4 (SAFI 128) advertise paths.";
-      }
       container policy {
         ext:sort "40";
         ext:help "Per-family route-policy references";

--- a/zebra-rs/yang/zebra-bgp-afi-knobs.yang
+++ b/zebra-rs/yang/zebra-bgp-afi-knobs.yang
@@ -41,7 +41,7 @@ module zebra-bgp-afi-knobs {
      is the only thing standing between a typo and a silently ignored
      commit.
 
-     Two knobs are deliberately NOT here:
+     One knob is deliberately NOT here:
 
        * `graceful-restart` — the global container takes
          `mp-afi-safi-graceful-restart-config`, whose `enabled` leaf
@@ -50,12 +50,8 @@ module zebra-bgp-afi-knobs {
          tree and would be wrong under `vrf/neighbor`. The global
          container also carries `if-feature` and three `config false`
          state leaves the per-VRF one has no use for.
-       * `next-hop-self` — not yet imported into the per-VRF subtree at
-         all (it needs neighbor-group precedence resolution). It belongs
-         in this grouping the moment it is, and moving it here should be
-         part of that change.
 
-     Both exclusions are also recorded, with reasons, in
+     That exclusion is also recorded, with its reason, in
      VRF_AFI_KNOB_EXCLUSIONS / docs/orphan-report.txt.";
 
   grouping bgp-neighbor-afi-knobs {
@@ -115,6 +111,40 @@ module zebra-bgp-afi-knobs {
          filtered), `srv6-relax` SRv6-relaxed (SID-less routes still
          exchanged). Absent = no SRv6 encapsulation filtering for the
          family.";
+    }
+
+    leaf next-hop-self {
+      ext:help "Advertise self as next hop to this neighbor";
+      ext:sort "30";
+      type boolean;
+      description
+        "Advertise our own address as the BGP next-hop for routes sent
+         to this neighbor in this address family, even when the route
+         was learned from another peer. Equivalent to `neighbor X
+         next-hop-self` (per address-family) in FRR / Cisco IOS.
+
+         By default the next-hop is rewritten to self only for eBGP and
+         locally-originated routes; a route learned from one iBGP/eBGP
+         peer and reflected/forwarded to another keeps its received
+         next-hop. Setting this forces next-hop-self on those forwarded
+         routes too.
+
+         Required on the iBGP IPv4/IPv6 Labeled-Unicast session an
+         Inter-AS MPLS/VPN Option C ASBR runs toward its PE, and on the
+         iBGP VPNv4 session an Inter-AS Option B ASBR runs toward its PE:
+         the PE must resolve the ASBR's loopback (reachable via the IGP)
+         and push the ASBR's swap label, not the unreachable foreign-AS
+         next-hop carried across the inter-AS eBGP link. Honored on the
+         Labeled-Unicast (SAFI 4) and VPNv4 (SAFI 128) advertise paths.
+
+         Unlike the other knobs here this one is not simply stored: the
+         statement is recorded verbatim and the EFFECTIVE value is then
+         resolved through neighbor-group precedence
+         (`neighbor_group::resolve_next_hop_self`) — explicit statement
+         first, else the referenced group's per-family opinion, else
+         off. Both subtrees do that resolution, the global neighbor in
+         its config callback and the per-VRF neighbor in
+         `materialize_peers`.";
     }
 
     leaf next-hop-unchanged {


### PR DESCRIPTION
## Problem

`next-hop-self` was the last per-AFI neighbor knob that was neither imported
into the per-VRF subtree nor shared between the two. It was excluded from
#2080's import and called out in #2081's grouping module as the one that should
join it later — this is that follow-up.

It is also the only per-AFI knob that is **not merely stored**. The staged value
is the *verbatim* statement; the effective value has to be resolved through
neighbor-group precedence — explicit statement first, else the referenced
group's per-family opinion, else off.

## Change

- **Move the leaf into `bgp-neighbor-afi-knobs`** (`zebra-bgp-afi-knobs.yang`),
  so both subtrees share one definition, exactly as that module said it should.
- **Register the per-VRF callback** through the existing macro, staging via the
  shared `set_next_hop_self_explicit` setter.
- **Resolve the effective value in `materialize_peers`** with
  `neighbor_group::resolve_next_hop_self`, against the `groups` map that
  function is already handed. That is the *same helper* the global neighbor's
  callback uses, so the precedence rule has a single implementation rather than
  two that agree today. Resolution runs over the negotiated families plus any
  family carrying an explicit statement.
- **Drop `next-hop-self` from `VRF_AFI_KNOB_EXCLUSIONS`.** Only `policy` and
  `prefix-set` remain excluded, still gated on the policy-actor plumbing and the
  `peer_policy_ident` cross-wiring hazard.

The per-VRF neighbor now exposes **8** per-AFI knobs, up from 1 before this
arc. `graceful-restart` is the sole knob still defined per-subtree, because
`mp-afi-safi-graceful-restart-config`'s `must` path is anchored to the global
neighbor's depth in the tree.

## On the test

`materialize_peers_resolves_next_hop_self_through_group_precedence` pins all
three arms, and the one that carries the weight is **explicit `false` beating
the group's `true`**. The other two arms would pass even if the resolution were
skipped and the group consulted directly — only that arm distinguishes real
precedence from a plausible shortcut.

## Verification

- Schema diff is **exactly one added path**
  (`/router/bgp/vrf/neighbor/afi-safi/next-hop-self`) plus its handler. The
  **global** path is unchanged despite the leaf moving into the grouping,
  confirming that move was path-preserving.
- Live on both subtrees: the knob is accepted, a non-boolean is rejected, and
  the global neighbor still works with its leaf moved out from under it.
- `cargo fmt --all --check`, workspace clippy, full suite (**2518 tests**), and
  all four `bgp_config_audit` tests green.
- `docs/orphan-report.txt` counts updated by hand as its header requires
  (settable 287 → 288, handled 274 → 275; orphans unchanged at 3).

Remaining in this area, all separate work: Tier 3 (policy/prefix-set), a BDD
scenario for the imported knobs on the dual-CE topology from #2078, and two
stale comments worth correcting (`config.rs`'s claim that the `when` guard
restricts `encapsulation-type` to IPv6 — disproven live on both subtrees — and
`vrf/spawn.rs:203`'s claim that per-VRF FSM timer events are dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
