### PR TITLE
bgp: per-VRF neighbor auth — TCP-MD5 + TCP-AO (active-only)

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -245,6 +245,7 @@
 /router/bgp/vrf/neighbor/enforce-first-as
 /router/bgp/vrf/neighbor/ip-transparent
 /router/bgp/vrf/neighbor/neighbor-group
+/router/bgp/vrf/neighbor/password
 /router/bgp/vrf/neighbor/port
 /router/bgp/vrf/neighbor/remote-as
 /router/bgp/vrf/neighbor/remove-private-as

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -252,6 +252,8 @@
 /router/bgp/vrf/neighbor/remove-private-as/all
 /router/bgp/vrf/neighbor/remove-private-as/replace-as
 /router/bgp/vrf/neighbor/route-reflector/client
+/router/bgp/vrf/neighbor/tcp-ao/include-tcp-options
+/router/bgp/vrf/neighbor/tcp-ao/key-chain
 /router/bgp/vrf/neighbor/timers/connect-retry-time
 /router/bgp/vrf/neighbor/timers/hold-time
 /router/bgp/vrf/neighbor/timers/idle-hold-time

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -21,8 +21,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 313
-Handled: 300
+Total settable schema nodes: 314
+Handled: 301
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -57,8 +57,11 @@ SessionKey has no VRF dimension and the daemon socket is not VRF-bound.
 `bfd multihop` is not offered (omitted from the schema, so the attempt fails YANG validation rather than reporting a misleading success). BgpVrf holds its own BFD
 client + event channels (client id `bfd-vrf:<name>`), and despawn
 withdraws the sessions synchronously ahead of a respawn's re-subscribe,
-the same ordering the policy watches use. Auth (password, tcp-ao) remains
-the last follow-up. The `neighbor-group` leaf was
+the same ordering the policy watches use. TCP-MD5 `password` is wired for the active/outbound direction only: the
+resolved secret lands on config.transport.md5_password, which the shared
+connect path applies to the VRF-bound dial socket. Passive/inbound auth
+needs a per-VRF listener socket (the FRR model) and is out of scope.
+TCP-AO (key-chain) is the last auth follow-up. The `neighbor-group` leaf was
 renamed from `peer-group` to match the global neighbor and the list it
 resolves against.
 

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -14,6 +14,7 @@ ORPHAN leaf         /router/bgp/sharding/peer-sharding
   /router/bgp/color-policy  [p-container]
   /router/bgp/sr-policy  [p-container]
   /router/bgp/vrf/neighbor/afi-safi  [list]
+  /router/bgp/vrf/neighbor/tcp-ao  [p-container]
 
 Note: the bare /router/bgp/neighbor list path is deliberately absent
 here — it IS handled, registered as `callback_peer("", config_peer)`
@@ -21,8 +22,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 314
-Handled: 301
+Total settable schema nodes: 317
+Handled: 303
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -61,7 +62,15 @@ the same ordering the policy watches use. TCP-MD5 `password` is wired for the ac
 resolved secret lands on config.transport.md5_password, which the shared
 connect path applies to the VRF-bound dial socket. Passive/inbound auth
 needs a per-VRF listener socket (the FRR model) and is out of scope.
-TCP-AO (key-chain) is the last auth follow-up. The `neighbor-group` leaf was
+TCP-AO (key-chain) is wired too, active/outbound only: the ao_config binding
+resolves onto config.transport.ao_config, materialize_peers registers the
+key-chain with the policy actor under proto bgp-vrf:<name> (KeyChain scope),
+and the PolicyRx::KeyChain reply populates resolved_ao_key (BgpVrf keeps its
+own key_chains snapshot + resolve_ao_keys, the per-VRF twin of
+apply_ao_refresh_all minus the listener install). Despawn withdraws the
+key-chain watches alongside the policy watches. This completes the non-AFI
+knob import; per-VRF passive-side MD5/AO (a per-VRF listener socket, the FRR
+model) is the one remaining architectural follow-up. The `neighbor-group` leaf was
 renamed from `peer-group` to match the global neighbor and the list it
 resolves against.
 

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -334,6 +334,7 @@
 /router/bgp/vrf/neighbor/enforce-first-as	p-container
 /router/bgp/vrf/neighbor/ip-transparent	p-container
 /router/bgp/vrf/neighbor/neighbor-group	leaf
