### PR TITLE
docs: retire the xdp-bfd-echo helper from the docs and comments

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -328,8 +328,9 @@ isis_endx_ipv6:
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_endx_ipv6"
 
 # IS-IS BFD over IPv6. The `_echo` targets exercise the Echo scenarios, which
-# require the IPv6 `xdp-bfd-echo` dataplane helper (built out-of-workspace) and
-# XDP-capable namespaces; the plain targets run only the no-echo scenario.
+# require the cradle engine (`/usr/bin/cradle`, from the cradle-rs package) for
+# the IPv6 Echo dataplane and XDP-capable namespaces; the plain targets run only
+# the no-echo scenario.
 isis_bfd_ipv6_p2p:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and not @bfd_echo"
@@ -347,8 +348,9 @@ isis_bfd_ipv6_lan_echo:
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and @bfd_echo"
 
 # IS-IS BFD over IPv4. The `_echo` targets exercise the Echo scenarios, which
-# require the `xdp-bfd-echo` dataplane helper (built out-of-workspace) and
-# XDP-capable namespaces; the plain targets run only the no-echo scenario.
+# require the cradle engine (`/usr/bin/cradle`, from the cradle-rs package) for
+# the Echo dataplane and XDP-capable namespaces; the plain targets run only the
+# no-echo scenario.
 isis_bfd_ipv4_p2p:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and not @bfd_echo"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -124,7 +124,7 @@
 ## Failure Detection
 
 - [BFD](ch-10-00-bfd.md)
-  - [The XDP/eBPF Data-Plane Helper](ch-10-01-bfd-xdp-helper.md)
+  - [BFD Offload in the eBPF Data Plane](ch-10-01-bfd-xdp-helper.md)
 
 ## Fast Reroute
 

--- a/book/src/ch-00-00-introduction.md
+++ b/book/src/ch-00-00-introduction.md
@@ -63,8 +63,8 @@ and eBPF. Latency- and throughput-sensitive paths are pushed down into the
 kernel — and, where the NIC supports it, onto the hardware — so they run at line
 rate instead of bouncing through user space.
 
-[BFD](ch-10-00-bfd.md) liveness runs in an [XDP/eBPF data-plane
-helper](ch-10-01-bfd-xdp-helper.md), sustaining sub-second failure detection —
+[BFD](ch-10-00-bfd.md) liveness runs in the [XDP/eBPF data
+plane](ch-10-01-bfd-xdp-helper.md), sustaining sub-second failure detection —
 including Echo mode, across BFD, S-BFD, and STAMP — without loading the control
 plane. [EVPN BUM replication](ch-02-34-bgp-evpn-segmentation.md) is offloaded to
 eBPF, fanning out broadcast, unknown-unicast, and multicast traffic inside the

--- a/book/src/ch-00-07-building.md
+++ b/book/src/ch-00-07-building.md
@@ -11,8 +11,7 @@ zebra-rs itself. The steps mirror the CI build scripts under
 
 The quickest way to get a build host ready is the `setup-build-env.sh` script
 under `packaging/`. It installs everything the rest of this chapter describes —
-the APT system packages, the stable Rust toolchain, the XDP/eBPF toolchain
-(nightly Rust with `rust-src`, LLVM, and `bpf-linker`), and the `cargo-deb`
+the APT system packages, the stable Rust toolchain, and the `cargo-deb`
 package builder — in a single, idempotent pass, mirroring the CI workflows:
 
 ``` shell
@@ -24,13 +23,15 @@ down to what you actually need:
 
 | Flag | Effect |
 |---|---|
-| `--no-xdp` | Skip the XDP/eBPF toolchain (nightly `rust-src`, LLVM, `bpf-linker`). Use this if you only build with `make all` / `cargo test`. |
 | `--no-cargo-deb` | Skip `cargo-deb` (only needed to build the `.deb` package). |
 | `--no-rust` | Do not install rustup/Rust (assume a toolchain is already present). |
 | `-h`, `--help` | Show the help and exit. |
 
-Two environment variables override the pinned tool versions:
-`LLVM_VERSION` (default `18`) and `BPF_LINKER_VERSION` (default `0.10.3`).
+Building zebra-rs needs only the **stable** Rust toolchain: all XDP/eBPF
+data-plane code lives in
+[cradle-rs](https://github.com/zebra-rs/cradle-rs), which is built and
+packaged separately, so no nightly Rust, LLVM, or `bpf-linker` is required
+here.
 
 The script targets Ubuntu/Debian (it drives `apt-get`). On other distributions,
 install the equivalent pieces by hand — the rest of this chapter documents each
@@ -68,31 +69,14 @@ Building or testing only the Rust workspace (`cargo build`, `cargo test`)
 needs just `protobuf-compiler` and `libpam0g-dev` — that is all `ci.yaml`
 installs. The remaining packages are used by the `vty` build and packaging.
 
-### XDP/eBPF toolchain: LLVM and bpf-linker
+### XDP/eBPF toolchain
 
-The XDP BFD Echo helper (`offload/xdp-bfd-echo`) offloads BFD Echo
-reflection to XDP. It is compiled for the `bpfel-unknown-none` target, which
-requires a nightly Rust toolchain with `rust-src`, LLVM 18, and
-[`bpf-linker`](https://github.com/aya-rs/bpf-linker) (which links against
-LLVM). The validated combination is bpf-linker 0.10.3 with LLVM 18.1:
-
-``` shell
-# Nightly Rust + rust-src for the BPF target
-rustup toolchain install nightly --component rust-src
-
-# LLVM 18 from apt.llvm.org
-wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-chmod +x /tmp/llvm.sh
-sudo /tmp/llvm.sh 18
-export PATH="/usr/lib/llvm-18/bin:$PATH"
-
-# bpf-linker, linked against the LLVM installed above
-cargo install bpf-linker --version 0.10.3 --locked
-```
-
-This toolchain is **not** required for `make all`. It is required for
-`make xdp-bfd-echo` and for building the Debian package, which bundles the
-helper.
+Not needed. The eBPF data plane — including the BFD Echo reflector and the
+in-kernel detection watchdog — lives in
+[cradle-rs](https://github.com/zebra-rs/cradle-rs), a separate repository
+with its own build (nightly Rust, LLVM, `bpf-linker`) and its own `.deb`.
+Nothing in the zebra-rs workspace targets `bpfel-unknown-none`, so `make
+all`, `cargo test`, and the Debian package all build with stable Rust alone.
 
 ## Build and install from source
 
@@ -131,10 +115,9 @@ cd packaging
 make amd64   # or: make arm64
 ```
 
-This builds the `vty` shell and the Rust workspace if needed, compiles the
-`xdp-bfd-echo` XDP helper, and produces a `.deb` package for the selected
-architecture — the same steps `build-amd64.yaml` and `build-arm64.yaml` run
-in CI.
+This builds the `vty` shell and the Rust workspace if needed and produces a
+`.deb` package for the selected architecture — the same steps
+`build-amd64.yaml` and `build-arm64.yaml` run in CI.
 
 ``` shell
 sudo dpkg -i zebra-rs_26.7.1_arm64.deb

--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -94,8 +94,8 @@ but Echo is **single-hop only** (RFC 5883 multihop has no Echo), so it applies
 **only to directly-connected eBGP** (`multihop` inferred or forced `false`). On
 an iBGP or multihop-eBGP neighbour the `echo-mode` leaf is accepted but inert.
 Within that constraint it works like the OSPF/IS-IS form — `transmit` originates,
-`receive` advertises + reflects, `both` does both, via the per-interface
-`xdp-bfd-echo` helper. IPv4 and IPv6 neighbours are covered alike (the Echo
+`receive` advertises + reflects, `both` does both, via the
+[eBPF data plane](ch-16-00-ebpf.md). IPv4 and IPv6 neighbours are covered alike (the Echo
 session uses the same addresses as the control session):
 
 ```
