### PR TITLE
bgp: per-VRF passive listener socket (phase 1)

### DIFF
--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -95,6 +95,12 @@ pub struct BgpVrfHandle {
     pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     /// The BFD client id (`bfd-vrf:<name>`) the unsubscribes must use.
     pub bfd_client: String,
+    /// Accept-loop tasks for this VRF's own listener sockets (v4/v6).
+    /// Held so they abort when the handle is dropped at despawn, closing
+    /// the listeners; a respawn opens fresh ones. Empty for a
+    /// placeholder-ctx spawn (no VRF-bound socket yet).
+    #[allow(dead_code)]
+    pub listen_tasks: Vec<Task<()>>,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -139,6 +145,70 @@ pub fn compute_vrf_diff(
 /// `global_tx` is the shared sender every VRF task uses to push
 /// back to the global runtime (one channel, fanned in from every
 /// VRF).
+/// Open this VRF's own passive listener sockets (v4 + v6) on the BGP
+/// port and spawn an accept loop per family that hands each connection to
+/// the VRF task via [`BgpVrfMsg::Accept`] — the same message the global
+/// accept dispatcher forwards, so both feed one `handle_peer_connection`.
+///
+/// Returns the accept-loop [`Task`]s; the caller stashes them on the
+/// handle so they abort (and the listeners close) at despawn. Empty when
+/// `ctx` is not VRF-bound: a device-unbound listener on the shared BGP
+/// port would join the global listener's REUSEPORT group and steal
+/// default-VRF connections, so the listener waits for the kernel-ctx
+/// respawn.
+fn spawn_vrf_listeners(ctx: &ProtoContext, inbox: &BgpVrfInbox, name: &str) -> Vec<Task<()>> {
+    use std::net::SocketAddr;
+    if !ctx.is_vrf_bound() {
+        return Vec::new();
+    }
+    let mut tasks = Vec::new();
+    let v4: SocketAddr = "0.0.0.0:179".parse().unwrap();
+    let v6: SocketAddr = "[::]:179".parse().unwrap();
+    for (addr, is_v6) in [(v4, false), (v6, true)] {
+        let ctx = ctx.clone();
+        let inbox = inbox.clone();
+        let name = name.to_string();
+        tasks.push(Task::spawn(async move {
+            let listener = if is_v6 {
+                ctx.tcp_listen_v6_only(addr).await
+            } else {
+                ctx.tcp_listen(addr).await
+            };
+            let listener = match listener {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::warn!(
+                        vrf = %name,
+                        %addr,
+                        error = %e,
+                        "bgp vrf: failed to open per-VRF listener; passive \
+                         accept for this family falls back to the global \
+                         dispatcher",
+                    );
+                    return;
+                }
+            };
+            loop {
+                match listener.accept().await {
+                    Ok((stream, sockaddr)) => {
+                        // Unbounded send; the VRF task's inbox never
+                        // backpressures. If the task is gone the send
+                        // errors and we exit the loop.
+                        if inbox.send(BgpVrfMsg::Accept(stream, sockaddr)).is_err() {
+                            return;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(vrf = %name, error = %e, "bgp vrf: accept error");
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
+                }
+            }
+        }));
+    }
+    tasks
+}
+
 pub fn spawn_bgp_vrf(
     name: String,
     cfg: &BgpVrfConfig,
@@ -327,6 +397,21 @@ pub fn spawn_bgp_vrf(
     let bfd_sessions = vrf.bfd_session_list();
     let bfd_client_handle = vrf.bfd_client_tx.clone();
     let bfd_client_id = vrf.bfd_client();
+
+    // Per-VRF passive listener. Only when the ctx is VRF-bound (the
+    // kernel-ctx spawn) so the socket carries `SO_BINDTODEVICE`: a
+    // device-unbound listener on the BGP port would join the global
+    // listener's REUSEPORT group and steal default-VRF connections.
+    // A placeholder spawn (no kernel info yet) skips this; the
+    // kernel-ctx respawn opens it, like the ILM/SID installs.
+    //
+    // Behaviour is equivalent to today's global-dispatch detour
+    // (`peer_index` → `BgpVrfMsg::Accept`): the CE's inbound now lands on
+    // this VRF-bound socket directly (which wins over the global listener
+    // for the VRF's interfaces) and feeds the same `handle_peer_connection`
+    // path. The detour stays as a fallback for the pre-respawn window.
+    let listen_tasks = spawn_vrf_listeners(&vrf.ctx, &inbox, &name);
+
     let task = serve_vrf(vrf);
     if crate::rib::tracing::task() {
         tracing::info!(
@@ -349,6 +434,7 @@ pub fn spawn_bgp_vrf(
         bfd_sessions,
         bfd_client_tx: bfd_client_handle,
         bfd_client: bfd_client_id,
+        listen_tasks,
         show_tx,
         task,
         label,

--- a/zebra-rs/src/context/proto.rs
+++ b/zebra-rs/src/context/proto.rs
@@ -152,6 +152,12 @@ impl ProtoContext {
             SocketAddr::V6(_) => self.tcp_socket_v6()?,
         };
         sock.set_reuseaddr(true)?;
+        // SO_REUSEPORT so a VRF-bound listener can share the BGP port
+        // with the (device-unbound) global listener. The kernel routes a
+        // SYN arriving on a VRF-enslaved interface to the SO_BINDTODEVICE
+        // socket and the rest to the global one (verified: device-bound
+        // wins, no tcp_l3mdev_accept dependency).
+        sock.set_reuseport(true)?;
         sock.bind(addr)?;
         sock.listen(128)
     }
@@ -175,6 +181,9 @@ impl ProtoContext {
         let sock = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
         sock.set_only_v6(true)?;
         sock.set_reuse_address(true)?;
+        // See `tcp_listen`: shared port between the global and per-VRF
+        // listeners.
+        sock.set_reuse_port(true)?;
         self.maybe_bind_device(&sock)?;
         sock.bind(&addr.into())?;
         sock.listen(128)?;
@@ -203,6 +212,15 @@ impl ProtoContext {
         let sock = Socket::new(domain, Type::RAW, Some(protocol))?;
         self.maybe_bind_device(&sock)?;
         Ok(sock)
+    }
+
+    /// Whether this context is bound to a VRF device — i.e. sockets it
+    /// creates carry `SO_BINDTODEVICE`. A per-VRF BGP task only opens its
+    /// own listener when this is true; a device-unbound listener on the
+    /// BGP port would otherwise join the global listener's REUSEPORT group
+    /// and steal default-VRF connections.
+    pub fn is_vrf_bound(&self) -> bool {
+        self.vrf_ifname.is_some()
     }
 
     /// Apply `SO_BINDTODEVICE` if this context is attached to a


### PR DESCRIPTION
## What

Each per-VRF BGP task now opens its **own VRF-bound listener** on port 179 and
accepts CE-initiated (passive) connections directly, instead of relying on the
global listener + `peer_index` source-IP dispatch (`BgpVrfMsg::Accept` forward).

This is **Phase 1** of adopting FRR's per-VRF listener model. It is
behaviourally equivalent to today (the global detour stays as a fallback), and
is the foundation that makes per-VRF **passive-side** auth (MD5/AO) and BFD
possible — those are follow-up phases.

## How

- `spawn_bgp_vrf` opens v4/v6 listeners via `vrf.ctx.tcp_listen*` and spawns an
  accept loop per family that feeds the VRF's own inbox with `BgpVrfMsg::Accept`
  — the same message the global dispatcher forwards, so both land in one
  `handle_peer_connection`. The accept-loop `Task`s ride `BgpVrfHandle` and abort
  at despawn, closing the listeners; a respawn opens fresh ones.
- Gated on `ProtoContext::is_vrf_bound()` — the kernel-ctx spawn only. The VRF
  ctx carries the VRF ifname, so its listener gets `SO_BINDTODEVICE`. A
  placeholder-ctx spawn skips it: a device-**unbound** listener on 179 would join
  the global listener's REUSEPORT group and steal default-VRF connections. The
  kernel-ctx respawn opens it, like the ILM/SID installs.
- Both listeners share 179 via `SO_REUSEPORT` (added to `ctx.tcp_listen` /
  `tcp_listen_v6_only`, used only by BGP + tests). The kernel routes a SYN
  arriving on a VRF-enslaved interface to the device-bound socket and everything
  else to the global one.

## Verification

This is a passive-accept change, so unit tests can't confirm it — the evidence
is live:

- **Phase 0 experiment** (done separately) proved the device-bound listener wins
  over the global for VRF-interface SYNs, order-independent, with
  `tcp_l3mdev_accept = 0` (no sysctl dependency), and the global still wins
  default-VRF traffic.
- **Live PE-CE-in-VRF session**: `ss` shows both `0.0.0.0%cust:179` (VRF-bound)
  and `0.0.0.0:179` (global) up together; the session establishes and a
  temporary trace confirmed the accept came **via the VRF-own listener**, not the
  global detour.
- **BDD regression**: `@l3vpn_bgp_v4` (6/6) and `@l3vpn_dual_ce` (5/5, the
  multi-neighbor-per-VRF case) pass unchanged.
- `cargo fmt --all --check`, **clean-build** workspace clippy, full suite
  (**2523 tests**), all four `bgp_config_audit` tests — green.

**Code-only — no schema change.** The `peer_index` / `BgpVrfMsg::Accept` global
detour stays as a fallback for the pre-respawn window; removing it is a later
phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
