### PR TITLE
bgp: per-VRF neighbor BFD (single-hop)

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -234,6 +234,11 @@
 /router/bgp/vrf/neighbor/allowas-in/count
 /router/bgp/vrf/neighbor/allowas-in/origin
 /router/bgp/vrf/neighbor/as-override
+/router/bgp/vrf/neighbor/bfd/detect-offload
+/router/bgp/vrf/neighbor/bfd/echo-mode
+/router/bgp/vrf/neighbor/bfd/echo-receive-interval
+/router/bgp/vrf/neighbor/bfd/echo-transmit-interval
+/router/bgp/vrf/neighbor/bfd/enabled
 /router/bgp/vrf/neighbor/description
 /router/bgp/vrf/neighbor/disable-connected-check
 /router/bgp/vrf/neighbor/ebgp-multihop

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -21,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 308
-Handled: 295
+Total settable schema nodes: 313
+Handled: 300
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -51,7 +51,14 @@ The remaining inheritable knobs (allowas-in, as-override, enforce-first-as,
 remove-private-as, route-reflector) are now exposed as per-neighbor leaves
 too; the two structured ones (allowas-in, remove-private-as) share the
 global neighbor's staging state machine via InheritableKnobs::stage_*.
-Auth (password, tcp-ao) and BFD are separate follow-ups. The `neighbor-group` leaf was
+BFD is now wired too (single-hop only): the CE session is disambiguated
+and reached by its directly-connected egress ifindex, since the BFD
+SessionKey has no VRF dimension and the daemon socket is not VRF-bound.
+`bfd multihop` is not offered (omitted from the schema, so the attempt fails YANG validation rather than reporting a misleading success). BgpVrf holds its own BFD
+client + event channels (client id `bfd-vrf:<name>`), and despawn
+withdraws the sessions synchronously ahead of a respawn's re-subscribe,
+the same ordering the policy watches use. Auth (password, tcp-ao) remains
+the last follow-up. The `neighbor-group` leaf was
 renamed from `peer-group` to match the global neighbor and the list it
 resolves against.
 

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -322,6 +322,12 @@
 /router/bgp/vrf/neighbor/allowas-in/count	leaf
 /router/bgp/vrf/neighbor/allowas-in/origin	leaf
 /router/bgp/vrf/neighbor/as-override	p-container
