### PR TITLE
bgp-vrf: live BFD for runtime-added neighbors

### DIFF
--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -123,6 +123,12 @@ pub enum ClientReq {
     /// Drop `client`'s interest in `key`. When the last subscriber
     /// unsubscribes, BFD tears the session down.
     Unsubscribe { client: ClientId, key: SessionKey },
+    /// Drop every subscription `client` holds, in one shot, tearing down
+    /// any session left with no subscribers. Used at task teardown when a
+    /// client (e.g. a per-VRF BGP task) can't enumerate its own live keys —
+    /// a runtime-added session may not be in any spawn-time snapshot. The
+    /// BFD analog of the policy actor's `UnregisterProto`.
+    UnsubscribeClient { client: ClientId },
 }
 
 /// While the in-kernel expiration watchdog owns detection for a session, its
@@ -360,6 +366,7 @@ impl Bfd {
                 notifier,
             } => self.subscribe(client, key, params, notifier),
             ClientReq::Unsubscribe { client, key } => self.unsubscribe(&client, &key),
+            ClientReq::UnsubscribeClient { client } => self.unsubscribe_client(&client),
         }
     }
 
@@ -419,6 +426,26 @@ impl Bfd {
         if now_empty {
             self.subscribers.remove(key);
             self.remove_session(key);
+        }
+    }
+
+    /// Drop every subscription held by `client`, tearing down each session
+    /// left with no remaining subscribers. Lets a client clear all its
+    /// interest at teardown without enumerating its own keys — the per-key
+    /// [`Self::unsubscribe`] applied client-wide. See
+    /// [`ClientReq::UnsubscribeClient`].
+    pub fn unsubscribe_client(&mut self, client: &str) {
+        // Collect the keys that lose their last subscriber first — can't
+        // remove a session while iterating `subscribers`.
+        let mut orphaned: Vec<SessionKey> = Vec::new();
+        for (key, subs) in self.subscribers.iter_mut() {
+            if subs.remove(client).is_some() && subs.is_empty() {
+                orphaned.push(*key);
+            }
+        }
+        for key in orphaned {
+            self.subscribers.remove(&key);
+            self.remove_session(&key);
         }
     }
 
@@ -1420,6 +1447,42 @@ mod tests {
         bfd.unsubscribe("solo", &key);
         assert!(bfd.sessions.get_by_key(&key).is_none());
         assert!(!bfd.subscribers.contains_key(&key));
+    }
+
+    /// `unsubscribe_client` drops every session a client holds in one shot —
+    /// tearing down those with no other subscriber, keeping a session another
+    /// client still holds, and leaving that other client's own sessions
+    /// intact. This is the teardown a per-VRF task uses at despawn without
+    /// enumerating its own (possibly runtime-added) keys.
+    #[tokio::test]
+    async fn unsubscribe_client_drops_all_of_one_clients_sessions() {
+        let mut bfd = fresh_bfd();
+        let k1 = loopback_key(11);
+        let k2 = loopback_key(12);
+        let shared = loopback_key(13);
+        let k_other = loopback_key(14);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        // "vrf" holds k1, k2, and shares `shared` with "other".
+        bfd.subscribe("vrf".into(), k1, SessionParams::default(), tx.clone());
+        bfd.subscribe("vrf".into(), k2, SessionParams::default(), tx.clone());
+        bfd.subscribe("vrf".into(), shared, SessionParams::default(), tx.clone());
+        bfd.subscribe("other".into(), shared, SessionParams::default(), tx.clone());
+        // "other" also has its own exclusive session.
+        bfd.subscribe("other".into(), k_other, SessionParams::default(), tx);
+
+        bfd.unsubscribe_client("vrf");
+
+        // vrf's exclusive sessions are torn down.
+        assert!(bfd.sessions.get_by_key(&k1).is_none());
+        assert!(bfd.sessions.get_by_key(&k2).is_none());
+        assert!(!bfd.subscribers.contains_key(&k1));
+        assert!(!bfd.subscribers.contains_key(&k2));
+        // The shared session survives — "other" still subscribes it, alone now.
+        assert!(bfd.sessions.get_by_key(&shared).is_some());
+        assert_eq!(bfd.subscribers.get(&shared).map(BTreeMap::len), Some(1));
+        // "other"'s own session is untouched.
+        assert!(bfd.sessions.get_by_key(&k_other).is_some());
     }
 
     /// process_client_req dispatches Subscribe / Unsubscribe so

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1566,19 +1566,6 @@ impl BgpVrf {
         }
     }
 