+/router/bgp/vrf/neighbor/password	leaf
 /router/bgp/vrf/neighbor/port	leaf
 /router/bgp/vrf/neighbor/remote-as	leaf
 /router/bgp/vrf/neighbor/remove-private-as	p-container

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -342,6 +342,9 @@
 /router/bgp/vrf/neighbor/remove-private-as/replace-as	leaf
 /router/bgp/vrf/neighbor/route-reflector	container
 /router/bgp/vrf/neighbor/route-reflector/client	leaf
+/router/bgp/vrf/neighbor/tcp-ao	p-container
+/router/bgp/vrf/neighbor/tcp-ao/include-tcp-options	leaf
+/router/bgp/vrf/neighbor/tcp-ao/key-chain	leaf
 /router/bgp/vrf/neighbor/timers	container
 /router/bgp/vrf/neighbor/timers/connect-retry-time	leaf
 /router/bgp/vrf/neighbor/timers/hold-time	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4343,6 +4343,14 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_password,
         );
         self.callback_add(
+            "/router/bgp/vrf/neighbor/tcp-ao/key-chain",
+            super::vrf_config::config_vrf_neighbor_tcp_ao_key_chain,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/tcp-ao/include-tcp-options",
+            super::vrf_config::config_vrf_neighbor_tcp_ao_include_tcp_options,
+        );
+        self.callback_add(
             "/router/bgp/vrf/neighbor/as-override",
             super::vrf_config::config_vrf_neighbor_as_override,
         );

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4339,6 +4339,10 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_disable_connected_check,
         );
         self.callback_add(
+            "/router/bgp/vrf/neighbor/password",
+            super::vrf_config::config_vrf_neighbor_password,
+        );
+        self.callback_add(
             "/router/bgp/vrf/neighbor/as-override",
             super::vrf_config::config_vrf_neighbor_as_override,
         );

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -1296,6 +1296,14 @@ pub(super) fn apply_inherited_session_knobs(
     // therefore discarded.
     let password = resolve_knob(groups, &peer.config, |k| k.password.clone());
     let _ = super::config::apply_md5_password(peer, password);
+    // TCP-AO: resolve the referenced key-chain *binding* onto
+    // `config.transport.ao_config`. The resolved key material
+    // (`resolved_ao_key`) is filled in later, when the policy actor
+    // answers the per-VRF key-chain Register — see
+    // `BgpVrf::process_policy_msg`'s KeyChain arm. Active/outbound only,
+    // same listener limitation as the MD5 password.
+    let ao_config = resolve_knob(groups, &peer.config, |k| k.ao_config.clone());
+    let _ = super::config::apply_ao_config(peer, ao_config);
 }
 
 pub(super) fn apply_inherited(

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -1286,6 +1286,16 @@ pub(super) fn apply_inherited_session_knobs(
     let update_source = resolve_knob(groups, &peer.config, |k| k.update_source);
     // The BFD re-arm this returns is only meaningful for a live session.
     let _ = super::config::apply_update_source(peer, update_source);
+    // TCP-MD5 password: resolve the verbatim statement over the group
+    // and write the effective value onto `config.transport.md5_password`.
+    // The shared FSM connect path (`peer_start_connection`) reads it and
+    // applies it to this peer's VRF-bound *connect* socket, so the PE's
+    // outbound dial to the CE is authenticated. The listener (passive)
+    // side is not keyed here — per-VRF passive-side auth needs a
+    // per-VRF listener (see the FRR model); the `_refresh` outcome is
+    // therefore discarded.
+    let password = resolve_knob(groups, &peer.config, |k| k.password.clone());
+    let _ = super::config::apply_md5_password(peer, password);
 }
 
 pub(super) fn apply_inherited(

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -221,6 +221,12 @@ pub struct BgpVrf {
     /// distinct subscriptions.
     pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
     bfd_notifier: UnboundedSender<crate::bfd::inst::BfdEvent>,
+    /// This VRF's snapshot of the key-chains its CE peers reference for
+    /// TCP-AO, populated from the policy actor's `PolicyRx::KeyChain`
+    /// replies (subscribed under `bgp-vrf:<name>`, so a chain edit is
+    /// delivered here rather than to the global task). Read to resolve
+    /// each peer's `resolved_ao_key`.
+    pub key_chains: std::collections::BTreeMap<String, crate::policy::KeyChain>,
     /// VRF-first MUP origination tracking: per PFCP SEID, the RD-free ST
     /// prefixes this VRF exported to the global SAFI-85 RIB. Lets a Session
     /// Deletion / Modification (`MupWithdrawOriginate`) withdraw exactly the
@@ -789,6 +795,7 @@ impl BgpVrf {
             bfd_client_tx: None,
             bfd_event_rx,
             bfd_notifier,
+            key_chains: std::collections::BTreeMap::new(),
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
@@ -1278,8 +1285,56 @@ impl BgpVrf {
                     peer.rebuild_out_policy();
                 }
             }
-            // Key-chains and table-maps are not bound by per-VRF peers.
-            _ => {}
+            PolicyRx::KeyChain {
+                name, key_chain, ..
+            } => {
+                // A CE peer's TCP-AO key-chain resolved (or changed). Store
+                // the snapshot by name, then re-resolve every peer that
+                // references it. The ident in the reply is only for the
+                // actor's unregister matching; resolution is by name, like
+                // the global `apply_ao_refresh_all`.
+                if let Some(kc) = key_chain {
+                    self.key_chains.insert(name, kc);
+                } else {
+                    self.key_chains.remove(&name);
+                }
+                self.resolve_ao_keys();
+            }
+        }
+    }
+
+    /// Re-resolve `resolved_ao_key` for every CE peer from the current
+    /// key-chain snapshot, and bounce a live session whose key materially
+    /// changed so its next dial carries the new key. The per-VRF twin of
+    /// the global `apply_ao_refresh_all`, minus the listener install
+    /// (active/outbound only — the connect socket reads
+    /// `resolved_ao_key`). An Idle peer just adopts the new key on its
+    /// next connect, so it is not bounced.
+    fn resolve_ao_keys(&mut self) {
+        use super::super::peer::State;
+        let key_chains = self.key_chains.clone();
+        let mut bounce: Vec<usize> = Vec::new();
+        for ident in self.peers.idents() {
+            let Some(peer) = self.peers.get_mut_by_idx(ident) else {
+                continue;
+            };
+            let resolved = peer
+                .config
+                .transport
+                .ao_config
+                .as_ref()
+                .and_then(|ao| ao.resolve(&key_chains));
+            if peer.config.transport.resolved_ao_key != resolved {
+                if !matches!(peer.state, State::Idle) {
+                    bounce.push(ident);
+                }
+                peer.config.transport.resolved_ao_key = resolved;
+            }
+        }
+        for ident in bounce {
+            let _ = self
+                .tx
+                .try_send(Message::Event(ident, super::super::peer::Event::Stop));
         }
     }
 
@@ -1500,6 +1555,19 @@ impl BgpVrf {
                     PolicyType::PrefixSetOut,
                     *fam,
                 );
+            }
+            // TCP-AO key-chain watch. Keyed by the raw peer ident (not
+            // `peer_policy_ident`) matching the global neighbor, and by a
+            // distinct `KeyChain` policy_type, so it never collides with a
+            // policy/prefix-set watch even if the idents coincide.
+            if let Some(ao) = &peer.config.transport.ao_config
+                && !ao.key_chain.is_empty()
+            {
+                out.push((
+                    ao.key_chain.clone(),
+                    idx,
+                    PolicyType::KeyChain(crate::policy::KeyChainScope::BgpNeighbor),
+                ));
             }
         }
         out

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -971,6 +971,88 @@ mod tests {
         );
     }
 