@@ -115,8 +115,8 @@ router bgp {
 ## Offloading expiration detection
 
 `detect-offload true` moves the RFC 5880 §6.8.4 detection timer into the
-kernel via the per-interface `xdp-bfd-echo` helper — **single-hop
-neighbours only** (the helper attaches per interface; on iBGP / multihop
+kernel via the [eBPF data plane](ch-16-00-ebpf.md) — **single-hop
+neighbours only** (the XDP program runs on attached ports; on iBGP / multihop
 eBGP the leaf is accepted but inert, like `echo-mode`). See
 [the overview](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload)
 for the mechanism and guard-rails.

--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -76,8 +76,9 @@ this interface's adjacencies — single-hop only. Both IPv4 and IPv6 are
 supported: the Echo session is built from the interface's and neighbour's
 addresses (an IPv6-only adjacency uses the two ends' link-locals). `transmit`
 originates Echo + detects on the return; `receive` advertises + reflects (the
-peer detects); `both` does both — backed by the per-interface `xdp-bfd-echo`
-helper, whose XDP reflector handles 0x0800 and 0x86DD frames alike.
+peer detects); `both` does both — backed by the
+[eBPF data plane](ch-16-00-ebpf.md), whose XDP reflector handles 0x0800 and
+0x86DD frames alike.
 
 ```
 router isis {
@@ -95,7 +96,7 @@ router isis {
 ## Offloading expiration detection
 
 `detect-offload true` moves the RFC 5880 §6.8.4 detection timer into the
-kernel via the same per-interface `xdp-bfd-echo` helper that backs Echo:
+kernel via the same [eBPF data plane](ch-16-00-ebpf.md) that backs Echo:
 the XDP program re-arms a per-session timer on every arriving control
 packet and the expiry fires in softirq, immune to daemon scheduling
 latency. The adjacency teardown on expiry — and the

--- a/book/src/ch-08-02-ospf-bfd.md
+++ b/book/src/ch-08-02-ospf-bfd.md
@@ -82,7 +82,7 @@ router ospf {
 this interface's sessions — single-hop only, both address families: IPv4 on
 OSPFv2, and on OSPFv3 the Echo session runs over the same IPv6 link-local pair
 as the control session. The two halves are independent (RFC 5880 §6.4), backed
-by the per-interface `xdp-bfd-echo` helper, whose XDP program handles IPv4 and
+by the [eBPF data plane](ch-16-00-ebpf.md), whose XDP program handles IPv4 and
 IPv6 frames alike:
 
 - **`receive`** — advertise a non-zero Required Min Echo RX and loop the peer's
@@ -108,8 +108,8 @@ router ospf {
 ```
 
 A forwarding-path fault is then caught in sub-second time independent of the
-OSPF Hello/Dead timers. The helper needs `cap_net_admin,cap_bpf,cap_net_raw`
-and a kernel with XDP + `bpf_timer` support; if it can't start, the session
+OSPF Hello/Dead timers. The engine needs `cap_net_admin,cap_bpf,cap_net_raw`
+and a kernel with XDP + `bpf_timer` support; if it can't run, the session
 stays up on control packets and advertises echo-rx `0`. `show bfd peers` shows
 the negotiated `Echo receive interval` / `Echo transmission interval`.
 
@@ -117,8 +117,8 @@ the negotiated `Echo receive interval` / `Echo transmission interval`.
 
 `detect-offload true` moves the RFC 5880 §6.8.4 detection timer — the
 clock that drives the session `Down` when the neighbour's control
-packets stop arriving — into the kernel, via the same per-interface
-`xdp-bfd-echo` helper that backs Echo. The XDP program re-arms a
+packets stop arriving — into the kernel, via the same
+[eBPF data plane](ch-16-00-ebpf.md) that backs Echo. The XDP program re-arms a
 per-session `bpf_timer` on every arriving control packet and the expiry
 fires in softirq, so detection neither false-fires because the daemon
 was busy (packets queued but unprocessed) nor waits on its event loop.

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -186,8 +186,8 @@ Each command also accepts a trailing `json` for machine-readable output.
 
 The BFD task is quiet by default. A single runtime flag turns on its
 diagnostic traces — session FSM transitions, control-packet handling, and
-the `xdp-bfd-echo` helper lifecycle (Echo and the in-kernel expiration
-watchdog it hosts):
+the eBPF-offload lifecycle (Echo and the in-kernel expiration watchdog the
+data plane hosts):
 
 ```
 set bfd tracing true     # enable
@@ -196,8 +196,8 @@ set bfd tracing false    # disable (or: delete bfd tracing)
 
 It is a runtime toggle — no restart, and no rebuild — backed by a single
 global flag, so it also covers the parts of BFD that run outside the main
-task (the socket read/write tasks and the per-interface Echo reflector
-IPC). It is not per-session or per-interface; it is on or off for the
+task (the socket read/write tasks and the Echo/detect offload driver's
+RPCs). It is not per-session or per-interface; it is on or off for the
 whole BFD task.
 
 The info- and warn-level traces appear at the **default** log level once
@@ -222,34 +222,36 @@ a node slow its control-packet rate while keeping fast detection. Echo is
 **single-hop only** (RFC 5883 multi-hop has no Echo); **both IPv4 and IPv6**
 are supported.
 
-The two halves are independent and zebra-rs implements both, offloaded to a
-per-interface XDP/eBPF helper, **`xdp-bfd-echo`**:
+The two halves are independent and zebra-rs implements both, offloaded to the
+[eBPF data plane](ch-16-00-ebpf.md):
 
 - **Responder** — when we advertise a non-zero `Required Min Echo RX Interval`,
-  the helper's XDP program loops a peer's Echo back in the data plane, so the
-  *peer* gets fast detection. We only advertise non-zero once the helper is
-  confirmed running, so the promise to loop is honest. The loop differs per
+  the data plane's XDP program loops a peer's Echo back in the kernel, so the
+  *peer* gets fast detection. We only advertise non-zero once the engine is
+  confirmed reachable, so the promise to loop is honest. The loop differs per
   family to match what real peers send: IPv4 Echo is *self-addressed* and
   looped as a forwarding hop (TTL decremented to 254), while IPv6 Echo (as FRR
   sends it) is *peer-addressed*, so the reflector also swaps the IPv6
   source/destination and decrements the Hop Limit — both interop-validated
   against FRR `echo-mode`.
-- **Originator** — the helper sends our Echo from a raw `AF_PACKET` socket and
+- **Originator** — the engine sends our Echo from a raw `AF_PACKET` socket and
   the XDP program arms a per-session in-kernel `bpf_timer` on each return; if
   returns stop for `interval × detect-mult`, the session goes `Down` with
   diagnostic `Echo Function Failed` (RFC 5880 §6.8.5). We only originate while
   the session is `Up` and the peer advertised a non-zero echo-rx (§6.8.9).
 
-The helper is reference-counted **per interface**: one `xdp-bfd-echo` process is
-spawned for each interface that has at least one Echo-enabled (or
+The datapath is keyed by discriminator, but it only runs on interfaces the
+engine has attached, so an Echo-enabled (or
 [`detect-offload`](#offloading-expiration-detection-detect-offload)-enabled)
-session, shared by all sessions on that link, and stopped when the last one
-goes away. It needs
-`cap_net_admin,cap_bpf` (load/attach XDP) and `cap_net_raw` (the originator's
-raw socket); the packaged install grants these. A node with no Echo configured
-runs no helper and advertises `Required Min Echo RX Interval = 0`. Deployment,
-attach modes, and troubleshooting are covered in
-[The XDP/eBPF Data-Plane Helper](ch-10-01-bfd-xdp-helper.md).
+session **auto-attaches its egress interface** as a data-plane port — no
+explicit `interface <name> ebpf enabled` line — and releases it when the last
+such session on that link goes away. The engine itself must be enabled with
+`system ebpf enabled true`; it needs `cap_net_admin,cap_bpf` (load/attach XDP)
+and `cap_net_raw` (the originator's raw socket), which the packaged install
+grants. A node with no Echo configured attaches no BFD port and advertises
+`Required Min Echo RX Interval = 0`. Deployment, attach modes, and
+troubleshooting are covered in
+[BFD Offload in the eBPF Data Plane](ch-10-01-bfd-xdp-helper.md).
 
 Echo is enabled per attachment — on OSPFv2/v3 and IS-IS interfaces, and on
 single-hop eBGP neighbours, where `echo-mode` selects the role
@@ -277,8 +279,8 @@ loop, which has two failure modes under load:
   behind the same backlog.
 
 `detect-offload` moves that timing into the kernel, using the same
-per-interface `xdp-bfd-echo` helper as the [Echo
-function](#echo-function). Once the session is `Up`, the helper's XDP
+[eBPF data plane](ch-16-00-ebpf.md) as the [Echo
+function](#echo-function). Once the session is `Up`, its XDP
 program *observes* every BFD control packet (UDP 3784 at TTL 255) on the
 interface: it matches the packet's `Your Discriminator` against the
 session, re-arms a per-session in-kernel `bpf_timer`, and **passes the
@@ -300,20 +302,20 @@ Notes and guard-rails:
   zebra-rs arms the watchdog on the `Up` transition and disarms it when
   the session leaves `Up`. Renegotiated timers retune the armed value
   automatically.
-- **Single-hop only.** The helper attaches per interface; multi-hop
+- **Single-hop only.** The XDP program runs on attached ports; multi-hop
   ingress is not bound to one (and its TTL floor is below the GTSM 255
   the observer requires). IPv4 and IPv6 are both supported.
 - **The userspace timer stays as a backstop.** While the watchdog is
   armed, the normal detection timer keeps running, stretched to 4× the
-  detection time; if the helper process ever dies, zebra-rs reverts the
+  detection time; if the engine ever goes away, zebra-rs reverts the
   session to ordinary userspace detection immediately.
-- **Honesty gate.** The watchdog is only armed once the helper is
-  confirmed running — if it cannot start (missing binary, capabilities,
-  kernel without XDP/`bpf_timer`), detection simply stays in userspace.
-  A watchdog-only helper needs `cap_net_admin,cap_bpf` (no `cap_net_raw`
-  — there is no transmit half; the daemon keeps sending its own control
-  packets). See
-  [The XDP/eBPF Data-Plane Helper](ch-10-01-bfd-xdp-helper.md) for
+- **Honesty gate.** The watchdog is only armed once the engine is
+  confirmed reachable — if it cannot run (`system ebpf` disabled,
+  missing binary or capabilities, kernel without XDP/`bpf_timer`),
+  detection simply stays in userspace. A watchdog-only deployment needs
+  no `cap_net_raw` — there is no transmit half; the daemon keeps sending
+  its own control packets. See
+  [BFD Offload in the eBPF Data Plane](ch-10-01-bfd-xdp-helper.md) for
   requirements and troubleshooting.
 
 It is enabled per attachment, with the same per-interface /
@@ -350,8 +352,8 @@ native timers would allow.
   Sequences (both initiating and answering); BGP `update-source`
   inherited as the session's local address; the **Echo function**
   (RFC 5880 §6.4, single-hop, IPv4 **and** IPv6) — both reflecting a
-  peer's Echo and originating our own, offloaded to the `xdp-bfd-echo`
-  XDP/eBPF helper (see [Echo function](#echo-function) below), with
+  peer's Echo and originating our own, offloaded to the XDP/eBPF data
+  plane (see [Echo function](#echo-function) below), with
   per-role (`transmit` / `receive` / `both`) config applied live on
   commit and an instance-level `router <proto> { bfd {} }` default
   inherited and overridden per interface / neighbour. Echo is

--- a/book/src/ch-10-01-bfd-xdp-helper.md
+++ b/book/src/ch-10-01-bfd-xdp-helper.md
@@ -1,14 +1,13 @@
-# The XDP/eBPF Data-Plane Helper (`xdp-bfd-echo`)
+# BFD Offload in the eBPF Data Plane
 
 Two BFD features run partly *outside* the daemon, in the kernel data
 plane: the [Echo function](ch-10-00-bfd.md#echo-function) and
 [expiration-detection offload](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload)
-(`detect-offload`). Both are backed by one helper program,
-**`xdp-bfd-echo`** — an XDP/eBPF program with a small userspace loader
-that zebra-rs spawns and supervises automatically, one process per
-interface that needs it.
+(`detect-offload`). Both are hosted by the
+[eBPF data plane](ch-16-00-ebpf.md) — the `cradle` engine — which
+zebra-rs launches and supervises, and drives over gRPC.
 
-This chapter is the operational view: what runs where, what the helper
+This chapter is the operational view: what runs where, what the offload
 needs from the system, how its lifecycle works, and what to check when
 it doesn't come up. The protocol-facing configuration lives in the
 per-protocol BFD chapters; the deeper design rationale (including the
@@ -25,73 +24,90 @@ in software, while every receive-side deadline moves into the kernel.
 
 | Function | Where | How |
 |---|---|---|
-| Echo reflect (peer's Echo, UDP/3785) | XDP | Rewrite in place (MAC swap, TTL/Hop-Limit decrement, IPv6 src/dst swap for FRR-style peers), `XDP_TX` back out the same interface |
-| Echo originate (our Echo) | helper userspace | `AF_PACKET` raw socket, self-addressed frames on a jittered timer |
-| Echo detection (our returns stop) | XDP + `bpf_timer` | Each return re-arms a per-session kernel timer; expiry fires in softirq |
-| Control-packet expiration (`detect-offload`, UDP/3784) | XDP + `bpf_timer` | Each control packet for an Up session re-arms the timer; the frame is **always passed** to the daemon |
-| BFD state machine, Poll/Final, negotiation, control TX | zebra-rs | Unchanged — the helper never makes protocol decisions |
+| Echo reflect (peer's Echo, UDP/3785) | engine XDP (`cradle_xdp`) | Rewrite in place (MAC swap, TTL/Hop-Limit decrement, IPv6 src/dst swap for FRR-style peers), `XDP_TX` back out the same interface |
+| Echo originate (our Echo) | engine userspace | `AF_PACKET` raw socket, self-addressed frames on a jittered timer |
+| Echo detection (our returns stop) | engine XDP + `bpf_timer` | Each return re-arms a per-session kernel timer; expiry fires in softirq |
+| Control-packet expiration (`detect-offload`, UDP/3784) | engine XDP + `bpf_timer` | Each control packet for an Up session re-arms the timer; the frame is **always passed** to the daemon |
+| BFD state machine, Poll/Final, negotiation, control TX | zebra-rs | Unchanged — the data plane never makes protocol decisions |
 
-The daemon and the helper talk over a one-line-per-message stdin/stdout
-protocol: `echo-add <discr> <local> <peer> <tx-us> <mult>` / `echo-del`
-and `detect-add <discr> <detect-us>` / `detect-del` go down;
-`echo-down <discr>` / `detect-down <discr>` come back when a kernel
-timer fires. You never drive this by hand in production, but the verbs
-appear in traces and are handy to know when debugging.
+The daemon and the engine talk over cradle's gRPC control plane, keyed
+by our local BFD discriminator: `ArmBfdEcho` / `DisarmBfdEcho` for the
+Echo originator and return detector, `ArmBfdDetect` / `DisarmBfdDetect`
+for the control watchdog, and a `WatchBfd` server stream that carries
+`echo-down` / `detect-down` back when a kernel timer fires. You never
+drive this by hand in production, but the verbs appear in traces and
+are handy to know when debugging.
 
-## What the helper needs
+## What the offload needs
 
+- **The engine enabled**: `system ebpf enabled true`. The datapath that
+  reflects and originates Echo *is* the eBPF data plane, so BFD offload
+  is coupled to it. Interfaces do **not** need an explicit
+  `interface <name> ebpf enabled` line — a single-hop `echo-mode` /
+  `detect-offload` session
+  [auto-attaches its egress interface](ch-16-00-ebpf.md#automatic-port-attach-for-bfd)
+  as a data-plane port and releases it when the last such session goes.
 - **Kernel**: XDP support, and `bpf_timer` (Linux ≥ 5.15) for the two
   detection offloads. The reflect-only path works without `bpf_timer`.
-- **Capabilities**: `cap_net_admin,cap_bpf` to load and attach the XDP
-  program, plus `cap_net_raw` only if Echo *origination* is used (the
-  `AF_PACKET` socket). The packaged `.deb` install grants all three via
-  postinstall; a hand-installed binary needs
-  `setcap cap_net_admin,cap_bpf,cap_net_raw+ep` (or root).
-- **Binary**: resolved in this order —
-  `$ZEBRA_XDP_BFD_ECHO_BIN` → `~/.zebra/bin/xdp-bfd-echo` →
-  `/usr/sbin/xdp-bfd-echo` (the packaged location).
-- **Attach mode**: `$ZEBRA_XDP_BFD_ECHO_MODE` = `auto` (default) |
-  `native` | `skb`. `auto` tries native/driver XDP and falls back to
-  generic (SKB) mode.
+- **Capabilities**: the engine needs `cap_net_admin,cap_bpf` (plus
+  `cap_perfmon`) to load and attach the XDP program, and `cap_net_raw`
+  for the Echo originator's `AF_PACKET` socket. The `cradle-rs` package
+  grants all of these on `/usr/bin/cradle` via its postinstall.
+- **Binary**: `/usr/bin/cradle`, shipped by the `cradle-rs` Debian
+  package (a `recommends` of the zebra-rs package). No separate BFD
+  helper is installed — the reflector, originator, and watchdogs all
+  live inside the engine.
+- **Control endpoint**: the driver dials `$ZEBRA_CRADLE_BFD_ENDPOINT`,
+  defaulting to `unix:cradle/grpc` — the same per-netns abstract socket
+  the rest of zebra-rs uses to reach the engine.
 
-> **Virtual NICs and veth need SKB mode.** On veth pairs and most
-> virtual NICs, native XDP *attaches successfully* but frames never
-> reach the program — a classic silent failure. Set
-> `ZEBRA_XDP_BFD_ECHO_MODE=skb` in labs and VMs. Physical NICs with
-> real driver support (mlx5, i40e/ice, ixgbe, …) should use native mode
-> for the lowest reflect jitter.
+> **Virtual NICs and veth need generic (SKB) mode.** In native/driver
+> mode, an `XDP_TX` reflection is only delivered to a peer that also has
+> XDP attached, so reflecting off a veth whose far end is a bridge port
+> is silently dropped — the session flaps `Up`↔`Down` with
+> `Echo Function Failed`. Set `CRADLE_XDP_MODE=skb` (equivalently
+> `generic`) in the engine's environment for labs and VMs; the engine
+> then re-injects through the stack and reflects regardless of the
+> peer. Physical NICs with real driver support (mlx5, i40e/ice, ixgbe,
+> …) should stay in native mode for the lowest reflect jitter.
 
-The helper tree lives in `offload/xdp-bfd-echo/` and is **excluded from
-the main cargo workspace** — building it needs the nightly toolchain,
-`bpf-linker`, and LLVM (see its `README.md`). The packaged build does
-this for you; `cargo build` of zebra-rs alone never touches it.
+All of the eBPF/XDP code lives in the separate
+[cradle-rs](https://github.com/zebra-rs/cradle-rs) repository, which
+needs the nightly toolchain, `bpf-linker`, and LLVM to build. `cargo
+build` of zebra-rs never touches it, and the packaged builds are
+independent.
 
 ## Lifecycle
 
-The helper is **reference-counted per interface**. The first session on
-an interface that needs it — any Echo role, or `detect-offload` —
-spawns one process attached to that interface; further sessions share
-it; the last one to go away stops it (SIGTERM, which detaches the XDP
-program cleanly). A node where neither feature is configured runs no
-helper at all.
+zebra-rs keeps a **per-interface refcount** of sessions that need the
+offload — any Echo role, or `detect-offload`. The first one on an
+interface asks the engine to attach that port; the last one to go away
+releases it (unless an `interface … ebpf enabled` leaf keeps it). The
+datapath itself is keyed by discriminator, not by interface; the
+refcount only governs *where* the XDP program is attached. A node where
+neither feature is configured attaches no BFD port at all.
 
-Everything the helper does is gated on it being **confirmed running**
-("honesty gates"):
+Everything the offload does is gated on the engine being **confirmed
+reachable** ("honesty gates"):
 
 - A non-zero `Required Min Echo RX Interval` — the promise to loop a
-  peer's Echo — is only advertised once the child is up.
-- The `detect-offload` watchdog is only armed once the child is up;
-  until then (and on any helper death) detection runs in userspace as
-  usual, and the stretched backstop timer is restored to normal
-  immediately.
+  peer's Echo (RFC 5880 §6.8.1) — is only advertised once the driver's
+  `WatchBfd` stream is connected.
+- The `detect-offload` watchdog is only armed once the engine is up;
+  until then detection runs in userspace as usual.
 
-So a missing binary, missing capabilities, or an unsupported kernel
-never breaks BFD — the affected sessions simply behave as if the
-feature were not configured, and the daemon logs why.
+Reachability is **soft**. If the engine restarts or the stream drops,
+every offloaded session reverts to userspace detection and its
+stretched backstop timer is restored immediately; when the driver
+reconnects (2 s backoff), readiness is refreshed and the Echo/detect
+reconciles re-run for all active sessions. So a missing engine, missing
+capabilities, or an unsupported kernel never breaks BFD — the affected
+sessions simply behave as if the feature were not configured, and the
+daemon logs why.
 
 ## Verifying and troubleshooting
 
-`show bfd peers` tells you per session what the helper is doing:
+`show bfd peers` tells you per session what the offload is doing:
 
 ```
     Detection timeout: 900ms
@@ -101,32 +117,33 @@ feature were not configured, and the daemon logs why.
 ```
 
 `Detection runs in: userspace` with `detect-offload true` configured,
-or an Echo interval stuck at `disabled`, means the helper is not up for
-that interface. Check in order:
+or an Echo interval stuck at `disabled`, means the offload is not up
+for that session. Check in order:
 
-1. **Is the process running?** `pgrep -a xdp-bfd-echo` — one per
-   expected interface, with `-i <ifname>` in the arguments.
-2. **Binary present and executable** at one of the resolution paths
-   above, with the capabilities set (`getcap /usr/sbin/xdp-bfd-echo`).
-3. **Attach mode**: on veth/VM NICs, force `skb` (see above). The
-   helper's own log line says which mode actually attached.
-4. **Kernel support**: `bpf_timer` needs ≥ 5.15; the verifier rejects
+1. **Is the engine running?** `show ebpf` — `System ebpf: enabled` and
+   `Engine: managed (pid …)`. Without `system ebpf enabled true` there
+   is no BFD datapath.
+2. **Is the interface a port?** The same `show ebpf` port table should
+   list it, labelled `bfd` (auto-attached) or `config,bfd`:
+
+   ```
+     Ports:           1 wanted (0 config, 1 bfd), 1 attached
+       enp0s7           ifindex 4      vrf 0     bfd         attached
+   ```
+3. **Binary present with capabilities**: `/usr/bin/cradle`, and
+   `getcap /usr/bin/cradle` showing
+   `cap_net_admin,cap_bpf,cap_perfmon,cap_net_raw`.
+4. **Attach mode**: on veth/VM NICs, force `CRADLE_XDP_MODE=skb` (see
+   above). The engine logs which mode actually attached.
+5. **Kernel support**: `bpf_timer` needs ≥ 5.15; the verifier rejects
    the program on older kernels.
-5. **Traces**: `set bfd tracing true` makes the daemon log helper
-   spawn/stop, the IPC verbs, and session state changes; the helper
-   itself logs to stderr (`RUST_LOG=info`).
-
-The helper can also be run standalone for testing (`xdp-bfd-echo -i
-<iface> -m skb`), and the repository ships two self-contained veth
-tests that exercise the data plane end to end as root:
-`offload/xdp-bfd-echo/scripts/veth-test.sh` (Echo reflect) and
-`scripts/veth-detect-test.sh` (the expiration watchdog: streams control
-packets, asserts the kernel timer re-arms, then fires after the stream
-stops).
+6. **Traces**: `set bfd tracing true` makes the daemon log the arm /
+   disarm RPCs, engine reachability transitions, and session state
+   changes; the engine's own output is merged into the zebra-rs log.
 
 ## Scope and limits
 
-- **Single-hop sessions only.** The helper attaches per interface;
+- **Single-hop sessions only.** The XDP program runs on attached ports;
   multihop ingress is not bound to one (and multihop's TTL floor is
   below the GTSM 255 the watchdog requires). Multihop sessions simply
   keep full userspace behavior.
@@ -139,6 +156,6 @@ stops).
 - **No authentication.** If BFD authentication is added in the future,
   authenticated sessions must not be offloaded — XDP cannot verify
   MD5/SHA digests. Today zebra-rs has no BFD auth, so this is moot.
-- The same process/scaffolding is designed to grow the **S-BFD**
+- The same engine and scaffolding are designed to grow the **S-BFD**
   (UDP 7784/7785) and **STAMP** (UDP 862) reflectors later; see the
   design notes for that roadmap.

--- a/book/src/ch-14-05-show-bfd-stamp-nd.md
+++ b/book/src/ch-14-05-show-bfd-stamp-nd.md
@@ -52,7 +52,7 @@ JSON: an array of interface objects with `ra_scheduler`, `counters`,
 ## BFD
 
 See [BFD](ch-10-00-bfd.md) for configuration and the
-[XDP/eBPF data-plane helper](ch-10-01-bfd-xdp-helper.md).
+[BFD offload in the eBPF data plane](ch-10-01-bfd-xdp-helper.md).
 
 ### `show bfd`
 

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -268,7 +268,7 @@ message FdbEvent {
   uint32 event = 3;
 }
 
-// --- BFD Echo / detection offload (absorbed from the xdp-bfd-echo helper) ---
+// --- BFD Echo / detection offload ---
 // Arm the Echo *originator* + return detector for a single-hop session: cradle
 // transmits a self-addressed Echo (udp/3785) toward `peer` every `tx_us`
 // (jittered) and times the returns in-kernel (bpf_timer); if returns stop for
@@ -523,8 +523,8 @@ service Cradle {
   rpc AddFdbRemote(FdbRemote) returns (Empty);
   rpc DelFdbRemote(FdbRemoteDel) returns (Empty);
   rpc WatchFdb(WatchFdbRequest) returns (stream FdbEvent);
-  // BFD Echo / detection offload (absorbed xdp-bfd-echo). Arm/disarm are keyed
-  // by our local discriminator; WatchBfd streams echo-down / detect-down.
+  // BFD Echo / detection offload. Arm/disarm are keyed by our local
+  // discriminator; WatchBfd streams echo-down / detect-down.
   rpc ArmBfdEcho(BfdEcho) returns (Empty);
   rpc DisarmBfdEcho(BfdKey) returns (Empty);
   rpc ArmBfdDetect(BfdDetect) returns (Empty);

--- a/zebra-rs/src/bfd/fsm.rs
+++ b/zebra-rs/src/bfd/fsm.rs
@@ -22,7 +22,7 @@ pub enum Event {
     /// The Echo detection timer expired: our originated Echo stopped
     /// returning within `echo-interval × detect-mult` (RFC 5880 §6.8.5).
     /// Drives Down like `DetectExpired` but records `EchoFunctionFailed`.
-    /// Reported by the per-interface helper over its IPC channel.
+    /// Reported by the eBPF data plane over its IPC channel.
     EchoDetectExpired,
     /// Administrative shutdown requested (e.g. `shutdown` under a
     /// `bfd peer` block).

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -74,7 +74,7 @@ pub struct Bfd {
     /// up (the receiver is gone) — v6 simply doesn't work in that case.
     write_tx_v6: UnboundedSender<WriteRequest>,
     timer_handles: HashMap<SessionKey, TimerHandle>,
-    /// Supervises the per-interface XDP Echo reflector child processes.
+    /// Drives the Echo / detection offload in the eBPF data plane.
     /// Reference-counted by the single-hop echo sessions on each ifindex
     /// ([`Self::add_session`] / [`Self::remove_session`]).
     reflectors: super::reflector::EchoReflectors,
@@ -171,11 +171,11 @@ pub enum Message {
     /// watchdog armed this is the stretched *backstop* firing (helper dead or
     /// wedged); otherwise it is the primary RFC 5880 §6.8.4 detection.
     DetectExpired { key: SessionKey },
-    /// The per-interface helper reported that our originated Echo for the
+    /// The eBPF data plane reported that our originated Echo for the
     /// session with this local discriminator stopped returning (Echo detection
     /// timeout). Drives the session Down with `EchoFunctionFailed`.
     EchoDown { discr: u32 },
-    /// The per-interface helper reported that the in-kernel expiration
+    /// The eBPF data plane reported that the in-kernel expiration
     /// watchdog fired for this local discriminator: no control packet arrived
     /// at the interface within the programmed detection time (RFC 5880 §6.8.4
     /// evaluated in XDP/`bpf_timer`). Drives the same transition as the
@@ -457,7 +457,7 @@ impl Bfd {
         // Echo and the expiration watchdog are single-hop only; both IPv4 and
         // IPv6 are handled (the XDP helper reflects/observes either family).
         // Any active Echo role or a detect-offload intent needs the
-        // per-interface helper: `receive` reflects a peer's Echo, `transmit`
+        // eBPF data plane: `receive` reflects a peer's Echo, `transmit`
         // sends + detects ours, `detect-offload` times the peer's control
         // packets in-kernel. Bring it up and mark the session `echo_ready`
         // once the child is confirmed running — until then we advertise 0 (an
@@ -881,7 +881,7 @@ impl Bfd {
         self.detect_offload_reconcile(key);
     }
 
-    /// The per-interface helper reported that our originated Echo for the
+    /// The eBPF data plane reported that our originated Echo for the
     /// session with local discriminator `discr` stopped returning (RFC 5880
     /// §6.8.5). Drive the session Down with `EchoFunctionFailed`, then reconcile
     /// the originator — the session is no longer Up, so we stop sending Echo.
@@ -900,7 +900,7 @@ impl Bfd {
         self.detect_offload_reconcile(key);
     }
 
-    /// The per-interface helper reported that the in-kernel expiration
+    /// The eBPF data plane reported that the in-kernel expiration
     /// watchdog fired for the session with local discriminator `discr`: no
     /// control packet arrived at the interface within the programmed
     /// detection time (RFC 5880 §6.8.4, evaluated in XDP/`bpf_timer`). Drive
@@ -973,17 +973,17 @@ impl Bfd {
     }
 
     /// Arm, retune, or disarm the in-kernel expiration watchdog for `key` —
-    /// the XDP helper's `CONTROL_TIMERS` `bpf_timer`, re-armed by every
-    /// control packet arriving for our discriminator (see cradle-rs
-    /// `crates/xdp-bfd-echo`). Mirrors [`Self::echo_originate_reconcile`]:
-    /// the desired kernel detection time is compared to the armed one
-    /// (`Session::kernel_detect_us`) and `detect-add`/`detect-del` are sent
-    /// exactly on the edges; a changed value re-sends `detect-add`, which the
-    /// helper applies as an update.
+    /// the `cradle_xdp` program's `CONTROL_TIMERS` `bpf_timer`, re-armed by
+    /// every control packet arriving for our discriminator (see cradle-rs
+    /// `crates/cradle-ebpf/src/bfd.rs`). Mirrors
+    /// [`Self::echo_originate_reconcile`]: the desired kernel detection time
+    /// is compared to the armed one (`Session::kernel_detect_us`) and
+    /// `detect-add`/`detect-del` are sent exactly on the edges; a changed
+    /// value re-sends `detect-add`, which cradle applies as an update.
     ///
     /// Armed only while the session is **Up** — before establishment the
     /// peer may send `Your Discriminator = 0`, which the XDP program cannot
-    /// key — and only single-hop: the helper attaches per interface, and
+    /// key — and only single-hop: `cradle_xdp` runs on attached ports, and
     /// multihop ingress isn't bound to one (its TTL floor is also below the
     /// GTSM 255 the observer requires). While armed, the userspace detection
     /// timer is stretched to a backstop ([`DETECT_BACKSTOP_FACTOR`]) so the
@@ -1041,7 +1041,7 @@ impl Bfd {
 
     /// RFC 5880 §6.8.9 — start or stop *originating* Echo for `key` based on the
     /// session's current gate, emitting `echo-add`/`echo-del` to the
-    /// per-interface helper exactly on the edges (tracked by
+    /// eBPF data plane exactly on the edges (tracked by
     /// [`Session::echo_originating`]).
     ///
     /// We originate only while the session is **Up**, our configured Echo mode
@@ -1562,8 +1562,8 @@ mod tests {
     // ---- runtime Echo param updates (`Bfd::update_echo_params`) -------------
 
     /// An ifindex with no backing interface: `acquire` tracks the refcount
-    /// but the helper child never spawns (`if_indextoname` fails), so these
-    /// tests exercise the bookkeeping without launching real XDP processes.
+    /// but nothing reaches the data plane (there is no cradle engine under
+    /// test), so these tests exercise the bookkeeping in isolation.
     const ECHO_TEST_IFINDEX: u32 = 0xfff0;
 
     fn echo_key(remote_octet: u8) -> SessionKey {
@@ -1789,7 +1789,7 @@ mod tests {
     }
 
     /// A single-hop subscribe with detect-offload configured refcounts the
-    /// per-interface helper even with Echo off; the last unsubscribe
+    /// eBPF data plane even with Echo off; the last unsubscribe
     /// releases it. Multihop never does.
     #[tokio::test]
     async fn detect_offload_refcounts_reflector() {

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -107,7 +107,7 @@ pub struct SessionParams {
     /// `Required Min Echo RX` at send time (RFC 5880 §6.8.9).
     pub echo_transmit_us: u32,
     /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
-    /// per-interface XDP helper once the session is Up: the kernel re-arms a
+    /// XDP data plane once the session is Up: the kernel re-arms a
     /// per-session `bpf_timer` on every arriving control packet and reports
     /// `detect-down` when they stop — immune to daemon scheduling latency.
     /// Single-hop only. The userspace detection timer stays armed as a
@@ -197,8 +197,8 @@ pub struct Session {
     /// Interval (microseconds) at which we originate Echo when
     /// [`EchoMode::transmits`]; clamped up to the peer's advertised echo-rx.
     pub echo_transmit_us: u32,
-    /// Whether the per-interface XDP Echo reflector is confirmed up. The
-    /// instance sets this once the child has spawned; until then we advertise
+    /// Whether the XDP Echo reflector is confirmed up. The
+    /// instance sets this once the engine is reachable; until then we advertise
     /// 0 even with `required_min_echo_rx_us` configured, so the non-zero
     /// advertisement stays an honest promise to actually loop Echo back.
     pub echo_ready: bool,

--- a/zebra-rs/src/bfd/trace.rs
+++ b/zebra-rs/src/bfd/trace.rs
@@ -3,8 +3,8 @@
 //! Every trace emitted under `src/bfd/` is gated behind a single runtime flag,
 //! toggled with `set bfd tracing true`. The flag is a process-global atomic so
 //! the gate works from every BFD context — the instance methods, the spawned
-//! socket read/write tasks, and the per-interface `xdp-bfd-echo` reflector IPC
-//! tasks — without threading state through each call site.
+//! socket read/write tasks, and the cradle Echo/detect offload driver task —
+//! without threading state through each call site.
 //!
 //! Use the level-preserving macros [`bfd_info!`], [`bfd_warn!`] and
 //! [`bfd_debug!`] in place of `tracing::{info,warn,debug}!`; each expands to a

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1300,7 +1300,7 @@ pub(super) fn bfd_apply_ident(bgp: &mut Bgp, ident: usize) -> Option<()> {
             255 // GTSM (RFC 5881 §5): single-hop accepts only TTL 255.
         };
         // Key single-hop sessions by the connected interface when we know it
-        // (from `RibRx::AddrAdd`): the per-interface XDP helper — the Echo
+        // (from `RibRx::AddrAdd`): the XDP data plane — the Echo
         // reflector and the expiration watchdog — attaches by ifindex, so an
         // ifindex-0 key can never bring it up. Unknown (no address info yet,
         // or a v6 link-local peer) falls back to 0 — the session still works,
@@ -1492,7 +1492,7 @@ fn config_peer_bfd_echo_rx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 
 /// `set router bgp neighbor X bfd detect-offload <bool>` — offload
 /// control-packet expiration detection (RFC 5880 §6.8.4) to the
-/// per-interface XDP helper once the session is Up. Single-hop only
+/// XDP data plane once the session is Up. Single-hop only
 /// (inert on multihop sessions).
 fn config_peer_bfd_detect_offload(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
@@ -5139,7 +5139,7 @@ mod bfd_wiring_tests {
 
     /// A single-hop session is keyed by the connected interface once the
     /// covering address is known, and `detect-offload` rides the params —
-    /// both feed the per-interface XDP helper. An address learned AFTER
+    /// both feed the XDP data plane. An address learned AFTER
     /// `bfd enable` re-keys the session (unsubscribe + resubscribe).
     #[tokio::test]
     async fn single_hop_key_carries_connected_ifindex_and_detect_offload() {

--- a/zebra-rs/src/bgp/connected.rs
+++ b/zebra-rs/src/bgp/connected.rs
@@ -84,7 +84,7 @@ impl ConnectedSubnets {
     }
 
     /// The interface a directly-connected `ip` lives on, if known — used to
-    /// key single-hop BFD sessions so the per-interface XDP helper (Echo
+    /// key single-hop BFD sessions so the XDP data plane (Echo
     /// reflector + expiration watchdog) can attach to the right link.
     /// IPv6 link-locals are excluded: `fe80::/64` is recorded by *every*
     /// v6 interface, so a covering match would be meaningless (link-local
@@ -204,7 +204,7 @@ mod tests {
     }
 
     /// `ifindex_for` resolves a covered peer to the recording interface —
-    /// the key the per-interface XDP helper (Echo / expiration watchdog)
+    /// the key the XDP data plane (Echo / expiration watchdog)
     /// needs — and returns `None` for uncovered peers, link-local v6, and
     /// after the subnet's last address is forgotten.
     #[test]

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4013,7 +4013,7 @@ impl Bgp {
                 self.connected_subnets.record(&addr);
                 self.refresh_connected();
                 // The connected ifindex keys single-hop BFD sessions (the
-                // per-interface XDP helper attaches by it): re-reconcile so a
+                // XDP data plane attaches by it): re-reconcile so a
                 // session subscribed before this address was learned picks up
                 // its concrete ifindex. Per-neighbor no-op when unchanged.
                 super::config::bfd_reconcile_all(self);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -378,7 +378,7 @@ pub struct PeerBfdConfig {
     /// [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_receive_ms: Option<u32>,
     /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
-    /// per-interface XDP helper once the session is Up. Single-hop only —
+    /// XDP data plane once the session is Up. Single-hop only —
     /// inert on multihop sessions (the helper attaches per interface).
     /// `None` ⇒ inherit (hard default `false`: detection in userspace).
     pub detect_offload: Option<bool>,

--- a/zebra-rs/src/cradle/supervisor.rs
+++ b/zebra-rs/src/cradle/supervisor.rs
@@ -33,7 +33,7 @@ pub enum EngineEvent {
     Down,
 }
 
-/// Binary resolution override (mirrors `ZEBRA_XDP_BFD_ECHO_BIN`).
+/// Binary resolution override for the engine.
 const BIN_ENV: &str = "ZEBRA_CRADLE_BIN";
 /// Liveness-probe cadence for an adopted (externally-started) engine.
 const PROBE_INTERVAL: Duration = Duration::from_secs(5);

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1530,8 +1530,8 @@ impl CradleFib {
         Ok(resp.into_inner())
     }
 
-    /// Arm cradle's Echo originator + return detector for `discr` (absorbed
-    /// xdp-bfd-echo). cradle transmits self-addressed Echo out `oif` toward
+    /// Arm cradle's Echo originator + return detector for `discr`.
+    /// cradle transmits self-addressed Echo out `oif` toward
     /// `peer` at `tx_us` and times the returns in-kernel; `WatchBfd` streams
     /// echo-down when they stop. BFD state is soft — a lost session re-arms on
     /// the next reconcile — so this is not mirrored/replayed.

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -371,7 +371,7 @@ pub struct LinkBfdConfig {
     /// [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_receive_ms: Option<u32>,
     /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
-    /// per-interface XDP helper once the session is Up. `None` ⇒ inherit
+    /// XDP data plane once the session is Up. `None` ⇒ inherit
     /// (hard default `false`: detection in userspace).
     pub detect_offload: Option<bool>,
 }
@@ -1094,7 +1094,7 @@ pub fn config_bfd_echo_receive_interval(
 }
 
 /// `interface X bfd detect-offload <bool>` — offload control-packet expiration
-/// detection (RFC 5880 §6.8.4) to the per-interface XDP helper once the
+/// detection (RFC 5880 §6.8.4) to the XDP data plane once the
 /// session is Up. Overrides the instance default; the BFD instance arms /
 /// disarms the in-kernel watchdog on live sessions.
 pub fn config_bfd_detect_offload(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -1671,7 +1671,7 @@ pub(super) fn config_ospf_interface_bfd_echo_receive_interval<V: OspfVersion>(
 }
 
 /// `interface <if> bfd detect-offload <bool>` — offload control-packet
-/// expiration detection to the per-interface XDP helper once the session is
+/// expiration detection to the XDP data plane once the session is
 /// Up (RFC 5880 §6.8.4 evaluated in-kernel). Reconciles the link; the BFD
 /// instance arms/disarms the watchdog on live sessions.
 pub(super) fn config_ospf_interface_bfd_detect_offload<V: OspfVersion>(

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -262,7 +262,7 @@ pub struct OspfLinkBfdConfig {
     pub min_neighbor_state: Option<NbrStateThreshold>,
     /// BFD Echo role for this interface's single-hop sessions
     /// (`transmit` / `receive` / `both`); `None` ⇒ inherit (Echo off if unset
-    /// everywhere). Backed by the per-interface `xdp-bfd-echo` helper;
+    /// everywhere). Backed by the cradle eBPF data plane;
     /// honoured for OSPFv2, inert for v3 (IPv6).
     pub echo_mode: Option<EchoMode>,
     /// Echo transmit interval (milliseconds) — the rate we originate Echo at
@@ -272,7 +272,7 @@ pub struct OspfLinkBfdConfig {
     /// (`receive` / `both`). `None` ⇒ inherit / [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_receive_ms: Option<u32>,
     /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
-    /// per-interface XDP helper once the session is Up — detection immune to
+    /// XDP data plane once the session is Up — detection immune to
     /// daemon scheduling latency. `None` ⇒ inherit (hard default `false`:
     /// detection in userspace).
     pub detect_offload: Option<bool>,

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3603,7 +3603,7 @@ module config {
                 "Enable the BFD Echo function (RFC 5880 §6.4) on this
                  interface's single-hop adjacencies (IPv4, or IPv6 over
                  the link-local pair), choosing which half is active.
-                 Backed by the per-interface `xdp-bfd-echo` helper.
+                 Backed by the eBPF data plane (system ebpf enabled).
                  Overrides the instance default; absent ⇒ inherit.";
             }
             leaf echo-transmit-interval {
@@ -3623,11 +3623,11 @@ module config {
                  `receive`/`both`). Hard default 50 ms when unset.";
             }
             leaf detect-offload {
-              ext:help "Offload expiration detection to the XDP helper (kernel)";
+              ext:help "Offload expiration detection to the XDP data plane (kernel)";
               type boolean;
               description
                 "Once the session is Up, detect missing BFD control
-                 packets in the kernel: the per-interface XDP/eBPF helper
+                 packets in the kernel: the XDP/eBPF data plane
                  re-arms a per-session timer on every arriving control
                  packet (UDP/3784, TTL 255) and drives the session Down
                  with Control Detection Time Expired when they stop

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -131,17 +131,17 @@ module zebra-bgp-bfd {
          Hard default 50 ms when unset.";
     }
     leaf detect-offload {
-      ext:help "Offload expiration detection to the XDP helper (kernel)";
+      ext:help "Offload expiration detection to the XDP data plane (kernel)";
       type boolean;
       description
         "Once the session is Up, detect missing BFD control packets in
-         the kernel: the per-interface XDP/eBPF helper re-arms a
+         the kernel: the XDP/eBPF data plane re-arms a
          per-session timer on every arriving control packet (UDP/3784,
          TTL 255) and drives the session Down with Control Detection
          Time Expired when they stop (RFC 5880 §6.8.4) — immune to
          daemon scheduling latency. The userspace detection timer stays
          armed as a stretched backstop. **Single-hop only** — inert on
-         multihop sessions (the helper attaches per interface). Absent ⇒
+         multihop sessions (the XDP program runs on attached ports). Absent ⇒
          inherit (false: detection in userspace).";
     }
   }

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -459,9 +459,9 @@ module zebra-bgp-vrf {
           description "Advertised Required Min Echo RX. Default 50ms when unset.";
         }
         leaf detect-offload {
-          ext:help "Offload expiration detection to the XDP helper";
+          ext:help "Offload expiration detection to the XDP data plane";
           type boolean;
-          description "Detect missing control packets in the kernel XDP helper. Absent ⇒ userspace.";
+          description "Detect missing control packets in the kernel XDP data plane. Absent ⇒ userspace.";
         }
       }
 

--- a/zebra-rs/yang/zebra-ospf-bfd.yang
+++ b/zebra-rs/yang/zebra-ospf-bfd.yang
@@ -52,7 +52,7 @@ module zebra-ospf-bfd {
      single-hop (UDP/3784, GTSM TTL=255) — there is no multihop knob.
 
      OSPFv3 BFD runs over IPv6 link-local; Echo works there too — the
-     XDP helper reflects and originates both IPv4 and IPv6 Echo.";
+     XDP data plane reflects and originates both IPv4 and IPv6 Echo.";
 
   revision 2026-06-12 {
     description
@@ -145,8 +145,8 @@ module zebra-ospf-bfd {
       description
         "Enable the BFD Echo function (RFC 5880 §6.4) on this interface's
          single-hop sessions, choosing which half (or both) is active.
-         Backed by the per-interface `xdp-bfd-echo` XDP/eBPF helper,
-         which handles both address families: IPv4 on OSPFv2, IPv6 (the
+         Backed by the XDP/eBPF data plane (system ebpf enabled), which
+         handles both address families: IPv4 on OSPFv2, IPv6 (the
          link-local pair) on OSPFv3. Absent ⇒ Echo off.";
     }
 
@@ -171,11 +171,11 @@ module zebra-ospf-bfd {
     }
 
     leaf detect-offload {
-      ext:help "Offload expiration detection to the XDP helper (kernel)";
+      ext:help "Offload expiration detection to the XDP data plane (kernel)";
       type boolean;
       description
         "Once the session is Up, detect missing control packets in the
-         kernel: the per-interface XDP/eBPF helper re-arms a per-session
+         kernel: the XDP/eBPF data plane re-arms a per-session
          timer on every arriving BFD control packet (UDP/3784, TTL 255)
          and drives the session Down with Control Detection Time Expired
          when they stop (RFC 5880 §6.8.4) — immune to daemon scheduling


### PR DESCRIPTION
`/usr/sbin/xdp-bfd-echo` no longer exists. Phase 2 of the eBPF offload consolidation absorbed BFD Echo reflect/originate and the in-kernel detection watchdog into cradle (`cradle_xdp` + `crates/cradle/src/bfd_echo.rs`), driven by zebra over gRPC (`ArmBfdEcho` / `ArmBfdDetect` / `WatchBfd`), and `offload/` was deleted from this tree.

The docs and comments still described the retired per-interface child process, pointing operators at a binary that is not installed and a model that no longer holds.

## What changed

- **`ch-10-01` rewritten** as *BFD Offload in the eBPF Data Plane* — cradle gRPC verbs instead of the stdin line protocol, `system ebpf enabled` + BFD port auto-attach instead of per-interface spawn, `CRADLE_XDP_MODE=skb` instead of `ZEBRA_XDP_BFD_ECHO_MODE`, `show ebpf` in the troubleshooting steps, caps on `/usr/bin/cradle`. Filename kept so existing links resolve; title and the 4 inbound links updated.
- **`ch-00-07-building`** claimed a `--no-xdp` flag and an LLVM/`bpf-linker`/nightly requirement. Both stale — `packaging/setup-build-env.sh` already dropped them and the deb no longer bundles the helper. Now states stable Rust alone builds this tree.
- **BFD sections** of the BGP / IS-IS / OSPF chapters, `ch-10-00-bfd`, and the intro.
- **Beyond the literal name**, the wider *"per-interface XDP helper / child process"* model is also wrong now — the datapath is a multi-port engine keyed by discriminator. Swept out of the BFD/BGP/OSPF/IS-IS comments and 4 YANG modules, including user-visible `ext:help` strings.

## Deliberately not changed

- **`docs/design/*` (8 files)** — dated design records; `ebpf-offload-consolidation.md` *is* the plan that retired the helper, so stripping the name would make the record unreadable.
- **Symbols** like `Message::HelperReady` / `on_helper_gone()` — renaming is a refactor, not a doc fix.

## Verification

`cargo test -p zebra-rs` 1730 passed · `cargo fmt --all --check` clean · `mdbook build` clean. Documentation and comments only — no behaviour change. All four `@bfd_echo` BDD features pass on a host with no `xdp-bfd-echo` installed, which is what prompted this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)