### PR TITLE
bgp: per-VRF passive-side auth via the VRF listener (phase 2)

### DIFF
--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -58,19 +58,18 @@ SessionKey has no VRF dimension and the daemon socket is not VRF-bound.
 `bfd multihop` is not offered (omitted from the schema, so the attempt fails YANG validation rather than reporting a misleading success). BgpVrf holds its own BFD
 client + event channels (client id `bfd-vrf:<name>`), and despawn
 withdraws the sessions synchronously ahead of a respawn's re-subscribe,
-the same ordering the policy watches use. TCP-MD5 `password` is wired for the active/outbound direction only: the
-resolved secret lands on config.transport.md5_password, which the shared
-connect path applies to the VRF-bound dial socket. Passive/inbound auth
-needs a per-VRF listener socket (the FRR model) and is out of scope.
-TCP-AO (key-chain) is wired too, active/outbound only: the ao_config binding
-resolves onto config.transport.ao_config, materialize_peers registers the
-key-chain with the policy actor under proto bgp-vrf:<name> (KeyChain scope),
-and the PolicyRx::KeyChain reply populates resolved_ao_key (BgpVrf keeps its
-own key_chains snapshot + resolve_ao_keys, the per-VRF twin of
-apply_ao_refresh_all minus the listener install). Despawn withdraws the
-key-chain watches alongside the policy watches. This completes the non-AFI
-knob import; per-VRF passive-side MD5/AO (a per-VRF listener socket, the FRR
-model) is the one remaining architectural follow-up. The `neighbor-group` leaf was
+the same ordering the policy watches use. TCP-MD5 `password` and TCP-AO
+(key-chain) are wired for BOTH directions. The resolved key lands on
+config.transport (md5_password / ao_config->resolved_ao_key), which the shared
+connect path applies to the VRF-bound dial socket (active), and the per-VRF
+task installs on its OWN VRF-bound listener socket (passive) via
+refresh_listener_md5 / refresh_listener_ao. Since each VRF has its own listener
+socket, overlapping-address VRFs get independent per-address keys. TCP-AO's
+key-chain is registered with the policy actor under proto bgp-vrf:<name>
+(KeyChain scope); the PolicyRx::KeyChain reply re-resolves resolved_ao_key and
+re-installs it on the listener (BgpVrf keeps its own key_chains snapshot).
+Despawn withdraws the key-chain watches alongside the policy watches. This
+completes the non-AFI knob import. The `neighbor-group` leaf was
 renamed from `peer-group` to match the global neighbor and the list it
 resolves against.
 

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -227,6 +227,25 @@ pub struct BgpVrf {
     /// delivered here rather than to the global task). Read to resolve
     /// each peer's `resolved_ao_key`.
     pub key_chains: std::collections::BTreeMap<String, crate::policy::KeyChain>,
+    /// Dedicated channel for streams this VRF's own listener accepts.
+    /// Separate from the `BgpVrfMsg` inbox on purpose: the accept
+    /// sub-tasks hold `accept_tx` clones, and routing them through the
+    /// inbox would keep `global_rx` alive and defeat the "all senders
+    /// dropped -> exit" detection. The task drops `accept_rx` when it
+    /// ends, which lets the accept loops notice and exit.
+    accept_tx: tokio::sync::mpsc::UnboundedSender<(tokio::net::TcpStream, std::net::SocketAddr)>,
+    accept_rx: tokio::sync::mpsc::UnboundedReceiver<(tokio::net::TcpStream, std::net::SocketAddr)>,
+    /// Raw fds of this VRF's own listener sockets (VRF-bound, opened in
+    /// `open_listeners`). Held so the passive-side MD5/AO key installs
+    /// (`set_tcp_md5_key` / `set_tcp_ao_key`) can target them — the whole
+    /// point of the per-VRF listener. `None` until opened (a
+    /// placeholder-ctx spawn never opens one).
+    listen_fd_v4: Option<std::os::fd::RawFd>,
+    listen_fd_v6: Option<std::os::fd::RawFd>,
+    /// Accept-loop tasks for the listeners above; abort when the VRF task
+    /// ends (dropping `self`), closing the listeners.
+    #[allow(dead_code)]
+    listen_tasks: Vec<crate::context::Task<()>>,
     /// VRF-first MUP origination tracking: per PFCP SEID, the RD-free ST
     /// prefixes this VRF exported to the global SAFI-85 RIB. Lets a Session
     /// Deletion / Modification (`MupWithdrawOriginate`) withdraw exactly the
@@ -754,6 +773,7 @@ impl BgpVrf {
         let (tx, rx) = mpsc::channel(8192);
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let (bfd_notifier, bfd_event_rx) = mpsc::unbounded_channel();
+        let (accept_tx, accept_rx) = mpsc::unbounded_channel();
         let vrf = Self {
             name,
             ctx,
@@ -796,6 +816,11 @@ impl BgpVrf {
             bfd_event_rx,
             bfd_notifier,
             key_chains: std::collections::BTreeMap::new(),
+            accept_tx,
+            accept_rx,
+            listen_fd_v4: None,
+            listen_fd_v6: None,
+            listen_tasks: Vec::new(),
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
@@ -1336,6 +1361,9 @@ impl BgpVrf {
                 .tx
                 .try_send(Message::Event(ident, super::super::peer::Event::Stop));
         }
+        // Push the newly-resolved keys onto the VRF listener so a
+        // CE-initiated SYN authenticates passively too.
+        self.refresh_listener_ao();
     }
 
     /// The `proto` string this VRF uses with the policy actor.
@@ -1576,7 +1604,161 @@ impl BgpVrf {
     /// global task sends [`BgpVrfMsg::Shutdown`] or when the
     /// inbound channel is closed (i.e. every sender — the global
     /// task plus any per-peer holds — has dropped).
+    /// Open this VRF's own passive listener sockets, spawn an accept loop
+    /// per family, and install the passive-side auth keys any peer
+    /// already carries. Called once at the top of `event_loop`.
+    ///
+    /// Only when the ctx is VRF-bound (`SO_BINDTODEVICE`): a
+    /// device-unbound listener on the BGP port would join the global
+    /// listener's REUSEPORT group and steal default-VRF connections. A
+    /// placeholder-ctx spawn skips it; the kernel-ctx respawn opens it.
+    ///
+    /// The listener is created here (not in a sub-task) so the fd stays
+    /// on `self` for the MD5/AO installs — the reason the per-VRF listener
+    /// exists. Each `TcpListener` is then handed to a spawned accept loop
+    /// that feeds `BgpVrfMsg::Accept` back to this task.
+    async fn open_listeners(&mut self) {
+        use std::net::SocketAddr;
+        use std::os::fd::AsRawFd;
+        if !self.ctx.is_vrf_bound() {
+            return;
+        }
+        let v4: SocketAddr = "0.0.0.0:179".parse().unwrap();
+        let v6: SocketAddr = "[::]:179".parse().unwrap();
+        match self.ctx.tcp_listen(v4).await {
+            Ok(listener) => {
+                self.listen_fd_v4 = Some(listener.as_raw_fd());
+                self.listen_tasks.push(spawn_accept_loop(
+                    listener,
+                    self.accept_tx.clone(),
+                    self.name.clone(),
+                ));
+            }
+            Err(e) => {
+                tracing::warn!(vrf = %self.name, error = %e, "bgp vrf: v4 listener open failed")
+            }
+        }
+        match self.ctx.tcp_listen_v6_only(v6).await {
+            Ok(listener) => {
+                self.listen_fd_v6 = Some(listener.as_raw_fd());
+                self.listen_tasks.push(spawn_accept_loop(
+                    listener,
+                    self.accept_tx.clone(),
+                    self.name.clone(),
+                ));
+            }
+            Err(e) => {
+                tracing::warn!(vrf = %self.name, error = %e, "bgp vrf: v6 listener open failed")
+            }
+        }
+        // Install listener keys for peers materialised before the
+        // listener existed (the common case: materialize_peers runs at
+        // spawn, this runs at event-loop start).
+        self.refresh_listener_md5();
+        self.refresh_listener_ao();
+    }
+
+    /// Reconcile the passive-side TCP-MD5 key on this VRF's listener for
+    /// every peer, from `config.transport.md5_password`. The active-side
+    /// key is applied by the connect path; this is what lets a
+    /// CE-initiated SYN authenticate against the VRF listener.
+    pub fn refresh_listener_md5(&mut self) {
+        for ident in self.peers.idents() {
+            let Some(peer) = self.peers.get_by_idx(ident) else {
+                continue;
+            };
+            let addr = peer.address;
+            if addr.is_unspecified() {
+                continue;
+            }
+            let fd = match addr {
+                std::net::IpAddr::V4(_) => self.listen_fd_v4,
+                std::net::IpAddr::V6(_) => self.listen_fd_v6,
+            };
+            let Some(fd) = fd else { continue };
+            // Empty key removes the entry; a set key installs it.
+            let key = peer
+                .config
+                .transport
+                .md5_password
+                .clone()
+                .unwrap_or_default();
+            if let Err(e) = super::super::auth::set_tcp_md5_key(fd, addr, key.as_bytes()) {
+                tracing::warn!(vrf = %self.name, peer = %addr, error = %e, "bgp vrf: listener MD5 set failed");
+            }
+        }
+    }
+
+    /// Reconcile the passive-side TCP-AO MKT on this VRF's listener for
+    /// every peer from `config.transport.resolved_ao_key`, deleting a
+    /// stale entry before a re-add (the kernel keys MKTs by
+    /// `(addr, send_id, recv_id)` and rejects a duplicate).
+    pub fn refresh_listener_ao(&mut self) {
+        let idents = self.peers.idents();
+        for ident in idents {
+            let Some(peer) = self.peers.get_by_idx(ident) else {
+                continue;
+            };
+            let addr = peer.address;
+            if addr.is_unspecified() {
+                continue;
+            }
+            let fd = match addr {
+                std::net::IpAddr::V4(_) => self.listen_fd_v4,
+                std::net::IpAddr::V6(_) => self.listen_fd_v6,
+            };
+            let Some(fd) = fd else { continue };
+            let resolved = peer.config.transport.resolved_ao_key.clone();
+            let new_ids = resolved.as_ref().map(|r| (r.send_id, r.recv_id));
+            let prev_ids = peer.last_ao_installed;
+            // Delete a stale MKT when the key disappears or its ids change.
+            if let Some((s, r)) = prev_ids
+                && new_ids != Some((s, r))
+                && let Err(e) = super::super::auth::del_tcp_ao_key(fd, addr, s, r)
+            {
+                tracing::warn!(vrf = %self.name, peer = %addr, error = %e, "bgp vrf: listener AO del failed");
+            }
+            if let Some(r) = &resolved
+                && let Err(e) = super::super::auth::set_tcp_ao_key(
+                    fd,
+                    addr,
+                    r.alg_name,
+                    &r.key_material,
+                    r.send_id,
+                    r.recv_id,
+                    r.include_tcp_options,
+                )
+            {
+                tracing::warn!(vrf = %self.name, peer = %addr, error = %e, "bgp vrf: listener AO set failed");
+            }
+            if let Some(peer) = self.peers.get_mut_by_idx(ident) {
+                peer.last_ao_installed = new_ids;
+            }
+        }
+    }
+
+    /// Drive the passive side of the FSM for one accepted inbound
+    /// connection against this VRF's own `peers` — the same path
+    /// `peer::accept` runs for the global instance. Fed by both this
+    /// VRF's own listener (`accept_rx`) and the global dispatcher's
+    /// `BgpVrfMsg::Accept` forward (the pre-listener fallback).
+    fn handle_accept(&mut self, stream: tokio::net::TcpStream, sockaddr: std::net::SocketAddr) {
+        tracing::debug!(vrf = %self.name, peer = %sockaddr.ip(), "bgp vrf: inbound Accept");
+        let peer_addr = sockaddr.ip();
+        let scope_id = match sockaddr {
+            std::net::SocketAddr::V6(addr) if addr.scope_id() != 0 => Some(addr.scope_id()),
+            _ => None,
+        };
+        if let Some(stream) =
+            super::super::peer::handle_peer_connection(&mut self.peers, peer_addr, scope_id, stream)
+        {
+            // No matching peer in this VRF — drop, closing the TCP.
+            drop(stream);
+        }
+    }
+
     pub async fn event_loop(&mut self) {
+        self.open_listeners().await;
         loop {
             tokio::select! {
                 msg = self.global_rx.recv() => {
@@ -1631,6 +1813,10 @@ impl BgpVrf {
                     // BFD state change for one of this VRF's CE sessions;
                     // a transition to Down tears the BGP session down.
                     self.process_bfd_event(event);
+                }
+                Some((stream, sockaddr)) = self.accept_rx.recv() => {
+                    // A connection this VRF's own listener accepted.
+                    self.handle_accept(stream, sockaddr);
                 }
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);
@@ -2644,35 +2830,10 @@ impl BgpVrf {
                 self.tracing = tracing;
             }
             BgpVrfMsg::Accept(stream, sockaddr) => {
-                // Passive accept for the per-VRF PE-CE session. The global
-                // accept dispatcher routed this inbound connection here by
-                // source IP; drive the same FSM path the global `accept`
-                // does, but against this VRF's own `peers`. The active
-                // connect path already runs the per-VRF FSM, so adding the
-                // passive side lets two per-VRF speakers (e.g. two Inter-AS
-                // MPLS/VPN Option A ASBRs peering inside a VRF) resolve a
-                // §6.8 collision into Established — without it neither side's
-                // outbound connect is ever accepted and the session is stuck.
-                tracing::debug!(
-                    vrf = %self.name,
-                    peer = %sockaddr.ip(),
-                    "bgp vrf: inbound Accept",
-                );
-                let peer_addr = sockaddr.ip();
-                let scope_id = match sockaddr {
-                    std::net::SocketAddr::V6(addr) if addr.scope_id() != 0 => Some(addr.scope_id()),
-                    _ => None,
-                };
-                if let Some(stream) = super::super::peer::handle_peer_connection(
-                    &mut self.peers,
-                    peer_addr,
-                    scope_id,
-                    stream,
-                ) {
-                    // No matching peer in this VRF (listen-ranges aren't
-                    // supported inside a VRF yet) — drop, closing the TCP.
-                    drop(stream);
-                }
+                // Passive accept forwarded by the global dispatcher (the
+                // pre-listener fallback). Same handling as a connection
+                // this VRF's own listener accepts.
+                self.handle_accept(stream, sockaddr);
             }
             BgpVrfMsg::ImportV4 {
                 rd,
@@ -2909,6 +3070,32 @@ impl BgpVrf {
 
 /// Spawn the per-VRF event loop on its own tokio task. Mirrors
 /// [`crate::bgp::inst::serve`] / [`crate::nd::inst::serve`].
+/// Accept loop for one per-VRF listener socket: hand each accepted
+/// stream to the VRF task via `BgpVrfMsg::Accept` (the same message the
+/// global dispatcher forwards). Exits when the inbox is gone (task ended)
+/// or on a persistent accept error.
+fn spawn_accept_loop(
+    listener: tokio::net::TcpListener,
+    accept_tx: tokio::sync::mpsc::UnboundedSender<(tokio::net::TcpStream, std::net::SocketAddr)>,
+    name: String,
+) -> Task<()> {
+    Task::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, sockaddr)) => {
+                    if accept_tx.send((stream, sockaddr)).is_err() {
+                        return;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(vrf = %name, error = %e, "bgp vrf: accept error");
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+            }
+        }
+    })
+}
+
 pub fn serve_vrf(mut vrf: BgpVrf) -> Task<()> {
     Task::spawn(async move {
         vrf.event_loop().await;

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -95,12 +95,6 @@ pub struct BgpVrfHandle {
     pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     /// The BFD client id (`bfd-vrf:<name>`) the unsubscribes must use.
     pub bfd_client: String,
-    /// Accept-loop tasks for this VRF's own listener sockets (v4/v6).
-    /// Held so they abort when the handle is dropped at despawn, closing
-    /// the listeners; a respawn opens fresh ones. Empty for a
-    /// placeholder-ctx spawn (no VRF-bound socket yet).
-    #[allow(dead_code)]
-    pub listen_tasks: Vec<Task<()>>,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -145,70 +139,6 @@ pub fn compute_vrf_diff(
 /// `global_tx` is the shared sender every VRF task uses to push
 /// back to the global runtime (one channel, fanned in from every
 /// VRF).
-/// Open this VRF's own passive listener sockets (v4 + v6) on the BGP
-/// port and spawn an accept loop per family that hands each connection to
-/// the VRF task via [`BgpVrfMsg::Accept`] — the same message the global
-/// accept dispatcher forwards, so both feed one `handle_peer_connection`.
-///
-/// Returns the accept-loop [`Task`]s; the caller stashes them on the
-/// handle so they abort (and the listeners close) at despawn. Empty when
-/// `ctx` is not VRF-bound: a device-unbound listener on the shared BGP
-/// port would join the global listener's REUSEPORT group and steal
-/// default-VRF connections, so the listener waits for the kernel-ctx
-/// respawn.
-fn spawn_vrf_listeners(ctx: &ProtoContext, inbox: &BgpVrfInbox, name: &str) -> Vec<Task<()>> {
-    use std::net::SocketAddr;
-    if !ctx.is_vrf_bound() {
-        return Vec::new();
-    }
-    let mut tasks = Vec::new();
-    let v4: SocketAddr = "0.0.0.0:179".parse().unwrap();
-    let v6: SocketAddr = "[::]:179".parse().unwrap();
-    for (addr, is_v6) in [(v4, false), (v6, true)] {
-        let ctx = ctx.clone();
-        let inbox = inbox.clone();
-        let name = name.to_string();
-        tasks.push(Task::spawn(async move {
-            let listener = if is_v6 {
-                ctx.tcp_listen_v6_only(addr).await
-            } else {
-                ctx.tcp_listen(addr).await
-            };
-            let listener = match listener {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::warn!(
-                        vrf = %name,
-                        %addr,
-                        error = %e,
-                        "bgp vrf: failed to open per-VRF listener; passive \
-                         accept for this family falls back to the global \
-                         dispatcher",
-                    );
-                    return;
-                }
-            };
-            loop {
-                match listener.accept().await {
-                    Ok((stream, sockaddr)) => {
-                        // Unbounded send; the VRF task's inbox never
-                        // backpressures. If the task is gone the send
-                        // errors and we exit the loop.
-                        if inbox.send(BgpVrfMsg::Accept(stream, sockaddr)).is_err() {
-                            return;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(vrf = %name, error = %e, "bgp vrf: accept error");
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    }
-                }
-            }
-        }));
-    }
-    tasks
-}
-
 pub fn spawn_bgp_vrf(
     name: String,
     cfg: &BgpVrfConfig,
@@ -398,20 +328,6 @@ pub fn spawn_bgp_vrf(
     let bfd_client_handle = vrf.bfd_client_tx.clone();
     let bfd_client_id = vrf.bfd_client();
 
-    // Per-VRF passive listener. Only when the ctx is VRF-bound (the
-    // kernel-ctx spawn) so the socket carries `SO_BINDTODEVICE`: a
-    // device-unbound listener on the BGP port would join the global
-    // listener's REUSEPORT group and steal default-VRF connections.
-    // A placeholder spawn (no kernel info yet) skips this; the
-    // kernel-ctx respawn opens it, like the ILM/SID installs.
-    //
-    // Behaviour is equivalent to today's global-dispatch detour
-    // (`peer_index` → `BgpVrfMsg::Accept`): the CE's inbound now lands on
-    // this VRF-bound socket directly (which wins over the global listener
-    // for the VRF's interfaces) and feeds the same `handle_peer_connection`
-    // path. The detour stays as a fallback for the pre-respawn window.
-    let listen_tasks = spawn_vrf_listeners(&vrf.ctx, &inbox, &name);
-
     let task = serve_vrf(vrf);
     if crate::rib::tracing::task() {
         tracing::info!(
@@ -434,7 +350,6 @@ pub fn spawn_bgp_vrf(
         bfd_sessions,
         bfd_client_tx: bfd_client_handle,
         bfd_client: bfd_client_id,
-        listen_tasks,
         show_tx,
         task,
         label,

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -472,18 +472,12 @@ module zebra-bgp-vrf {
         }
         description
           "TCP-MD5 secret for the PE-CE session, same shape as the global
-           neighbor's `password`. Staged onto the peer and applied to the
-           VRF-bound *connect* socket, so the PE's OUTBOUND dial to the CE
-           is authenticated.
-
-           Per-VRF BFD-style caveat: only the active/outbound direction is
-           keyed. zebra-rs uses one shared BGP listener with per-source-IP
-           dispatch, so the passive/inbound side has no per-VRF socket to
-           carry the CE's MD5 key — a CE-initiated SYN is dropped by the
-           kernel at the global listener. The session therefore comes up
-           only when the PE initiates (the default; keep the PE side
-           non-passive). Per-VRF passive-side auth needs a per-VRF listener
-           socket (the FRR model) — a separate change.";
+           neighbor's `password`. Applied to BOTH directions: the
+           VRF-bound connect socket (PE-initiated dial) and this VRF's own
+           VRF-bound listener socket (CE-initiated inbound), so the session
+           authenticates whichever side connects. Overlapping-address VRFs
+           do not collide — each VRF has its own listener socket with its
+           own per-address key.";
       }
 
       container tcp-ao {
@@ -491,14 +485,14 @@ module zebra-bgp-vrf {
         presence "Enable TCP-AO on this CE";
         description
           "TCP-AO for the PE-CE session, same shape as the global
-           neighbor. Active/outbound only, with the same shared-listener
-           caveat as `password`: the key is applied to the PE's connect
-           socket, not the passive listener, so the session comes up on
-           the PE-initiated connection.
+           neighbor. Applied to both directions — the VRF-bound connect
+           socket and this VRF's own VRF-bound listener MKT — so the
+           session authenticates whichever side initiates.
 
            The key-chain is resolved through the policy actor (the CE
            peer's per-VRF task subscribes under `bgp-vrf:<name>`), so an
-           in-chain key rotation propagates without a reconfig.";
+           in-chain key rotation propagates without a reconfig, and a
+           resolved key is re-installed on the listener as it changes.";
         reference "RFC 5925, RFC 5926";
         leaf key-chain {
           ext:help "Key chain name";


### PR DESCRIPTION
## What

Builds on the per-VRF listener (#2090, phase 1) to install the TCP-MD5 / TCP-AO
key on the VRF's **own** listener socket, so a **CE-initiated (passive)** session
authenticates too. This **drops the "active/outbound only" limitation** from the
per-VRF auth PRs. Because each VRF has its own listener socket, overlapping-address
VRFs get independent per-address keys — the exact gap the single global listener
could not close.

## Refactor (and the bug it caught)

The VRF task now creates its listeners in `event_loop` startup (`open_listeners`)
instead of in `spawn_bgp_vrf`, so the fds stay on the task for the key installs —
the reason the per-VRF listener exists. Each `TcpListener` is handed to a spawned
accept loop that feeds a **dedicated accept channel**, not the `BgpVrfMsg` inbox:
routing accepts through the inbox would keep a `global_rx` sender alive and defeat
the "all senders dropped → exit" detection. A unit test (`inbox_drop_closes_event_loop`)
caught exactly this; the dedicated channel fixes it.

## Keys

- `refresh_listener_md5` installs each peer's resolved
  `config.transport.md5_password` on the listener fd (`set_tcp_md5_key`).
- `refresh_listener_ao` installs `resolved_ao_key` as a listener MKT
  (`set_tcp_ao_key`), del-before-set on an id/material change. Run at listener
  open **and** from `resolve_ao_keys`, so a key-chain reply or an in-chain
  rotation re-keys the listener.

Both reuse the same `auth.rs` helpers the global neighbor installs with, targeting
this VRF's device-bound socket.

## Verification — designed to be unfakeable

The **phase-2 gate experiment** (like phase 0) first proved a `TCP_MD5SIG` key on
a `SO_BINDTODEVICE` listener gates the handshake: correct key accepted, wrong/absent
key SYN dropped, `CONFIG_TCP_MD5SIG=y`.

Then live, with the **PE side PASSIVE** — so the session can only come up if the
CE's inbound authenticates against the PE's VRF listener key:

- **MD5**: matching → Established both sides; mismatched-from-start → stays
  `Active`, never establishes.
- **TCP-AO**: matching key-chains → Established both sides, no listener AO errors.
- BDD: `@l3vpn_bgp_v4` (6/6) and `@l3vpn_dual_ce` (5/5) pass after the accept-path
  refactor.
- `cargo fmt --all --check`, **clean-build** workspace clippy, full suite
  (**2523 tests**), all four `bgp_config_audit` tests — green.

## Scope note

BFD is **not** part of this. BFD uses its own UDP sockets, not the BGP listener,
and single-hop BFD already works via ifindex-keying — there is no BFD passive gap.

YANG / orphan-report updated to drop the active-only caveat (schema descriptions
only — no path change). The global `peer_index` / `BgpVrfMsg::Accept` detour stays
as a fallback for the pre-respawn window; removing it is phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