+    /// The TCP-MD5 `password` must resolve (explicit over group) onto
+    /// `config.transport.md5_password`, which the shared connect path
+    /// reads — that is what authenticates the PE's outbound dial.
+    #[tokio::test]
+    async fn materialize_peers_resolves_md5_password() {
+        use super::super::super::neighbor_group::{InheritableKnobs, NeighborGroup};
+        use super::super::super::vrf_config::{BgpVrfConfig, BgpVrfNeighborConfig};
+        use super::super::inst::BgpVrf;
+        use crate::context::ProtoContext;
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "v1".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            16,
+            global_tx,
+            rib_rx,
+        );
+
+        // Group carries a password; one peer inherits it, one overrides.
+        let g = NeighborGroup {
+            knobs: InheritableKnobs {
+                password: Some("group-secret".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut groups = BTreeMap::new();
+        groups.insert("g1".to_string(), g);
+
+        let inherits: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let overrides: std::net::IpAddr = "192.0.2.2".parse().unwrap();
+
+        let mut cfg = BgpVrfConfig::default();
+        cfg.neighbors.insert(inherits, {
+            let mut n = BgpVrfNeighborConfig {
+                remote_as: Some(65001),
+                ..Default::default()
+            };
+            n.config.neighbor_group = Some("g1".to_string());
+            n
+        });
+        cfg.neighbors.insert(overrides, {
+            let mut n = BgpVrfNeighborConfig {
+                remote_as: Some(65002),
+                ..Default::default()
+            };
+            n.config.neighbor_group = Some("g1".to_string());
+            n.config.knobs_explicit.password = Some("peer-secret".to_string());
+            n
+        });
+
+        materialize_peers(&mut vrf, &cfg, &groups);
+
+        assert_eq!(
+            vrf.peers
+                .get(&inherits)
+                .unwrap()
+                .config
+                .transport
+                .md5_password
+                .as_deref(),
+            Some("group-secret"),
+            "password inherited from the group"
+        );
+        assert_eq!(
+            vrf.peers
+                .get(&overrides)
+                .unwrap()
+                .config
+                .transport
+                .md5_password
+                .as_deref(),
+            Some("peer-secret"),
+            "explicit password beats the group's"
+        );
+    }
+
     /// The remaining inheritable knobs (as-override, allowas-in,
     /// remove-private-as, …) must reach the built peer with group
     /// precedence, exercising the structured staging state machines. The

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -578,7 +578,19 @@ fn materialize_peers(
             }
             peer.ident
         };
-        if !nbr_cfg.policy_refs.is_empty()
+        // The TCP-AO key-chain name a resolved `ao_config` references, if
+        // any — captured here (the peer borrow ends with the `ident`
+        // block above) so the Register below can subscribe it. Resolving
+        // the actual key material waits for the actor's reply, handled in
+        // `BgpVrf::process_policy_msg`.
+        let ao_key_chain = vrf
+            .peers
+            .get(addr)
+            .and_then(|p| p.config.transport.ao_config.as_ref())
+            .map(|ao| ao.key_chain.clone())
+            .filter(|c| !c.is_empty());
+
+        if (!nbr_cfg.policy_refs.is_empty() || ao_key_chain.is_some())
             && let Some(policy_tx) = vrf.policy_tx.clone()
         {
             let proto = vrf.policy_proto();
@@ -588,6 +600,19 @@ fn materialize_peers(
                     name: name.clone(),
                     ident: super::super::config::peer_policy_ident(ident, Some(*fam)),
                     policy_type: kind.policy_type(),
+                });
+            }
+            // TCP-AO key-chain: raw peer ident (matching the global
+            // neighbor) + the `KeyChain` policy type. The actor's reply
+            // lands on `policy_rx` and populates `resolved_ao_key`.
+            if let Some(chain) = &ao_key_chain {
+                let _ = policy_tx.send(crate::policy::Message::Register {
+                    proto: proto.clone(),
+                    name: chain.clone(),
+                    ident,
+                    policy_type: crate::policy::PolicyType::KeyChain(
+                        crate::policy::KeyChainScope::BgpNeighbor,
+                    ),
                 });
             }
         }
