### PR TITLE
bgp: per-VRF neighbor policy and prefix-set bindings

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -226,6 +226,10 @@
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time
 /router/bgp/vrf/neighbor/afi-safi/next-hop-self
 /router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged
+/router/bgp/vrf/neighbor/afi-safi/policy/in
+/router/bgp/vrf/neighbor/afi-safi/policy/out
+/router/bgp/vrf/neighbor/afi-safi/prefix-set/in
+/router/bgp/vrf/neighbor/afi-safi/prefix-set/out
 /router/bgp/vrf/neighbor/description
 /router/bgp/vrf/neighbor/peer-group
 /router/bgp/vrf/neighbor/remote-as

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -21,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 288
-Handled: 275
+Total settable schema nodes: 292
+Handled: 279
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -41,30 +41,26 @@ handled above. The tracing subtrees (/router/bgp/tracing and
 subtree is handled by config_tracing_dispatch in src/bgp/tracing.rs, so
 they count as handled above.
 
-Note: /router/bgp/vrf/neighbor/afi-safi mirrors the global neighbor's
-per-AFI knob set (add-path, graceful-restart, long-lived-graceful-restart,
-next-hop-unchanged, encapsulation-type), sharing one setter per knob from
-src/bgp/afi_knob.rs so the two subtrees cannot diverge in meaning. The
-`vrf_afi_knob_parity` test pins the knob *set*: importing a knob to the
-global neighbor without a per-VRF counterpart fails unless it is listed in
-VRF_AFI_KNOB_EXCLUSIONS with a reason. Currently excluded there: only
-policy/prefix-set in+out, which need a policy-actor Register that BgpVrf has
-no channel for (and peer_policy_ident encodes an index into the GLOBAL
-PeerMap, so a per-VRF peer would cross-wire onto whichever global peer sits
-at that index). Unlike the global neighbor these are staged and applied by
-materialize_peers, so an edit takes effect on the next VRF respawn.
+Note: /router/bgp/vrf/neighbor/afi-safi now mirrors the global neighbor's
+per-AFI knob set in full -- VRF_AFI_KNOB_EXCLUSIONS is empty and the
+`vrf_afi_knob_parity` test keeps it that way: a knob added to one subtree
+without the other fails CI unless it is listed there with a reason.
 
-next-hop-self is imported as of this change. It is the one knob that is not
-merely stored: the staged value is the verbatim statement, and the effective
-value is resolved through neighbor-group precedence
-(neighbor_group::resolve_next_hop_self) -- by the config callback on the
-global neighbor, and by materialize_peers for a per-VRF peer, using the same
-helper so the precedence rule has a single implementation.
-
-The shared leaves themselves live in zebra-bgp-afi-knobs.yang and are `uses`d
-by both subtrees, so they cannot diverge in TYPE either; graceful-restart is
+The leaves themselves live in zebra-bgp-afi-knobs.yang and are `uses`d by
+both subtrees, so they cannot diverge in TYPE either. graceful-restart is
 the sole knob still defined per-subtree, because the global container's
 `must` path is anchored to the global neighbor's depth in the tree.
+
+Two knobs need more than storing. next-hop-self records the verbatim
+statement and resolves the effective value through neighbor-group
+precedence (neighbor_group::resolve_next_hop_self) -- in the config callback
+for a global peer, in materialize_peers for a per-VRF one, sharing the
+helper. policy / prefix-set bind a NAME that the policy actor resolves: the
+per-VRF task subscribes under proto "bgp-vrf:<name>" (not the global "bgp",
+because peer_policy_ident encodes an index into the owning task's PeerMap),
+registers each binding from materialize_peers AFTER the peer has its ident,
+and unregisters them all on shutdown -- the actor has no unsubscribe, and
+its per-name watch lists only shrink on Unregister.
 
 Note: /router/bgp/vrf/neighbor/timers exposes only connect-retry-time,
 hold-time and idle-hold-time — the three leaves crate::bgp::timer::Config

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -312,6 +312,12 @@
 /router/bgp/vrf/neighbor/afi-safi/long-lived-graceful-restart/restart-time	leaf
 /router/bgp/vrf/neighbor/afi-safi/next-hop-self	leaf
 /router/bgp/vrf/neighbor/afi-safi/next-hop-unchanged	leaf
+/router/bgp/vrf/neighbor/afi-safi/policy	container
+/router/bgp/vrf/neighbor/afi-safi/policy/in	leaf
+/router/bgp/vrf/neighbor/afi-safi/policy/out	leaf
+/router/bgp/vrf/neighbor/afi-safi/prefix-set	container
+/router/bgp/vrf/neighbor/afi-safi/prefix-set/in	leaf
+/router/bgp/vrf/neighbor/afi-safi/prefix-set/out	leaf
 /router/bgp/vrf/neighbor/description	leaf
 /router/bgp/vrf/neighbor/peer-group	leaf
 /router/bgp/vrf/neighbor/remote-as	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4405,6 +4405,22 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_afi_safi_next_hop_self,
         );
         self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/policy/in",
+            super::vrf_config::config_vrf_neighbor_afi_safi_policy_in,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/policy/out",
+            super::vrf_config::config_vrf_neighbor_afi_safi_policy_out,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/prefix-set/in",
+            super::vrf_config::config_vrf_neighbor_afi_safi_prefix_set_in,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/afi-safi/prefix-set/out",
+            super::vrf_config::config_vrf_neighbor_afi_safi_prefix_set_out,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv4",
             super::vrf_config::config_vrf_afi_ipv4,
         );

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1812,7 +1812,7 @@ impl Bgp {
             return;
         };
         let preserved_label = if let Some(handle) = self.vrf_registry.remove(name) {
-            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber);
+            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber, &self.policy_tx);
             self.unregister_vrf_show(name);
             self.peer_index.retain(|_, owner| owner != name);
             // Withdraw the stale SID by its (old-prefix) address.