-    /// Every BFD key this VRF's peers currently subscribe, for the
-    /// synchronous unsubscribe on despawn — same ordering hazard as the
-    /// policy watches (a respawn reuses the client id + keys, so a late
-    /// unsubscribe from the outgoing incarnation would tear down the
-    /// incoming one's session).
-    pub fn bfd_session_list(&self) -> Vec<crate::bfd::session::SessionKey> {
-        self.peers
-            .idents()
-            .into_iter()
-            .filter_map(|idx| self.peers.get_by_idx(idx).and_then(|p| p.bfd_session_key))
-            .collect()
-    }
-
     /// Handle a BFD state change for one of this VRF's CE sessions.
     /// Mirrors the global `Bgp::process_bfd_event`: on a transition to
     /// Down, tear the BGP session down (RFC 5882 §5).
@@ -3052,6 +3039,20 @@ impl BgpVrf {
         if let Some(chain) = &ao_chain {
             self.ao_keychain_watch(chain, peer_idx, false);
         }
+        // Tear down this peer's BFD session (if any) before it leaves the map.
+        // `bfd_reconcile` can't do it — it reads `peer.config.bfd` (still
+        // "enabled") and would re-subscribe — so unsubscribe the tracked key
+        // directly. Whole-VRF despawn would clear it via `UnsubscribeClient`,
+        // but a per-peer remove must drop it now.
+        if let (Some(key), Some(bfd_client_tx)) = (
+            self.peers.get(&addr).and_then(|p| p.bfd_session_key),
+            self.bfd_client_tx.clone(),
+        ) {
+            let _ = bfd_client_tx.send(crate::bfd::inst::ClientReq::Unsubscribe {
+                client: self.bfd_client(),
+                key,
+            });
+        }
         self.peers.remove(&addr);
         self.unregister_policy_watches(&watches);
         // Notify the global accept dispatcher this VRF no longer claims the
@@ -3192,6 +3193,11 @@ impl BgpVrf {
             }
             self.resolve_ao_keys();
         }