@@ -1051,6 +1076,99 @@ mod tests {
             Some("peer-secret"),
             "explicit password beats the group's"
         );
+    }
+
+    /// TCP-AO: a staged key-chain reference must land on
+    /// `config.transport.ao_config` at materialize, and a subsequent
+    /// `PolicyRx::KeyChain` reply (the policy actor answering the
+    /// per-VRF Register) must resolve `resolved_ao_key` — which is what
+    /// the connect socket applies.
+    #[tokio::test]
+    async fn tcp_ao_key_chain_resolves_on_reply() {
+        use super::super::super::vrf_config::{BgpVrfConfig, BgpVrfNeighborConfig};
+        use super::super::inst::BgpVrf;
+        use crate::bgp::auth::AoConfig;
+        use crate::context::ProtoContext;
+        use crate::policy::{CryptoAlgorithm, PolicyRx, PolicyType};
+        use crate::policy::{Key, KeyChain, KeyChainScope};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "v1".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            16,
+            global_tx,
+            rib_rx,
+        );
+
+        let addr: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let mut cfg = BgpVrfConfig::default();
+        cfg.neighbors.insert(addr, {
+            let mut n = BgpVrfNeighborConfig {
+                remote_as: Some(65001),
+                ..Default::default()
+            };
+            n.config.knobs_explicit.ao_config = Some(AoConfig {
+                key_chain: "KC".to_string(),
+                include_tcp_options: true,
+            });
+            n
+        });
+
+        materialize_peers(&mut vrf, &cfg, &groups_none());
+
+        // Staged onto config; not resolved yet (no chain snapshot).
+        let peer = vrf.peers.get(&addr).unwrap();
+        assert_eq!(
+            peer.config
+                .transport
+                .ao_config
+                .as_ref()
+                .map(|a| &a.key_chain),
+            Some(&"KC".to_string()),
+        );
+        assert!(peer.config.transport.resolved_ao_key.is_none());
+
+        // The actor answers with the chain's key material.
+        let ident = vrf.peers.get(&addr).unwrap().ident;
+        let mut chain = KeyChain::default();
+        chain.keys.insert(
+            1,
+            Key {
+                algo: Some(CryptoAlgorithm::HmacSha256),
+                key_material: b"secret-material".to_vec(),
+                send_id: Some(10),
+                recv_id: Some(20),
+                ..Default::default()
+            },
+        );
+        vrf.process_policy_msg(PolicyRx::KeyChain {
+            name: "KC".to_string(),
+            ident,
+            policy_type: PolicyType::KeyChain(KeyChainScope::BgpNeighbor),
+            key_chain: Some(chain),
+        });
+
+        let resolved = vrf
+            .peers
+            .get(&addr)
+            .unwrap()
+            .config
+            .transport
+            .resolved_ao_key
+            .as_ref()
+            .expect("resolved_ao_key populated by the KeyChain reply");
+        assert_eq!(resolved.send_id, 10);
+        assert_eq!(resolved.recv_id, 20);
+        assert_eq!(resolved.key_material, b"secret-material");
+    }
+
+    fn groups_none() -> BTreeMap<String, super::super::super::neighbor_group::NeighborGroup> {
+        BTreeMap::new()
     }
 
     /// The remaining inheritable knobs (as-override, allowas-in,

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -1038,6 +1038,26 @@ pub fn config_vrf_neighbor_remove_private_as_replace_as(
     Some(())
 }
 