+/router/bgp/vrf/neighbor/bfd	container
+/router/bgp/vrf/neighbor/bfd/detect-offload	leaf
+/router/bgp/vrf/neighbor/bfd/echo-mode	leaf
+/router/bgp/vrf/neighbor/bfd/echo-receive-interval	leaf
+/router/bgp/vrf/neighbor/bfd/echo-transmit-interval	leaf
+/router/bgp/vrf/neighbor/bfd/enabled	leaf
 /router/bgp/vrf/neighbor/description	leaf
 /router/bgp/vrf/neighbor/disable-connected-check	p-container
 /router/bgp/vrf/neighbor/ebgp-multihop	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1443,7 +1443,7 @@ fn config_peer_bfd_min_ttl(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 
 /// Parse the `{transmit|receive|both}` echo-mode enum (set) → `Some(mode)`, or
 /// `None` on delete. `None`/parse-failure on a malformed value.
-fn parse_bfd_echo_mode(value: &str, op: ConfigOp) -> Option<Option<EchoMode>> {
+pub(super) fn parse_bfd_echo_mode(value: &str, op: ConfigOp) -> Option<Option<EchoMode>> {
     if !op.is_set() {
         return Some(None);
     }
@@ -4373,6 +4373,26 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/neighbor/remove-private-as/replace-as",
             super::vrf_config::config_vrf_neighbor_remove_private_as_replace_as,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/bfd/enabled",
+            super::vrf_config::config_vrf_neighbor_bfd_enabled,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/bfd/echo-mode",
+            super::vrf_config::config_vrf_neighbor_bfd_echo_mode,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/bfd/echo-transmit-interval",
+            super::vrf_config::config_vrf_neighbor_bfd_echo_tx,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/bfd/echo-receive-interval",
+            super::vrf_config::config_vrf_neighbor_bfd_echo_rx,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/bfd/detect-offload",
+            super::vrf_config::config_vrf_neighbor_bfd_detect_offload,
         );
         self.callback_add(
             "/router/bgp/vrf/neighbor/description",

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1838,6 +1838,7 @@ impl Bgp {
             self.tracing.clone(),
             self.vrf_global_tx.clone(),
             self.policy_tx.clone(),
+            self.bfd_client_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
@@ -2561,6 +2562,7 @@ impl Bgp {
                 self.tracing.clone(),
                 self.vrf_global_tx.clone(),
                 self.policy_tx.clone(),
+                self.bfd_client_tx.clone(),
             );
             self.register_vrf_show(&name, &handle);
             self.vrf_registry.insert(name, handle);
@@ -2917,6 +2919,7 @@ impl Bgp {
             self.tracing.clone(),
             self.vrf_global_tx.clone(),
             self.policy_tx.clone(),
+            self.bfd_client_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
@@ -4226,6 +4229,7 @@ impl Bgp {
             self.tracing.clone(),
             self.vrf_global_tx.clone(),
             self.policy_tx.clone(),
+            self.bfd_client_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -204,6 +204,23 @@ pub struct BgpVrf {
     /// Our half of the reply channel, kept so `subscribe_policy` can
     /// hand a clone to the actor (and a respawn can re-subscribe).
     policy_reply_tx: UnboundedSender<crate::policy::PolicyRx>,
+    /// Sender toward the BFD subsystem, set by [`Self::set_bfd_client`]
+    /// at spawn. `None` in unit tests / when BFD is unavailable, which
+    /// simply means CE peers never bring up a BFD session.
+    ///
+    /// Per-VRF BFD is single-hop only: the BFD `SessionKey` has no
+    /// VRF/table dimension and the daemon's socket is not VRF-bound, so
+    /// a session is disambiguated (and made reachable) purely by the
+    /// egress ifindex of a directly-connected CE. Multihop, which keys
+    /// on ifindex 0, would conflate overlapping-address VRFs and can't
+    /// egress a VRF-only route, so it is refused at config time.
+    pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+    /// BFD state-change events for THIS VRF's sessions. Each Subscribe
+    /// carries `bfd_notifier` as the notifier, and the client id is
+    /// `bfd-vrf:<name>` so two VRFs with overlapping CE addresses get
+    /// distinct subscriptions.
+    pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
+    bfd_notifier: UnboundedSender<crate::bfd::inst::BfdEvent>,
     /// VRF-first MUP origination tracking: per PFCP SEID, the RD-free ST
     /// prefixes this VRF exported to the global SAFI-85 RIB. Lets a Session
     /// Deletion / Modification (`MupWithdrawOriginate`) withdraw exactly the
@@ -730,6 +747,7 @@ impl BgpVrf {
         let (inbox_tx, global_rx) = mpsc::unbounded_channel();
         let (tx, rx) = mpsc::channel(8192);
         let policy_chan = crate::policy::PolicyRxChannel::new();
+        let (bfd_notifier, bfd_event_rx) = mpsc::unbounded_channel();
         let vrf = Self {
             name,
             ctx,
@@ -768,6 +786,9 @@ impl BgpVrf {
             policy_tx: None,
             policy_rx: policy_chan.rx,
             policy_reply_tx: policy_chan.tx,
+            bfd_client_tx: None,
+            bfd_event_rx,
+            bfd_notifier,
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
@@ -1271,6 +1292,146 @@ impl BgpVrf {
         format!("bgp-vrf:{}", self.name)
     }
 
+    /// The BFD client id this VRF uses. Per-VRF so two VRFs with
+    /// overlapping CE addresses subscribe as distinct clients (the BFD
+    /// `subscribers` map keys on `(SessionKey, ClientId)`).
+    pub fn bfd_client(&self) -> String {
+        format!("bfd-vrf:{}", self.name)
+    }
+
+    /// Stash the BFD client sender at spawn so `materialize_peers` can
+    /// bring up CE sessions.
+    pub fn set_bfd_client(
+        &mut self,
+        bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+    ) {
+        self.bfd_client_tx = bfd_client_tx;
+    }
+
+    /// Reconcile the BFD session for one CE peer, single-hop only.
+    ///
+    /// A trimmed per-VRF counterpart of the global `bfd_apply_ident`.
+    /// The differences, all forced by the single-hop scope:
+    ///   * `multihop` is always false — the config path refuses the
+    ///     `bfd multihop` leaf, and an inferred-multihop (iBGP) CE runs
+    ///     single-hop rather than a session that can't egress the VRF;
+    ///   * `min_ttl` is 255 (GTSM), never the multihop value;
+    ///   * the egress ifindex comes from this VRF's own
+    ///     `interface_addrs`, which is what both disambiguates
+    ///     overlapping VRFs and pins the BFD packet to the CE's link.
+    ///
+    /// There is no per-VRF `router bgp { bfd {} }` default, so the
+    /// per-neighbor config resolves over `PeerBfdConfig::default()`.
+    pub fn bfd_reconcile(&mut self, ident: usize) {
+        use crate::bfd::inst::ClientReq;
+        use crate::bfd::session::{EchoMode, SessionKey, SessionParams};
+        let Some(bfd_client_tx) = self.bfd_client_tx.clone() else {
+            return;
+        };
+        let Some(peer) = self.peers.get_by_idx(ident) else {
+            return;
+        };
+        let addr = peer.address;
+        let eff = peer
+            .config
+            .bfd
+            .resolve(&crate::bgp::peer::PeerBfdConfig::default());
+        let local = peer.config.transport.update_source.unwrap_or(match addr {
+            std::net::IpAddr::V4(_) => std::net::Ipv4Addr::UNSPECIFIED.into(),
+            std::net::IpAddr::V6(_) => std::net::Ipv6Addr::UNSPECIFIED.into(),
+        });
+        // Single-hop keying: the connected CE's veth ifindex. v6 CE
+        // (link-local) has no v4 lookup; falls back to 0 (session still
+        // forms, helper-backed Echo stays off) and re-reconciles when
+        // the interface is learned.
+        let ifindex = match addr {
+            std::net::IpAddr::V4(v4) => self.interface_addrs.ifindex_for_v4(v4).unwrap_or(0),
+            std::net::IpAddr::V6(_) => 0,
+        };
+        let key = SessionKey {
+            local,
+            remote: addr,
+            ifindex,
+            multihop: false,
+        };
+        let (echo_mode, echo_rx_us, echo_tx_us) = match eff.echo_mode {
+            Some(mode) => (
+                mode,
+                eff.echo_receive_ms.saturating_mul(1000),
+                eff.echo_transmit_ms.saturating_mul(1000),
+            ),
+            None => (EchoMode::Off, 0, 0),
+        };
+        let params = SessionParams {
+            dst_port: crate::bfd::socket::BFD_SINGLE_HOP_PORT,
+            min_ttl: 255,
+            echo_mode,
+            required_min_echo_rx_us: echo_rx_us,
+            echo_transmit_us: echo_tx_us,
+            detect_offload: eff.detect_offload,
+            ..SessionParams::default()
+        };
+
+        let current = self.peers.get_by_idx(ident).and_then(|p| p.bfd_session_key);
+        let want = eff.enable.then_some(key);
+        let want_params = eff.enable.then_some(params);
+        let client = self.bfd_client();
+        // A key/params change re-subscribes (BFD treats a repeat
+        // Subscribe on the same key as an in-place param update); a
+        // disable or key change unsubscribes the stale key first.
+        if let Some(old) = current
+            && want != current
+        {
+            let _ = bfd_client_tx.send(ClientReq::Unsubscribe {
+                client: client.clone(),
+                key: old,
+            });
+        }
+        if eff.enable {
+            let _ = bfd_client_tx.send(ClientReq::Subscribe {
+                client,
+                key,
+                params,
+                notifier: self.bfd_notifier.clone(),
+            });
+        }
+        if let Some(peer) = self.peers.get_mut_by_idx(ident) {
+            peer.bfd_session_key = want;
+            peer.bfd_session_params = want_params;
+        }
+    }
+
+    /// Every BFD key this VRF's peers currently subscribe, for the
+    /// synchronous unsubscribe on despawn — same ordering hazard as the
+    /// policy watches (a respawn reuses the client id + keys, so a late
+    /// unsubscribe from the outgoing incarnation would tear down the
+    /// incoming one's session).
+    pub fn bfd_session_list(&self) -> Vec<crate::bfd::session::SessionKey> {
+        self.peers
+            .idents()
+            .into_iter()
+            .filter_map(|idx| self.peers.get_by_idx(idx).and_then(|p| p.bfd_session_key))
+            .collect()
+    }
+
+    /// Handle a BFD state change for one of this VRF's CE sessions.
+    /// Mirrors the global `Bgp::process_bfd_event`: on a transition to
+    /// Down, tear the BGP session down (RFC 5882 §5).
+    pub fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
+        let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
+        if change.from == change.to || change.to != bfd_packet::State::Down {
+            return;
+        }
+        let Some(peer) = self.peers.get_mut(&key.remote) else {
+            return;
+        };
+        let peer_idx = peer.ident;
+        peer.down_reason = Some(super::super::peer::PeerDownReason::BfdDown);
+        let _ = self
+            .tx
+            .try_send(Message::Event(peer_idx, super::super::peer::Event::Stop));
+    }
+
     /// Subscribe this VRF's reply channel with the policy actor and
     /// remember the sender so peers can register their bindings.
     ///
@@ -1397,6 +1558,11 @@ impl BgpVrf {
                     // the global task because we subscribed under our own
                     // proto — see `policy_rx`.
                     self.process_policy_msg(msg);
+                }
+                Some(event) = self.bfd_event_rx.recv() => {
+                    // BFD state change for one of this VRF's CE sessions;
+                    // a transition to Down tears the BGP session down.
+                    self.process_bfd_event(event);
                 }
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -87,6 +87,14 @@ pub struct BgpVrfHandle {
     /// doing it from the task's own shutdown path would delete the
     /// incoming incarnation's watches instead of the outgoing one's.
     pub policy_watches: Vec<(String, usize, crate::policy::PolicyType)>,
+    /// BFD session keys this VRF's peers subscribed, withdrawn
+    /// synchronously by `despawn_bgp_vrf` before a respawn re-subscribes
+    /// — same ordering hazard as `policy_watches`.
+    pub bfd_sessions: Vec<crate::bfd::session::SessionKey>,
+    /// Kept so `despawn_bgp_vrf` can address the BFD unsubscribes.
+    pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+    /// The BFD client id (`bfd-vrf:<name>`) the unsubscribes must use.
+    pub bfd_client: String,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -144,6 +152,7 @@ pub fn spawn_bgp_vrf(
     tracing_cfg: crate::bgp::tracing::BgpTracing,
     global_tx: UnboundedSender<BgpGlobalMsg>,
     policy_tx: UnboundedSender<crate::policy::Message>,
+    bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
 ) -> BgpVrfHandle {
     // Snapshot for logging + ILM install so we can move
     // `kernel` into the ctx-building arm without re-borrowing
@@ -195,6 +204,7 @@ pub fn spawn_bgp_vrf(
     // the Subscribe would be answered into a channel the actor does not
     // have yet.
     vrf.subscribe_policy(policy_tx);
+    vrf.set_bfd_client(bfd_client_tx);
     // Inter-AS Option AB: re-export imported VPNv4 routes (see the field
     // doc on `BgpVrf`). Carried from the staged VRF config.
     vrf.inter_as_hybrid = cfg.inter_as_hybrid;
@@ -314,6 +324,9 @@ pub fn spawn_bgp_vrf(
     let show_tx = vrf.show.tx.clone();
     // Snapshot before `vrf` moves into the task.
     let policy_watches = vrf.policy_watch_list();
+    let bfd_sessions = vrf.bfd_session_list();
+    let bfd_client_handle = vrf.bfd_client_tx.clone();
+    let bfd_client_id = vrf.bfd_client();
     let task = serve_vrf(vrf);
     if crate::rib::tracing::task() {
         tracing::info!(
@@ -333,6 +346,9 @@ pub fn spawn_bgp_vrf(
     BgpVrfHandle {
         inbox,
         policy_watches,
+        bfd_sessions,
+        bfd_client_tx: bfd_client_handle,
+        bfd_client: bfd_client_id,
         show_tx,
         task,
         label,
@@ -585,6 +601,13 @@ fn materialize_peers(
             .get_mut(addr)
             .expect("peer was just inserted")
             .start();
+
+        // Bring up BFD for this CE if configured. After the ident is
+        // assigned (the session key derives from `peer.address`, but the
+        // subscription is tracked by ident) and after start(), matching
+        // the global neighbor's order. A no-op when `bfd enabled` is
+        // unset or no BFD client is wired (placeholder spawn / tests).
+        vrf.bfd_reconcile(ident);
         count += 1;
     }
     count
@@ -712,6 +735,18 @@ pub fn despawn_bgp_vrf(
             policy_type: *policy_type,
         });
     }
+    // Withdraw this incarnation's BFD sessions, on this thread, ahead of
+    // any Subscribe a respawn's `materialize_peers` sends on the same
+    // client channel — the same ordering hazard as the policy watches:
+    // BFD matches on `(client, key)`, both of which a respawn reuses.
+    if let Some(bfd_client_tx) = &handle.bfd_client_tx {
+        for key in &handle.bfd_sessions {
+            let _ = bfd_client_tx.send(crate::bfd::inst::ClientReq::Unsubscribe {
+                client: handle.bfd_client.clone(),
+                key: *key,
+            });
+        }
+    }
     // Drop this VRF's RIB redistribute subscription (client-registry +
     // redist-filter rows) so a respawn under the same `bgp:vrf:<name>`
     // proto doesn't leave a stale subscriber shadowing the live one —
@@ -772,6 +807,7 @@ mod tests {
             /* tracing */ Default::default(),
             global_tx,
             policy_tx,
+            /* bfd */ None,
         )
     }
 
@@ -1025,6 +1061,70 @@ mod tests {
             }),
             "remove-private-as replace-as must be staged and applied"
         );
+    }
+
+    /// A CE with `bfd enabled true` must have `materialize_peers` fire a
+    /// single-hop BFD Subscribe (multihop false, GTSM min-ttl 255, the
+    /// single-hop port); a CE without it must fire nothing. Proves the
+    /// reconcile is wired and that the single-hop invariant holds even
+    /// though the config path never sets multihop.
+    #[tokio::test]
+    async fn materialize_peers_brings_up_single_hop_bfd() {
+        use super::super::super::vrf_config::{BgpVrfConfig, BgpVrfNeighborConfig};
+        use super::super::inst::BgpVrf;
+        use crate::bfd::inst::ClientReq;
+        use crate::context::ProtoContext;
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "v1".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            16,
+            global_tx,
+            rib_rx,
+        );
+        let (bfd_tx, mut bfd_rx) = unbounded_channel::<ClientReq>();
+        vrf.set_bfd_client(Some(bfd_tx));
+
+        let on: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let off: std::net::IpAddr = "192.0.2.2".parse().unwrap();
+
+        let mut cfg = BgpVrfConfig::default();
+        cfg.neighbors.insert(on, {
+            let mut n = BgpVrfNeighborConfig {
+                remote_as: Some(65001),
+                ..Default::default()
+            };
+            n.config.bfd.enable = Some(true);
+            n
+        });
+        cfg.neighbors.insert(
+            off,
+            BgpVrfNeighborConfig {
+                remote_as: Some(65002),
+                ..Default::default()
+            },
+        );
+
+        materialize_peers(&mut vrf, &cfg, &BTreeMap::new());
+
+        // Exactly one Subscribe, for the enabled CE, single-hop.
+        let mut subscribes = Vec::new();
+        while let Ok(req) = bfd_rx.try_recv() {
+            if let ClientReq::Subscribe { key, params, .. } = req {
+                subscribes.push((key, params));
+            }
+        }
+        assert_eq!(subscribes.len(), 1, "only the bfd-enabled CE subscribes");
+        let (key, params) = &subscribes[0];
+        assert_eq!(key.remote, on);
+        assert!(!key.multihop, "per-VRF BFD must be single-hop");
+        assert_eq!(params.min_ttl, 255, "single-hop GTSM min-ttl");
+        assert_eq!(params.dst_port, crate::bfd::socket::BFD_SINGLE_HOP_PORT);
     }
 
     /// `neighbor <addr> timers { … }` must reach the peer that

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -1038,6 +1038,83 @@ pub fn config_vrf_neighbor_remove_private_as_replace_as(
     Some(())
 }
 
+// BFD, single-hop only. The values stage onto the peer's `config.bfd`
+// (a PeerConfig field, so they ride the wholesale config adoption); the
+// session is brought up by `materialize_peers` via `BgpVrf::bfd_reconcile`.
+// `multihop` is refused — per-VRF BFD keys on the CE's egress ifindex,
+// which multihop (ifindex 0) does not have.
+
+pub fn config_vrf_neighbor_bfd_enabled(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.bfd.enable = match op {
+        ConfigOp::Set => Some(args.boolean()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    Some(())
+}
+
+pub fn config_vrf_neighbor_bfd_echo_mode(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let value = args.string().unwrap_or_default();
+    let mode = super::config::parse_bfd_echo_mode(&value, op)?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.bfd.echo_mode = mode;
+    Some(())
+}
+
+pub fn config_vrf_neighbor_bfd_echo_tx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.bfd.echo_transmit_ms = match op {
+        ConfigOp::Set => Some(args.u32()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    Some(())
+}
+
+pub fn config_vrf_neighbor_bfd_echo_rx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.bfd.echo_receive_ms = match op {
+        ConfigOp::Set => Some(args.u32()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    Some(())
+}
+
+pub fn config_vrf_neighbor_bfd_detect_offload(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.bfd.detect_offload = match op {
+        ConfigOp::Set => Some(args.boolean()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    Some(())
+}
+
 /// `set router bgp vrf <NAME> neighbor <addr> afi-safi {ipv4|ipv6} enabled
 /// <BOOL>` — per-family activation for a CE peer, mirroring the global
 /// neighbor's `config_afi_safi`. Records the verbatim statement into the

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -410,6 +410,60 @@ module zebra-bgp-vrf {
           description "Rewrite each stripped private AS to the local AS, keeping path length.";
         }
       }
+
+      container bfd {
+        ext:help "BFD attachment for this CE (single-hop only)";
+        description
+          "Per-VRF BFD is SINGLE-HOP ONLY. The BFD SessionKey carries no
+           VRF/table dimension and the daemon's socket is not VRF-bound,
+           so a session is disambiguated and made reachable purely by the
+           directly-connected CE's egress ifindex. Multihop (ifindex 0)
+           would conflate overlapping-address VRFs and cannot egress a
+           VRF-only route, so the `multihop` leaf is refused at commit.
+           `minimum-ttl` (multihop only) is deliberately absent.
+
+           On a BFD-down the CE's BGP session is torn down (RFC 5882 §5).
+           There is no per-VRF instance-level `bfd {}` default, so each
+           leaf resolves over the built-in default (BFD off unless
+           `enabled true`).";
+        leaf enabled {
+          ext:help "Activate BFD for this CE";
+          type boolean;
+          description "Bring up a single-hop BFD session to this CE. Absent ⇒ off.";
+        }
+        // NB: no `multihop` / `minimum-ttl` leaves. Per-VRF BFD is
+        // single-hop only, and a config callback cannot fail a commit
+        // (`Bgp::process_cm_msg` discards the callback's return), so an
+        // accept-then-warn leaf would report "applied" while silently
+        // ignoring the value. Omitting the leaf makes `bfd multihop …`
+        // fail YANG validation instead — a real rejection.
+        leaf echo-mode {
+          ext:help "BFD Echo role (transmit | receive | both)";
+          type enumeration {
+            enum transmit { description "Originate Echo only."; }
+            enum receive { description "Advertise + reflect only."; }
+            enum both { description "Both."; }
+          }
+          description "BFD Echo function (RFC 5880 §6.4). Same values as the global neighbor.";
+        }
+        leaf echo-transmit-interval {
+          ext:help "Echo transmit interval (ms)";
+          type uint32;
+          units "milliseconds";
+          description "Rate we originate Echo at. Default 50ms when unset.";
+        }
+        leaf echo-receive-interval {
+          ext:help "Advertised Required Min Echo RX Interval (ms)";
+          type uint32;
+          units "milliseconds";
+          description "Advertised Required Min Echo RX. Default 50ms when unset.";
+        }
+        leaf detect-offload {
+          ext:help "Offload expiration detection to the XDP helper";
+          type boolean;
+          description "Detect missing control packets in the kernel XDP helper. Absent ⇒ userspace.";
+        }
+      }
       list afi-safi {
         ext:help "Per-address-family activation for this CE peer";
         key "name";


### PR DESCRIPTION
## What

Brings up BFD for a per-VRF PE-CE session and tears the BGP session down on a
BFD-down (RFC 5882 §5). **Single-hop only, by construction.**

## Why single-hop only

The BFD `SessionKey` is `{local, remote, ifindex, multihop}` — **no VRF/table
dimension** — and the BFD daemon's socket is not VRF-bound. A directly-connected
CE's egress ifindex is what both (a) disambiguates two VRFs with overlapping CE
addresses and (b) pins the BFD packet to the CE's link (the send path uses
`IP_PKTINFO.ipi_ifindex`). Multihop keys on ifindex 0, so it would conflate
overlapping VRFs *and* cannot egress a VRF-only route. Full multihop needs a
VRF-aware `SessionKey` in the BFD subsystem — a separate, cross-cutting change.

## Plumbing (mirrors the policy channel)

- `BgpVrf` holds its own BFD client sender + event receiver. Subscribes with
  client id `bfd-vrf:<name>` so overlapping-address VRFs are distinct clients in
  BFD's `(SessionKey, ClientId)` map.
- `bfd_reconcile` is a trimmed per-VRF `bfd_apply_ident`: forced single-hop, GTSM
  min-ttl 255, ifindex from the VRF's own `interface_addrs`, resolving over
  `PeerBfdConfig::default()` (there is no per-VRF instance-level `bfd {}`). Called
  from `materialize_peers` after the peer has its ident.
- An event-loop arm drives a per-VRF `process_bfd_event` (mirror of the global
  one: on Down → `BfdDown` + `Event::Stop`).
- despawn withdraws the sessions **synchronously** ahead of a respawn's
  re-subscribe — the same ordering hazard the policy watches have, since BFD
  matches on `(client, key)` and a respawn reuses both.

Config: `bfd { enabled | echo-mode | echo-transmit-interval |
echo-receive-interval | detect-offload }`, staged onto the peer's `config.bfd`
(a `PeerConfig` field, so it rides the wholesale adoption).

## The multihop rejection, corrected after live test

`multihop` and `minimum-ttl` are deliberately **not** in the schema. A config
callback cannot fail a commit — `Bgp::process_cm_msg` discards the callback's
return value — so a first cut with an accept-then-warn `multihop` leaf reported
**"applied"** while silently dropping the value (caught live). Omitting the leaf
makes `bfd multihop …` fail YANG validation instead: a real `error reply`.
Verified both ways.

## Test plan

- New unit test: `materialize_peers` fires **exactly one** single-hop `Subscribe`
  for a bfd-enabled CE (multihop false, min-ttl 255, single-hop port) and none
  for a disabled one.
- Live: `bfd enabled true` and the echo/detect-offload leaves accepted;
  `bfd multihop true` → `error reply`; `bfd echo-mode bogus` rejected by the enum.
- `cargo fmt --all --check`; **clean-build** workspace clippy with CI flags; full
  suite (**2521 tests**); all four `bgp_config_audit` tests — green.
- Schema diff is the six BFD nodes; **no global paths changed**. Orphan report
  counts updated by hand (settable 308 → 313, handled 295 → 300; orphans
  unchanged at 3).

## Not covered / follow-ups

- **No end-to-end BDD**: this proves config→Subscribe and the reconcile logic,
  not a live BFD session bringing a VRF CE up and tearing it down across two
  namespaces. The datapath is asserted by construction (reuses the global BFD
  paths); a BDD scenario is a worthwhile follow-up.
- Auth (`password`, `tcp-ao`) is the last remaining non-AFI knob group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
