### PR TITLE
bgp: document the per-VRF accept detour as pre-respawn fallback

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1013,6 +1013,12 @@ pub struct Bgp {
     /// forwarded via `BgpVrfMsg::Accept` to that VRF's task; every
     /// other connection falls through to the existing
     /// global-instance accept path.
+    ///
+    /// This is the PRE-RESPAWN fallback for per-VRF passive accept —
+    /// a per-VRF task's own VRF-bound listener wins for its
+    /// interfaces once it is open, so this map only routes inbound
+    /// during the placeholder-ctx window before the listener exists.
+    /// See the `Message::Accept` handler for why it is retained.
     pub peer_index: BTreeMap<std::net::IpAddr, String>,
     /// Outbound sender every per-VRF task uses to push messages
     /// back to the global runtime — peer registration, exports,
@@ -2261,6 +2267,24 @@ impl Bgp {
                 // through to the existing global-instance accept
                 // path — that's how default-VRF peers and the
                 // dynamic-neighbor fallback still work.
+                //
+                // NOTE: this per-VRF forward is the PRE-RESPAWN
+                // FALLBACK, not the primary path. Each per-VRF task
+                // now opens its own VRF-bound (`SO_BINDTODEVICE`)
+                // listener (`BgpVrf::open_listeners`), and the kernel
+                // routes a SYN arriving on a VRF-enslaved interface to
+                // that device-bound socket in preference to this
+                // (device-unbound) global listener. So in steady state
+                // a VRF CE's inbound never reaches here. It only does
+                // during the window between a placeholder-ctx spawn
+                // (kernel VRF not yet known → no ifname → no listener)
+                // and the kernel-ctx respawn that opens the listener —
+                // `net.ipv4.tcp_l3mdev_accept = 1` lets this global
+                // socket catch the l3mdev SYN in the meantime. The
+                // detour is therefore intentionally retained, not dead
+                // code: deleting it would silently regress passive
+                // accept for a VRF whose BGP config commits before RIB
+                // learns its kernel device, if the PE side is passive.
                 let src_ip = sockaddr.ip();
                 if let Some(vrf_name) = self.peer_index.get(&src_ip).cloned()
                     && let Some(handle) = self.vrf_registry.get(&vrf_name)

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1741,7 +1741,9 @@ impl BgpVrf {
     /// connection against this VRF's own `peers` — the same path
     /// `peer::accept` runs for the global instance. Fed by both this
     /// VRF's own listener (`accept_rx`) and the global dispatcher's
-    /// `BgpVrfMsg::Accept` forward (the pre-listener fallback).
+    /// `BgpVrfMsg::Accept` forward (the pre-respawn fallback: it only
+    /// carries inbound during the placeholder-ctx window, before this
+    /// task's own listener opens on the kernel-ctx respawn).
     fn handle_accept(&mut self, stream: tokio::net::TcpStream, sockaddr: std::net::SocketAddr) {
         tracing::debug!(vrf = %self.name, peer = %sockaddr.ip(), "bgp vrf: inbound Accept");
         let peer_addr = sockaddr.ip();
@@ -2831,8 +2833,9 @@ impl BgpVrf {
             }
             BgpVrfMsg::Accept(stream, sockaddr) => {
                 // Passive accept forwarded by the global dispatcher (the
-                // pre-listener fallback). Same handling as a connection
-                // this VRF's own listener accepts.
+                // pre-respawn fallback, before this task's own listener
+                // opens). Same handling as a connection our own listener
+                // accepts.
                 self.handle_accept(stream, sockaddr);
             }
             BgpVrfMsg::ImportV4 {

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -233,7 +233,11 @@ pub fn spawn_bgp_vrf(
     // Register each materialised peer with the global accept
     // dispatcher so an inbound `:179` from that IP lands on this
     // VRF task via `BgpVrfMsg::Accept` instead of the global
-    // instance.
+    // instance. This is the pre-respawn fallback: once this task's
+    // own VRF-bound listener is open (kernel-ctx spawn) the CE's
+    // inbound lands there directly and this forward is unused. It
+    // still matters for a placeholder-ctx spawn, whose listener does
+    // not exist yet — see `Bgp::process_msg`'s `Message::Accept`.
     for addr in vrf.peers.keys().copied().collect::<Vec<_>>() {
         let _ = vrf.global_tx.send(BgpGlobalMsg::RegisterPeer {
             vrf: name.clone(),


### PR DESCRIPTION
## What

Phase 3 of the per-VRF listener work. **Comment-only** — no behaviour change.

The original plan was to remove the global `peer_index` / `RegisterPeer` /
`Message::Accept` detour as redundant once each VRF opened its own listener
(#2090/#2091). Research overturned that premise, so this instead corrects the
code to say what the detour actually is now — so a future reader doesn't delete
it and silently regress passive accept.

## Why the detour is NOT redundant

- zebra-rs sets `net.ipv4.tcp_l3mdev_accept = 1` (`fib/netlink/sysctl.rs`), so
  the global device-unbound listener **does** receive VRF-interface SYNs.
- A per-VRF listener can only open on the **kernel-ctx** spawn (it needs the VRF
  ifname for `SO_BINDTODEVICE`). A **placeholder-ctx** spawn — BGP config commits
  before RIB has learned the kernel VRF — has no listener, and the detour is the
  only thing carrying passive accept until the kernel-ctx respawn opens one.

So the detour is the permanent **pre-respawn fallback**: the VRF listener owns
steady state, the detour covers the placeholder window. Deleting it would
regress passive accept for a passive-PE VRF neighbor in that window — and BDD
would **not** catch it, because every l3vpn config is active-PE (passive accept
is never exercised).

## Change

Updated the three detour sites — the global `Message::Accept` handler, the
`peer_index` field doc, the `RegisterPeer` send in spawn — plus the two
`vrf/inst.rs` accept comments, to explain the detour is the intentional
pre-respawn fallback, not leftover.

## Test plan

- Comment-only: diff verified to touch no code lines; `cargo fmt --all --check`
  and `cargo clippy -p zebra-rs -- -D warnings` green.
- Regression check for the merged phases 1+2 (BGP-in-VRF BDD sweep):
  `@l3vpn_bgp_v4` (6), `@l3vpn_bgp_v6` (5), `@l3vpn_dual_ce` (5),
  `@l3vpn_isis_bgppe_v4` (5), `@l3vpn_ospf_bgppe_v4` (5), `@bgp_vrf_vpnv4_export`
  (7), `@bgp_vrf_vpnv6_export` (5), `@bgp_vrf_dual_home` (6) — **44 scenarios,
  all pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
