### PR TITLE
bgp: add a `sharding` tracing category; repair 6 BDD regressions

### DIFF
--- a/bdd/tests/configs/bgp_egress_group_task/z2.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z2.yaml
@@ -1,5 +1,7 @@
 router:
   bgp:
+    tracing:
+      sharding: null
     global:
       as: 65002
       router-id: 10.0.0.2

--- a/bdd/tests/configs/bgp_network_origin_shard_pet/z1.yaml
+++ b/bdd/tests/configs/bgp_network_origin_shard_pet/z1.yaml
@@ -1,5 +1,7 @@
 router:
   bgp:
+    tracing:
+      sharding: null
     global:
       as: 65501
       router-id: 10.0.0.1

--- a/bdd/tests/configs/bgp_peer_task_config_knob/z2.yaml
+++ b/bdd/tests/configs/bgp_peer_task_config_knob/z2.yaml
@@ -1,5 +1,7 @@
 router:
   bgp:
+    tracing:
+      sharding: null
     global:
       as: 65002
       router-id: 10.0.0.2

--- a/bdd/tests/configs/bgp_shard_config_knob/z2.yaml
+++ b/bdd/tests/configs/bgp_shard_config_knob/z2.yaml
@@ -1,5 +1,7 @@
 router:
   bgp:
+    tracing:
+      sharding: null
     global:
       as: 65002
       router-id: 10.0.0.2

--- a/bdd/tests/configs/bgp_sync_backpressure/z2.yaml
+++ b/bdd/tests/configs/bgp_sync_backpressure/z2.yaml
@@ -1,5 +1,7 @@
 router:
   bgp:
+    tracing:
+      adj-out: null
     global:
       as: 65002
       router-id: 10.0.0.2

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/d.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/d.yaml
@@ -36,8 +36,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n1.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n1.yaml
@@ -41,8 +41,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n2.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n2.yaml
@@ -35,8 +35,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n3.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n3.yaml
@@ -35,8 +35,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r1.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r1.yaml
@@ -41,8 +41,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r2.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r2.yaml
@@ -38,8 +38,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r3.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r3.yaml
@@ -35,8 +35,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/s.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/s.yaml
@@ -44,8 +44,6 @@ router:
       advertise-definition: true
       dataplane:
         srv6: true
-      fast-reroute:
-        ti-lfa: {}
     interface:
     - if-name: lo
       ipv6:

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -22,8 +22,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 317
-Handled: 303
+Total settable schema nodes: 318
+Handled: 304
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -265,6 +265,7 @@
 /router/bgp/tracing/packet/update	p-container
 /router/bgp/tracing/packet/update/detail	leaf
 /router/bgp/tracing/packet/update/direction	leaf