+/// `set router bgp vrf <NAME> neighbor <addr> password <SECRET>` —
+/// TCP-MD5 for the CE session. Stages the verbatim secret onto
+/// `knobs_explicit.password`; `materialize_peers` resolves it over the
+/// neighbor-group and writes the effective value onto
+/// `config.transport.md5_password`, which the shared connect path applies
+/// to the VRF-bound outbound socket. Active/outbound only — see the YANG
+/// leaf and the FRR per-VRF-listener note.
+pub fn config_vrf_neighbor_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.knobs_explicit.password = match op {
+        ConfigOp::Set => Some(args.string()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    Some(())
+}
+
 // BFD, single-hop only. The values stage onto the peer's `config.bfd`
 // (a PeerConfig field, so they ride the wholesale config adoption); the
 // session is brought up by `materialize_peers` via `BgpVrf::bfd_reconcile`.

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -1058,6 +1058,61 @@ pub fn config_vrf_neighbor_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp)
     Some(())
 }
 
+/// `set router bgp vrf <NAME> neighbor <addr> tcp-ao key-chain <NAME>` —
+/// TCP-AO (RFC 5925) for the CE session, active/outbound only. Stages the
+/// key-chain name onto `knobs_explicit.ao_config`; `materialize_peers`
+/// resolves it onto `config.transport.ao_config` and registers the
+/// key-chain with the policy actor (proto `bgp-vrf:<name>`), whose reply
+/// fills in `resolved_ao_key`.
+pub fn config_vrf_neighbor_tcp_ao_key_chain(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    match op {
+        ConfigOp::Set => {
+            let chain = args.string()?;
+            nbr.config
+                .knobs_explicit
+                .ao_config
+                .get_or_insert_with(super::auth::AoConfig::default)
+                .key_chain = chain;
+        }
+        ConfigOp::Delete => nbr.config.knobs_explicit.ao_config = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `… tcp-ao include-tcp-options <BOOL>` — whether the AO MAC covers
+/// other TCP options. Seeds the container if it arrives before the
+/// key-chain leaf (order-independent within a commit).
+pub fn config_vrf_neighbor_tcp_ao_include_tcp_options(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    let ao = nbr
+        .config
+        .knobs_explicit
+        .ao_config
+        .get_or_insert_with(super::auth::AoConfig::default);
+    ao.include_tcp_options = match op {
+        ConfigOp::Set => args.boolean()?,
+        ConfigOp::Delete => true,
+        _ => return Some(()),
+    };
+    Some(())
+}
+
 // BFD, single-hop only. The values stage onto the peer's `config.bfd`
 // (a PeerConfig field, so they ride the wholesale config adoption); the
 // session is brought up by `materialize_peers` via `BgpVrf::bfd_reconcile`.

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -485,6 +485,41 @@ module zebra-bgp-vrf {
            non-passive). Per-VRF passive-side auth needs a per-VRF listener
            socket (the FRR model) — a separate change.";
       }
+
+      container tcp-ao {
+        ext:help "TCP Authentication Option (RFC 5925)";
+        presence "Enable TCP-AO on this CE";
+        description
+          "TCP-AO for the PE-CE session, same shape as the global
+           neighbor. Active/outbound only, with the same shared-listener
+           caveat as `password`: the key is applied to the PE's connect
+           socket, not the passive listener, so the session comes up on
+           the PE-initiated connection.
+
+           The key-chain is resolved through the policy actor (the CE
+           peer's per-VRF task subscribes under `bgp-vrf:<name>`), so an
+           in-chain key rotation propagates without a reconfig.";
+        reference "RFC 5925, RFC 5926";
+        leaf key-chain {
+          ext:help "Key chain name";
+          type string;
+          mandatory true;
+          description
+            "Name of a key chain under /key-chains. Existence is not
+             enforced by the schema; an unresolved chain simply yields no
+             key (the dial goes out unauthenticated) until it appears.";
+        }
+        leaf include-tcp-options {
+          ext:help "Include TCP options in MAC";
+          type boolean;
+          default "true";
+          description
+            "If true (default) the TCP-AO MAC covers other TCP options;
+             false covers only the fixed header + data. Both endpoints
+             MUST agree. Same as the global neighbor.";
+          reference "RFC 5925 §3.1";
+        }
+      }
       list afi-safi {
         ext:help "Per-address-family activation for this CE peer";
         key "name";

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -464,6 +464,27 @@ module zebra-bgp-vrf {
           description "Detect missing control packets in the kernel XDP helper. Absent ⇒ userspace.";
         }
       }
+
+      leaf password {
+        ext:help "Shared TCP-MD5 secret for this CE (RFC 2385)";
+        type string {
+          length "1..80";
+        }
+        description
+          "TCP-MD5 secret for the PE-CE session, same shape as the global
+           neighbor's `password`. Staged onto the peer and applied to the
+           VRF-bound *connect* socket, so the PE's OUTBOUND dial to the CE
+           is authenticated.
+
+           Per-VRF BFD-style caveat: only the active/outbound direction is
+           keyed. zebra-rs uses one shared BGP listener with per-source-IP
+           dispatch, so the passive/inbound side has no per-VRF socket to
+           carry the CE's MD5 key — a CE-initiated SYN is dropped by the
+           kernel at the global listener. The session therefore comes up
+           only when the PE initiates (the default; keep the PE side
+           non-passive). Per-VRF passive-side auth needs a per-VRF listener
+           socket (the FRR model) — a separate change.";
+      }
       list afi-safi {
         ext:help "Per-address-family activation for this CE peer";
         key "name";


### PR DESCRIPTION
## What

Adds session authentication to the per-VRF neighbor — **TCP-MD5 `password`** and
**TCP-AO `tcp-ao { key-chain … }`** — authenticating the PE's **outbound dial**
to the CE. Two commits (MD5, then TCP-AO).

With this the per-VRF neighbor exposes every non-AFI knob group the global
neighbor does (session, auth, BFD), modulo the passive-listener limitation below.

## Active/outbound only — and why

Both apply the key to the peer's **VRF-bound connect socket** via the shared FSM
connect path (`peer_start_connection`), so a **PE-initiated** session is
authenticated. The passive/inbound side is *not* keyed: zebra-rs uses a single
shared BGP listener with per-source-IP dispatch (`BgpVrfMsg::Accept`), so there
is no per-VRF socket on which to install the CE's listener-side key. A
CE-initiated SYN is dropped by the kernel at the global listener, so the session
comes up only when the PE initiates (the default; keep the PE side non-passive).

This matches how FRR structures it — FRR installs the key on a **per-VRF listener
socket** (netns or `SO_BINDTODEVICE`-bound), matched by `listener->bgp == peer->bgp`.
Adopting that model in zebra-rs is a separate listener-architecture change,
documented in the YANG and orphan report as the one remaining follow-up.

## MD5

The secret stages onto `knobs_explicit.password`; `apply_inherited_session_knobs`
resolves it (explicit over group) onto `config.transport.md5_password`, which the
connect path reads. No channel needed.

## TCP-AO

Needs the referenced key-chain resolved to key material, which lives behind the
policy actor — so it mirrors the policy channel:

- The binding stages onto `knobs_explicit.ao_config`, resolved onto
  `config.transport.ao_config`.
- `materialize_peers` registers the key-chain with the policy actor under proto
  `bgp-vrf:<name>` (KeyChain scope, raw peer ident like the global neighbor).
  Reusing the `BgpNeighbor` scope is safe — the per-VRF proto already isolates
  the watch space, which is the only thing distinct scopes exist to separate.
- `BgpVrf` keeps its own `key_chains` snapshot; the `PolicyRx::KeyChain` reply
  stores it and runs `resolve_ao_keys` (the per-VRF twin of the global
  `apply_ao_refresh_all`: re-resolve every peer's `resolved_ao_key`, bounce a
  live session whose key changed — no listener install).
- despawn withdraws the key-chain watches alongside the policy watches
  (`PolicyType::KeyChain` is just another variant on `policy_watches`),
  synchronously ahead of a respawn.

## Test plan

- MD5 unit test: group inheritance + explicit-wins on the resolved
  `config.transport.md5_password`.
- TCP-AO unit test drives the **full round trip**: staged key-chain → materialize
  (binding set, `resolved_ao_key` still None) → a `PolicyRx::KeyChain` reply
  populates `resolved_ao_key` with the chain's send/recv id and material.
- Live: `password` applies (parity with the global neighbor, incl. that the YANG
  `length 1..80` is not engine-enforced on either subtree); `tcp-ao key-chain`
  binds against a real key-chain, `include-tcp-options` applies, and the
  `mandatory key-chain` is enforced.
- `cargo fmt --all --check`; **clean-build** workspace clippy with CI flags; full
  suite (**2523 tests**); all four `bgp_config_audit` tests — green.
- Schema diff is the `password` leaf + three `tcp-ao` nodes; **no global paths
  changed**. Orphan report counts updated by hand.

## Not covered

- **No end-to-end BDD** — the round trip and resolution are unit- and
  live-config-verified, not a real authenticated session across two namespaces.
- Passive-side auth (the per-VRF listener) — the remaining architectural
  follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
