### PR TITLE
bdd: cover per-VRF neighbor add/reconfigure/remove at runtime

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -275,6 +275,10 @@ l3vpn_dual_ce:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@l3vpn_dual_ce"
 
+bgp_vrf_runtime_neighbor:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_runtime_neighbor"
+
 bgp_vrf_redistribute:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_redistribute"
@@ -487,4 +491,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover bgp_mp_reach_ipv4 l3vpn_dual_ce generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover bgp_mp_reach_ipv4 l3vpn_dual_ce bgp_vrf_runtime_neighbor generate open docs FORCE

--- a/bdd/tests/configs/bgp_vrf_runtime_neighbor/ce1.yaml
+++ b/bdd/tests/configs/bgp_vrf_runtime_neighbor/ce1.yaml
@@ -1,0 +1,31 @@
+# CE1 — customer edge 1 (AS 65001). The control neighbor: configured at
+# start and never touched at runtime, so it is the "must stay Established
+# while CE2 is added/removed" witness that the incremental path does not
+# respawn the VRF task.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.1.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.1.0.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/bgp_vrf_runtime_neighbor/ce2.yaml
+++ b/bdd/tests/configs/bgp_vrf_runtime_neighbor/ce2.yaml
@@ -1,0 +1,32 @@
+# CE2 — customer edge 2 (AS 65002). Fully configured from the start on
+# its own side; PE1 has NO neighbor for it until the runtime `set` adds
+# one. `connect-retry-time 3` makes CE2 re-dial quickly so the session
+# comes up soon after PE1's neighbor is added, without waiting a full
+# 30 s connect-retry.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: pe1
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.2.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.2.0.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/bgp_vrf_runtime_neighbor/pe1.yaml
+++ b/bdd/tests/configs/bgp_vrf_runtime_neighbor/pe1.yaml
@@ -1,0 +1,45 @@
+# PE1 — the router under test (AS 65000). vrf-cust starts with ONE CE
+# neighbor (CE1); CE2 is added, given BFD, and removed at RUNTIME via
+# `vtyctl apply -c` (surgical set/delete), exercising the incremental
+# per-VRF neighbor path (AddPeer / ReconfigurePeer / RemovePeer) on a
+# task that keeps running the whole time — never a respawn, so CE1 must
+# stay Established throughout.
+#
+# Both PE-CE interfaces are enslaved to vrf-cust from the start; only the
+# BGP *neighbor* for CE2 is deferred, so adding it is a pure neighbor edit
+# (not a task-global change) and does not respawn the VRF task.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      # Only CE1 at start. CE2 (10.2.0.2) is added at runtime.
+      - remote-address: 10.1.0.2
+        remote-as: 65001
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/features/bgp_vrf_runtime_neighbor.feature
+++ b/bdd/tests/features/bgp_vrf_runtime_neighbor.feature
@@ -1,0 +1,101 @@
+@serial
+@bgp_vrf_runtime_neighbor
+Feature: Per-VRF BGP neighbors applied to a running VRF at runtime
+  As an operator of an L3VPN PE
+  I want to add, reconfigure, and remove a `router bgp vrf <name>`
+  neighbor on a VRF that is already running
+  So that a customer-edge change takes effect on the live task without
+  respawning it — CE1 keeps its session while CE2 is added, given BFD,
+  and removed.
+
+  Regression guard for the incremental per-VRF neighbor path (PR #2087)
+  and its two follow-ups: TCP-AO re-subscribe on reconfigure (#2094) and
+  live BFD for runtime-added neighbors (#2095). Before #2087 a neighbor
+  edit either did nothing until the next respawn or reset every session
+  in the VRF; these scenarios prove the edit is surgical.
+
+  The whole point is that CE1's session must NOT flap while CE2 is
+  churned: `runtime_structure_eq` keeps a neighbor-only edit off the
+  respawn path, so CE1 is the "still Established" witness. CE2's BFD
+  session appearing in `show bfd peers` after enable and disappearing
+  after the neighbor delete guards the `AddPeer` BFD subscribe and the
+  `remove_peer` / `UnsubscribeClient` teardown (a leaked session would
+  linger).
+
+  Test Topology (3 namespaces):
+  ```
+   ce1 ────────── pe1 ────────── ce2
+   AS 65001    AS 65000        AS 65002
+   lo          vrf-cust        lo
+   10.0.1.1/32 RD 65000:1      10.0.2.1/32
+        .2 ── .1        .1 ── .2
+       10.1.0.0/30    10.2.0.0/30
+  ```
+  Both PE-CE interfaces are enslaved to vrf-cust from the start; only
+  the BGP neighbor for CE2 is deferred and driven in at runtime with
+  `vtyctl apply -c`.
+
+  Scenario: Build the runtime-neighbor VRF topology
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "ce2"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "ce2" to namespace "ce2" interface "pe1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "ce2"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp vrf" in namespace "pe1" should contain "vrf-cust"
+    And show command "show bgp vrf" in namespace "pe1" should contain "running"
+    And BGP session in "ce1" to "10.1.0.1" should eventually be "Established"
+
+  Scenario: Adding a neighbor at runtime brings it up without disturbing CE1
+    # `AddPeer`: the CE2 neighbor is created on the live VRF task. CE2
+    # comes up and its prefix lands in the shared Loc-RIB, while CE1 —
+    # checked immediately after the edit, when a respawn's reconnect would
+    # still be in flight — stays Established.
+    Given the test topology exists
+    When I apply command "set router bgp vrf vrf-cust neighbor 10.2.0.2 remote-as 65002" in namespace "pe1"
+    Then BGP session in "ce2" to "10.2.0.1" should eventually be "Established"
+    And BGP session in "ce1" to "10.1.0.1" should be "Established"
+    And show command "show bgp vrf vrf-cust" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vrf vrf-cust" in namespace "pe1" should contain "10.0.1.1/32"
+
+  Scenario: Enabling BFD on a live neighbor subscribes a session
+    # `ReconfigurePeer` toggling `bfd enabled`: the per-VRF task subscribes
+    # a BFD session for CE2 without bouncing either BGP session (BFD is a
+    # separate datapath). The session appears in `show bfd peers` even if it
+    # never reaches Up (CE2 runs no BFD) — the point is that it is
+    # subscribed, not leaked.
+    Given the test topology exists
+    When I apply command "set router bgp vrf vrf-cust neighbor 10.2.0.2 bfd enabled true" in namespace "pe1"
+    Then show command "show bfd peers" in namespace "pe1" should eventually contain "10.2.0.2"
+    And BGP session in "ce1" to "10.1.0.1" should be "Established"
+    And BGP session in "ce2" to "10.2.0.1" should be "Established"
+
+  Scenario: Removing a neighbor at runtime tears down its session, route, and BFD
+    # `RemovePeer`: `route_clean` withdraws CE2's prefix from the VRF
+    # Loc-RIB, the session drops, and the BFD subscription is dropped —
+    # `show bfd peers` no longer lists 10.2.0.2 (guards the per-peer
+    # unsubscribe; a leak would keep it). CE1 and its route are untouched.
+    Given the test topology exists
+    When I apply command "delete router bgp vrf vrf-cust neighbor 10.2.0.2" in namespace "pe1"
+    Then show command "show bgp vrf vrf-cust" in namespace "pe1" should eventually not contain "10.0.2.1/32"
+    And show command "show bfd peers" in namespace "pe1" should eventually not contain "10.2.0.2"
+    And BGP session in "ce2" to "10.2.0.1" should eventually not be "Established"
+    And BGP session in "ce1" to "10.1.0.1" should be "Established"
+    And show command "show bgp vrf vrf-cust" in namespace "pe1" should contain "10.0.1.1/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "ce2"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "ce2"
+    Then the test environment should be clean


### PR DESCRIPTION
Follow-up #3 to #2087 — the last item in the per-VRF neighbor live-config arc.

End-to-end BDD coverage for the incremental per-VRF neighbor path (#2087)
and its follow-ups: TCP-AO re-subscribe on reconfigure (#2094) and live BFD
for runtime-added neighbors (#2095). These were unit-tested only; the
existing l3vpn scenarios cover the *spawn* path, not runtime edits.

## Topology
`ce1 — pe1 — ce2`, both PE-CE interfaces enslaved to `vrf-cust` from the
start, CE2's BGP neighbor deferred and driven in at runtime with
`vtyctl apply -c` (the surgical incremental commit path).

## Scenarios (5, all pass locally; clean teardown)
- **Add** (`AddPeer`): `set … neighbor 10.2.0.2 remote-as 65002` on the live
  task → CE2 Established + prefix in the shared Loc-RIB, while **CE1 stays
  Established** — checked immediately after the edit, when a respawn's
  reconnect would still be in flight, so it proves the edit is incremental.
- **Reconfigure** (`ReconfigurePeer` + BFD): `set … neighbor 10.2.0.2 bfd
  enabled true` → BFD session appears in `show bfd peers`, no BGP bounce.
- **Remove** (`RemovePeer`): `delete … neighbor 10.2.0.2` → prefix withdrawn
  from the VRF Loc-RIB, session drops, and the BFD session **disappears from
  `show bfd peers`** (guards the per-peer unsubscribe — a leak would keep
  it); CE1 and its route untouched.

## Notes
- Test-only: a new `.feature` + configs + a `bgp_vrf_runtime_neighbor`
  Makefile target. No source change (CI's fmt/clippy/test unaffected; BDD is
  excluded from CI, so this ran locally: `5 scenarios (5 passed), 42 steps`).
- `tag_guard` lib tests pass (tag unique, no prefix conflict).

Closes the #2087 follow-up list.

Generated with [Claude Code](https://claude.com/claude-code)