+/router/bgp/tracing/sharding	leaf
 /router/bgp/tracing/srv6	leaf
 /router/bgp/tracing/vpn	leaf
 /router/bgp/tracing/vrf	leaf

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -124,16 +124,31 @@ impl GroupEgressTask {
     /// (the group emptied).
     pub fn spawn(id: UpdateGroupId) -> Self {
         let (delta_tx, mut delta_rx) = mpsc::unbounded_channel::<GroupEgressDeltaV4>();
-        // Debug, matching the "exited" line below: `spawn` is a plain
-        // constructor with no `BgpTracing` in reach, and it fires once
-        // per update-group.
-        tracing::debug!("BGP egress group task: spawned (group {id:?})");
+        // `spawn` is a plain constructor with no `BgpTracing` in reach, so
+        // both this and the "exited" line below ride the process-global
+        // `sharding` gate (see `bgp::tracing::TRACE_SHARDING`). Read once
+        // here so the spawned task carries the decision instead of
+        // re-reading the global after an unrelated config edit.
+        let trace = crate::bgp::tracing::trace_sharding();
+        if trace {
+            tracing::info!(
+                proto = "bgp",
+                category = "sharding",
+                "BGP egress group task: spawned (group {id:?})"
+            );
+        }
         let task = Task::spawn(async move {
             let mut engine = Engine::default();
             while let Some(delta) = delta_rx.recv().await {
                 engine.handle(delta);
             }
-            tracing::debug!("BGP egress group task: exited (group {id:?})");
+            if trace {
+                tracing::info!(
+                    proto = "bgp",
+                    category = "sharding",
+                    "BGP egress group task: exited (group {id:?})"
+                );
+            }
         });
         GroupEgressTask { delta_tx, task }
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -525,13 +525,25 @@ pub fn init_shard_count(config_shards: Option<usize>) -> usize {
     } else {
         "default"
     };
-    if n > 1 {
-        // Debug, not info: this runs inside `spawn_bgp`, before any
-        // `BgpTracing` exists to gate it against.
-        tracing::debug!("BGP RIB sharding: {n} shards (from {source})");
-    } else {
-        // Disable default logging.
-        // tracing::info!("BGP RIB sharding: 1 shard, synchronous (from {source})");
+    // Gated on the process-global `sharding` category rather than a
+    // `BgpTracing`: this runs inside `spawn_bgp`, before `Bgp::new`
+    // builds one. `spawn_bgp` seeds the global from the candidate
+    // config first, so a `router bgp tracing sharding` in the same
+    // commit is already visible here.
+    if crate::bgp::tracing::trace_sharding() {
+        if n > 1 {
+            tracing::info!(
+                proto = "bgp",
+                category = "sharding",
+                "BGP RIB sharding: {n} shards (from {source})"
+            );
+        } else {
+            tracing::info!(
+                proto = "bgp",
+                category = "sharding",
+                "BGP RIB sharding: 1 shard, synchronous (from {source})"
+            );
+        }
     }
     n
 }

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -66,13 +66,15 @@ pub fn init_peer_task(config: Option<bool>) -> bool {
     } else {
         "default"
     };
-    if on {
-        // Debug, not info: this runs inside `spawn_bgp`, before any
-        // `BgpTracing` exists to gate it against.
-        tracing::debug!("BGP per-peer egress task: enabled (from {source})");
-    } else {
-        // Disable default logging.
-        // tracing::info!("BGP per-peer egress task: disabled (from {source})");
+    // Same gate as `init_shard_count` — see `bgp::tracing::TRACE_SHARDING`
+    // for why this is a process-global and not a `BgpTracing` read.
+    if crate::bgp::tracing::trace_sharding() {
+        let state = if on { "enabled" } else { "disabled" };
+        tracing::info!(
+            proto = "bgp",
+            category = "sharding",
+            "BGP per-peer egress task: {state} (from {source})"
+        );
     }
     on
 }

--- a/zebra-rs/src/bgp/tracing.rs
+++ b/zebra-rs/src/bgp/tracing.rs
@@ -291,6 +291,11 @@ pub struct BgpTracing {
     pub srv6: bool,
     pub vrf: bool,
     pub bfd: bool,
+    /// Instance-lifetime knobs frozen at spawn: the RIB shard count, the
+    /// per-peer egress-task model, and update-group egress task
+    /// spawn/exit. Mirrored into [`TRACE_SHARDING`] because those sites
+    /// run where no `BgpTracing` is in reach — see [`trace_sharding`].
+    pub sharding: bool,
 }
 
 impl BgpTracing {
@@ -358,6 +363,36 @@ impl BgpTracing {
     pub fn should_trace_bfd(&self) -> bool {
         self.all || self.bfd
     }
+
+    pub fn should_trace_sharding(&self) -> bool {
+        self.all || self.sharding
+    }
+}
+
+/// Process-global mirror of [`BgpTracing::should_trace_sharding`].
+///
+/// The sharding trace sites cannot reach a `BgpTracing`: `init_shard_count`
+/// and `init_peer_task` run inside `spawn_bgp` *before* `Bgp::new` builds
+/// the instance, and `GroupEgressTask::spawn` is a plain constructor with
+/// neither a `Bgp` nor a `Peer` in scope. A process-global atomic gives
+/// every one of them the same gate — the pattern `bfd::trace` already uses
+/// for its socket tasks.
+///
+/// Seeded by `spawn_bgp` from a candidate-config scan *before*
+/// `init_shard_count` runs (so the freeze-time lines see it), then kept in
+/// step with the live config by [`config_tracing_dispatch`] so a runtime
+/// `set router bgp tracing sharding` reaches update-group tasks spawned
+/// later.
+static TRACE_SHARDING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Set the process-global sharding gate. See [`TRACE_SHARDING`].
+pub fn set_trace_sharding(on: bool) {
+    TRACE_SHARDING.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether the spawn-time sharding / egress-model traces are enabled.
+pub fn trace_sharding() -> bool {
+    TRACE_SHARDING.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 fn parse_direction(args: &mut Args) -> Direction {
@@ -418,6 +453,7 @@ fn apply_tracing(t: &mut BgpTracing, rest: &str, args: &mut Args, op: ConfigOp) 
         "/srv6" => t.srv6 = op.is_set(),
         "/vrf" => t.vrf = op.is_set(),
         "/bfd" => t.bfd = op.is_set(),
+        "/sharding" => t.sharding = op.is_set(),
         other => {
             let pkt = other.strip_prefix("/packet/")?;
             let (typ, sub) = match pkt.split_once('/') {
@@ -481,6 +517,11 @@ pub fn propagate_instance_tracing(bgp: &mut Bgp) {
     for (_, peer) in bgp.peers.iter_mut_all() {
         peer.tracing_instance = snapshot.clone();
     }
+    // Sharding is instance-scoped and read from contexts that hold no
+    // `BgpTracing` at all, so it rides a process-global rather than a
+    // per-peer snapshot. Only the instance config feeds it — a
+    // per-neighbor `tracing sharding` would be meaningless.
+    set_trace_sharding(snapshot.should_trace_sharding());
     bgp.broadcast_tracing();
 }
 
@@ -515,6 +556,36 @@ mod tests {
         assert!(t.vpn && t.srv6 && t.vrf && t.bfd);
         apply_tracing(&mut t, "/vpn", &mut args(&[]), ConfigOp::Delete);
         assert!(!t.vpn);
+
+        apply_tracing(&mut t, "/sharding", &mut args(&[]), ConfigOp::Set);
+        assert!(t.sharding);
+        apply_tracing(&mut t, "/sharding", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.sharding);
+    }
+
+    #[test]
+    fn sharding_follows_all_master_switch() {
+        let mut t = BgpTracing::default();
+        assert!(!t.should_trace_sharding());
+
+        // The `all` master switch implies the category, matching
+        // `trace_sharding_from_config_text`'s spawn-time scan.
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_sharding());
+
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.should_trace_sharding());
+        apply_tracing(&mut t, "/sharding", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_sharding());
+    }
+
+    #[test]
+    fn trace_sharding_global_tracks_setter() {
+        // The spawn-time sites read this global, not a `BgpTracing`.
+        set_trace_sharding(true);
+        assert!(trace_sharding());
+        set_trace_sharding(false);
+        assert!(!trace_sharding());
     }
 
     #[test]

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -49,6 +49,14 @@ pub fn spawn_bgp(config: &ConfigManager) {
     let nd_client_tx = config.nd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("bgp");
     let ctx = crate::context::ProtoContext::default_table(rib_client);
+    // Seed the `sharding` trace gate *before* the two freeze calls below:
+    // they log the value they froze, and neither can reach a `BgpTracing`
+    // (the instance does not exist until `Bgp::new`). Scanning the
+    // candidate config here — the same text `configured_shards` reads —
+    // means a `router bgp tracing sharding` landing in the same commit as
+    // `router bgp` is already visible, with no node-ordering dependency.
+    // `config_tracing_dispatch` keeps the global in step afterwards.
+    crate::bgp::tracing::set_trace_sharding(configured_trace_sharding(config));
     // C.4: freeze the shard count from the `router bgp sharding rib-sharding
     // <n>` leaf (else `ZEBRA_BGP_SHARDS`, else 1) before `Bgp::new` spawns the
     // pool.
@@ -137,9 +145,58 @@ fn peer_task_from_config_text(text: &str) -> Option<bool> {
     })
 }
 
+/// Read the `router bgp tracing sharding` / `tracing all` presence leaves from
+/// the committed candidate config. Same flattened-text scan as
+/// [`configured_shards`], for the same reason: the spawn-time sharding traces
+/// fire before `Bgp::new` exists to hold a `BgpTracing`, so the gate has to be
+/// resolved from the config text directly.
+fn configured_trace_sharding(config: &ConfigManager) -> bool {
+    let mut text = String::new();
+    config.store.candidate.borrow().list(&mut text);
+    trace_sharding_from_config_text(&text)
+}
+
+/// Pure line-scan (unit-tested): is the instance-level `sharding` trace
+/// category on? `tracing all` is the master switch and implies it, matching
+/// [`BgpTracing::should_trace_sharding`]. Neighbor-scoped lines
+/// (`router bgp neighbor … tracing …`) must NOT match — sharding is an
+/// instance property.
+fn trace_sharding_from_config_text(text: &str) -> bool {
+    text.lines().any(|line| {
+        matches!(
+            line.trim_end(),
+            "router bgp tracing sharding" | "router bgp tracing all"
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::shards_from_config_text;
+    use super::{shards_from_config_text, trace_sharding_from_config_text};
+
+    #[test]
+    fn trace_sharding_line_scan() {
+        // The category itself, and the `all` master switch that implies it.
+        assert!(trace_sharding_from_config_text(
+            "router bgp tracing sharding\nrouter bgp sharding rib-sharding 4\n"
+        ));
+        assert!(trace_sharding_from_config_text("router bgp tracing all\n"));
+        // Absent ⇒ off (the spawn-time traces stay silent).
+        assert!(!trace_sharding_from_config_text(
+            "router bgp sharding rib-sharding 4\n"
+        ));
+        assert!(!trace_sharding_from_config_text(""));
+        // A different category must not turn it on.
+        assert!(!trace_sharding_from_config_text("router bgp tracing fsm\n"));
+        // Instance-scoped: the neighbor-scoped path must NOT match, and
+        // neither may a longer line that merely starts with the same text.
+        assert!(!trace_sharding_from_config_text(
+            "router bgp neighbor 10.0.0.1 tracing sharding\n"
+        ));
+        assert!(!trace_sharding_from_config_text(
+            "router bgp tracing sharding-something-else\n"
+        ));
+    }
 
     #[test]
     fn shards_line_scan() {

--- a/zebra-rs/yang/zebra-bgp-tracing.yang
+++ b/zebra-rs/yang/zebra-bgp-tracing.yang
@@ -69,6 +69,19 @@ module zebra-bgp-tracing {
      key off set vs delete and never read a value, so `type empty` is
      the honest type here.";
 
+  revision 2026-07-23 {
+    description
+      "Add the `sharding` category, covering the instance-lifetime
+       concurrency knobs frozen at spawn (RIB shard count, per-peer
+       egress-task model) and update-group egress task spawn/exit.
+       Those sites previously logged unconditionally, then dropped to
+       debug! because they run before `Bgp::new` builds a BgpTracing;
+       the category restores them at info! behind a gate that
+       `spawn_bgp` resolves from the candidate config text.
+       Instance-scoped: a per-neighbour `tracing sharding` has no
+       meaning and is not honoured.";
+  }
+
   revision 2026-06-06 {
     description
       "Add categories vpn, srv6, vrf and bfd so the conditional
@@ -117,133 +130,167 @@ module zebra-bgp-tracing {
     }
   }
 
+  grouping bgp-tracing-categories {
+    description
+      "The tracing categories that are meaningful at BOTH the instance
+       and the neighbor scope. Kept separate from the enclosing
+       container so the two scopes stay identical by construction while
+       still allowing an instance-only category to be added alongside —
+       see `bgp-tracing-instance-extension`.";
+
+    leaf all {
+      ext:help "Enable every tracing category";
+      type empty;
+      description
+        "Master switch — when present, every category below is traced
+         regardless of its individual leaf.";
+    }
+
+    leaf fsm {
+      ext:help "Trace BGP finite-state-machine transitions";
+      type empty;
+      description
+        "Log peer FSM state changes (Idle/Connect/Active/OpenSent/
+         OpenConfirm/Established) and the events that drive them.";
+    }
+
+    container packet {
+      ext:help "Trace BGP protocol messages";
+      description
+        "Per-message-type tracing. Each message type is a presence
+         container: naming it (e.g. `tracing packet open`) enables
+         tracing for that type in both directions at summary level,
+         and the `detail` / `direction` children refine it. `all`
+         covers every message type at once.";
+
+      container all {
+        ext:help "Trace all BGP message types";
+        presence "Trace every BGP message type";
+        uses bgp-tracing-packet-options;
+      }
+      container open {
+        ext:help "Trace OPEN messages";
+        presence "Trace OPEN messages";
+        uses bgp-tracing-packet-options;
+      }
+      container update {
+        ext:help "Trace UPDATE messages";
+        presence "Trace UPDATE messages";
+        uses bgp-tracing-packet-options;
+      }
+      container keepalive {
+        ext:help "Trace KEEPALIVE messages";
+        presence "Trace KEEPALIVE messages";
+        uses bgp-tracing-packet-options;
+      }
+      container notification {
+        ext:help "Trace NOTIFICATION messages";
+        presence "Trace NOTIFICATION messages";
+        uses bgp-tracing-packet-options;
+      }
+      container route-refresh {
+        ext:help "Trace ROUTE-REFRESH messages";
+        presence "Trace ROUTE-REFRESH messages";
+        uses bgp-tracing-packet-options;
+      }
+    }
+
+    leaf label {
+      ext:help "Trace MPLS label allocation / binding";
+      type empty;
+      description
+        "Log label operations for labeled-unicast / L3VPN routes
+         learned from or advertised to this scope.";
+    }
+
+    leaf adj-in {
+      ext:help "Trace Adj-RIB-In route processing";
+      type empty;
+      description
+        "Log routes entering the inbound Adj-RIB (pre-policy
+         received NLRI and their post-policy disposition).";
+    }
+
+    leaf adj-out {
+      ext:help "Trace Adj-RIB-Out route processing";
+      type empty;
+      description
+        "Log routes leaving via the outbound Adj-RIB (what is
+         advertised to the scope after export policy).";
+    }
+
+    leaf vpn {
+      ext:help "Trace L3VPN import / export";
+      type empty;
+      description
+        "Log L3VPN route import/export: per-VRF prefixes written to
+         the VPNv4 / VPNv6 Loc-RIB and advertised to PE/CE peers,
+         with their RD, route-targets and MPLS label.";
+    }
+
+    leaf srv6 {
+      ext:help "Trace SRv6 locator / SID resolution";
+      type empty;
+      description
+        "Log SRv6 locator resolution and per-VRF End.DT46 service-SID
+         reconciliation used for L3VPN over SRv6.";
+    }
+
+    leaf vrf {
+      ext:help "Trace per-VRF task lifecycle";
+      type empty;
+      description
+        "Log per-VRF BGP task lifecycle — spawn / respawn / despawn /
+         shutdown, inbound-connection routing, and the staged per-VRF
+         config observed at commit.";
+    }
+
+    leaf bfd {
+      ext:help "Trace BFD session interaction";
+      type empty;
+      description
+        "Log BGP's interaction with the BFD client — session state
+         changes and client-readiness — that drive RFC 5882 peer
+         teardown.";
+    }
+  }
+
   grouping bgp-tracing-extension {
     description
-      "The `tracing` block shared by the BGP instance and each BGP
-       neighbor. `uses` at both augment points so the two scopes stay
-       identical by construction.";
+      "The per-neighbor `tracing` block: the shared categories only.";
 
     container tracing {
       ext:help "BGP conditional tracing";
       description
-        "Per-category BGP log toggles. When applied under a neighbor,
-         the block scopes tracing to that session; under the instance
-         it applies to every peer.";
+        "Per-category BGP log toggles scoped to this session.";
 
-      leaf all {
-        ext:help "Enable every tracing category";
+      uses bgp-tracing-categories;
+    }
+  }
+
+  grouping bgp-tracing-instance-extension {
+    description
+      "The instance-wide `tracing` block: the shared categories plus the
+       categories that only make sense for the instance as a whole.";
+
+    container tracing {
+      ext:help "BGP conditional tracing";
+      description
+        "Per-category BGP log toggles applying to every peer.";
+
+      uses bgp-tracing-categories;
+
+      leaf sharding {
+        ext:help "Trace RIB sharding / egress-model selection";
         type empty;
         description
-          "Master switch — when present, every category below is traced
-           regardless of its individual leaf.";
-      }
-
-      leaf fsm {
-        ext:help "Trace BGP finite-state-machine transitions";
-        type empty;
-        description
-          "Log peer FSM state changes (Idle/Connect/Active/OpenSent/
-           OpenConfirm/Established) and the events that drive them.";
-      }
-
-      container packet {
-        ext:help "Trace BGP protocol messages";
-        description
-          "Per-message-type tracing. Each message type is a presence
-           container: naming it (e.g. `tracing packet open`) enables
-           tracing for that type in both directions at summary level,
-           and the `detail` / `direction` children refine it. `all`
-           covers every message type at once.";
-
-        container all {
-          ext:help "Trace all BGP message types";
-          presence "Trace every BGP message type";
-          uses bgp-tracing-packet-options;
-        }
-        container open {
-          ext:help "Trace OPEN messages";
-          presence "Trace OPEN messages";
-          uses bgp-tracing-packet-options;
-        }
-        container update {
-          ext:help "Trace UPDATE messages";
-          presence "Trace UPDATE messages";
-          uses bgp-tracing-packet-options;
-        }
-        container keepalive {
-          ext:help "Trace KEEPALIVE messages";
-          presence "Trace KEEPALIVE messages";
-          uses bgp-tracing-packet-options;
-        }
-        container notification {
-          ext:help "Trace NOTIFICATION messages";
-          presence "Trace NOTIFICATION messages";
-          uses bgp-tracing-packet-options;
-        }
-        container route-refresh {
-          ext:help "Trace ROUTE-REFRESH messages";
-          presence "Trace ROUTE-REFRESH messages";
-          uses bgp-tracing-packet-options;
-        }
-      }
-
-      leaf label {
-        ext:help "Trace MPLS label allocation / binding";
-        type empty;
-        description
-          "Log label operations for labeled-unicast / L3VPN routes
-           learned from or advertised to this scope.";
-      }
-
-      leaf adj-in {
-        ext:help "Trace Adj-RIB-In route processing";
-        type empty;
-        description
-          "Log routes entering the inbound Adj-RIB (pre-policy
-           received NLRI and their post-policy disposition).";
-      }
-
-      leaf adj-out {
-        ext:help "Trace Adj-RIB-Out route processing";
-        type empty;
-        description
-          "Log routes leaving via the outbound Adj-RIB (what is
-           advertised to the scope after export policy).";
-      }
-
-      leaf vpn {
-        ext:help "Trace L3VPN import / export";
-        type empty;
-        description
-          "Log L3VPN route import/export: per-VRF prefixes written to
-           the VPNv4 / VPNv6 Loc-RIB and advertised to PE/CE peers,
-           with their RD, route-targets and MPLS label.";
-      }
-
-      leaf srv6 {
-        ext:help "Trace SRv6 locator / SID resolution";
-        type empty;
-        description
-          "Log SRv6 locator resolution and per-VRF End.DT46 service-SID
-           reconciliation used for L3VPN over SRv6.";
-      }
-
-      leaf vrf {
-        ext:help "Trace per-VRF task lifecycle";
-        type empty;
-        description
-          "Log per-VRF BGP task lifecycle — spawn / respawn / despawn /
-           shutdown, inbound-connection routing, and the staged per-VRF
-           config observed at commit.";
-      }
-
-      leaf bfd {
-        ext:help "Trace BFD session interaction";
-        type empty;
-        description
-          "Log BGP's interaction with the BFD client — session state
-           changes and client-readiness — that drive RFC 5882 peer
-           teardown.";
+          "Log the instance-lifetime concurrency knobs frozen at spawn —
+           the RIB shard count and the per-peer egress-task model, each
+           with the source it came from (config, environment, or
+           default) — plus update-group egress task spawn/exit.
+           Instance-scoped only, and deliberately absent from the
+           per-neighbour block: the values it reports are chosen once for
+           the whole BGP instance, before any neighbour exists.";
       }
     }
   }
@@ -255,14 +302,14 @@ module zebra-bgp-tracing {
   augment "/configure:set/config:router/bgp:bgp" {
     description
       "Instance-wide `router bgp tracing` in the candidate-set subtree.";
-    uses bgp-tracing-extension;
+    uses bgp-tracing-instance-extension;
   }
 
   augment "/configure:delete/config:router/bgp:bgp" {
     description
       "Same attachment for the delete subtree so
        `delete router bgp tracing ...` is path-valid.";
-    uses bgp-tracing-extension;
+    uses bgp-tracing-instance-extension;
   }
 
   augment "/configure:set/config:router"


### PR DESCRIPTION
A full BDD run at **concurrency 16** (250/258) surfaced six failures that are **deterministic, not load flakes** — every one fails solo at concurrency 1. Both causes are commits merged 2026-07-21, after the last green full run, and both are the same mistake: *a source change that the BDD suite reads, without sweeping the suite*. CI excludes `bdd`, so only a full run catches this.

## 1. `28caccc3` — five log lines demoted to `debug!`

"gate every unconditional `tracing::info!` behind a tracing category" dropped five sites to `debug!` because `init_shard_count` / `init_peer_task` run inside `spawn_bgp` before `Bgp::new` builds a `BgpTracing`, and `GroupEgressTask::spawn` is a plain constructor. Four features assert those strings, and BDD sets no `RUST_LOG`, so they went silent.

Rather than revert to unconditional `info!`, **give them the category they were missing**:

- `router bgp tracing sharding` — RIB shard count, per-peer egress-task model (each with its source), and update-group egress task spawn/exit.
- The gate is a **process-global atomic** (the pattern `bfd::trace` already uses for its socket tasks), seeded by `spawn_bgp` from a flattened-candidate-config scan **before** the two freeze calls run — the same technique `configured_shards` uses, so there is no node-ordering dependency and a `tracing sharding` line landing in the same commit as `router bgp` is already visible.
- `config_tracing_dispatch` keeps the global in step afterwards, so a runtime toggle reaches update-group tasks spawned later.

**`sharding` is instance-only.** Putting it in `bgp-tracing-extension` would have published `/router/bgp/neighbor/tracing/sharding` too — a knob that parses and does nothing, since the values it reports are chosen once per instance before any neighbour exists. The grouping is split into `bgp-tracing-categories` (shared) plus thin instance / neighbour wrappers; `docs/schema-paths.txt` gains exactly one path.

## 2. `b188eb3d` — flex-algo schema change not swept into BDD configs

"per-algorithm fast-reroute becomes an opt-out" narrowed `router isis flex-algo <n> fast-reroute` to a `disable` leaf, but all **8** `flexalgo_tilfa_srv6` configs still wrote the removed `fast-reroute: ti-lfa: {}` — so `vtyctl apply` rejected them outright (`unknown key \`ti-lfa\``) and the whole feature cascaded.

Each config already carries the instance-level `fast-reroute: ti-lfa`, so dropping the per-algo block is semantically neutral. **The feature now passes all 5 scenarios including the fast-reroute pings and the `uA`/`uA(LIB)` adjacency-SID checks — confirming per-algo TI-LFA does inherit correctly, and that this was a stale test rather than a product bug.**

## 3. `bgp_sync_backpressure` — no source change needed

`v4 sync parked` is still `info!`; it just moved behind the existing `adj-out` category. The config now enables it.

## Verification

| | |
|---|---|
| The 6 features solo (c=1) | all pass, previously-failing steps ✔ |
| Full suite re-run at c=16 | **256/257**, only failure the known `isis_srv6_replace` LSP-flooding load flake |
| `cargo test -p zebra-rs` | 1733 passed (3 new) |
| `cargo fmt --all --check`, workspace clippy | clean |

New tests cover the line-scan (including that the neighbour path and a `sharding-something-else` prefix must **not** match) and `all` implying the category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)