### PR TITLE
bgp: apply per-VRF neighbor config to running VRFs (respawn + incremental)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -157,6 +157,21 @@ pub(crate) fn peer_index_register(
     }
 }
 
+/// Inverse of [`peer_index_register`]: drop the `peer_index` row for
+/// `addr` only when it is still claimed by `vrf`. The guard avoids a
+/// stale RemovePeer for `vrfA` clobbering a fresh claim `vrfB` made on
+/// the same address after a move — the most-recent-writer semantics of
+/// `peer_index_register` win.
+pub(crate) fn peer_index_unregister(
+    index: &mut BTreeMap<std::net::IpAddr, String>,
+    vrf: &str,
+    addr: std::net::IpAddr,
+) {
+    if index.get(&addr).is_some_and(|owner| owner == vrf) {
+        index.remove(&addr);
+    }
+}
+
 /// Append `export_rts` to `attr.ecom` as Route-Target extended
 /// communities (RFC 4360 §4.1 — subtype `0x02`). RTs share the
 /// 6-octet on-wire encoding with RDs; the `From<RouteDistinguisher>`
@@ -2519,6 +2534,18 @@ impl Bgp {
             self.router_id,
             self.asn,
         );
+        // Incremental per-neighbor apply for VRFs that stay running at the
+        // task level (not spawned, despawned, or respawned this
+        // transaction). A neighbor add/remove/edit no longer forces a
+        // respawn (`runtime_structure_eq` dropped the neighbor term); apply
+        // it to the live task instead — the per-VRF equivalent of the
+        // global neighbor path, resolved GLOBAL-side against
+        // `neighbor_groups` and shipped as `AddPeer`/`RemovePeer`/
+        // `ReconfigurePeer`. Done BEFORE the despawn/respawn mutations
+        // below so a respawned VRF (which re-materializes every neighbor at
+        // spawn) is correctly skipped.
+        self.apply_vrf_neighbor_diffs(&to_respawn);
+
         // Reuse the full teardown/spawn path: it unregisters the old show
         // client, purges exports before label reuse, clears peer_index, then
         // registers fresh peers/show routing from final config.
@@ -2625,6 +2652,89 @@ impl Bgp {
         // Originate / withdraw config-driven MUP DSD segment routes now the
         // VRF set (and its SIDs / kernel context) may have changed.
         self.reconcile_mup_segment();
+    }
+
+    /// Apply per-neighbor config changes incrementally to every VRF that
+    /// stays running unchanged at the task level this transaction. For
+    /// each such VRF, diff the baseline neighbors against the desired ones
+    /// (resolving each side against its own neighbor-group snapshot) and
+    /// send the running task an `AddPeer` / `RemovePeer` /
+    /// `ReconfigurePeer` per delta — the per-VRF twin of the global
+    /// neighbor path, which mutates a live peer directly. `to_respawn`
+    /// names the VRFs already handled by the full teardown/spawn path
+    /// (they re-materialize every neighbor at spawn), so they are skipped.
+    ///
+    /// Resolution happens here, on the global side, because the VRF task
+    /// holds no neighbor-group map; the resolved `(remote_as, PeerConfig,
+    /// knobs, policy_refs)` travels in the message. `RegisterPeer` /
+    /// `UnregisterPeer` are applied directly to `peer_index` (we are
+    /// already the global task, so no round-trip through `global_tx` is
+    /// needed) so the accept dispatcher routes inbound connects correctly.
+    fn apply_vrf_neighbor_diffs(&mut self, to_respawn: &[String]) {
+        use super::vrf::msg::BgpVrfMsg;
+
+        // Collect the resolved diffs first so the `neighbor_groups` /
+        // `vrf_commit_baseline` borrows are released before the dispatch
+        // loop mutates `peer_index`.
+        let mut plan: Vec<(String, super::vrf::VrfNeighborDiff)> = Vec::new();
+        for (name, desired) in &self.vrfs {
+            // Only VRFs already running (not newly spawned this commit) …
+            if !self.vrf_registry.contains_key(name) {
+                continue;
+            }
+            // … and not being fully respawned (that path re-materializes
+            // every neighbor from final config).
+            if to_respawn.iter().any(|n| n == name) {
+                continue;
+            }
+            let Some(baseline) = self.vrf_commit_baseline.get(name) else {
+                continue;
+            };
+            let diff = super::vrf::compute_vrf_neighbor_diff(
+                &baseline.neighbors,
+                &self.vrf_neighbor_group_commit_baseline,
+                &desired.neighbors,
+                &self.neighbor_groups,
+            );
+            if !diff.adds.is_empty() || !diff.removes.is_empty() || !diff.reconfigures.is_empty() {
+                plan.push((name.clone(), diff));
+            }
+        }
+
+        for (name, diff) in plan {
+            for peer in diff.adds {
+                if let Some(handle) = self.vrf_registry.get(&name) {
+                    let _ = handle.inbox.send(BgpVrfMsg::AddPeer {
+                        addr: peer.addr,
+                        remote_as: peer.remote_as,
+                        config: Box::new(peer.config),
+                        knobs: Box::new(peer.knobs),
+                        policy_refs: peer.policy_refs,
+                    });
+                }
+                // Route inbound `:179` connects from this IP to the VRF.
+                peer_index_register(&mut self.peer_index, name.clone(), peer.addr);
+            }
+            for peer in diff.reconfigures {
+                if let Some(handle) = self.vrf_registry.get(&name) {
+                    let _ = handle.inbox.send(BgpVrfMsg::ReconfigurePeer {
+                        addr: peer.addr,
+                        remote_as: peer.remote_as,
+                        config: Box::new(peer.config),
+                        knobs: Box::new(peer.knobs),
+                        policy_refs: peer.policy_refs,
+                    });
+                }
+                // The address→VRF mapping is unchanged by a reconfigure,
+                // so `peer_index` needs no update.
+            }
+            for addr in diff.removes {
+                if let Some(handle) = self.vrf_registry.get(&name) {
+                    let _ = handle.inbox.send(BgpVrfMsg::RemovePeer { addr });
+                }
+                peer_index_unregister(&mut self.peer_index, &name, addr);
+            }
+        }
     }
 
     /// Withdraw every export a despawning VRF left in the VPNv4/v6
@@ -6042,6 +6152,9 @@ impl Bgp {
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);
             }
+            super::vrf::BgpGlobalMsg::UnregisterPeer { vrf, addr } => {
+                peer_index_unregister(&mut self.peer_index, &vrf, addr);
+            }
             // VRF-first MUP origination: a per-VRF task built a controller ST
             // route and exported it. Stamp the RD / export-RTs / controller
             // next-hop and promote it into the SAFI-85 Loc-RIB + advertise.