+        // Reconcile BFD against the new config: `bfd_reconcile` subscribes /
+        // unsubscribes / re-parametrizes the session to match `peer.config.bfd`
+        // (a no-op when unchanged). Covers a runtime `bfd enabled` toggle or an
+        // echo-param edit on a live CE session.
+        self.bfd_reconcile(ident);
         bgp_vrf_trace!(
             &self.tracing,
             vrf = %self.name,
@@ -3934,6 +3940,69 @@ mod tests {
         );
         assert_eq!(resolved.recv_id, 40);
         assert_eq!(resolved.key_material, b"two");
+    }
+
+    /// A CE neighbor added at runtime with `bfd enabled` subscribes a BFD
+    /// session immediately — BFD is now live on the runtime path, not just at
+    /// spawn — and removing it unsubscribes. The client-scoped teardown
+    /// (`UnsubscribeClient`) is what makes tracking a runtime-added session
+    /// safe without a spawn-time snapshot.
+    #[tokio::test]
+    async fn runtime_add_and_remove_peer_drives_bfd() {
+        use crate::bfd::inst::ClientReq;
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(12, "vrf-bfd");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-bfd".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        // Wire a BFD client channel so the Subscribe / Unsubscribe are
+        // observable.
+        let (bfd_tx, mut bfd_rx) = mpsc::unbounded_channel::<ClientReq>();
+        vrf.set_bfd_client(Some(bfd_tx));
+
+        let a: std::net::IpAddr = "192.0.2.1".parse().unwrap();
+        let mut n = crate::bgp::vrf_config::BgpVrfNeighborConfig {
+            remote_as: Some(65001),
+            ..Default::default()
+        };
+        n.config.bfd.enable = Some(true);
+        let (ra, cfg, knobs) = super::super::spawn::resolve_vrf_peer_config(
+            &a,
+            &n,
+            &std::collections::BTreeMap::new(),
+        )
+        .unwrap();
+
+        vrf.process_global_msg(BgpVrfMsg::AddPeer {
+            addr: a,
+            remote_as: ra,
+            config: Box::new(cfg),
+            knobs: Box::new(knobs),
+            policy_refs: std::collections::BTreeMap::new(),
+        });
+        let subscribed = std::iter::from_fn(|| bfd_rx.try_recv().ok())
+            .any(|r| matches!(r, ClientReq::Subscribe { key, .. } if key.remote == a));
+        assert!(
+            subscribed,
+            "runtime AddPeer with bfd enabled subscribes a session",
+        );
+
+        vrf.process_global_msg(BgpVrfMsg::RemovePeer { addr: a });
+        let unsubscribed = std::iter::from_fn(|| bfd_rx.try_recv().ok())
+            .any(|r| matches!(r, ClientReq::Unsubscribe { key, .. } if key.remote == a));
+        assert!(
+            unsubscribed,
+            "removing the peer unsubscribes its BFD session",
+        );
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -85,12 +85,9 @@ pub struct BgpVrfHandle {
     /// have.
     pub evpn_advertise_v4: bool,
     pub evpn_advertise_v6: bool,
-    /// BFD session keys this VRF's peers subscribed, withdrawn
-    /// synchronously by `despawn_bgp_vrf` before a respawn re-subscribes —
-    /// same ordering hazard the policy watches have (now cleared in one shot
-    /// via `policy::Message::UnregisterProto`).
-    pub bfd_sessions: Vec<crate::bfd::session::SessionKey>,
-    /// Kept so `despawn_bgp_vrf` can address the BFD unsubscribes.
+    /// Kept so `despawn_bgp_vrf` can address the BFD unsubscribes
+    /// (`ClientReq::UnsubscribeClient`, client-scoped so runtime-added
+    /// sessions are cleared too).
     pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     /// The BFD client id (`bfd-vrf:<name>`) the unsubscribes must use.
     pub bfd_client: String,
@@ -468,7 +465,6 @@ pub fn spawn_bgp_vrf(
     // `show bgp vrf <name> …` redirection.
     let show_tx = vrf.show.tx.clone();
     // Snapshot before `vrf` moves into the task.
-    let bfd_sessions = vrf.bfd_session_list();
     let bfd_client_handle = vrf.bfd_client_tx.clone();
     let bfd_client_id = vrf.bfd_client();
 
@@ -492,7 +488,6 @@ pub fn spawn_bgp_vrf(
         inbox,
         router_id: effective_router_id,
         asn,
-        bfd_sessions,
         bfd_client_tx: bfd_client_handle,
         bfd_client: bfd_client_id,
         show_tx,
@@ -782,12 +777,14 @@ pub(super) fn insert_started_peer(
         .get_mut(addr)
         .expect("peer was just inserted")
         .start();
-    // NOTE: BFD reconcile is deliberately NOT done here. It is spawn-only
-    // (`materialize_peers`), because the despawn-time teardown enumerates a
-    // spawn-captured `handle.bfd_sessions` snapshot — a session created by a
-    // runtime `AddPeer` would not be in it and would leak. Runtime-added CE
-    // peers therefore don't get BFD live (a documented follow-up), the same
-    // scope the PR states.
+    // Bring up BFD for this CE if configured — after the ident is assigned
+    // and after start(), matching the global neighbor's order. Shared by the
+    // spawn-time materialize and the runtime `AddPeer`: teardown is
+    // client-scoped (`ClientReq::UnsubscribeClient`), so a runtime-added
+    // session is torn down at despawn without needing a spawn-time snapshot.
+    // A no-op when `bfd enabled` is unset or no BFD client is wired
+    // (placeholder spawn / tests).
+    vrf.bfd_reconcile(ident);
 }
 
 /// Build `Peer` objects from `cfg.neighbors` and insert them into
@@ -814,15 +811,6 @@ fn materialize_peers(
             continue;
         };
         insert_started_peer(vrf, addr, remote_as, config, &knobs, &nbr_cfg.policy_refs);
-        // Bring up BFD for this CE if configured — after the ident is
-        // assigned and after start(), matching the global neighbor's order.
-        // Spawn-only: the despawn teardown reads a spawn-captured
-        // `bfd_sessions` snapshot, so a runtime-add's session isn't tracked
-        // there (see the note in `insert_started_peer`). A no-op when `bfd
-        // enabled` is unset or no BFD client is wired (placeholder / tests).
-        if let Some(ident) = vrf.peers.get(addr).map(|p| p.ident) {
-            vrf.bfd_reconcile(ident);
-        }
         count += 1;
     }
     count
@@ -946,17 +934,16 @@ pub fn despawn_bgp_vrf(
     let _ = policy_tx.send(crate::policy::Message::UnregisterProto {
         proto: format!("bgp-vrf:{name}"),
     });
-    // Withdraw this incarnation's BFD sessions, on this thread, ahead of
-    // any Subscribe a respawn's `materialize_peers` sends on the same
-    // client channel — the same ordering hazard as the policy watches:
-    // BFD matches on `(client, key)`, both of which a respawn reuses.
+    // Withdraw every BFD session this VRF holds, on this thread, ahead of
+    // any Subscribe a respawn's `materialize_peers` sends on the same client
+    // channel. Client-scoped (`UnsubscribeClient`) in one shot rather than
+    // enumerating a snapshot: peers added at runtime (`AddPeer`) subscribe
+    // sessions the spawn-time list never captured, so an enumeration would
+    // leak them — the same hazard the policy watches had (now `UnregisterProto`).
     if let Some(bfd_client_tx) = &handle.bfd_client_tx {
-        for key in &handle.bfd_sessions {
-            let _ = bfd_client_tx.send(crate::bfd::inst::ClientReq::Unsubscribe {
-                client: handle.bfd_client.clone(),
-                key: *key,
-            });
-        }
+        let _ = bfd_client_tx.send(crate::bfd::inst::ClientReq::UnsubscribeClient {
+            client: handle.bfd_client.clone(),
+        });
     }
     // Drop this VRF's RIB redistribute subscription (client-registry +
     // redist-filter rows) so a respawn under the same `bgp:vrf:<name>`


### PR DESCRIPTION
Follow-up #1 to #2087 (per-VRF neighbor live config) — the last functional gap.

## Problem
BFD reconcile was **spawn-only**: a CE neighbor added/reconfigured at runtime
got no BFD session. It couldn't be wired into the runtime path because
`despawn_bgp_vrf` tore BFD down by enumerating a spawn-captured
`handle.bfd_sessions` snapshot — a runtime-added session isn't in it and would
leak (the same staleness the policy watches had before `UnregisterProto`).

## Fix
- **BFD actor**: add `ClientReq::UnsubscribeClient { client }` — drops every
  session a client holds, tearing down those left with no other subscriber.
  The BFD analog of `policy::Message::UnregisterProto`.
- **despawn**: send `UnsubscribeClient` in one shot instead of iterating a
  per-key list; remove the now-dead `handle.bfd_sessions` field +
  `bfd_session_list()`.
- **runtime paths** (teardown no longer snapshot-bound):
  - `insert_started_peer` calls `bfd_reconcile` (shared by spawn + `AddPeer`),
    so a runtime-added peer brings BFD up identically to a spawn-time one;
  - `reconfigure_peer` reconciles BFD (runtime `bfd enabled` / echo toggle);
  - `remove_peer` unsubscribes the departed peer's session directly
    (`bfd_reconcile` can't — it reads the still-"enabled" config).

Single-hop only, unchanged; multihop/echo semantics untouched. Spawn-time BFD
is behavior-preserving (`bfd_reconcile` still runs at spawn, from
`insert_started_peer` instead of the `materialize_peers` loop).

## Test plan
- `unsubscribe_client_drops_all_of_one_clients_sessions` — BFD actor: the
  client's exclusive sessions are torn down, a shared session and another
  client's own survive.
- `runtime_add_and_remove_peer_drives_bfd` — a runtime `AddPeer` with `bfd
  enabled` subscribes a session; `RemovePeer` unsubscribes. Verified failing
  without the wiring.
- `cargo fmt --all --check`, clean-build `RUSTFLAGS="-D warnings" cargo clippy
  --workspace --all-targets` (exit 0), `cargo test --workspace --exclude bdd`
  all green.

With this, all three #2087 follow-ups are closed except the runtime-path BDD
scenarios (tracked separately).

Generated with [Claude Code](https://claude.com/claude-code)