@@ -1837,6 +1837,7 @@ impl Bgp {
             srv6,
             self.tracing.clone(),
             self.vrf_global_tx.clone(),
+            self.policy_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
@@ -2474,7 +2475,7 @@ impl Bgp {
 
         for name in to_despawn {
             if let Some(handle) = self.vrf_registry.remove(&name) {
-                super::vrf::despawn_bgp_vrf(&name, &handle, &self.rib_subscriber);
+                super::vrf::despawn_bgp_vrf(&name, &handle, &self.rib_subscriber, &self.policy_tx);
                 self.unregister_vrf_show(&name);
                 // Withdraw everything this VRF exported into the
                 // VPNv4/v6 Loc-RIBs from PE peers and sibling VRFs —
@@ -2559,6 +2560,7 @@ impl Bgp {
                 srv6,
                 self.tracing.clone(),
                 self.vrf_global_tx.clone(),
+                self.policy_tx.clone(),
             );
             self.register_vrf_show(&name, &handle);
             self.vrf_registry.insert(name, handle);
@@ -2888,7 +2890,7 @@ impl Bgp {
         // new handle.
         let (preserved_label, preserved_sid) = if let Some(handle) = self.vrf_registry.remove(name)
         {
-            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber);
+            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber, &self.policy_tx);
             self.unregister_vrf_show(name);
             // Clear stale `peer_index` entries — the spawned task
             // is about to push fresh RegisterPeer messages.
@@ -2914,6 +2916,7 @@ impl Bgp {
             srv6,
             self.tracing.clone(),
             self.vrf_global_tx.clone(),
+            self.policy_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
@@ -4200,7 +4203,7 @@ impl Bgp {
         };
         let kernel = self.rib_known_vrfs.get(name).cloned();
         let preserved_sid = if let Some(handle) = self.vrf_registry.remove(name) {
-            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber);
+            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber, &self.policy_tx);
             self.unregister_vrf_show(name);
             self.peer_index.retain(|_, owner| owner != name);
             handle.srv6_sid
@@ -4222,6 +4225,7 @@ impl Bgp {
             srv6,
             self.tracing.clone(),
             self.vrf_global_tx.clone(),
+            self.policy_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -186,6 +186,24 @@ pub struct BgpVrf {
     /// SID. Empty until the first snapshot arrives.
     pub color_policy: super::super::color_policy::ColorPolicy,
     pub flex_algo_srv6_routes: super::super::color_policy::FlexAlgoSrv6Shadow,
+    /// Sender toward the policy actor, set by
+    /// [`Self::subscribe_policy`] at spawn. `None` in unit tests that
+    /// build a `BgpVrf` directly, which simply means their peers never
+    /// register a policy watch.
+    pub policy_tx: Option<UnboundedSender<crate::policy::Message>>,
+    /// Replies from the policy actor for THIS VRF's registrations.
+    ///
+    /// The actor keys its client channels by `proto`, so the per-VRF
+    /// subscription uses `bgp-vrf:<name>` rather than the global
+    /// `"bgp"`. That is not cosmetic: `peer_policy_ident` encodes an
+    /// index into the *owning task's* `PeerMap`, and a per-VRF peer's
+    /// index means nothing in the global map. Sharing the `"bgp"` proto
+    /// would deliver this VRF's resolutions to whichever global peer
+    /// happened to sit at that index.
+    pub policy_rx: UnboundedReceiver<crate::policy::PolicyRx>,
+    /// Our half of the reply channel, kept so `subscribe_policy` can
+    /// hand a clone to the actor (and a respawn can re-subscribe).
+    policy_reply_tx: UnboundedSender<crate::policy::PolicyRx>,
     /// VRF-first MUP origination tracking: per PFCP SEID, the RD-free ST
     /// prefixes this VRF exported to the global SAFI-85 RIB. Lets a Session
     /// Deletion / Modification (`MupWithdrawOriginate`) withdraw exactly the
@@ -711,6 +729,7 @@ impl BgpVrf {
     ) -> (Self, BgpVrfInbox) {
         let (inbox_tx, global_rx) = mpsc::unbounded_channel();
         let (tx, rx) = mpsc::channel(8192);
+        let policy_chan = crate::policy::PolicyRxChannel::new();
         let vrf = Self {
             name,
             ctx,
@@ -746,6 +765,9 @@ impl BgpVrf {
             import_transport_v6: std::collections::BTreeMap::new(),
             color_policy: Default::default(),
             flex_algo_srv6_routes: Default::default(),
+            policy_tx: None,
+            policy_rx: policy_chan.rx,
+            policy_reply_tx: policy_chan.tx,
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
@@ -1155,6 +1177,173 @@ impl BgpVrf {
     }
 
     /// Drive the per-VRF task. The loop exits cleanly when the
+    /// Apply a resolution the policy actor pushed back for one of this
+    /// VRF's peers.
+    ///
+    /// The mirror of `Bgp::process_policy_msg`, minus two things the
+    /// global task does:
+    ///
+    ///   * `shard_replace_in_policy` — per-VRF tasks don't drive the
+    ///     shard pool; their ingest is synchronous.
+    ///   * the soft-in / soft-out replay. `apply_soft_in_peer` /
+    ///     `apply_soft_out_peer` take `&mut Bgp` and reach global state,
+    ///     so replaying a per-VRF peer needs its own implementation.
+    ///     Until that lands, a resolution updates the binding but does
+    ///     NOT re-evaluate routes already in Adj-RIB-In / Adj-RIB-Out.
+    ///
+    /// That gap is invisible for the common case — bindings are
+    /// registered by `materialize_peers` at spawn, so the resolution
+    /// arrives long before the CE session establishes and any route
+    /// exists to re-evaluate. It bites only when an operator edits a
+    /// policy definition while a VRF session is up, which is the
+    /// follow-up.
+    ///
+    /// An unresolved name is *not* special-cased here: the actor always
+    /// answers, sending `None` when the name is undefined, and a
+    /// bound-but-unresolved set is deny-all by construction in the
+    /// filter path. Clearing the slot on `None` is what makes a rebind
+    /// to an undefined name fail closed rather than silently keep the
+    /// previous set.
+    pub fn process_policy_msg(&mut self, msg: crate::policy::PolicyRx) {
+        use super::super::policy::InOut;
+        use crate::policy::{PolicyRx, PolicyType};
+        match msg {
+            PolicyRx::PrefixSet {
+                name: _,
+                ident,
+                policy_type,
+                prefix_set,
+            } => {
+                let (peer_idx, afi_opt) = super::super::config::peer_policy_ident_decode(ident);
+                let Some(afi) = afi_opt else {
+                    // The peer-wide slot is only populated by a
+                    // neighbor-group, which per-VRF peers resolve
+                    // eagerly rather than registering for.
+                    return;
+                };
+                let Some(peer) = self.peers.get_mut_by_idx(peer_idx) else {
+                    return;
+                };
+                let direction = match policy_type {
+                    PolicyType::PrefixSetIn => InOut::Input,
+                    PolicyType::PrefixSetOut => InOut::Output,
+                    _ => return,
+                };
+                peer.prefix_set_slot(afi, direction).prefix_set = prefix_set;
+                if direction == InOut::Output {
+                    peer.rebuild_out_policy();
+                }
+            }
+            PolicyRx::PolicyList {
+                name: _,
+                ident,
+                policy_type,
+                policy_list,
+            } => {
+                let (peer_idx, afi_opt) = super::super::config::peer_policy_ident_decode(ident);
+                let Some(afi) = afi_opt else {
+                    return;
+                };
+                let Some(peer) = self.peers.get_mut_by_idx(peer_idx) else {
+                    return;
+                };
+                let direction = match policy_type {
+                    PolicyType::PolicyListIn => InOut::Input,
+                    PolicyType::PolicyListOut => InOut::Output,
+                    _ => return,
+                };
+                peer.policy_list_slot(afi, direction).policy_list = policy_list;
+                if direction == InOut::Output {
+                    peer.rebuild_out_policy();
+                }
+            }
+            // Key-chains and table-maps are not bound by per-VRF peers.
+            _ => {}
+        }
+    }
+
+    /// The `proto` string this VRF uses with the policy actor.
+    ///
+    /// Per-VRF rather than the global `"bgp"` because the actor routes
+    /// replies by proto and `peer_policy_ident` encodes an index into
+    /// the owning task's `PeerMap` — see [`Self::policy_rx`].
+    pub fn policy_proto(&self) -> String {
+        format!("bgp-vrf:{}", self.name)
+    }
+
+    /// Subscribe this VRF's reply channel with the policy actor and
+    /// remember the sender so peers can register their bindings.
+    ///
+    /// Called by `spawn_bgp_vrf`. A respawn re-subscribes under the same
+    /// proto key, which the actor treats as a replace — the stale
+    /// channel from the previous incarnation is simply overwritten.
+    pub fn subscribe_policy(&mut self, policy_tx: UnboundedSender<crate::policy::Message>) {
+        let _ = policy_tx.send(crate::policy::Message::Subscribe {
+            proto: self.policy_proto(),
+            tx: self.policy_reply_tx.clone(),
+        });
+        self.policy_tx = Some(policy_tx);
+    }
+
+    /// Every policy watch this VRF's peers registered, as
+    /// `(name, ident, policy_type)`.
+    ///
+    /// Handed to `BgpVrfHandle` so `despawn_bgp_vrf` can withdraw them
+    /// **synchronously**, on the global task, before a respawn registers
+    /// the replacements. Doing it from this task's shutdown path instead
+    /// would be a use-after-free in slow motion: the actor's `retain`
+    /// matches on `(proto, ident, policy_type)`, and a respawned VRF
+    /// reuses both the proto and its peers' idents, so a late Unregister
+    /// from the outgoing incarnation deletes the incoming one's watch —
+    /// and the `None` reply it triggers clears the freshly resolved
+    /// policy, leaving the session fail-closed for good.
+    ///
+    /// Both messages ride the same `policy_tx`, so FIFO ordering is what
+    /// guarantees the withdraw is processed before the re-register.
+    pub fn policy_watch_list(&self) -> Vec<(String, usize, crate::policy::PolicyType)> {
+        use crate::policy::PolicyType;
+        let mut out = Vec::new();
+        for idx in self.peers.idents() {
+            let Some(peer) = self.peers.get_by_idx(idx) else {
+                continue;
+            };
+            let mut push = |name: Option<&String>, policy_type: PolicyType, fam| {
+                if let Some(name) = name {
+                    out.push((
+                        name.clone(),
+                        super::super::config::peer_policy_ident(idx, Some(fam)),
+                        policy_type,
+                    ));
+                }
+            };
+            for (fam, io) in &peer.policy_list {
+                push(
+                    io.get(&super::super::policy::InOut::Input).name.as_ref(),
+                    PolicyType::PolicyListIn,
+                    *fam,
+                );
+                push(
+                    io.get(&super::super::policy::InOut::Output).name.as_ref(),
+                    PolicyType::PolicyListOut,
+                    *fam,
+                );
+            }
+            for (fam, io) in &peer.prefix_set {
+                push(
+                    io.get(&super::super::policy::InOut::Input).name.as_ref(),
+                    PolicyType::PrefixSetIn,
+                    *fam,
+                );
+                push(
+                    io.get(&super::super::policy::InOut::Output).name.as_ref(),
+                    PolicyType::PrefixSetOut,
+                    *fam,
+                );
+            }
+        }
+        out
+    }
+
     /// global task sends [`BgpVrfMsg::Shutdown`] or when the
     /// inbound channel is closed (i.e. every sender — the global
     /// task plus any per-peer holds — has dropped).
@@ -1201,6 +1390,13 @@ impl BgpVrf {
                     // `vrf <name>` selector and redirected the plain
                     // command here; render against this VRF's RIB/peers.
                     crate::bgp::show::process_vrf_show(self, msg).await;
+                }
+                Some(msg) = self.policy_rx.recv() => {
+                    // Resolution (or clearing) of a policy / prefix-set
+                    // this VRF's peers bound. Routed here rather than to
+                    // the global task because we subscribed under our own
+                    // proto — see `policy_rx`.
+                    self.process_policy_msg(msg);
                 }
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -80,6 +80,13 @@ pub struct BgpVrfHandle {
     /// have.
     pub evpn_advertise_v4: bool,
     pub evpn_advertise_v6: bool,
+    /// Policy / prefix-set watches this VRF's peers registered, as
+    /// `(name, ident, policy_type)`. Kept on the handle so
+    /// [`despawn_bgp_vrf`] can withdraw them synchronously *before* a
+    /// respawn re-registers — see [`BgpVrf::policy_watch_list`] for why
+    /// doing it from the task's own shutdown path would delete the
+    /// incoming incarnation's watches instead of the outgoing one's.
+    pub policy_watches: Vec<(String, usize, crate::policy::PolicyType)>,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -136,6 +143,7 @@ pub fn spawn_bgp_vrf(
     srv6: Option<Srv6VrfSid>,
     tracing_cfg: crate::bgp::tracing::BgpTracing,
     global_tx: UnboundedSender<BgpGlobalMsg>,
+    policy_tx: UnboundedSender<crate::policy::Message>,
 ) -> BgpVrfHandle {
     // Snapshot for logging + ILM install so we can move
     // `kernel` into the ctx-building arm without re-borrowing
@@ -182,6 +190,11 @@ pub fn spawn_bgp_vrf(
         global_tx,
         rib_rx,
     );
+    // Subscribe before `materialize_peers` runs: peers register their
+    // policy bindings during materialisation, and a Register sent before
+    // the Subscribe would be answered into a channel the actor does not
+    // have yet.
+    vrf.subscribe_policy(policy_tx);
     // Inter-AS Option AB: re-export imported VPNv4 routes (see the field
     // doc on `BgpVrf`). Carried from the staged VRF config.
     vrf.inter_as_hybrid = cfg.inter_as_hybrid;
@@ -299,6 +312,8 @@ pub fn spawn_bgp_vrf(
     // the global instance can register it with the config manager for
     // `show bgp vrf <name> …` redirection.
     let show_tx = vrf.show.tx.clone();
+    // Snapshot before `vrf` moves into the task.
+    let policy_watches = vrf.policy_watch_list();
     let task = serve_vrf(vrf);
     if crate::rib::tracing::task() {
         tracing::info!(
@@ -317,6 +332,7 @@ pub fn spawn_bgp_vrf(
     }
     BgpVrfHandle {
         inbox,
+        policy_watches,
         show_tx,
         task,
         label,
@@ -498,6 +514,59 @@ fn materialize_peers(
         }
 
         vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
+
+        // Bind the staged policy / prefix-set names and register a watch
+        // for each, so the actor resolves them and keeps them current.
+        //
+        // This MUST run after the insert, for the same reason `start()`
+        // does: `peer_policy_ident` encodes `peer.ident`, which
+        // `insert_with_key` is what assigns. Registering beforehand would
+        // key every peer's watch under ident 0, and the resolution would
+        // come back addressed to the first peer in the map — the exact
+        // shape of the bug fixed in #2071, but silent, because a
+        // mis-delivered policy just filters the wrong session's routes.
+        //
+        // The names go straight onto the peer's slots; the resolved set
+        // arrives later on `policy_rx` (see
+        // `BgpVrf::process_policy_msg`). Until it does the binding is
+        // deny-all, which is the same fail-closed posture the global
+        // neighbor has.
+        let ident = {
+            let peer = vrf.peers.get_mut(addr).expect("peer was just inserted");
+            for ((fam, kind), name) in &nbr_cfg.policy_refs {
+                use super::super::policy::InOut;
+                use super::super::vrf_config::VrfPolicyRef;
+                match kind {
+                    VrfPolicyRef::PolicyIn => {
+                        peer.policy_list_slot(*fam, InOut::Input).name = Some(name.clone())
+                    }
+                    VrfPolicyRef::PolicyOut => {
+                        peer.policy_list_slot(*fam, InOut::Output).name = Some(name.clone())
+                    }
+                    VrfPolicyRef::PrefixSetIn => {
+                        peer.prefix_set_slot(*fam, InOut::Input).name = Some(name.clone())
+                    }
+                    VrfPolicyRef::PrefixSetOut => {
+                        peer.prefix_set_slot(*fam, InOut::Output).name = Some(name.clone())
+                    }
+                }
+            }
+            peer.ident
+        };
+        if !nbr_cfg.policy_refs.is_empty()
+            && let Some(policy_tx) = vrf.policy_tx.clone()
+        {
+            let proto = vrf.policy_proto();
+            for ((fam, kind), name) in &nbr_cfg.policy_refs {
+                let _ = policy_tx.send(crate::policy::Message::Register {
+                    proto: proto.clone(),
+                    name: name.clone(),
+                    ident: super::super::config::peer_policy_ident(ident, Some(*fam)),
+                    policy_type: kind.policy_type(),
+                });
+            }
+        }
+
         // `PeerMap::insert_with_key` assigns the stable ident used in every
         // timer/FSM message. Starting before insertion leaves every peer at
         // Peer::new's ident 0, so a second neighbor's Start events are
@@ -612,7 +681,28 @@ fn materialize_vrf_redistribute(
 /// `BgpVrfMsg` send window — the FSM might miss state it needs to
 /// flush. The handle's `Task` aborts on drop regardless, so a
 /// failure path here doesn't strand the runtime.
-pub fn despawn_bgp_vrf(name: &str, handle: &BgpVrfHandle, rib_subscriber: &RibSubscriber) {
+pub fn despawn_bgp_vrf(
+    name: &str,
+    handle: &BgpVrfHandle,
+    rib_subscriber: &RibSubscriber,
+    policy_tx: &UnboundedSender<crate::policy::Message>,
+) {
+    // Withdraw this incarnation's policy watches first, on this thread,
+    // so they are ordered ahead of the Registers a respawn's
+    // `materialize_peers` is about to send on the same channel. The
+    // actor matches watches on `(proto, ident, policy_type)`, all of
+    // which a respawned VRF reuses, so a later withdraw would take out
+    // the new task's watch and its `None` reply would clear the freshly
+    // resolved policy. Same ordering argument as the RIB cleanup below.
+    let proto = format!("bgp-vrf:{name}");
+    for (watch_name, ident, policy_type) in &handle.policy_watches {
+        let _ = policy_tx.send(crate::policy::Message::Unregister {
+            proto: proto.clone(),
+            name: watch_name.clone(),
+            ident: *ident,
+            policy_type: *policy_type,
+        });
+    }
     // Drop this VRF's RIB redistribute subscription (client-registry +
     // redist-filter rows) so a respawn under the same `bgp:vrf:<name>`
     // proto doesn't leave a stale subscriber shadowing the live one —
@@ -657,6 +747,9 @@ mod tests {
         // placeholder context is enough for lifecycle testing.
         let subscriber = test_rib_subscriber();
         let groups = BTreeMap::new();
+        // The policy actor isn't running in these lifecycle tests; the
+        // Subscribe just lands in a channel nobody drains.
+        let (policy_tx, _policy_rx) = unbounded_channel();
         spawn_bgp_vrf(
             name.to_string(),
             &cfg,
@@ -669,6 +762,7 @@ mod tests {
             /* srv6 */ None,
             /* tracing */ Default::default(),
             global_tx,
+            policy_tx,
         )
     }
 

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -109,6 +109,41 @@ impl BgpVrfEncapsulation {
 pub struct BgpVrfNeighborConfig {
     pub remote_as: Option<u32>,
     pub config: PeerConfig,
+    /// Staged `afi-safi <af> {policy,prefix-set} {in,out} <name>`
+    /// references.
+    ///
+    /// These are the one per-AFI knob that cannot ride `config` like
+    /// every other: the resolved slots live on [`super::peer::Peer`]
+    /// (`policy_list` / `prefix_set`), not on `PeerConfig`, because each
+    /// holds the *resolved* set the policy actor hands back alongside
+    /// the operator's name. `materialize_peers` therefore copies these
+    /// onto the built peer separately, and — unlike every other knob —
+    /// must also register a watch so the name resolves at all.
+    pub policy_refs: BTreeMap<(AfiSafi, VrfPolicyRef), String>,
+}
+
+/// Which of a CE peer's four per-family policy bindings a staged name
+/// refers to. Maps 1:1 onto [`crate::policy::PolicyType`]; kept separate
+/// so the staging map has a total order and carries no variants (key
+/// chains, table maps) a per-VRF neighbor cannot bind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VrfPolicyRef {
+    PolicyIn,
+    PolicyOut,
+    PrefixSetIn,
+    PrefixSetOut,
+}
+
+impl VrfPolicyRef {
+    pub fn policy_type(self) -> crate::policy::PolicyType {
+        use crate::policy::PolicyType;
+        match self {
+            Self::PolicyIn => PolicyType::PolicyListIn,
+            Self::PolicyOut => PolicyType::PolicyListOut,
+            Self::PrefixSetIn => PolicyType::PrefixSetIn,
+            Self::PrefixSetOut => PolicyType::PrefixSetOut,
+        }
+    }
 }
 
 impl BgpVrfNeighborConfig {
@@ -713,6 +748,53 @@ pub fn config_vrf_neighbor_idle_hold_time(
         _ => {}
     }
     Some(())
+}
+
+/// Generate a `… afi-safi <af> {policy,prefix-set} {in,out} <name>`
+/// callback. Unlike the `vrf_afi_knob!` family these do not go through a
+/// shared `afi_knob` setter: the value is not a `PeerConfig` field but a
+/// name that has to be resolved by the policy actor, so it is staged in
+/// [`BgpVrfNeighborConfig::policy_refs`] and bound (with a `Register`)
+/// by `materialize_peers` once the peer has its ident.
+macro_rules! vrf_policy_ref {
+    ($(#[$m:meta])* $name:ident => $kind:expr) => {
+        $(#[$m])*
+        pub fn $name(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+            let vrf = args.string()?;
+            let addr = args.addr()?;
+            let afi_safi: AfiSafi = args.afi_safi()?;
+            let cfg = vrf_entry(bgp, vrf, op)?;
+            let nbr = neighbor_entry(cfg, addr, op)?;
+            match op {
+                ConfigOp::Set => {
+                    let name = args.string()?;
+                    nbr.policy_refs.insert((afi_safi, $kind), name);
+                }
+                ConfigOp::Delete => {
+                    nbr.policy_refs.remove(&(afi_safi, $kind));
+                }
+                _ => {}
+            }
+            Some(())
+        }
+    };
+}
+
+vrf_policy_ref! {
+    /// `… afi-safi <af> policy in <name>`.
+    config_vrf_neighbor_afi_safi_policy_in => VrfPolicyRef::PolicyIn
+}
+vrf_policy_ref! {
+    /// `… afi-safi <af> policy out <name>`.
+    config_vrf_neighbor_afi_safi_policy_out => VrfPolicyRef::PolicyOut
+}
+vrf_policy_ref! {
+    /// `… afi-safi <af> prefix-set in <name>`.
+    config_vrf_neighbor_afi_safi_prefix_set_in => VrfPolicyRef::PrefixSetIn
+}
+vrf_policy_ref! {
+    /// `… afi-safi <af> prefix-set out <name>`.
+    config_vrf_neighbor_afi_safi_prefix_set_out => VrfPolicyRef::PrefixSetOut
 }
 
 /// `set router bgp vrf <NAME> neighbor <addr> afi-safi {ipv4|ipv6} enabled

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4971,19 +4971,17 @@ mod bgp_config_audit_tests {
     /// Anything listed here is a decision; anything *not* listed is
     /// expected to exist in both subtrees. Entries are the path suffix
     /// below `afi-safi`.
-    const VRF_AFI_KNOB_EXCLUSIONS: &[(&str, &str)] = &[
-        (
-            "policy/in",
-            "Needs a policy-actor Register to resolve the name; BgpVrf holds \
-             no policy_tx, and peer_policy_ident encodes an index into the \
-             GLOBAL PeerMap, so a per-VRF peer would cross-wire onto whichever \
-             global peer sits at that index. Blocked on namespacing the \
-             registration (proto \"bgp-vrf:<name>\").",
-        ),
-        ("policy/out", "See policy/in."),
-        ("prefix-set/in", "See policy/in."),
-        ("prefix-set/out", "See policy/in."),
-    ];
+    /// Per-AFI neighbor knobs the per-VRF neighbor deliberately does NOT
+    /// mirror from the global neighbor, each with the reason it is out.
+    ///
+    /// Anything listed here is a decision; anything *not* listed is
+    /// expected to exist in both subtrees. Entries are the path suffix
+    /// below `afi-safi`.
+    ///
+    /// Empty: every per-AFI knob the global neighbor exposes is now
+    /// mirrored. Keep the list (and this test) — it is what makes the
+    /// next divergence fail CI instead of going unnoticed for a release.
+    const VRF_AFI_KNOB_EXCLUSIONS: &[(&str, &str)] = &[];
 
     /// The per-VRF neighbor's `afi-safi` knob set must equal the global
     /// neighbor's, modulo [`VRF_AFI_KNOB_EXCLUSIONS`].

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -180,42 +180,10 @@ submodule ietf-bgp-neighbor {
       // (/router/bgp/vrf/neighbor/afi-safi) so the two subtrees are the
       // same definition rather than two copies. See
       // zebra-bgp-afi-knobs.yang for why graceful-restart stays defined
-      // per-subtree.
+      // per-subtree. policy / prefix-set are in the grouping too: they
+      // are bound by name and resolved by the policy actor, which the
+      // per-VRF task now subscribes to under its own proto.
       uses zbak:bgp-neighbor-afi-knobs;
-      container policy {
-        ext:sort "40";
-        ext:help "Per-family route-policy references";
-        description
-          "Per-direction route-policy references applied to routes of
-           THIS address family. This is the only per-neighbor
-           route-policy binding; when a family has no per-family binding
-           it falls back to a route-policy inherited from a
-           neighbor-group (if any).";
-        leaf in {
-          ext:help "Inbound route-policy for this family";
-          type string;
-        }
-        leaf out {
-          ext:help "Outbound route-policy for this family";
-          type string;
-        }
-      }
-      container prefix-set {
-        ext:sort "50";
-        ext:help "Per-family prefix-set references";
-        description
-          "Per-direction prefix-set references applied to routes of THIS
-           address family. The per-family successor of the (removed)
-           peer-wide `neighbor X prefix-set {in,out}`.";
-        leaf in {
-          ext:help "Inbound prefix-set filter for this family";
-          type string;
-        }
-        leaf out {
-          ext:help "Outbound prefix-set filter for this family";
-          type string;
-        }
-      }
     }
   }
 }

--- a/zebra-rs/yang/zebra-bgp-afi-knobs.yang
+++ b/zebra-rs/yang/zebra-bgp-afi-knobs.yang
@@ -169,6 +169,42 @@ module zebra-bgp-afi-knobs {
          next-hop.";
     }
 
+    container policy {
+      ext:sort "40";
+      ext:help "Per-family route-policy references";
+      description
+        "Per-direction route-policy references applied to routes of
+         THIS address family. This is the only per-neighbor
+         route-policy binding; when a family has no per-family binding
+         it falls back to a route-policy inherited from a
+         neighbor-group (if any).";
+      leaf in {
+        ext:help "Inbound route-policy for this family";
+        type string;
+      }
+      leaf out {
+        ext:help "Outbound route-policy for this family";
+        type string;
+      }
+    }
+
+    container prefix-set {
+      ext:sort "50";
+      ext:help "Per-family prefix-set references";
+      description
+        "Per-direction prefix-set references applied to routes of THIS
+         address family. The per-family successor of the (removed)
+         peer-wide `neighbor X prefix-set {in,out}`.";
+      leaf in {
+        ext:help "Inbound prefix-set filter for this family";
+        type string;
+      }
+      leaf out {
+        ext:help "Outbound prefix-set filter for this family";
+        type string;
+      }
+    }
+
     container long-lived-graceful-restart {
       ext:help "Per-family long-lived GR settings (RFC 9494)";
       description


### PR DESCRIPTION
## What

Completes the per-AFI knob import to the per-VRF neighbor:
`VRF_AFI_KNOB_EXCLUSIONS` is now **empty**, so every per-AFI knob the global
neighbor exposes is mirrored, and `vrf_afi_knob_parity` keeps it that way.

Adds `policy {in,out}` and `prefix-set {in,out}` under
`/router/bgp/vrf/neighbor/afi-safi`.

## Plumbing (3a)

- `BgpVrf` gains a policy channel pair and subscribes with the policy actor
  under proto **`bgp-vrf:<name>`**, not the global `bgp`. That is load-bearing:
  `peer_policy_ident` encodes an index into the *owning task's* `PeerMap`, and a
  per-VRF peer's index means nothing in the global map — sharing the proto would
  deliver this VRF's resolutions to whichever global peer sat at that index.
- An event-loop arm feeds `BgpVrf::process_policy_msg`, the mirror of the global
  handler minus `shard_replace_in_policy` (per-VRF ingest is synchronous) and
  minus the soft-in/out replay, which needs `&mut Bgp` and is the follow-up
  (3c). Bindings register at spawn, long before a CE session establishes, so
  that gap only affects editing a policy while a VRF session is already up.

## Binding (3b)

- `policy` / `prefix-set` move into the shared `bgp-neighbor-afi-knobs` grouping.
  Per-VRF callbacks stage the **name** in `BgpVrfNeighborConfig::policy_refs` —
  the one knob that cannot ride the staged `PeerConfig`, because the slots live
  on `Peer` (they hold the *resolved* set alongside the name).
- `materialize_peers` binds the names and registers each watch **after** the
  insert, because `peer_policy_ident` needs the ident `insert_with_key` assigns.
  Registering earlier would key every peer's watch under ident 0 — the same
  shape as the #2071 bug, but silent, since a mis-delivered policy just filters
  the wrong session's routes.

Fail-closed needed no new decision: the actor already always answers, sending
`None` for an undefined name, and a bound-but-unresolved set is deny-all in the
filter path.

## The race caught while verifying

Unregistering from the task's own shutdown path is wrong. `resid_vrf` sends
`Shutdown` (async) then respawns (sync), and the actor matches watches on
`(proto, ident, policy_type)` — all of which a respawn reuses — so the outgoing
incarnation's `Unregister` would land **after** the incoming one's `Register`,
delete its watch, and the `None` reply would clear the freshly resolved policy,
leaving the session fail-closed permanently.

Fixed by carrying the watch list on `BgpVrfHandle` and having `despawn_bgp_vrf`
withdraw it **synchronously**, ahead of the respawn — the same ordering argument
the RIB cleanup beside it already makes.

## Test plan

- Verified live end to end (temporary tracing, since a clean commit proves
  nothing on this path): `DENY-ALL` resolved with its real entry, an undefined
  `PSET-A` came back as `None`, and the two peers registered under **distinct
  idents** (257 and 16777473) — the cross-wiring the namespacing prevents,
  observed rather than assumed. Tracing removed; grep-verified absent.
- `cargo fmt --all --check`, workspace clippy, full suite (**2518 tests**), all
  four `bgp_config_audit` tests green.
- Schema diff is exactly the six new VRF nodes; the global `policy` /
  `prefix-set` paths are unchanged despite both containers moving into the
  grouping. Orphan report counts updated by hand (settable 288 → 292, handled
  275 → 279; orphans unchanged at 3).

Follow-up (3c): soft-in/soft-out replay so a policy *edit* re-evaluates routes
already in a live per-VRF session's Adj-RIB-In / Adj-RIB-Out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