@@ -6365,6 +6478,24 @@ mod tests {
         peer_index_register(&mut index, "vrfA".to_string(), addr("192.0.2.1"));
         assert_eq!(index.get(&addr("192.0.2.1")), Some(&"vrfA".to_string()));
         assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn unregister_drops_the_owning_mapping() {
+        let mut index: BTreeMap<IpAddr, String> = BTreeMap::new();
+        peer_index_register(&mut index, "vrfA".to_string(), addr("192.0.2.1"));
+        super::peer_index_unregister(&mut index, "vrfA", addr("192.0.2.1"));
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn unregister_leaves_a_reclaimed_mapping_alone() {
+        // A stale RemovePeer for vrfA must not clobber a fresh claim vrfB
+        // made on the same address after a move.
+        let mut index: BTreeMap<IpAddr, String> = BTreeMap::new();
+        peer_index_register(&mut index, "vrfB".to_string(), addr("192.0.2.1"));
+        super::peer_index_unregister(&mut index, "vrfA", addr("192.0.2.1"));
+        assert_eq!(index.get(&addr("192.0.2.1")), Some(&"vrfB".to_string()));
     }
 
     /// Helper that takes a `BgpAttr` and tags it with one

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -907,6 +907,16 @@ pub struct Bgp {
     /// [`super::vrf::spawn_bgp_vrf`] and
     /// [`super::vrf::despawn_bgp_vrf`].
     pub vrfs: BTreeMap<String, super::vrf_config::BgpVrfConfig>,
+    /// Candidate snapshot captured at `CommitStart`. At `CommitEnd`, an
+    /// existing VRF whose spawn-time structure differs is safely despawned
+    /// and spawned again.
+    pub(crate) vrf_commit_baseline: BTreeMap<String, super::vrf_config::BgpVrfConfig>,
+    /// Neighbor-group snapshot paired with `vrf_commit_baseline`. Per-VRF
+    /// peers resolve group remote-AS and AFI/SAFI opinions at spawn time, so
+    /// the structural diff must compare effective values from both sides of
+    /// the transaction.
+    pub(crate) vrf_neighbor_group_commit_baseline:
+        BTreeMap<String, super::neighbor_group::NeighborGroup>,
     /// Per-VRF tasks currently running. The diff against
     /// [`Self::vrfs`] at `CommitEnd` spawns the names that show up
     /// in the desired set but not here, and despawns names that
@@ -1224,6 +1234,8 @@ impl Bgp {
             group_keychain_watch_next: 0,
             interface_neighbors: super::interface_neighbor::empty_map(),
             vrfs: BTreeMap::new(),
+            vrf_commit_baseline: BTreeMap::new(),
+            vrf_neighbor_group_commit_baseline: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
             rib_subscriber,
@@ -2496,7 +2508,22 @@ impl Bgp {
     }
 
     fn apply_vrf_commit_diff(&mut self) {
-        let (to_spawn, to_despawn) = super::vrf::compute_vrf_diff(&self.vrfs, &self.vrf_registry);
+        let (mut to_spawn, mut to_despawn) =
+            super::vrf::compute_vrf_diff(&self.vrfs, &self.vrf_registry);
+        let to_respawn = super::vrf::compute_vrf_respawn(
+            &self.vrf_commit_baseline,
+            &self.vrf_neighbor_group_commit_baseline,
+            &self.vrfs,
+            &self.neighbor_groups,
+            &self.vrf_registry,
+            self.router_id,
+            self.asn,
+        );
+        // Reuse the full teardown/spawn path: it unregisters the old show
+        // client, purges exports before label reuse, clears peer_index, then
+        // registers fresh peers/show routing from final config.
+        to_despawn.extend(to_respawn.iter().cloned());
+        to_spawn.extend(to_respawn);
 
         for name in to_despawn {
             if let Some(handle) = self.vrf_registry.remove(&name) {
@@ -2961,7 +2988,9 @@ impl Bgp {
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         match msg.op {
             ConfigOp::CommitStart => {
-                //
+                self.vrf_commit_baseline.clone_from(&self.vrfs);
+                self.vrf_neighbor_group_commit_baseline
+                    .clone_from(&self.neighbor_groups);
             }
             ConfigOp::Set | ConfigOp::Delete => {
                 let (path, args) = path_from_command(&msg.paths);
@@ -2980,11 +3009,12 @@ impl Bgp {
                 // Log the per-VRF intent at debug, then diff
                 // `self.vrfs` (desired) against `self.vrf_registry`
                 // (running), spawn the additions, despawn the
-                // removals. Edits to an already-spawned VRF are
-                // not detected here — a follow-up will layer
-                // cfg-hash comparison on top.
+                // removals. Spawn-time structural edits to an existing VRF
+                // use the same full teardown/spawn path.
                 super::vrf_config::log_commit_diff(self);
                 self.apply_vrf_commit_diff();
+                self.vrf_commit_baseline.clear();
+                self.vrf_neighbor_group_commit_baseline.clear();
                 self.apply_mup_c_commit_diff();
             }
             ConfigOp::Completion => {

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -1229,81 +1229,98 @@ pub(super) struct InheritOutcome {
     pub bfd_reapply: bool,
 }
 
-/// Resolve and apply the inheritable *session* knobs onto a freshly
-/// materialized peer, for a caller that does its own `mp` / next-hop-self
-/// resolution and has no live session to reconcile.
-///
-/// This is the per-VRF counterpart to [`apply_inherited`]. It cannot use
-/// that function directly for two reasons:
-///
-///   * [`apply_inherited`] calls [`recompute_peer_mp`], whose base family
-///     is a *forced* IPv4 unicast ([`effective_mp`]). A per-VRF CE peer
-///     derives its base from its own address instead — a bare IPv6 CE
-///     must negotiate IPv6 unicast only — so `materialize_peers` resolves
-///     `mp` itself and this helper leaves `config.mp` alone.
-///   * The auth / MSS / BFD knobs return cross-borrow *refresh* outcomes
-///     that a live global neighbor reconciles against its shared listener
-///     and BFD client. A CE peer is built before it dials and (today) has
-///     no such shared state, so those knobs are handled in their own
-///     phases; this helper covers only the knobs that are a pure mutation
-///     of peer state.
-///
-/// Returns nothing: every knob here applies at (re)spawn, and a bounce is
-/// meaningless for a peer that has not started. The knobs it does NOT yet
-/// cover (`password`, `ao_config`, `tcp_mss`, `update_source`'s BFD
-/// re-arm) are the auth / BFD follow-ups.
-pub(super) fn apply_inherited_session_knobs(
+/// Resolve the full inheritable-knob record for `config` against `groups`,
+/// field-wise `explicit.or(group)` via [`resolve_knob`]. Factored out of
+/// [`apply_inherited`] so the resolution has one implementation, shared by
+/// the live global sweep and the per-VRF spawn / runtime path
+/// ([`super::vrf::spawn::resolve_vrf_peer_config`]) — the latter resolves on
+/// the global side and ships the record to the VRF task, which then applies
+/// it with [`apply_resolved_session_knobs`].
+pub(super) fn resolve_inherited_knobs(
     groups: &BTreeMap<String, NeighborGroup>,
-    peer: &mut Peer,
-) {
+    config: &PeerConfig,
+) -> InheritableKnobs {
+    // The struct literal names each field, so adding a knob to
+    // `InheritableKnobs` refuses to compile until this site decides how to
+    // resolve it.
+    InheritableKnobs {
+        passive: resolve_knob(groups, config, |k| k.passive),
+        update_source: resolve_knob(groups, config, |k| k.update_source),
+        port: resolve_knob(groups, config, |k| k.port),
+        ttl_security: resolve_knob(groups, config, |k| k.ttl_security),
+        ebgp_multihop: resolve_knob(groups, config, |k| k.ebgp_multihop),
+        tcp_mss: resolve_knob(groups, config, |k| k.tcp_mss),
+        password: resolve_knob(groups, config, |k| k.password.clone()),
+        ao_config: resolve_knob(groups, config, |k| k.ao_config.clone()),
+        disable_connected_check: resolve_knob(groups, config, |k| k.disable_connected_check),
+        ip_transparent: resolve_knob(groups, config, |k| k.ip_transparent),
+        policy_in: resolve_knob(groups, config, |k| k.policy_in.clone()),
+        policy_out: resolve_knob(groups, config, |k| k.policy_out.clone()),
+        prefix_set_in: resolve_knob(groups, config, |k| k.prefix_set_in.clone()),
+        prefix_set_out: resolve_knob(groups, config, |k| k.prefix_set_out.clone()),
+        allowas_in: resolve_knob(groups, config, |k| k.allowas_in),
+        as_override: resolve_knob(groups, config, |k| k.as_override),
+        remove_private_as: resolve_knob(groups, config, |k| k.remove_private_as),
+        enforce_first_as: resolve_knob(groups, config, |k| k.enforce_first_as),
+        route_reflector_client: resolve_knob(groups, config, |k| k.route_reflector_client),
+        region_id: resolve_knob(groups, config, |k| k.region_id),
+    }
+}
+
+/// Apply the already-resolved inheritable *session* knobs onto a peer and
+/// return whether the change requires a re-OPEN (bounce). The apply half
+/// of the knob machinery, paired with [`resolve_inherited_knobs`], so a
+/// caller that resolved the knobs elsewhere (the per-VRF runtime path,
+/// which resolves global-side and ships the record) can apply them
+/// directly to a live peer. The per-VRF spawn / add path resolves via
+/// [`resolve_inherited_knobs`] then applies here; the reconfigure path
+/// reuses the returned bounce.
+///
+/// Covers the knobs that are a pure mutation of peer session state and
+/// accumulates the bounce bool exactly as [`apply_inherited`] does. The
+/// active/connect-side auth knobs (`password`, `ao_config`) ARE applied
+/// here — they write `config.transport` fields the shared FSM connect path
+/// reads when the PE dials the CE; their `_refresh` outcomes (which key a
+/// shared listener) are discarded, since the per-VRF listener is keyed
+/// separately by `refresh_listener_md5` / `refresh_listener_ao`. The
+/// remaining refresh-only knobs (`tcp_mss`, `update_source`'s BFD re-arm)
+/// still need a live-session reconcile a freshly-materialized peer has no
+/// state for, so they are not applied here.
+pub(super) fn apply_resolved_session_knobs(peer: &mut Peer, want: &InheritableKnobs) -> bool {
+    let mut bounce = false;
     // ebgp-multihop before ttl-security: the two are mutually exclusive
     // and each guard observes the other, so the order must match
     // `apply_inherited`.
-    let ebgp_multihop = resolve_knob(groups, &peer.config, |k| k.ebgp_multihop);
-    super::config::apply_ebgp_multihop(peer, ebgp_multihop);
-    let ttl_security = resolve_knob(groups, &peer.config, |k| k.ttl_security).unwrap_or(false);
-    super::config::apply_ttl_security(peer, ttl_security);
-    let port = resolve_knob(groups, &peer.config, |k| k.port);
-    super::config::apply_port(peer, port);
-    let dcc = resolve_knob(groups, &peer.config, |k| k.disable_connected_check).unwrap_or(false);
-    super::config::apply_disable_connected_check(peer, dcc);
-    let ipt = resolve_knob(groups, &peer.config, |k| k.ip_transparent).unwrap_or(false);
-    super::config::apply_ip_transparent(peer, ipt);
-    let passive = resolve_knob(groups, &peer.config, |k| k.passive).unwrap_or(false);
-    super::config::apply_passive(peer, passive);
-    let allowas_in = resolve_knob(groups, &peer.config, |k| k.allowas_in);
-    super::config::apply_allowas_in(peer, allowas_in);
-    let as_override = resolve_knob(groups, &peer.config, |k| k.as_override).unwrap_or(false);
-    super::config::apply_as_override(peer, as_override);
-    let remove_private_as = resolve_knob(groups, &peer.config, |k| k.remove_private_as);
-    super::config::apply_remove_private_as(peer, remove_private_as);
-    let enforce_first_as =
-        resolve_knob(groups, &peer.config, |k| k.enforce_first_as).unwrap_or(false);
-    super::config::apply_enforce_first_as(peer, enforce_first_as);
-    let rr_client =
-        resolve_knob(groups, &peer.config, |k| k.route_reflector_client).unwrap_or(false);
-    super::config::apply_route_reflector_client(peer, rr_client);
-    let update_source = resolve_knob(groups, &peer.config, |k| k.update_source);
+    bounce |= super::config::apply_ebgp_multihop(peer, want.ebgp_multihop);
+    bounce |= super::config::apply_ttl_security(peer, want.ttl_security.unwrap_or(false));
+    bounce |= super::config::apply_port(peer, want.port);
+    bounce |= super::config::apply_disable_connected_check(
+        peer,
+        want.disable_connected_check.unwrap_or(false),
+    );
+    bounce |= super::config::apply_ip_transparent(peer, want.ip_transparent.unwrap_or(false));
+    super::config::apply_passive(peer, want.passive.unwrap_or(false));
+    super::config::apply_allowas_in(peer, want.allowas_in);
+    super::config::apply_as_override(peer, want.as_override.unwrap_or(false));
+    super::config::apply_remove_private_as(peer, want.remove_private_as);
+    super::config::apply_enforce_first_as(peer, want.enforce_first_as.unwrap_or(false));
+    super::config::apply_route_reflector_client(peer, want.route_reflector_client.unwrap_or(false));
     // The BFD re-arm this returns is only meaningful for a live session.
-    let _ = super::config::apply_update_source(peer, update_source);
-    // TCP-MD5 password: resolve the verbatim statement over the group
-    // and write the effective value onto `config.transport.md5_password`.
-    // The shared FSM connect path (`peer_start_connection`) reads it and
-    // applies it to this peer's VRF-bound *connect* socket, so the PE's
-    // outbound dial to the CE is authenticated. The listener (passive)
-    // side is not keyed here — per-VRF passive-side auth needs a
-    // per-VRF listener (see the FRR model); the `_refresh` outcome is
-    // therefore discarded.
-    let password = resolve_knob(groups, &peer.config, |k| k.password.clone());
-    let _ = super::config::apply_md5_password(peer, password);
-    // TCP-AO: resolve the referenced key-chain *binding* onto
+    let _ = super::config::apply_update_source(peer, want.update_source);
+    // TCP-MD5 password (active/connect side): apply the already-resolved
+    // knob onto `config.transport.md5_password`. The shared FSM connect path
+    // (`peer_start_connection`) reads it and keys this peer's VRF-bound
+    // *connect* socket, so the PE's outbound dial to the CE is authenticated.
+    // The listener (passive) side is keyed separately by
+    // `BgpVrf::refresh_listener_md5`; the `_refresh` outcome here is discarded.
+    let _ = super::config::apply_md5_password(peer, want.password.clone());
+    // TCP-AO (active/connect side): apply the resolved key-chain binding onto
     // `config.transport.ao_config`. The resolved key material
-    // (`resolved_ao_key`) is filled in later, when the policy actor
-    // answers the per-VRF key-chain Register — see
-    // `BgpVrf::process_policy_msg`'s KeyChain arm. Active/outbound only,
-    // same listener limitation as the MD5 password.
-    let ao_config = resolve_knob(groups, &peer.config, |k| k.ao_config.clone());
-    let _ = super::config::apply_ao_config(peer, ao_config);
+    // (`resolved_ao_key`) is filled in later, when the policy actor answers
+    // the per-VRF key-chain Register — see `BgpVrf::process_policy_msg`'s
+    // KeyChain arm. The listener side is keyed by `refresh_listener_ao`.
+    let _ = super::config::apply_ao_config(peer, want.ao_config.clone());
+    bounce
 }
 
 pub(super) fn apply_inherited(
@@ -1314,32 +1331,10 @@ pub(super) fn apply_inherited(
     recompute_peer_mp(groups, &mut peer.config);
     recompute_peer_nhs(groups, peer);
 
-    // Resolve every knob up front by constructing the full record —
-    // the struct literal names each field, so adding a knob to
-    // `InheritableKnobs` refuses to compile until this site decides
-    // how to apply it.
-    let resolved = InheritableKnobs {
-        passive: resolve_knob(groups, &peer.config, |k| k.passive),
-        update_source: resolve_knob(groups, &peer.config, |k| k.update_source),
-        port: resolve_knob(groups, &peer.config, |k| k.port),
-        ttl_security: resolve_knob(groups, &peer.config, |k| k.ttl_security),
-        ebgp_multihop: resolve_knob(groups, &peer.config, |k| k.ebgp_multihop),
-        tcp_mss: resolve_knob(groups, &peer.config, |k| k.tcp_mss),
-        password: resolve_knob(groups, &peer.config, |k| k.password.clone()),
-        ao_config: resolve_knob(groups, &peer.config, |k| k.ao_config.clone()),
-        disable_connected_check: resolve_knob(groups, &peer.config, |k| k.disable_connected_check),
-        ip_transparent: resolve_knob(groups, &peer.config, |k| k.ip_transparent),
-        policy_in: resolve_knob(groups, &peer.config, |k| k.policy_in.clone()),
-        policy_out: resolve_knob(groups, &peer.config, |k| k.policy_out.clone()),
-        prefix_set_in: resolve_knob(groups, &peer.config, |k| k.prefix_set_in.clone()),
-        prefix_set_out: resolve_knob(groups, &peer.config, |k| k.prefix_set_out.clone()),
-        allowas_in: resolve_knob(groups, &peer.config, |k| k.allowas_in),
-        as_override: resolve_knob(groups, &peer.config, |k| k.as_override),
-        remove_private_as: resolve_knob(groups, &peer.config, |k| k.remove_private_as),
-        enforce_first_as: resolve_knob(groups, &peer.config, |k| k.enforce_first_as),
-        route_reflector_client: resolve_knob(groups, &peer.config, |k| k.route_reflector_client),
-        region_id: resolve_knob(groups, &peer.config, |k| k.region_id),
-    };
+    // Resolve every knob up front by constructing the full record. Shared
+    // with the per-VRF path via `resolve_inherited_knobs`; the destructure
+    // below still makes an unapplied field a compile error here.
+    let resolved = resolve_inherited_knobs(groups, &peer.config);
     // Destructure so an unapplied field is a compile error, not a
     // silently-ignored knob. Fields whose apply lands in a follow-up
     // batch are discarded explicitly below — remove the discard when

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -18,6 +18,8 @@ use crate::{bgp_vpn_trace, bgp_vrf_trace};
 use super::super::Message;
 use super::super::config::BgpRedistSource;
 use super::super::interface_addrs::InterfaceAddrs;
+use super::super::neighbor_group::InheritableKnobs;
+use super::super::peer::PeerConfig;
 use super::super::peer_map::PeerMap;
 use super::super::route::{LocalRib, ORIGINATED_PEER};
 use super::super::shard::BgpShard;
@@ -2890,6 +2892,363 @@ impl BgpVrf {
         }
     }
 
+    /// Add a CE peer to this running VRF task. Task-side half of the
+    /// incremental neighbor-add path: the global side already resolved
+    /// `remote_as`, `config` (family set + next-hop-self) and `knobs`
+    /// against `Bgp::neighbor_groups`, so this simply builds and starts
+    /// the peer with the SAME `insert_started_peer` the spawn-time
+    /// materialize uses — a peer added at runtime is built identically to
+    /// one present at spawn. Idempotent on the running FSM: `insert_with_key`
+    /// reuses the slot ident on a re-add.
+    fn add_peer(
+        &mut self,
+        addr: std::net::IpAddr,
+        remote_as: u32,
+        config: PeerConfig,
+        knobs: &InheritableKnobs,
+        policy_refs: &std::collections::BTreeMap<
+            (bgp_packet::AfiSafi, super::super::vrf_config::VrfPolicyRef),
+            String,
+        >,
+    ) {
+        super::spawn::insert_started_peer(self, &addr, remote_as, config, knobs, policy_refs);
+        bgp_vrf_trace!(
+            &self.tracing,
+            vrf = %self.name,
+            peer = %addr,
+            remote_as,
+            "bgp vrf: added CE peer at runtime",
+        );
+    }
+
+    /// Enumerate one peer's registered policy / prefix-set watches, as
+    /// `(name, ident, policy_type)` — the per-peer slice of
+    /// [`Self::policy_watch_list`], captured before a peer leaves the map
+    /// so the runtime remove path can Unregister them.
+    fn peer_policy_watches(
+        &self,
+        addr: &std::net::IpAddr,
+    ) -> Vec<(String, usize, crate::policy::PolicyType)> {
+        use crate::policy::PolicyType;
+        let mut out = Vec::new();
+        let Some(peer) = self.peers.get(addr) else {
+            return out;
+        };
+        let idx = peer.ident;
+        let mut push = |name: Option<&String>, policy_type: PolicyType, fam| {
+            if let Some(name) = name {
+                out.push((
+                    name.clone(),
+                    super::super::config::peer_policy_ident(idx, Some(fam)),
+                    policy_type,
+                ));
+            }
+        };
+        for (fam, io) in &peer.policy_list {
+            push(
+                io.get(&super::super::policy::InOut::Input).name.as_ref(),
+                PolicyType::PolicyListIn,
+                *fam,
+            );
+            push(
+                io.get(&super::super::policy::InOut::Output).name.as_ref(),
+                PolicyType::PolicyListOut,
+                *fam,
+            );
+        }
+        for (fam, io) in &peer.prefix_set {
+            push(
+                io.get(&super::super::policy::InOut::Input).name.as_ref(),
+                PolicyType::PrefixSetIn,
+                *fam,
+            );
+            push(
+                io.get(&super::super::policy::InOut::Output).name.as_ref(),
+                PolicyType::PrefixSetOut,
+                *fam,
+            );
+        }
+        out
+    }
+
+    /// Unregister a set of `(name, ident, policy_type)` policy watches on
+    /// this VRF's policy channel — the per-peer analog of the despawn-time
+    /// cleanup, so a removed / rebound CE peer's watches don't linger in
+    /// the actor (and a stale `None` reply can't clear a live binding).
+    fn unregister_policy_watches(&self, watches: &[(String, usize, crate::policy::PolicyType)]) {
+        if watches.is_empty() {
+            return;
+        }
+        let Some(policy_tx) = &self.policy_tx else {
+            return;
+        };
+        let proto = self.policy_proto();
+        for (name, ident, policy_type) in watches {
+            let _ = policy_tx.send(crate::policy::Message::Unregister {
+                proto: proto.clone(),
+                name: name.clone(),
+                ident: *ident,
+                policy_type: *policy_type,
+            });
+        }
+    }
+
+    /// Remove a CE peer from this running VRF task. Mirrors the global
+    /// `remove_peer_full` (`config.rs`): `route_clean` withdraws the
+    /// peer's routes (Adj-RIB-In sweep + best-path re-run + CE
+    /// re-advertise), `update_group::detach` drops its update-group
+    /// membership so a future slot reuse can't inherit it, then the peer
+    /// leaves `peers`. The listener auth / TCP-MSS / IP_TRANSPARENT
+    /// reconciliations the global path also runs have no per-VRF analog
+    /// (the VRF task owns no shared listener — passive connects arrive
+    /// via `BgpVrfMsg::Accept`), so they are deliberately omitted. The
+    /// peer's policy watches are Unregistered, the per-peer analog of the
+    /// despawn cleanup.
+    fn remove_peer(&mut self, addr: std::net::IpAddr) {
+        let Some(peer_idx) = self.peers.get(&addr).map(|p| p.ident) else {
+            // Nothing to remove — the peer was never materialized (e.g.
+            // it had no remote-as, so `resolve_vrf_peer_config` skipped
+            // it and the global diff still emitted a RemovePeer).
+            return;
+        };
+        // Capture the peer's policy watches before it leaves the map.
+        let watches = self.peer_policy_watches(&addr);
+        // Withdraw exports (`vrf_export: Some`), NOT `None` as the global
+        // `remove_peer_full` uses. The global instance has no VPNv4 export
+        // concept, but a per-VRF CE peer's learned routes WERE exported to
+        // the global VPNv4 table (the normal session-down path runs
+        // `route_clean` inside `fsm` with this same `Some(&exporter)`), so
+        // deleting the neighbor must withdraw them the same way — else a
+        // stale VPNv4 advertisement outlives the CE route that fed it.
+        let exporter = self.exporter();
+        let mut top = super::super::peer::BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: None,
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: Some(&exporter),
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: None,
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: Some(&self.transport_v4),
+            vrf_transport_v6: Some(&self.transport_v6),
+            central_label_alloc: None,
+            as_sets_withdraw: true,
+        };
+        // Per-VRF tasks don't drive the global shard pool (their RIB is
+        // the VRF's own), so pass `None` for shards — same as every other
+        // per-VRF route op.
+        super::super::route::route_clean(peer_idx, &mut top, &mut self.peers, None);
+        // Update-groups live outside `PeerMap`: the removal below purges
+        // the membership index, but the group member sets must be
+        // detached explicitly or the freed ident lingers and a future
+        // slot reuse inherits the group.
+        super::super::update_group::detach(&mut self.update_groups, &mut self.peers, peer_idx);
+        self.peers.remove(&addr);
+        self.unregister_policy_watches(&watches);
+        // Notify the global accept dispatcher this VRF no longer claims the
+        // address — the symmetric counterpart to the spawn-site
+        // `RegisterPeer` emission. The global runtime-diff dispatch also
+        // clears `peer_index` directly for immediacy; this message is the
+        // owner-guarded async backstop (a stale unregister can't clobber a
+        // fresh claim another VRF made on the same address).
+        let _ = self.global_tx.send(BgpGlobalMsg::UnregisterPeer {
+            vrf: self.name.clone(),
+            addr,
+        });
+        bgp_vrf_trace!(
+            &self.tracing,
+            vrf = %self.name,
+            peer = %addr,
+            "bgp vrf: removed CE peer at runtime",
+        );
+    }
+
+    /// Reconfigure an existing CE peer on this running VRF task. The
+    /// global side resolved the new `remote_as`, `config` and `knobs`
+    /// against the group map; this applies them to the live peer and
+    /// bounces only when re-OPEN is required.
+    ///
+    /// Bounce criteria — a faithful subset of the global neighbor rules.
+    /// The session knobs are applied through the SHARED
+    /// `apply_resolved_session_knobs` (the same `apply_*` primitives the
+    /// global path uses), which returns whether any of them needs a fresh
+    /// OPEN; a change to the negotiated address-family set (`config.mp`)
+    /// on an Established session adds to that. Everything else (timers,
+    /// description, next-hop-self, per-AFI knobs) takes effect on the next
+    /// advertisement without dropping the session.
+    ///
+    /// remote-as: a bare remote-as change does NOT bounce, mirroring the
+    /// global `config_remote_as` (`config.rs`), which only sets
+    /// remote_as / peer_type / start() with no `Event::Stop`. Only the
+    /// mp / session-knob change bounces.
+    fn reconfigure_peer(
+        &mut self,
+        addr: std::net::IpAddr,
+        remote_as: u32,
+        config: PeerConfig,
+        knobs: &InheritableKnobs,
+        policy_refs: &std::collections::BTreeMap<
+            (bgp_packet::AfiSafi, super::super::vrf_config::VrfPolicyRef),
+            String,
+        >,
+    ) {
+        use super::super::peer::{Event, PeerType};
+        if self.peers.get(&addr).is_none() {
+            // Not present (e.g. it never had a remote-as). Treat a
+            // reconfigure of an absent peer as an add so a peer that
+            // gains a remote-as via edit still comes up.
+            self.add_peer(addr, remote_as, config, knobs, policy_refs);
+            return;
+        }
+        // Capture the currently-registered policy watches so we can diff
+        // them against the new refs after applying the config.
+        let old_watches = self.peer_policy_watches(&addr);
+
+        let peer = self.peers.get_mut(&addr).expect("peer present");
+        let ident = peer.ident;
+        // `AfiSafis` is not `PartialEq`; compare its inner
+        // `BTreeMap<AfiSafi, bool>` key set directly for the family-set
+        // change.
+        let before_mp: std::collections::BTreeSet<bgp_packet::AfiSafi> =
+            peer.config.mp.0.keys().copied().collect();
+        peer.remote_as = remote_as;
+        peer.peer_type = if remote_as == self.asn {
+            PeerType::IBGP
+        } else {
+            PeerType::EBGP
+        };
+        // Apply the config blob first, then the resolved session knobs on
+        // top: knob-applied `Peer` fields (e.g. `reflector_client`, a
+        // `Peer` field NOT in `PeerConfig`) must win over a blob-swap that
+        // would otherwise drop them.
+        peer.config = config;
+        let mut bounce = super::super::neighbor_group::apply_resolved_session_knobs(peer, knobs);
+        let after_mp: std::collections::BTreeSet<bgp_packet::AfiSafi> =
+            peer.config.mp.0.keys().copied().collect();
+        bounce |= before_mp != after_mp && peer.state.is_established();
+        // A peer that was never started (added while it lacked a
+        // remote-as) needs arming now that one resolved. `start()` is
+        // idempotent and self-gating, so calling it unconditionally is
+        // safe.
+        peer.start();
+
+        // Re-bind the policy / prefix-set slots and reconcile watches:
+        // Unregister the ones that were dropped or changed, Register the
+        // new set. Done after the config swap (which does NOT touch the
+        // resolved slots — those live on `Peer`, not `PeerConfig`).
+        self.rebind_policy_refs(&addr, policy_refs, &old_watches);
+
+        if bounce {
+            // Bounce through the FSM event channel, exactly like the
+            // global `clear bgp <peer>` / config-change path
+            // (`Message::Event(idx, Event::Stop)`). `fsm_stop` returns
+            // Idle with no NOTIFICATION; the peer re-dials and OPENs with
+            // the new family set / session parameters.
+            let _ = self.tx.try_send(Message::Event(ident, Event::Stop));
+        }
+        bgp_vrf_trace!(
+            &self.tracing,
+            vrf = %self.name,
+            peer = %addr,
+            remote_as,
+            bounced = bounce,
+            "bgp vrf: reconfigured CE peer at runtime",
+        );
+    }
+
+    /// Set a peer's policy / prefix-set slots to `policy_refs` and
+    /// reconcile the actor watches: Unregister any of `old_watches` whose
+    /// `(name, ident, policy_type)` is no longer wanted, and Register the
+    /// wanted set (a Register for an unchanged watch is a harmless
+    /// refresh). Used by [`Self::reconfigure_peer`].
+    fn rebind_policy_refs(
+        &mut self,
+        addr: &std::net::IpAddr,
+        policy_refs: &std::collections::BTreeMap<
+            (bgp_packet::AfiSafi, super::super::vrf_config::VrfPolicyRef),
+            String,
+        >,
+        old_watches: &[(String, usize, crate::policy::PolicyType)],
+    ) {
+        use super::super::policy::InOut;
+        use super::super::vrf_config::VrfPolicyRef;
+
+        // First clear every currently-bound slot, then set the wanted
+        // ones, so a dropped ref leaves an empty slot (fail-closed) rather
+        // than a stale name.
+        let Some(peer) = self.peers.get_mut(addr) else {
+            return;
+        };
+        let ident = peer.ident;
+        for io in peer.policy_list.values_mut() {
+            io.get_mut(&InOut::Input).name = None;
+            io.get_mut(&InOut::Output).name = None;
+        }
+        for io in peer.prefix_set.values_mut() {
+            io.get_mut(&InOut::Input).name = None;
+            io.get_mut(&InOut::Output).name = None;
+        }
+        for ((fam, kind), name) in policy_refs {
+            match kind {
+                VrfPolicyRef::PolicyIn => {
+                    peer.policy_list_slot(*fam, InOut::Input).name = Some(name.clone())
+                }
+                VrfPolicyRef::PolicyOut => {
+                    peer.policy_list_slot(*fam, InOut::Output).name = Some(name.clone())
+                }
+                VrfPolicyRef::PrefixSetIn => {
+                    peer.prefix_set_slot(*fam, InOut::Input).name = Some(name.clone())
+                }
+                VrfPolicyRef::PrefixSetOut => {
+                    peer.prefix_set_slot(*fam, InOut::Output).name = Some(name.clone())
+                }
+            }
+        }
+
+        // The wanted watch set, computed from the resolved refs.
+        let wanted: Vec<(String, usize, crate::policy::PolicyType)> = policy_refs
+            .iter()
+            .map(|((fam, kind), name)| {
+                (
+                    name.clone(),
+                    super::super::config::peer_policy_ident(ident, Some(*fam)),
+                    kind.policy_type(),
+                )
+            })
+            .collect();
+
+        // Unregister the old watches that are no longer wanted.
+        let dropped: Vec<(String, usize, crate::policy::PolicyType)> = old_watches
+            .iter()
+            .filter(|w| !wanted.contains(w))
+            .cloned()
+            .collect();
+        self.unregister_policy_watches(&dropped);
+
+        // Register the wanted set (idempotent refresh for unchanged ones).
+        if !wanted.is_empty()
+            && let Some(policy_tx) = self.policy_tx.clone()
+        {
+            let proto = self.policy_proto();
+            for ((fam, kind), name) in policy_refs {
+                let _ = policy_tx.send(crate::policy::Message::Register {
+                    proto: proto.clone(),
+                    name: name.clone(),
+                    ident: super::super::config::peer_policy_ident(ident, Some(*fam)),
+                    policy_type: kind.policy_type(),
+                });
+            }
+        }
+    }
+
     /// Per-task handling of cross-task messages that aren't
     /// `Shutdown`.
     fn process_global_msg(&mut self, msg: BgpVrfMsg) {
@@ -2917,6 +3276,27 @@ impl BgpVrf {
                 // opens). Same handling as a connection our own listener
                 // accepts.
                 self.handle_accept(stream, sockaddr);
+            }
+            BgpVrfMsg::AddPeer {
+                addr,
+                remote_as,
+                config,
+                knobs,
+                policy_refs,
+            } => {
+                self.add_peer(addr, remote_as, *config, &knobs, &policy_refs);
+            }
+            BgpVrfMsg::RemovePeer { addr } => {
+                self.remove_peer(addr);
+            }
+            BgpVrfMsg::ReconfigurePeer {
+                addr,
+                remote_as,
+                config,
+                knobs,
+                policy_refs,
+            } => {
+                self.reconfigure_peer(addr, remote_as, *config, &knobs, &policy_refs);
             }
             BgpVrfMsg::ImportV4 {
                 rd,
@@ -3230,6 +3610,163 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), vrf.event_loop())
             .await
             .expect("event_loop returns after Shutdown");
+    }
+
+    /// The runtime `AddPeer` / `RemovePeer` handlers insert and remove a CE
+    /// peer on a live task without touching any other session — the core of
+    /// the incremental-neighbor path. `AddPeer` builds the peer via the same
+    /// `insert_started_peer` the spawn-time materialize uses, so its
+    /// peer-type derives from the AS comparison; `RemovePeer` mirrors the
+    /// global `remove_peer_full` (route_clean + detach + remove).
+    #[tokio::test]
+    async fn add_and_remove_peer_at_runtime() {
+        use crate::bgp::peer::PeerType;
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(7, "vrf-nbr");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-nbr".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let a: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        // Resolve exactly as the global side would, so the test drives the
+        // real message payload.
+        let (remote_as, config, knobs) = super::super::spawn::resolve_vrf_peer_config(
+            &a,
+            &crate::bgp::vrf_config::BgpVrfNeighborConfig {
+                remote_as: Some(65001),
+                ..Default::default()
+            },
+            &std::collections::BTreeMap::new(),
+        )
+        .expect("neighbor with remote-as resolves");
+
+        vrf.process_global_msg(BgpVrfMsg::AddPeer {
+            addr: a,
+            remote_as,
+            config: Box::new(config),
+            knobs: Box::new(knobs),
+            policy_refs: std::collections::BTreeMap::new(),
+        });
+
+        let peer = vrf.peers.get(&a).expect("peer added at runtime");
+        assert_eq!(peer.remote_as, 65001);
+        // remote-as 65001 != VRF AS 65000 → eBGP, derived from the AS
+        // comparison in `insert_started_peer`.
+        assert_eq!(peer.peer_type, PeerType::EBGP);
+
+        vrf.process_global_msg(BgpVrfMsg::RemovePeer { addr: a });
+        assert!(
+            vrf.peers.get(&a).is_none(),
+            "peer removed from the map at runtime"
+        );
+    }
+
+    /// A runtime `ReconfigurePeer` swaps the resolved config on the running
+    /// peer. Not Established here (no session), so no bounce fires; the new
+    /// remote-as (and derived peer-type) simply take effect.
+    #[tokio::test]
+    async fn reconfigure_peer_at_runtime() {
+        use crate::bgp::peer::PeerType;
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(8, "vrf-recfg");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-recfg".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let a: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let resolve = |asn: u32| {
+            super::super::spawn::resolve_vrf_peer_config(
+                &a,
+                &crate::bgp::vrf_config::BgpVrfNeighborConfig {
+                    remote_as: Some(asn),
+                    ..Default::default()
+                },
+                &std::collections::BTreeMap::new(),
+            )
+            .unwrap()
+        };
+
+        let (ra, cfg, knobs) = resolve(65001);
+        vrf.process_global_msg(BgpVrfMsg::AddPeer {
+            addr: a,
+            remote_as: ra,
+            config: Box::new(cfg),
+            knobs: Box::new(knobs),
+            policy_refs: std::collections::BTreeMap::new(),
+        });
+        assert_eq!(vrf.peers.get(&a).unwrap().peer_type, PeerType::EBGP);
+
+        // Reconfigure to the VRF's own AS → now iBGP.
+        let (ra, cfg, knobs) = resolve(65000);
+        vrf.process_global_msg(BgpVrfMsg::ReconfigurePeer {
+            addr: a,
+            remote_as: ra,
+            config: Box::new(cfg),
+            knobs: Box::new(knobs),
+            policy_refs: std::collections::BTreeMap::new(),
+        });
+        let peer = vrf
+            .peers
+            .get(&a)
+            .expect("peer still present after reconfigure");
+        assert_eq!(peer.remote_as, 65000);
+        assert_eq!(peer.peer_type, PeerType::IBGP);
+    }
+
+    /// A `ReconfigurePeer` for a peer that is not present is treated as an
+    /// add — a neighbor that gains a remote-as via edit still comes up.
+    #[tokio::test]
+    async fn reconfigure_absent_peer_is_treated_as_add() {
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(9, "vrf-recfg-add");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-recfg-add".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let a: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let (ra, cfg, knobs) = super::super::spawn::resolve_vrf_peer_config(
+            &a,
+            &crate::bgp::vrf_config::BgpVrfNeighborConfig {
+                remote_as: Some(65001),
+                ..Default::default()
+            },
+            &std::collections::BTreeMap::new(),
+        )
+        .unwrap();
+        vrf.process_global_msg(BgpVrfMsg::ReconfigurePeer {
+            addr: a,
+            remote_as: ra,
+            config: Box::new(cfg),
+            knobs: Box::new(knobs),
+            policy_refs: std::collections::BTreeMap::new(),
+        });
+        assert!(
+            vrf.peers.get(&a).is_some(),
+            "reconfigure of an absent peer adds it"
+        );
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1611,78 +1611,6 @@ impl BgpVrf {
         self.policy_tx = Some(policy_tx);
     }
 
-    /// Every policy watch this VRF's peers registered, as
-    /// `(name, ident, policy_type)`.
-    ///
-    /// Handed to `BgpVrfHandle` so `despawn_bgp_vrf` can withdraw them
-    /// **synchronously**, on the global task, before a respawn registers
-    /// the replacements. Doing it from this task's shutdown path instead
-    /// would be a use-after-free in slow motion: the actor's `retain`
-    /// matches on `(proto, ident, policy_type)`, and a respawned VRF
-    /// reuses both the proto and its peers' idents, so a late Unregister
-    /// from the outgoing incarnation deletes the incoming one's watch —
-    /// and the `None` reply it triggers clears the freshly resolved
-    /// policy, leaving the session fail-closed for good.
-    ///
-    /// Both messages ride the same `policy_tx`, so FIFO ordering is what
-    /// guarantees the withdraw is processed before the re-register.
-    pub fn policy_watch_list(&self) -> Vec<(String, usize, crate::policy::PolicyType)> {
-        use crate::policy::PolicyType;
-        let mut out = Vec::new();
-        for idx in self.peers.idents() {
-            let Some(peer) = self.peers.get_by_idx(idx) else {
-                continue;
-            };
-            let mut push = |name: Option<&String>, policy_type: PolicyType, fam| {
-                if let Some(name) = name {
-                    out.push((
-                        name.clone(),
-                        super::super::config::peer_policy_ident(idx, Some(fam)),
-                        policy_type,
-                    ));
-                }
-            };
-            for (fam, io) in &peer.policy_list {
-                push(
-                    io.get(&super::super::policy::InOut::Input).name.as_ref(),
-                    PolicyType::PolicyListIn,
-                    *fam,
-                );
-                push(
-                    io.get(&super::super::policy::InOut::Output).name.as_ref(),
-                    PolicyType::PolicyListOut,
-                    *fam,
-                );
-            }
-            for (fam, io) in &peer.prefix_set {
-                push(
-                    io.get(&super::super::policy::InOut::Input).name.as_ref(),
-                    PolicyType::PrefixSetIn,
-                    *fam,
-                );
-                push(
-                    io.get(&super::super::policy::InOut::Output).name.as_ref(),
-                    PolicyType::PrefixSetOut,
-                    *fam,
-                );
-            }
-            // TCP-AO key-chain watch. Keyed by the raw peer ident (not
-            // `peer_policy_ident`) matching the global neighbor, and by a
-            // distinct `KeyChain` policy_type, so it never collides with a
-            // policy/prefix-set watch even if the idents coincide.
-            if let Some(ao) = &peer.config.transport.ao_config
-                && !ao.key_chain.is_empty()
-            {
-                out.push((
-                    ao.key_chain.clone(),
-                    idx,
-                    PolicyType::KeyChain(crate::policy::KeyChainScope::BgpNeighbor),
-                ));
-            }
-        }
-        out
-    }
-
     /// global task sends [`BgpVrfMsg::Shutdown`] or when the
     /// inbound channel is closed (i.e. every sender — the global
     /// task plus any per-peer holds — has dropped).
@@ -2912,6 +2840,14 @@ impl BgpVrf {
         >,
     ) {
         super::spawn::insert_started_peer(self, &addr, remote_as, config, knobs, policy_refs);
+        // Install this peer's MD5 key on the VRF listener so a CE-initiated
+        // (passive) authenticated session comes up without waiting for a
+        // respawn. The active/dial side is keyed from `peer.config` directly;
+        // the listener needs an explicit per-address install. TCP-AO rides
+        // the key-chain watch `insert_started_peer` just registered — its
+        // resolve reply runs `resolve_ao_keys`, which keys the listener — so
+        // it needs no call here (the resolved key isn't known yet anyway).
+        self.refresh_listener_md5();
         bgp_vrf_trace!(
             &self.tracing,
             vrf = %self.name,
@@ -2922,9 +2858,10 @@ impl BgpVrf {
     }
 
     /// Enumerate one peer's registered policy / prefix-set watches, as
-    /// `(name, ident, policy_type)` — the per-peer slice of
-    /// [`Self::policy_watch_list`], captured before a peer leaves the map
-    /// so the runtime remove path can Unregister them.
+    /// `(name, ident, policy_type)`, captured before a peer leaves the map
+    /// so the runtime remove / rebind path can Unregister them. (Whole-VRF
+    /// teardown instead clears every watch in one shot via
+    /// `policy::Message::UnregisterProto` in `despawn_bgp_vrf`.)
     fn peer_policy_watches(
         &self,
         addr: &std::net::IpAddr,
@@ -3051,6 +2988,25 @@ impl BgpVrf {
         // detached explicitly or the freed ident lingers and a future
         // slot reuse inherits the group.
         super::super::update_group::detach(&mut self.update_groups, &mut self.peers, peer_idx);
+        // Drop this peer's key from the VRF listener before it leaves the
+        // map. `refresh_listener_*` only (re)installs for peers still
+        // present, so it can't clear a departed peer's key; a lingering MD5
+        // key would make the kernel demand MD5 on future SYNs from this
+        // address, breaking a later no-auth peer re-added at the same IP.
+        // `last_ao_installed` is maintained by `refresh_listener_ao`.
+        if let Some(peer) = self.peers.get(&addr) {
+            let ao_ids = peer.last_ao_installed;
+            let fd = match addr {
+                std::net::IpAddr::V4(_) => self.listen_fd_v4,
+                std::net::IpAddr::V6(_) => self.listen_fd_v6,
+            };
+            if let Some(fd) = fd {
+                let _ = super::super::auth::set_tcp_md5_key(fd, addr, b"");
+                if let Some((s, r)) = ao_ids {
+                    let _ = super::super::auth::del_tcp_ao_key(fd, addr, s, r);
+                }
+            }
+        }
         self.peers.remove(&addr);
         self.unregister_policy_watches(&watches);
         // Notify the global accept dispatcher this VRF no longer claims the
@@ -3154,6 +3110,12 @@ impl BgpVrf {
             // the new family set / session parameters.
             let _ = self.tx.try_send(Message::Event(ident, Event::Stop));
         }
+        // Push a changed/removed MD5 password to the VRF listener (passive
+        // side); the active dial already picked it up from `peer.config`.
+        // TCP-AO on reconfigure is not refreshed here: `resolved_ao_key`
+        // only updates when the key-chain re-resolves, which a reconfigure
+        // doesn't re-subscribe — that remains the documented auth follow-up.
+        self.refresh_listener_md5();
         bgp_vrf_trace!(
             &self.tracing,
             vrf = %self.name,

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -31,4 +31,6 @@ pub use inst::{
     vrf_emit_withdraw_v6, withdraw_mup_segment, withdraw_mup_session,
 };
 pub use msg::BgpGlobalMsg;
-pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};
+pub use spawn::{
+    BgpVrfHandle, compute_vrf_diff, compute_vrf_respawn, despawn_bgp_vrf, spawn_bgp_vrf,
+};

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -32,5 +32,6 @@ pub use inst::{
 };
 pub use msg::BgpGlobalMsg;
 pub use spawn::{
-    BgpVrfHandle, compute_vrf_diff, compute_vrf_respawn, despawn_bgp_vrf, spawn_bgp_vrf,
+    BgpVrfHandle, VrfNeighborDiff, compute_vrf_diff, compute_vrf_neighbor_diff,
+    compute_vrf_respawn, despawn_bgp_vrf, spawn_bgp_vrf,
 };

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -2,22 +2,28 @@
 //! `Bgp` task and a per-VRF [`BgpVrf`] task.
 //!
 //! - [`BgpVrfMsg`] travels global → VRF. It carries handoffs from
-//!   the global passive-accept dispatcher, VPNv4/v6 import
-//!   deliveries from the global Loc-RIB, and the `Shutdown` signal
-//!   that ends the VRF task's event loop.
+//!   the global passive-accept dispatcher, incremental CE-peer
+//!   add/remove/reconfigure (the neighbor edits the global side
+//!   resolves and ships rather than respawning the task), VPNv4/v6
+//!   import deliveries from the global Loc-RIB, and the `Shutdown`
+//!   signal that ends the VRF task's event loop.
 //! - [`BgpGlobalMsg`] travels VRF → global. It carries the
 //!   inverse: best-path exports the global task should re-emit as
 //!   VPNv4/v6, peer registration so the global accept dispatcher
 //!   knows which VRF to forward a given source IP to, and the
 //!   matching withdraw/unregister events.
 
-use std::net::SocketAddr;
+use std::collections::BTreeMap;
+use std::net::{IpAddr, SocketAddr};
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use tokio::net::TcpStream;
 
-use bgp_packet::{BgpAttr, RouteDistinguisher};
+use bgp_packet::{AfiSafi, BgpAttr, RouteDistinguisher};
 
+use crate::bgp::neighbor_group::InheritableKnobs;
+use crate::bgp::peer::PeerConfig;
+use crate::bgp::vrf_config::VrfPolicyRef;
 use crate::rib::nht::ResolvedNexthop;
 
 /// Message from the global `Bgp` task to a per-VRF [`BgpVrf`]
@@ -30,6 +36,54 @@ pub enum BgpVrfMsg {
     /// drives it through the per-VRF passive-accept FSM path
     /// (`peer::handle_peer_connection` against the VRF's own peers).
     Accept(TcpStream, SocketAddr),
+
+    /// Add a CE peer to a running VRF task (`router bgp vrf <name>
+    /// neighbor <addr>` created *after* the VRF task spawned). The
+    /// global side computes the neighbor add/remove diff at `CommitEnd`
+    /// (`compute_vrf_neighbor_diff`) and resolves the peer's config
+    /// against `Bgp::neighbor_groups` there (the VRF task holds no group
+    /// map), shipping already-resolved values: `remote_as`, the fully
+    /// resolved [`PeerConfig`] (its `mp` family set and per-family
+    /// `next_hop_self` filled), the resolved [`InheritableKnobs`], and the
+    /// staged policy / prefix-set references. The handler builds the peer
+    /// with `insert_started_peer`, mirroring the spawn-time materialize —
+    /// the same primitive, so a peer added at runtime is built identically
+    /// to one present at spawn. `config` / `knobs` are boxed to keep the
+    /// enum small. The global side also emits
+    /// [`BgpGlobalMsg::RegisterPeer`] so the accept dispatcher routes
+    /// inbound connects from this IP here.
+    AddPeer {
+        addr: IpAddr,
+        remote_as: u32,
+        config: Box<PeerConfig>,
+        knobs: Box<InheritableKnobs>,
+        policy_refs: BTreeMap<(AfiSafi, VrfPolicyRef), String>,
+    },
+
+    /// Remove a CE peer from a running VRF task (`neighbor <addr>`
+    /// deleted). Mirrors the global `remove_peer_full`: `route_clean`
+    /// withdraws the peer's routes, `update_group::detach` drops its
+    /// update-group membership, then the peer leaves `peers`. The global
+    /// side pairs this with [`BgpGlobalMsg::UnregisterPeer`] so the
+    /// accept dispatcher stops routing this IP here.
+    RemovePeer { addr: IpAddr },
+
+    /// Reconfigure an existing CE peer on a running VRF task (a leaf under
+    /// `neighbor <addr>` changed). Carries the same already-resolved
+    /// values as [`Self::AddPeer`]. The handler applies the new config to
+    /// the running peer and bounces it (`Event::Stop`) only when the
+    /// change requires re-OPEN (the negotiated family set changed via the
+    /// resolved session knobs) and the session is Established; otherwise
+    /// it swaps the config live (timers / description / next-hop-self take
+    /// effect on the next advertisement). `config` / `knobs` are boxed to
+    /// keep the enum small.
+    ReconfigurePeer {
+        addr: IpAddr,
+        remote_as: u32,
+        config: Box<PeerConfig>,
+        knobs: Box<InheritableKnobs>,
+        policy_refs: BTreeMap<(AfiSafi, VrfPolicyRef), String>,
+    },
 
     /// VPNv4 best-path import. The global Loc-RIB resolved a route
     /// whose RT list intersects this VRF's `import_rts_v4`; the
@@ -303,4 +357,11 @@ pub enum BgpGlobalMsg {
     /// via [`BgpVrfMsg::Accept`]. Emitted by the per-VRF spawn
     /// site for every materialised peer.
     RegisterPeer { vrf: String, addr: std::net::IpAddr },
+
+    /// Inverse of [`Self::RegisterPeer`]: drop the `Bgp::peer_index`
+    /// entry claiming `addr` for `vrf` so an inbound `:179` connect from
+    /// that IP is no longer handed to this VRF. Emitted by the global
+    /// runtime-diff dispatch when a CE peer is removed from a running VRF
+    /// (paired with [`BgpVrfMsg::RemovePeer`]).
+    UnregisterPeer { vrf: String, addr: std::net::IpAddr },
 }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -156,6 +156,117 @@ pub fn compute_vrf_respawn(
         .collect()
 }
 
+/// One resolved neighbor the incremental apply must add / reconfigure on
+/// a running VRF task: the peer address plus the already-resolved
+/// `(remote_as, PeerConfig, InheritableKnobs, policy_refs)`. Shipped
+/// straight into a [`BgpVrfMsg::AddPeer`] / [`BgpVrfMsg::ReconfigurePeer`].
+pub struct ResolvedVrfPeer {
+    pub addr: std::net::IpAddr,
+    pub remote_as: u32,
+    pub config: super::super::peer::PeerConfig,
+    pub knobs: super::super::neighbor_group::InheritableKnobs,
+    pub policy_refs:
+        BTreeMap<(bgp_packet::AfiSafi, super::super::vrf_config::VrfPolicyRef), String>,
+}
+
+/// The per-neighbor delta between a VRF's baseline and desired config,
+/// resolved GLOBAL-side against the two neighbor-group snapshots. Only
+/// neighbors that resolve to a live peer (a `remote-as` exists) count:
+///   * `adds` — resolve to a peer in `after` but not in `before`.
+///   * `removes` — resolved to a peer in `before` but no longer do.
+///   * `reconfigures` — resolve to a peer in both, but the resolved
+///     `(remote_as, PeerConfig, knobs, policy_refs)` differs.
+///
+/// A neighbor with no `remote-as` in either config is absent from all
+/// three sets (it was never materialized). A neighbor that gains a
+/// `remote-as` is an add; one that loses it is a remove.
+#[derive(Default)]
+pub struct VrfNeighborDiff {
+    pub adds: Vec<ResolvedVrfPeer>,
+    pub removes: Vec<std::net::IpAddr>,
+    pub reconfigures: Vec<ResolvedVrfPeer>,
+}
+
+/// Compute the per-neighbor add/remove/reconfigure diff for one running
+/// VRF, resolving each side against its own neighbor-group snapshot
+/// (baseline groups for `before`, committed groups for `after`) so a
+/// neighbor-group edit that changes a member's resolved config surfaces as
+/// a reconfigure. Pure (no I/O) so the classification is unit-testable;
+/// the caller ([`super::inst`]'s `apply_vrf_neighbor_diffs`) ships each
+/// entry as the matching [`BgpVrfMsg`]. Group resolution lives here, on the
+/// global side, because the VRF task holds no neighbor-group map.
+pub fn compute_vrf_neighbor_diff(
+    before: &BTreeMap<std::net::IpAddr, super::super::vrf_config::BgpVrfNeighborConfig>,
+    before_groups: &BTreeMap<String, NeighborGroup>,
+    after: &BTreeMap<std::net::IpAddr, super::super::vrf_config::BgpVrfNeighborConfig>,
+    after_groups: &BTreeMap<String, NeighborGroup>,
+) -> VrfNeighborDiff {
+    // Two resolved configs are "the same peer" when their remote-as and
+    // the Debug form of the resolved PeerConfig + knobs match (neither is
+    // `Eq`), plus the policy-ref map (which IS `Eq`). This is the same
+    // comparison `runtime_structure_eq` used before the neighbor term
+    // moved from respawn to incremental — extended to cover the knobs and
+    // policy refs the current model stages.
+    let sig = |peer: &ResolvedVrfPeer| {
+        (
+            peer.remote_as,
+            format!("{:?}", peer.config),
+            format!("{:?}", peer.knobs),
+            peer.policy_refs.clone(),
+        )
+    };
+    let resolve = |addr: &std::net::IpAddr,
+                   nbr: &super::super::vrf_config::BgpVrfNeighborConfig,
+                   groups: &BTreeMap<String, NeighborGroup>|
+     -> Option<ResolvedVrfPeer> {
+        let (remote_as, config, knobs) = resolve_vrf_peer_config(addr, nbr, groups)?;
+        Some(ResolvedVrfPeer {
+            addr: *addr,
+            remote_as,
+            config,
+            knobs,
+            policy_refs: nbr.policy_refs.clone(),
+        })
+    };
+
+    let mut diff = VrfNeighborDiff::default();
+
+    // Adds + reconfigures: walk `after`.
+    for (addr, nbr) in after {
+        let Some(resolved) = resolve(addr, nbr, after_groups) else {
+            continue;
+        };
+        let before_resolved = before
+            .get(addr)
+            .and_then(|b| resolve(addr, b, before_groups));
+        match before_resolved {
+            Some(old) => {
+                if sig(&old) != sig(&resolved) {
+                    diff.reconfigures.push(resolved);
+                }
+            }
+            None => diff.adds.push(resolved),
+        }
+    }
+
+    // Removes: a neighbor that resolved to a peer in `before` but does
+    // not in `after` (deleted, or lost its remote-as).
+    for (addr, nbr) in before {
+        if resolve(addr, nbr, before_groups).is_none() {
+            continue;
+        }
+        let still_present = after
+            .get(addr)
+            .and_then(|a| resolve(addr, a, after_groups))
+            .is_some();
+        if !still_present {
+            diff.removes.push(*addr);
+        }
+    }
+
+    diff
+}
+
 /// Build + spawn a per-VRF task. Returns the handle the caller
 /// stashes on `vrf_registry`. `kernel` carries the matching
 /// kernel VRF master info if RIB has already told us about it;
@@ -403,41 +514,305 @@ pub fn spawn_bgp_vrf(
     }
 }
 
+/// Resolve one staged VRF neighbor into `(remote_as, PeerConfig,
+/// InheritableKnobs)` — the group-dependent part of building a per-VRF
+/// peer, factored out of [`materialize_peers`] so the spawn-time
+/// materialize and the runtime add/reconfigure handlers share ONE
+/// resolution. Returns `None` when no `remote-as` resolves (own leaf, else
+/// the group's): `Peer::start` gates on `remote_as != 0`, so a peer without
+/// one would sit permanently Idle and only clutter the show path.
+///
+/// The returned `PeerConfig` is the FULLY-resolved config the peer runs
+/// with: the staged `nbr_cfg.config` cloned wholesale, plus the two knobs
+/// whose staged value is the *verbatim* statement rather than the effective
+/// one — `config.mp` (the negotiated address-family set) and each family's
+/// `config.sub[fam].next_hop_self`. The [`InheritableKnobs`] record is the
+/// resolved session knobs (passive, ebgp-multihop, …) the task-side apply
+/// consumes. Group resolution happens here, on the caller's side (the
+/// global task or the spawn site), because the group map lives on the
+/// global `Bgp` and never reaches the per-VRF task — the task only ever
+/// receives already-resolved values. This function neither applies the
+/// knobs nor registers policy watches; that is the task-side
+/// [`insert_started_peer`]'s job.
+pub(super) fn resolve_vrf_peer_config(
+    addr: &std::net::IpAddr,
+    nbr_cfg: &super::super::vrf_config::BgpVrfNeighborConfig,
+    groups: &BTreeMap<String, NeighborGroup>,
+) -> Option<(
+    u32,
+    super::super::peer::PeerConfig,
+    super::super::neighbor_group::InheritableKnobs,
+)> {
+    use bgp_packet::{Afi, AfiSafi, AfiSafis, Safi};
+
+    // Resolve the optionally-referenced neighbor-group once. Its
+    // attributes act as a fallback layer beneath the neighbor's own —
+    // the same precedence the global neighbor uses.
+    let group = nbr_cfg.peer_group().and_then(|name| groups.get(name));
+
+    // The neighbor's own `remote-as` wins; otherwise inherit the group's
+    // (so a peer-group carrying `remote-as` makes its members live without
+    // a per-neighbor leaf). No `remote-as` at all ⇒ skip the peer.
+    let remote_as = nbr_cfg
+        .remote_as
+        .or_else(|| group.and_then(|g| g.remote_as))?;
+
+    // Adopt the staged config wholesale. `BgpVrfNeighborConfig::config`
+    // IS a `PeerConfig`, so every knob the per-VRF schema stages —
+    // description, peer-group binding, `timers`, and the per-family
+    // `afi-safi` knobs — lands here in one move. Anything the schema
+    // doesn't expose keeps its `PeerConfig::default()` value, which is
+    // exactly what `Peer::new` installs, so this is behaviour-preserving
+    // for unconfigured fields.
+    let mut config = nbr_cfg.config.clone();
+
+    // Derive the negotiated address-family set for this CE peer.
+    // `Peer::new` defaults to IPv4 unicast only, which is wrong for
+    // an IPv6 CE peer — so resolve the family set in three layers,
+    // lowest precedence first (mirroring `neighbor_group::effective_mp`
+    // for the global neighbor, but with an address-derived base):
+    //
+    //   1. base = the peer's own address family (an IPv6 peer →
+    //      IPv6 unicast, an IPv4 peer → IPv4 unicast). Unlike the
+    //      global neighbor we deliberately do NOT force IPv4 unicast
+    //      on for a v6 peer.
+    //   2. the referenced neighbor-group's `afi-safi` opinions
+    //      (`enabled true` adds a family, `false` removes it).
+    //   3. the per-neighbor explicit `afi-safi <fam> enabled`
+    //      statements — "any field set on the neighbor itself wins".
+    //
+    // The family set is a Multiprotocol capability fixed at OPEN
+    // time; peers are (re)materialized before the session
+    // establishes, so the resolved set rides the first OPEN with no
+    // bounce needed.
+    let base = if addr.is_ipv6() {
+        AfiSafi::new(Afi::Ip6, Safi::Unicast)
+    } else {
+        AfiSafi::new(Afi::Ip, Safi::Unicast)
+    };
+    let mut mp = AfiSafis::new();
+    mp.insert(base, true);
+    if let Some(g) = group {
+        for (fam, entry) in &g.afi_safi {
+            if entry.enabled {
+                mp.insert(*fam, true);
+            } else {
+                mp.remove(fam);
+            }
+        }
+    }
+    for (fam, enabled) in &nbr_cfg.config.mp_explicit {
+        if *enabled {
+            mp.insert(*fam, true);
+        } else {
+            mp.remove(fam);
+        }
+    }
+    // `mp` is the *resolved* set, so it is computed here rather than
+    // staged; `mp_explicit` (the verbatim statements it was resolved
+    // from) already arrived with the config adoption above.
+    config.mp = mp;
+
+    // `next-hop-self` is the one imported knob that is not simply
+    // stored: like `mp`, the staged value is the *verbatim* statement
+    // and the effective value has to be resolved through
+    // neighbor-group precedence (explicit wins, else the group's
+    // per-family opinion, else off). The global neighbor does this in
+    // its config callback against `Bgp::neighbor_groups`; here the
+    // same helper runs against the `groups` map, so the precedence rule
+    // has one implementation.
+    //
+    // Resolve over the negotiated families plus any family carrying an
+    // explicit statement: a statement for a family that never
+    // negotiates is inert, but resolving it costs nothing and keeps
+    // the stored state honest if the family is enabled later.
+    let nhs_families: std::collections::BTreeSet<AfiSafi> = config
+        .mp
+        .0
+        .keys()
+        .copied()
+        .chain(config.nhs_explicit.keys().copied())
+        .collect();
+    for fam in nhs_families {
+        let value = super::super::neighbor_group::resolve_next_hop_self(groups, &config, fam);
+        config.sub.entry(fam).or_default().next_hop_self = value;
+    }
+
+    // Resolve the inheritable session knobs (passive, ebgp-multihop,
+    // ttl-security, …) the same way the global neighbor does, layering
+    // the referenced neighbor-group under the peer's own explicit
+    // statements. Resolved here (group-side) and applied task-side by
+    // `insert_started_peer` / the reconfigure handler.
+    let knobs = super::super::neighbor_group::resolve_inherited_knobs(groups, &config);
+
+    Some((remote_as, config, knobs))
+}
+
+/// Insert a fully-resolved peer into `vrf.peers` and `start()` it — the
+/// task-side half of building a per-VRF peer, factored out of
+/// [`materialize_peers`] so the spawn-time materialize and the runtime
+/// `AddPeer` handler share ONE insert. `config` / `knobs` are already
+/// resolved by [`resolve_vrf_peer_config`]; this builds the `Peer`, derives
+/// its peer-type from the AS comparison, adopts the config, applies the
+/// session knobs, inserts under a stable ident, binds + registers the
+/// staged policy watches, then arms the idle-hold timer.
+pub(super) fn insert_started_peer(
+    vrf: &mut BgpVrf,
+    addr: &std::net::IpAddr,
+    remote_as: u32,
+    config: super::super::peer::PeerConfig,
+    knobs: &super::super::neighbor_group::InheritableKnobs,
+    policy_refs: &BTreeMap<(bgp_packet::AfiSafi, super::super::vrf_config::VrfPolicyRef), String>,
+) {
+    use super::super::peer::{Peer, PeerType};
+    use super::super::peer_key::PeerKey;
+
+    let mut peer = Peer::new(
+        0,
+        vrf.asn,
+        vrf.router_id,
+        remote_as,
+        *addr,
+        // Per-VRF hostnames aren't a thing today; the global
+        // hostname / OS hostname applies to every session.
+        None,
+        vrf.tx.clone(),
+        vrf.ctx.clone(),
+    );
+    // `Peer::new` defaults `peer_type` to IBGP and, unlike the global
+    // `config_remote_as` path, nothing else recomputes it for a VRF
+    // peer — so derive it here from the AS comparison. Without this a
+    // per-VRF PE-CE *eBGP* session (remote-as != the VRF's AS) is
+    // treated as iBGP: its routes are marked internal, carry no
+    // AS-path prepend, and (the symptom) are never re-advertised to
+    // the iBGP VPNv4 core, so an Inter-AS Option A remote-AS customer
+    // prefix never reaches the far PE.
+    peer.peer_type = if remote_as == vrf.asn {
+        PeerType::IBGP
+    } else {
+        PeerType::EBGP
+    };
+    // Adopt the resolved config before applying knobs / `start()` so the
+    // first idle-hold timer a peer arms already honours a configured
+    // `idle-hold-time`; arming from the default and fixing up afterwards
+    // would leave the first dial on the wrong cadence.
+    peer.config = config;
+    // Apply the resolved session knobs. The bounce is meaningless for a
+    // peer that has not started, so it is discarded here (the reconfigure
+    // handler keeps it).
+    let _ = super::super::neighbor_group::apply_resolved_session_knobs(&mut peer, knobs);
+
+    vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
+
+    // Bind the staged policy / prefix-set names and register a watch
+    // for each, so the actor resolves them and keeps them current.
+    //
+    // This MUST run after the insert, for the same reason `start()`
+    // does: `peer_policy_ident` encodes `peer.ident`, which
+    // `insert_with_key` is what assigns. Registering beforehand would
+    // key every peer's watch under ident 0, and the resolution would
+    // come back addressed to the first peer in the map — the exact
+    // shape of the bug fixed in #2071, but silent, because a
+    // mis-delivered policy just filters the wrong session's routes.
+    //
+    // The names go straight onto the peer's slots; the resolved set
+    // arrives later on `policy_rx` (see
+    // `BgpVrf::process_policy_msg`). Until it does the binding is
+    // deny-all, which is the same fail-closed posture the global
+    // neighbor has.
+    let ident = {
+        let peer = vrf.peers.get_mut(addr).expect("peer was just inserted");
+        for ((fam, kind), name) in policy_refs {
+            use super::super::policy::InOut;
+            use super::super::vrf_config::VrfPolicyRef;
+            match kind {
+                VrfPolicyRef::PolicyIn => {
+                    peer.policy_list_slot(*fam, InOut::Input).name = Some(name.clone())
+                }
+                VrfPolicyRef::PolicyOut => {
+                    peer.policy_list_slot(*fam, InOut::Output).name = Some(name.clone())
+                }
+                VrfPolicyRef::PrefixSetIn => {
+                    peer.prefix_set_slot(*fam, InOut::Input).name = Some(name.clone())
+                }
+                VrfPolicyRef::PrefixSetOut => {
+                    peer.prefix_set_slot(*fam, InOut::Output).name = Some(name.clone())
+                }
+            }
+        }
+        peer.ident
+    };
+    // The TCP-AO key-chain name a resolved `ao_config` references, if any —
+    // captured after the `ident` block (its peer borrow has ended) so the
+    // Register below can subscribe it. Resolving the actual key material
+    // waits for the actor's reply, handled in `BgpVrf::process_policy_msg`,
+    // which then keys both the active dial and the VRF listener.
+    let ao_key_chain = vrf
+        .peers
+        .get(addr)
+        .and_then(|p| p.config.transport.ao_config.as_ref())
+        .map(|ao| ao.key_chain.clone())
+        .filter(|c| !c.is_empty());
+
+    if (!policy_refs.is_empty() || ao_key_chain.is_some())
+        && let Some(policy_tx) = vrf.policy_tx.clone()
+    {
+        let proto = vrf.policy_proto();
+        for ((fam, kind), name) in policy_refs {
+            let _ = policy_tx.send(crate::policy::Message::Register {
+                proto: proto.clone(),
+                name: name.clone(),
+                ident: super::super::config::peer_policy_ident(ident, Some(*fam)),
+                policy_type: kind.policy_type(),
+            });
+        }
+        // TCP-AO key-chain: raw peer ident (matching the global neighbor) +
+        // the `KeyChain` policy type. The actor's reply lands on `policy_rx`
+        // and populates `resolved_ao_key`.
+        if let Some(chain) = &ao_key_chain {
+            let _ = policy_tx.send(crate::policy::Message::Register {
+                proto: proto.clone(),
+                name: chain.clone(),
+                ident,
+                policy_type: crate::policy::PolicyType::KeyChain(
+                    crate::policy::KeyChainScope::BgpNeighbor,
+                ),
+            });
+        }
+    }
+
+    // `PeerMap::insert_with_key` assigns the stable ident used in every
+    // timer/FSM message. Starting before insertion leaves every peer at
+    // Peer::new's ident 0, so a second neighbor's Start events are
+    // delivered to the first neighbor and the second session never
+    // leaves Idle/Active.
+    vrf.peers
+        .get_mut(addr)
+        .expect("peer was just inserted")
+        .start();
+
+    // Bring up BFD for this CE if configured — after the ident is assigned
+    // and after start(), matching the global neighbor's order and the
+    // spawn-time materialize this was factored out of. A no-op when `bfd
+    // enabled` is unset or no BFD client is wired (placeholder spawn / tests).
+    vrf.bfd_reconcile(ident);
+}
+
 /// Build `Peer` objects from `cfg.neighbors` and insert them into
 /// `vrf.peers`. Calls `peer.start()` on each — that arms the
 /// idle-hold timer; once it fires the FSM event lands on
-/// `vrf.tx`.
+/// `vrf.tx`. Behaviour-preserving wrapper over
+/// [`resolve_vrf_peer_config`] + [`insert_started_peer`] — the same two
+/// primitives the runtime add path uses, so spawn-time and post-spawn
+/// peers are built identically.
 fn materialize_peers(
     vrf: &mut BgpVrf,
     cfg: &BgpVrfConfig,
     groups: &BTreeMap<String, NeighborGroup>,
 ) -> usize {
-    use super::super::peer::{Peer, PeerType};
-    use super::super::peer_key::PeerKey;
-    use bgp_packet::{Afi, AfiSafi, AfiSafis, Safi};
-
     let mut count = 0usize;
     for (addr, nbr_cfg) in &cfg.neighbors {
-        // Resolve the optionally-referenced neighbor-group once. Its
-        // attributes act as a fallback layer beneath the neighbor's own —
-        // the same precedence the global neighbor uses, except a CE peer's
-        // group is resolved here at materialization (and re-resolved on the
-        // next respawn) rather than swept live, because the group lives on
-        // the global `Bgp` and these peers run in a separate per-VRF task.
-        let group = nbr_cfg.peer_group().and_then(|name| groups.get(name));
-
-        // `Peer::start()` gates on `remote_as != 0` already, but
-        // skipping the insert entirely keeps the per-VRF peer map
-        // free of dormant rows the show path would have to render
-        // as "remote-as: unset". When the operator later types
-        // the missing leaf the follow-up commit re-runs
-        // `materialize_peers` and the peer arrives. The neighbor's own
-        // `remote-as` wins; otherwise inherit the group's (so a peer-group
-        // that carries `remote-as` makes its members live without a
-        // per-neighbor leaf).
-        let Some(remote_as) = nbr_cfg
-            .remote_as
-            .or_else(|| group.and_then(|g| g.remote_as))
+        let Some((remote_as, config, knobs)) = resolve_vrf_peer_config(addr, nbr_cfg, groups)
         else {
             tracing::debug!(
                 vrf = %vrf.name,
@@ -446,236 +821,7 @@ fn materialize_peers(
             );
             continue;
         };
-        let mut peer = Peer::new(
-            0,
-            vrf.asn,
-            vrf.router_id,
-            remote_as,
-            *addr,
-            // Per-VRF hostnames aren't a thing today; the global
-            // hostname / OS hostname applies to every session.
-            None,
-            vrf.tx.clone(),
-            vrf.ctx.clone(),
-        );
-        // `Peer::new` defaults `peer_type` to IBGP and, unlike the global
-        // `config_remote_as` path, nothing else recomputes it for a VRF
-        // peer — so derive it here from the AS comparison. Without this a
-        // per-VRF PE-CE *eBGP* session (remote-as != the VRF's AS) is
-        // treated as iBGP: its routes are marked internal, carry no
-        // AS-path prepend, and (the symptom) are never re-advertised to
-        // the iBGP VPNv4 core, so an Inter-AS Option A remote-AS customer
-        // prefix never reaches the far PE.
-        peer.peer_type = if remote_as == vrf.asn {
-            PeerType::IBGP
-        } else {
-            PeerType::EBGP
-        };
-        // Adopt the staged config wholesale. `BgpVrfNeighborConfig::config`
-        // IS a `PeerConfig`, so every knob the per-VRF schema stages —
-        // description, peer-group binding, `timers`, and the per-family
-        // `afi-safi` knobs — lands here in one move, and importing another
-        // knob from the global neighbor needs no line of its own.
-        //
-        // Anything the schema doesn't expose keeps its
-        // `PeerConfig::default()` value, which is exactly what `Peer::new`
-        // had just installed, so this is behaviour-preserving for
-        // unconfigured fields.
-        //
-        // Done before `start()` below so the first idle-hold timer a peer
-        // arms already honours a configured `idle-hold-time`; arming from
-        // the default and fixing up afterwards would leave the first dial
-        // on the wrong cadence.
-        //
-        // Two things this deliberately does NOT carry:
-        //   - MRAI. Advertisement pacing comes from the `AdvInterval`
-        //     snapshot on the peer, which per-VRF tasks have no plumbing
-        //     for, so a CE session still runs the stock 30s eBGP / 5s iBGP
-        //     cadence.
-        //   - Policy / prefix-set names. Those need a policy-actor
-        //     Register to resolve, and `BgpVrf` holds no `policy_tx`; a
-        //     staged name would sit inert. They stay out of the schema
-        //     until that plumbing exists.
-        peer.config = nbr_cfg.config.clone();
-
-        // Derive the negotiated address-family set for this CE peer.
-        // `Peer::new` defaults to IPv4 unicast only, which is wrong for
-        // an IPv6 CE peer — so resolve the family set in three layers,
-        // lowest precedence first (mirroring `neighbor_group::effective_mp`
-        // for the global neighbor, but with an address-derived base):
-        //
-        //   1. base = the peer's own address family (an IPv6 peer →
-        //      IPv6 unicast, an IPv4 peer → IPv4 unicast). Unlike the
-        //      global neighbor we deliberately do NOT force IPv4 unicast
-        //      on for a v6 peer.
-        //   2. the referenced neighbor-group's `afi-safi` opinions
-        //      (`enabled true` adds a family, `false` removes it).
-        //   3. the per-neighbor explicit `afi-safi <fam> enabled`
-        //      statements — "any field set on the neighbor itself wins".
-        //
-        // The family set is a Multiprotocol capability fixed at OPEN
-        // time; peers are (re)materialized before the session
-        // establishes, so the resolved set rides the first OPEN with no
-        // bounce needed.
-        let base = if addr.is_ipv6() {
-            AfiSafi::new(Afi::Ip6, Safi::Unicast)
-        } else {
-            AfiSafi::new(Afi::Ip, Safi::Unicast)
-        };
-        let mut mp = AfiSafis::new();
-        mp.insert(base, true);
-        if let Some(g) = group {
-            for (fam, entry) in &g.afi_safi {
-                if entry.enabled {
-                    mp.insert(*fam, true);
-                } else {
-                    mp.remove(fam);
-                }
-            }
-        }
-        for (fam, enabled) in &nbr_cfg.config.mp_explicit {
-            if *enabled {
-                mp.insert(*fam, true);
-            } else {
-                mp.remove(fam);
-            }
-        }
-        // `mp` is the *resolved* set, so it is computed here rather than
-        // staged; `mp_explicit` (the verbatim statements it was resolved
-        // from) already arrived with the config adoption above.
-        peer.config.mp = mp;
-
-        // `next-hop-self` is the one imported knob that is not simply
-        // stored: like `mp`, the staged value is the *verbatim* statement
-        // and the effective value has to be resolved through
-        // neighbor-group precedence (explicit wins, else the group's
-        // per-family opinion, else off). The global neighbor does this in
-        // its config callback against `Bgp::neighbor_groups`; here the
-        // same helper runs against the `groups` map this function is
-        // already handed, so the precedence rule has one implementation.
-        //
-        // Resolve over the negotiated families plus any family carrying an
-        // explicit statement: a statement for a family that never
-        // negotiates is inert, but resolving it costs nothing and keeps
-        // the stored state honest if the family is enabled later.
-        let nhs_families: std::collections::BTreeSet<AfiSafi> = peer
-            .config
-            .mp
-            .0
-            .keys()
-            .copied()
-            .chain(peer.config.nhs_explicit.keys().copied())
-            .collect();
-        for fam in nhs_families {
-            let value =
-                super::super::neighbor_group::resolve_next_hop_self(groups, &peer.config, fam);
-            peer.config.sub.entry(fam).or_default().next_hop_self = value;
-        }
-
-        // Resolve + apply the inheritable session knobs (passive,
-        // ebgp-multihop, ttl-security, …) the same way the global
-        // neighbor does, layering the referenced neighbor-group under the
-        // peer's own explicit statements. `mp` and next-hop-self are done
-        // above (the VRF's base-family rule differs from the global one),
-        // so this covers everything else that is a pure peer mutation;
-        // auth and BFD knobs land in their own follow-ups.
-        super::super::neighbor_group::apply_inherited_session_knobs(groups, &mut peer);
-
-        vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
-
-        // Bind the staged policy / prefix-set names and register a watch
-        // for each, so the actor resolves them and keeps them current.
-        //
-        // This MUST run after the insert, for the same reason `start()`
-        // does: `peer_policy_ident` encodes `peer.ident`, which
-        // `insert_with_key` is what assigns. Registering beforehand would
-        // key every peer's watch under ident 0, and the resolution would
-        // come back addressed to the first peer in the map — the exact
-        // shape of the bug fixed in #2071, but silent, because a
-        // mis-delivered policy just filters the wrong session's routes.
-        //
-        // The names go straight onto the peer's slots; the resolved set
-        // arrives later on `policy_rx` (see
-        // `BgpVrf::process_policy_msg`). Until it does the binding is
-        // deny-all, which is the same fail-closed posture the global
-        // neighbor has.
-        let ident = {
-            let peer = vrf.peers.get_mut(addr).expect("peer was just inserted");
-            for ((fam, kind), name) in &nbr_cfg.policy_refs {
-                use super::super::policy::InOut;
-                use super::super::vrf_config::VrfPolicyRef;
-                match kind {
-                    VrfPolicyRef::PolicyIn => {
-                        peer.policy_list_slot(*fam, InOut::Input).name = Some(name.clone())
-                    }
-                    VrfPolicyRef::PolicyOut => {
-                        peer.policy_list_slot(*fam, InOut::Output).name = Some(name.clone())
-                    }
-                    VrfPolicyRef::PrefixSetIn => {
-                        peer.prefix_set_slot(*fam, InOut::Input).name = Some(name.clone())
-                    }
-                    VrfPolicyRef::PrefixSetOut => {
-                        peer.prefix_set_slot(*fam, InOut::Output).name = Some(name.clone())
-                    }
-                }
-            }
-            peer.ident
-        };
-        // The TCP-AO key-chain name a resolved `ao_config` references, if
-        // any — captured here (the peer borrow ends with the `ident`
-        // block above) so the Register below can subscribe it. Resolving
-        // the actual key material waits for the actor's reply, handled in
-        // `BgpVrf::process_policy_msg`.
-        let ao_key_chain = vrf
-            .peers
-            .get(addr)
-            .and_then(|p| p.config.transport.ao_config.as_ref())
-            .map(|ao| ao.key_chain.clone())
-            .filter(|c| !c.is_empty());
-
-        if (!nbr_cfg.policy_refs.is_empty() || ao_key_chain.is_some())
-            && let Some(policy_tx) = vrf.policy_tx.clone()
-        {
-            let proto = vrf.policy_proto();
-            for ((fam, kind), name) in &nbr_cfg.policy_refs {
-                let _ = policy_tx.send(crate::policy::Message::Register {
-                    proto: proto.clone(),
-                    name: name.clone(),
-                    ident: super::super::config::peer_policy_ident(ident, Some(*fam)),
-                    policy_type: kind.policy_type(),
-                });
-            }
-            // TCP-AO key-chain: raw peer ident (matching the global
-            // neighbor) + the `KeyChain` policy type. The actor's reply
-            // lands on `policy_rx` and populates `resolved_ao_key`.
-            if let Some(chain) = &ao_key_chain {
-                let _ = policy_tx.send(crate::policy::Message::Register {
-                    proto: proto.clone(),
-                    name: chain.clone(),
-                    ident,
-                    policy_type: crate::policy::PolicyType::KeyChain(
-                        crate::policy::KeyChainScope::BgpNeighbor,
-                    ),
-                });
-            }
-        }
-
-        // `PeerMap::insert_with_key` assigns the stable ident used in every
-        // timer/FSM message. Starting before insertion leaves every peer at
-        // Peer::new's ident 0, so a second neighbor's Start events are
-        // delivered to the first neighbor and the second session never
-        // leaves Idle/Active.
-        vrf.peers
-            .get_mut(addr)
-            .expect("peer was just inserted")
-            .start();
-
-        // Bring up BFD for this CE if configured. After the ident is
-        // assigned (the session key derives from `peer.address`, but the
-        // subscription is tracked by ident) and after start(), matching
-        // the global neighbor's order. A no-op when `bfd enabled` is
-        // unset or no BFD client is wired (placeholder spawn / tests).
-        vrf.bfd_reconcile(ident);
+        insert_started_peer(vrf, addr, remote_as, config, &knobs, &nbr_cfg.policy_refs);
         count += 1;
     }
     count
@@ -1974,5 +2120,188 @@ mod tests {
             )
             .is_empty()
         );
+    }
+
+    // ---- compute_vrf_neighbor_diff ----
+
+    fn nbr(remote_as: Option<u32>) -> super::super::super::vrf_config::BgpVrfNeighborConfig {
+        super::super::super::vrf_config::BgpVrfNeighborConfig {
+            remote_as,
+            ..Default::default()
+        }
+    }
+
+    fn diff_addr(s: &str) -> std::net::IpAddr {
+        s.parse().unwrap()
+    }
+
+    /// A neighbor present only in `after` (with a resolvable remote-as) is
+    /// an add; nothing is removed or reconfigured.
+    #[test]
+    fn neighbor_diff_classifies_add() {
+        let groups = BTreeMap::new();
+        let before = BTreeMap::new();
+        let mut after = BTreeMap::new();
+        after.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert_eq!(diff.adds.len(), 1);
+        assert_eq!(diff.adds[0].addr, diff_addr("192.0.2.1"));
+        assert_eq!(diff.adds[0].remote_as, 65001);
+        assert!(diff.removes.is_empty());
+        assert!(diff.reconfigures.is_empty());
+    }
+
+    /// A neighbor present only in `before` (that resolved to a peer) is a
+    /// remove.
+    #[test]
+    fn neighbor_diff_classifies_remove() {
+        let groups = BTreeMap::new();
+        let mut before = BTreeMap::new();
+        before.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+        let after = BTreeMap::new();
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert_eq!(diff.removes, vec![diff_addr("192.0.2.1")]);
+        assert!(diff.adds.is_empty());
+        assert!(diff.reconfigures.is_empty());
+    }
+
+    /// A neighbor in both, but with a differing resolved config
+    /// (remote-as here), is a reconfigure — never an add+remove.
+    #[test]
+    fn neighbor_diff_classifies_reconfigure() {
+        let groups = BTreeMap::new();
+        let mut before = BTreeMap::new();
+        before.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+        let mut after = BTreeMap::new();
+        after.insert(diff_addr("192.0.2.1"), nbr(Some(65002)));
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert_eq!(diff.reconfigures.len(), 1);
+        assert_eq!(diff.reconfigures[0].remote_as, 65002);
+        assert!(diff.adds.is_empty());
+        assert!(diff.removes.is_empty());
+    }
+
+    /// An identical neighbor map yields no work.
+    #[test]
+    fn neighbor_diff_identical_is_empty() {
+        let groups = BTreeMap::new();
+        let mut m = BTreeMap::new();
+        m.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+        let diff = compute_vrf_neighbor_diff(&m, &groups, &m.clone(), &groups);
+        assert!(diff.adds.is_empty() && diff.removes.is_empty() && diff.reconfigures.is_empty());
+    }
+
+    /// A neighbor with no resolvable remote-as never materializes a peer,
+    /// so it is absent from every set — adding or removing such a bare
+    /// neighbor entry is a no-op for the runtime.
+    #[test]
+    fn neighbor_diff_ignores_neighbor_without_remote_as() {
+        let groups = BTreeMap::new();
+        let before = BTreeMap::new();
+        let mut after = BTreeMap::new();
+        after.insert(diff_addr("192.0.2.1"), nbr(None));
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert!(diff.adds.is_empty() && diff.removes.is_empty() && diff.reconfigures.is_empty());
+    }
+
+    /// A neighbor that gains a remote-as (was bare, now resolvable) is an
+    /// add; one that loses it is a remove — the "resolved presence" view,
+    /// not the raw map membership.
+    #[test]
+    fn neighbor_diff_tracks_resolved_presence() {
+        let groups = BTreeMap::new();
+        let mut before = BTreeMap::new();
+        before.insert(diff_addr("192.0.2.1"), nbr(None));
+        let mut after = BTreeMap::new();
+        after.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert_eq!(diff.adds.len(), 1, "bare → remote-as is an add");
+        assert!(diff.removes.is_empty() && diff.reconfigures.is_empty());
+
+        // Inverse: remote-as → bare is a remove.
+        let diff = compute_vrf_neighbor_diff(&after, &groups, &before, &groups);
+        assert_eq!(diff.removes, vec![diff_addr("192.0.2.1")]);
+        assert!(diff.adds.is_empty() && diff.reconfigures.is_empty());
+    }
+
+    /// A neighbor-group edit that changes a member's resolved config
+    /// surfaces as a reconfigure even though the per-neighbor entry is
+    /// byte-for-byte unchanged (resolution differs across the two group
+    /// snapshots).
+    #[test]
+    fn neighbor_diff_detects_group_driven_reconfigure() {
+        use super::super::super::neighbor_group::NeighborGroup;
+        let mut before_groups = BTreeMap::new();
+        before_groups.insert(
+            "g1".to_string(),
+            NeighborGroup {
+                remote_as: Some(65001),
+                ..Default::default()
+            },
+        );
+        let mut after_groups = BTreeMap::new();
+        after_groups.insert(
+            "g1".to_string(),
+            NeighborGroup {
+                remote_as: Some(65002),
+                ..Default::default()
+            },
+        );
+
+        // Neighbor references the group and has no own remote-as, so it
+        // inherits the group's — which changed across the snapshots.
+        let mut n = nbr(None);
+        n.config.neighbor_group = Some("g1".to_string());
+        let mut m = BTreeMap::new();
+        m.insert(diff_addr("192.0.2.1"), n);
+
+        let diff = compute_vrf_neighbor_diff(&m, &before_groups, &m.clone(), &after_groups);
+        assert_eq!(diff.reconfigures.len(), 1);
+        assert_eq!(diff.reconfigures[0].remote_as, 65002);
+    }
+
+    /// A knob-only edit (here `passive`, part of the resolved
+    /// `InheritableKnobs`) with an unchanged remote-as still surfaces as a
+    /// reconfigure — the signature covers the knobs.
+    #[test]
+    fn neighbor_diff_detects_knob_only_reconfigure() {
+        let groups = BTreeMap::new();
+        let mut before = BTreeMap::new();
+        before.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+        let mut after_nbr = nbr(Some(65001));
+        after_nbr.config.knobs_explicit.passive = Some(true);
+        let mut after = BTreeMap::new();
+        after.insert(diff_addr("192.0.2.1"), after_nbr);
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert_eq!(diff.reconfigures.len(), 1);
+        assert!(diff.adds.is_empty() && diff.removes.is_empty());
+    }
+
+    /// A policy-ref-only edit (unchanged remote-as / config / knobs) still
+    /// surfaces as a reconfigure — the signature covers `policy_refs`.
+    #[test]
+    fn neighbor_diff_detects_policy_only_reconfigure() {
+        use super::super::super::vrf_config::VrfPolicyRef;
+        use bgp_packet::{Afi, AfiSafi, Safi};
+        let groups = BTreeMap::new();
+        let mut before = BTreeMap::new();
+        before.insert(diff_addr("192.0.2.1"), nbr(Some(65001)));
+        let mut after_nbr = nbr(Some(65001));
+        after_nbr.policy_refs.insert(
+            (AfiSafi::new(Afi::Ip, Safi::Unicast), VrfPolicyRef::PolicyIn),
+            "pol-in".to_string(),
+        );
+        let mut after = BTreeMap::new();
+        after.insert(diff_addr("192.0.2.1"), after_nbr);
+
+        let diff = compute_vrf_neighbor_diff(&before, &groups, &after, &groups);
+        assert_eq!(diff.reconfigures.len(), 1);
+        assert!(diff.adds.is_empty() && diff.removes.is_empty());
     }
 }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -17,7 +17,7 @@
 //! [`crate::rib::client::ClientRegistry`].
 
 use std::collections::BTreeMap;
-use std::net::Ipv6Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -38,6 +38,11 @@ use crate::config::RibSubscriber;
 /// [`Task`] so dropping the handle aborts the runtime cleanly.
 pub struct BgpVrfHandle {
     pub inbox: BgpVrfInbox,
+    /// Effective router ID captured by the running VRF task at spawn time.
+    /// Used to detect changes to the inherited global router ID.
+    pub router_id: Ipv4Addr,
+    /// Global ASN captured by the running VRF task at spawn time.
+    pub asn: u32,
     /// Clone of the per-VRF task's show channel sender. Registered with
     /// the config manager (`SubscribeShowVrf`) so `show bgp vrf <name>
     /// …` is redirected into this task; deregistered on despawn.
@@ -118,6 +123,37 @@ pub fn compute_vrf_diff(
         .cloned()
         .collect();
     (to_spawn, to_despawn)
+}
+
+/// Existing VRF tasks whose spawn-time structure changed during this config
+/// transaction. Additions and removals are handled by [`compute_vrf_diff`];
+/// only names present before, after, and in the running registry can respawn.
+pub fn compute_vrf_respawn(
+    before: &BTreeMap<String, BgpVrfConfig>,
+    before_groups: &BTreeMap<String, NeighborGroup>,
+    desired: &BTreeMap<String, BgpVrfConfig>,
+    desired_groups: &BTreeMap<String, NeighborGroup>,
+    running: &BTreeMap<String, BgpVrfHandle>,
+    router_id: Ipv4Addr,
+    asn: u32,
+) -> Vec<String> {
+    desired
+        .iter()
+        .filter(|(name, after)| {
+            running.get(*name).is_some_and(|handle| {
+                before.get(*name).is_some_and(|before| {
+                    !super::super::vrf_config::runtime_structure_eq(
+                        before,
+                        before_groups,
+                        after,
+                        desired_groups,
+                    ) || handle.router_id != after.router_id.unwrap_or(router_id)
+                        || handle.asn != asn
+                })
+            })
+        })
+        .map(|(name, _)| name.clone())
+        .collect()
 }
 
 /// Build + spawn a per-VRF task. Returns the handle the caller
@@ -350,6 +386,8 @@ pub fn spawn_bgp_vrf(
     }
     BgpVrfHandle {
         inbox,
+        router_id: effective_router_id,
+        asn,
         policy_watches,
         bfd_sessions,
         bfd_client_tx: bfd_client_handle,
@@ -1821,5 +1859,120 @@ mod tests {
         let (to_spawn, to_despawn) = compute_vrf_diff(&desired, &running);
         assert!(to_spawn.is_empty());
         assert!(to_despawn.is_empty());
+    }
+
+    /// A new VRF (desired, not yet running) and a removed VRF (running, no
+    /// longer desired) are spawn/despawn work for `compute_vrf_diff` — never
+    /// respawns. Only a name present before, after, AND running can respawn.
+    #[tokio::test]
+    async fn respawn_ignores_initial_load_and_whole_vrf_delete() {
+        let groups = BTreeMap::new();
+
+        // Initial load: desired but not running.
+        let mut desired = BTreeMap::new();
+        desired.insert("v1".to_string(), BgpVrfConfig::default());
+        let running: BTreeMap<String, BgpVrfHandle> = BTreeMap::new();
+        assert!(
+            compute_vrf_respawn(
+                &BTreeMap::new(),
+                &groups,
+                &desired,
+                &groups,
+                &running,
+                Ipv4Addr::UNSPECIFIED,
+                65000,
+            )
+            .is_empty()
+        );
+
+        // Whole-VRF delete: running + before but absent from desired.
+        let mut before = BTreeMap::new();
+        before.insert("v1".to_string(), BgpVrfConfig::default());
+        let mut running = BTreeMap::new();
+        running.insert("v1".to_string(), handle("v1"));
+        assert!(
+            compute_vrf_respawn(
+                &before,
+                &groups,
+                &BTreeMap::new(),
+                &groups,
+                &running,
+                Ipv4Addr::UNSPECIFIED,
+                65000,
+            )
+            .is_empty()
+        );
+    }
+
+    /// A spawn-time structural (task-global) edit — here the VRF's RD — to
+    /// an already-running VRF is routed through the respawn path. Neighbor
+    /// edits are no longer structural (they apply incrementally), so the
+    /// edit under test must be a task-global input.
+    #[tokio::test]
+    async fn respawn_detects_structural_edit_to_running_vrf() {
+        use std::str::FromStr;
+        let groups = BTreeMap::new();
+        let vrf_with_rd = |rd: &str| BgpVrfConfig {
+            rd: Some(bgp_packet::RouteDistinguisher::from_str(rd).unwrap()),
+            ..Default::default()
+        };
+        let mut before = BTreeMap::new();
+        before.insert("v1".to_string(), vrf_with_rd("65000:1"));
+        let mut after = BTreeMap::new();
+        after.insert("v1".to_string(), vrf_with_rd("65000:2"));
+        let mut running = BTreeMap::new();
+        running.insert("v1".to_string(), handle("v1"));
+
+        assert_eq!(
+            compute_vrf_respawn(
+                &before,
+                &groups,
+                &after,
+                &groups,
+                &running,
+                Ipv4Addr::UNSPECIFIED,
+                65000,
+            ),
+            vec!["v1".to_string()]
+        );
+    }
+
+    /// A neighbor-only edit to a running VRF must NOT respawn the task —
+    /// the incremental `AddPeer`/`RemovePeer`/`ReconfigurePeer` path owns
+    /// it now.
+    #[tokio::test]
+    async fn respawn_ignores_neighbor_only_edit() {
+        use super::super::super::vrf_config::BgpVrfNeighborConfig;
+        let groups = BTreeMap::new();
+        let vrf_with_as = |asn: u32| {
+            let mut cfg = BgpVrfConfig::default();
+            cfg.neighbors.insert(
+                "192.0.2.1".parse().unwrap(),
+                BgpVrfNeighborConfig {
+                    remote_as: Some(asn),
+                    ..Default::default()
+                },
+            );
+            cfg
+        };
+        let mut before = BTreeMap::new();
+        before.insert("v1".to_string(), vrf_with_as(65001));
+        let mut after = BTreeMap::new();
+        after.insert("v1".to_string(), vrf_with_as(65002));
+        let mut running = BTreeMap::new();
+        running.insert("v1".to_string(), handle("v1"));
+
+        assert!(
+            compute_vrf_respawn(
+                &before,
+                &groups,
+                &after,
+                &groups,
+                &running,
+                Ipv4Addr::UNSPECIFIED,
+                65000,
+            )
+            .is_empty()
+        );
     }
 }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -85,16 +85,10 @@ pub struct BgpVrfHandle {
     /// have.
     pub evpn_advertise_v4: bool,
     pub evpn_advertise_v6: bool,
-    /// Policy / prefix-set watches this VRF's peers registered, as
-    /// `(name, ident, policy_type)`. Kept on the handle so
-    /// [`despawn_bgp_vrf`] can withdraw them synchronously *before* a
-    /// respawn re-registers — see [`BgpVrf::policy_watch_list`] for why
-    /// doing it from the task's own shutdown path would delete the
-    /// incoming incarnation's watches instead of the outgoing one's.
-    pub policy_watches: Vec<(String, usize, crate::policy::PolicyType)>,
     /// BFD session keys this VRF's peers subscribed, withdrawn
-    /// synchronously by `despawn_bgp_vrf` before a respawn re-subscribes
-    /// — same ordering hazard as `policy_watches`.
+    /// synchronously by `despawn_bgp_vrf` before a respawn re-subscribes —
+    /// same ordering hazard the policy watches have (now cleared in one shot
+    /// via `policy::Message::UnregisterProto`).
     pub bfd_sessions: Vec<crate::bfd::session::SessionKey>,
     /// Kept so `despawn_bgp_vrf` can address the BFD unsubscribes.
     pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
@@ -474,7 +468,6 @@ pub fn spawn_bgp_vrf(
     // `show bgp vrf <name> …` redirection.
     let show_tx = vrf.show.tx.clone();
     // Snapshot before `vrf` moves into the task.
-    let policy_watches = vrf.policy_watch_list();
     let bfd_sessions = vrf.bfd_session_list();
     let bfd_client_handle = vrf.bfd_client_tx.clone();
     let bfd_client_id = vrf.bfd_client();
@@ -499,7 +492,6 @@ pub fn spawn_bgp_vrf(
         inbox,
         router_id: effective_router_id,
         asn,
-        policy_watches,
         bfd_sessions,
         bfd_client_tx: bfd_client_handle,
         bfd_client: bfd_client_id,
@@ -790,12 +782,12 @@ pub(super) fn insert_started_peer(
         .get_mut(addr)
         .expect("peer was just inserted")
         .start();
-
-    // Bring up BFD for this CE if configured — after the ident is assigned
-    // and after start(), matching the global neighbor's order and the
-    // spawn-time materialize this was factored out of. A no-op when `bfd
-    // enabled` is unset or no BFD client is wired (placeholder spawn / tests).
-    vrf.bfd_reconcile(ident);
+    // NOTE: BFD reconcile is deliberately NOT done here. It is spawn-only
+    // (`materialize_peers`), because the despawn-time teardown enumerates a
+    // spawn-captured `handle.bfd_sessions` snapshot — a session created by a
+    // runtime `AddPeer` would not be in it and would leak. Runtime-added CE
+    // peers therefore don't get BFD live (a documented follow-up), the same
+    // scope the PR states.
 }
 
 /// Build `Peer` objects from `cfg.neighbors` and insert them into
@@ -822,6 +814,15 @@ fn materialize_peers(
             continue;
         };
         insert_started_peer(vrf, addr, remote_as, config, &knobs, &nbr_cfg.policy_refs);
+        // Bring up BFD for this CE if configured — after the ident is
+        // assigned and after start(), matching the global neighbor's order.
+        // Spawn-only: the despawn teardown reads a spawn-captured
+        // `bfd_sessions` snapshot, so a runtime-add's session isn't tracked
+        // there (see the note in `insert_started_peer`). A no-op when `bfd
+        // enabled` is unset or no BFD client is wired (placeholder / tests).
+        if let Some(ident) = vrf.peers.get(addr).map(|p| p.ident) {
+            vrf.bfd_reconcile(ident);
+        }
         count += 1;
     }
     count
@@ -933,22 +934,18 @@ pub fn despawn_bgp_vrf(
     rib_subscriber: &RibSubscriber,
     policy_tx: &UnboundedSender<crate::policy::Message>,
 ) {
-    // Withdraw this incarnation's policy watches first, on this thread,
-    // so they are ordered ahead of the Registers a respawn's
-    // `materialize_peers` is about to send on the same channel. The
-    // actor matches watches on `(proto, ident, policy_type)`, all of
-    // which a respawned VRF reuses, so a later withdraw would take out
-    // the new task's watch and its `None` reply would clear the freshly
-    // resolved policy. Same ordering argument as the RIB cleanup below.
-    let proto = format!("bgp-vrf:{name}");
-    for (watch_name, ident, policy_type) in &handle.policy_watches {
-        let _ = policy_tx.send(crate::policy::Message::Unregister {
-            proto: proto.clone(),
-            name: watch_name.clone(),
-            ident: *ident,
-            policy_type: *policy_type,
-        });
-    }
+    // Withdraw every policy watch this VRF holds, on this thread, so they
+    // are ordered ahead of the Registers a respawn's `materialize_peers` is
+    // about to send on the same channel (a later withdraw would take out the
+    // new task's watch). Proto-scoped (`bgp-vrf:<name>`) in one shot rather
+    // than enumerating a snapshot: peers added at runtime (`AddPeer`)
+    // register watches the spawn-time list never captured, so an enumeration
+    // would leak them. `UnregisterProto` sends no `None` replies, so it also
+    // can't clear the respawn's freshly-resolved policy. Same ordering
+    // argument as the RIB cleanup below.
+    let _ = policy_tx.send(crate::policy::Message::UnregisterProto {
+        proto: format!("bgp-vrf:{name}"),
+    });
     // Withdraw this incarnation's BFD sessions, on this thread, ahead of
     // any Subscribe a respawn's `materialize_peers` sends on the same
     // client channel — the same ordering hazard as the policy watches:

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -332,6 +332,39 @@ pub struct BgpVrfConfig {
     pub mobile_uplane: BgpVrfMobileUplane,
 }
 
+/// Whether two candidate configs materialize the same long-lived VRF task.
+///
+/// "Task-global" inputs only — the things a per-VRF [`super::vrf::BgpVrf`]
+/// task captures at spawn and cannot change without a rebuild (rd,
+/// router-id, label-mode, encapsulation, the EVPN knobs, l3vni, router-mac,
+/// inter-as-hybrid, MUP dataplane). A difference in any of these forces a
+/// respawn via [`super::vrf::compute_vrf_respawn`].
+///
+/// Neighbor add / remove / edit is deliberately NOT part of this
+/// signature: those are applied incrementally to the running task by
+/// `Bgp::apply_vrf_neighbor_diffs` (`AddPeer`/`RemovePeer`/
+/// `ReconfigurePeer`), the per-VRF twin of the global neighbor path, so a
+/// CE-peer change no longer resets every other session in the VRF. The
+/// neighbor-group snapshots are still accepted (a future task-global input
+/// might need them) but no longer read here.
+pub(crate) fn runtime_structure_eq(
+    before: &BgpVrfConfig,
+    _before_groups: &BTreeMap<String, super::neighbor_group::NeighborGroup>,
+    after: &BgpVrfConfig,
+    _after_groups: &BTreeMap<String, super::neighbor_group::NeighborGroup>,
+) -> bool {
+    before.rd == after.rd
+        && before.router_id == after.router_id
+        && before.label_mode == after.label_mode
+        && before.encapsulation == after.encapsulation
+        && before.evpn_advertise_v4 == after.evpn_advertise_v4
+        && before.evpn_advertise_v6 == after.evpn_advertise_v6
+        && before.l3vni == after.l3vni
+        && before.router_mac == after.router_mac
+        && before.inter_as_hybrid == after.inter_as_hybrid
+        && before.mobile_uplane.dataplane == after.mobile_uplane.dataplane
+}
+
 /// Borrow the per-VRF entry on `Bgp::vrfs`, creating it for Set (the
 /// "set leaf before set list-key" firing order makes lazy creation
 /// necessary) but NEVER for Delete. A whole-subtree delete fires the
@@ -1957,5 +1990,74 @@ mod tests {
         );
         cfg.ipv6_unicast.as_mut().unwrap().networks.remove(&prefix);
         assert!(cfg.ipv6_unicast.as_ref().unwrap().networks.is_empty());
+    }
+
+    fn vrf_with_neighbor(addr: &str, remote_as: Option<u32>) -> BgpVrfConfig {
+        let mut cfg = BgpVrfConfig::default();
+        cfg.neighbors.insert(
+            addr.parse().unwrap(),
+            BgpVrfNeighborConfig {
+                remote_as,
+                ..Default::default()
+            },
+        );
+        cfg
+    }
+
+    #[test]
+    fn runtime_structure_eq_identical_config_is_stable() {
+        let groups = BTreeMap::new();
+        let cfg = vrf_with_neighbor("192.0.2.1", Some(65001));
+        assert!(runtime_structure_eq(&cfg, &groups, &cfg.clone(), &groups));
+    }
+
+    /// A neighbor's `remote-as` change is applied incrementally
+    /// (`ReconfigurePeer`), NOT by respawning the task, so it must not
+    /// read as a structural change — otherwise every other CE session in
+    /// the VRF would reset.
+    #[test]
+    fn runtime_structure_eq_ignores_remote_as_change() {
+        let groups = BTreeMap::new();
+        let before = vrf_with_neighbor("192.0.2.1", Some(65001));
+        let after = vrf_with_neighbor("192.0.2.1", Some(65002));
+        assert!(runtime_structure_eq(&before, &groups, &after, &groups));
+    }
+
+    /// Adding a neighbor is handled by `AddPeer` on the live task, not a
+    /// respawn, so it is no longer structural.
+    #[test]
+    fn runtime_structure_eq_ignores_neighbor_add() {
+        let groups = BTreeMap::new();
+        let before = vrf_with_neighbor("192.0.2.1", Some(65001));
+        let mut after = before.clone();
+        after.neighbors.insert(
+            "192.0.2.2".parse().unwrap(),
+            BgpVrfNeighborConfig {
+                remote_as: Some(65002),
+                ..Default::default()
+            },
+        );
+        assert!(runtime_structure_eq(&before, &groups, &after, &groups));
+    }
+
+    /// Router-id is a task-global input captured at spawn — a change still
+    /// forces a respawn.
+    #[test]
+    fn runtime_structure_eq_detects_router_id_change() {
+        let groups = BTreeMap::new();
+        let before = vrf_with_neighbor("192.0.2.1", Some(65001));
+        let mut after = before.clone();
+        after.router_id = Some("10.0.0.1".parse().unwrap());
+        assert!(!runtime_structure_eq(&before, &groups, &after, &groups));
+    }
+
+    /// RD is a task-global input — a change still forces a respawn.
+    #[test]
+    fn runtime_structure_eq_detects_rd_change() {
+        let groups = BTreeMap::new();
+        let before = vrf_with_neighbor("192.0.2.1", Some(65001));
+        let mut after = before.clone();
+        after.rd = Some(RouteDistinguisher::from_str("65000:1").unwrap());
+        assert!(!runtime_structure_eq(&before, &groups, &after, &groups));
     }
 }

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -942,8 +942,9 @@ pub fn config_vrf_neighbor_disable_connected_check(
 // flag; the two structured ones (allowas-in, remove-private-as) go
 // through the shared `InheritableKnobs::stage_*` state machines the
 // global neighbor's callbacks now also use, so the get-or-insert /
-// revert-to-default behaviour has one definition. `materialize_peers`
-// resolves and applies all of them via `apply_inherited_session_knobs`.
+// revert-to-default behaviour has one definition. `resolve_vrf_peer_config`
+// resolves all of them (via `resolve_inherited_knobs`) and the task-side
+// insert applies them (via `apply_resolved_session_knobs`).
 
 pub fn config_vrf_neighbor_as_override(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let vrf = args.string()?;

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -61,6 +61,12 @@ pub enum Message {
         ident: usize,
         policy_type: PolicyType,
     },
+    /// Drop every watch a protocol registered under `proto`, in one shot.
+    /// Used at per-VRF task teardown (`despawn_bgp_vrf`): the VRF's proto is
+    /// `bgp-vrf:<name>`, and its peers' watches accumulate at runtime
+    /// (incremental `AddPeer`), so no caller can enumerate them by ident.
+    /// No `None` reply is sent — the subscriber is being torn down.
+    UnregisterProto { proto: String },
 }
 
 // Message from rib to protocol module.
@@ -434,6 +440,18 @@ impl Policy {
                     let _ = tx.send(reply);
                 }
             }
+            Message::UnregisterProto { proto } => {
+                for map in [
+                    &mut self.watch_prefix,
+                    &mut self.watch_policy,
+                    &mut self.watch_keychain,
+                ] {
+                    map.retain(|_name, watches| {
+                        watches.retain(|w| w.proto != proto);
+                        !watches.is_empty()
+                    });
+                }
+            }
         }
     }
 
@@ -770,5 +788,64 @@ mod unregister_reply_tests {
             })
             .await;
         assert!(rx.try_recv().is_err(), "key-chain unbind pushes nothing");
+    }
+
+    /// `UnregisterProto` drops every watch a proto registered — across the
+    /// prefix-set / policy-list / key-chain maps — in one shot, and leaves
+    /// other protos' watches untouched. This is what lets a per-VRF task
+    /// teardown clear runtime-added peers' watches that no ident-enumerated
+    /// spawn snapshot ever captured (else they leak / mis-deliver on the
+    /// next respawn).
+    #[tokio::test]
+    async fn unregister_proto_drops_only_that_protos_watches() {
+        use crate::policy::KeyChainScope;
+        let mut policy = Policy::new();
+        let reg = |proto: &str, name: &str, ident: usize, ty: PolicyType| Message::Register {
+            proto: proto.to_string(),
+            name: name.to_string(),
+            ident,
+            policy_type: ty,
+        };
+        // Two VRF protos + one global, spread across all three watch maps.
+        policy
+            .process_msg(reg("bgp-vrf:v1", "PS", 1, PolicyType::PrefixSetIn))
+            .await;
+        policy
+            .process_msg(reg("bgp-vrf:v1", "PL", 1, PolicyType::PolicyListOut))
+            .await;
+        policy
+            .process_msg(reg(
+                "bgp-vrf:v1",
+                "KC",
+                1,
+                PolicyType::KeyChain(KeyChainScope::BgpNeighbor),
+            ))
+            .await;
+        policy
+            .process_msg(reg("bgp-vrf:v2", "PS", 9, PolicyType::PrefixSetIn))
+            .await;
+        policy
+            .process_msg(reg("bgp", "PS", 3, PolicyType::PrefixSetIn))
+            .await;
+
+        policy
+            .process_msg(Message::UnregisterProto {
+                proto: "bgp-vrf:v1".to_string(),
+            })
+            .await;
+
+        let has = |m: &BTreeMap<String, Vec<PolicyWatch>>, proto: &str| {
+            m.values().flatten().any(|w| w.proto == proto)
+        };
+        // Every v1 watch is gone, from all three maps.
+        assert!(!has(&policy.watch_prefix, "bgp-vrf:v1"));
+        assert!(!has(&policy.watch_policy, "bgp-vrf:v1"));
+        assert!(!has(&policy.watch_keychain, "bgp-vrf:v1"));
+        // The other protos survive.
+        assert!(has(&policy.watch_prefix, "bgp-vrf:v2"));
+        assert!(has(&policy.watch_prefix, "bgp"));
+        // The shared "PS" name entry is kept (v2 + bgp still reference it),
+        // not pruned away with v1's watch.
+        assert!(policy.watch_prefix.contains_key("PS"));
     }
 }


### PR DESCRIPTION
Two commits that make per-VRF BGP config edits take effect on a **running** VRF,
instead of only at the next spawn/respawn.

### 1. `bgp: respawn VRF tasks after task-global config changes` (ec84961)
Task-global inputs are captured at spawn — router-id, ASN, RD, encapsulation,
label-mode, dataplane, and the EVPN attributes (advertise v4/v6, l3vni,
router-mac, inter-as-hybrid). Editing them previously left the running task stale.
Now `CommitStart` snapshots the VRF + neighbor-group config, and at `CommitEnd`
`compute_vrf_respawn` / `runtime_structure_eq` compare the task-global inputs of
each running VRF and route changed ones through the existing despawn → spawn path
(inherited router-id/ASN changes respawn too). `runtime_structure_eq` compares
**only** task-global fields; per-neighbor edits are handled in commit 2.

*Known limitation:* respawn rebuilds the whole VRF task, so a task-global edit
resets every session in that VRF — unavoidable for spawn-captured inputs.

### 2. `bgp: apply per-VRF neighbor changes incrementally` (5d47651)
Per-neighbor edits (add / remove / reconfigure a CE peer) now apply to just the
affected peer at runtime, mirroring the global neighbor path and reusing its
primitives. `compute_vrf_neighbor_diff` classifies the change at `CommitEnd` and
dispatches `AddPeer` / `RemovePeer` / `ReconfigurePeer` to the running VRF task
(only for VRFs that are running and not being respawned):
- **AddPeer** uses `insert_started_peer` (factored from `materialize_peers`) — same
  identity/knob/policy/start path as a spawn-time peer, plus `peer_index`.
- **RemovePeer** mirrors global `remove_peer_full` (`route_clean` incl. VPNv4
  export withdrawal, `update_group::detach`, `peers.remove`, policy Unregister).
- **ReconfigurePeer** applies the resolved config live and bounces **only that
  peer**, only when re-OPEN is needed — a session-knob change (reused global
  `apply_*` via `apply_resolved_session_knobs`) or an AFI/SAFI capability change.
  A bare remote-as change does not bounce, mirroring global `config_remote_as`;
  policy / prefix-set edits rebind the watches without a bounce.

Group resolution runs global-side and the resolved config/knobs/policy-refs travel
in the message. The knob machinery in `neighbor_group.rs` is split into
`resolve_inherited_knobs` (shared with global `apply_inherited`) and
`apply_resolved_session_knobs`, so per-VRF uses the exact same `apply_*` and bounce
rules as the global neighbor — no parallel implementation.

*Known limitation:* as with the existing spawn path, per-VRF neighbors do not apply
auth (password / TCP-AO), TCP-MSS, or BFD-related knobs live (the VRF task has no
shared listener / BFD client); those remain follow-ups. Session knobs, AFI/SAFI,
next-hop-self, and policy / prefix-set edits are covered.