### PR TITLE
bdd: poll for the IS-IS adjacency SID instead of asserting it once

### DIFF
--- a/bdd/tests/features/isis_sr_switchover.feature
+++ b/bdd/tests/features/isis_sr_switchover.feature
@@ -206,7 +206,9 @@ Feature: Live switchover IS-IS SR-MPLS -> SRv6 (classic) -> SRv6 uSID -> SR-MPLS
     # locator-wide /48 uN with the NEXT-C-SID flavor and the classic
     # /128 End route disappears from the kernel.
     Then show command "show segment-routing srv6 sid" in namespace "s" should eventually contain "uN"
-    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA"
+    # Poll for the same reason as isis_srv6_replace: `uN` is the node SID,
+    # `uA` the adjacency SID, which only exists once the adjacency is Up.
+    And show command "show segment-routing srv6 sid" in namespace "s" should eventually contain "uA"
     And kernel route "fcbb:bbbb:1::/48" in namespace "s" should eventually contain "next-csid"
     And kernel route "fcbb:bbbb:1::" in namespace "s" should eventually be gone
     And show command "show ipv6 route fcbb:bbbb:8::/48" in namespace "s" should eventually contain "[115/2]"

--- a/bdd/tests/features/isis_srv6_replace.feature
+++ b/bdd/tests/features/isis_srv6_replace.feature
@@ -34,7 +34,10 @@ Feature: IS-IS advertises REPLACE-C-SID SRv6 endpoint behaviors
     And I apply config "z1.yaml" to namespace "z1"
     And I apply config "z2.yaml" to namespace "z2"
     Then show command "show isis database detail" in namespace "z2" should eventually contain "End (REP, PSP, USD)"
-    And show command "show isis database detail" in namespace "z2" should contain "End.X (REP, PSP)"
+    # Poll: `End` rides z1's FIRST LSP (locator, no adjacency yet), but
+    # `End.X` is the adjacency SID, added only when z1 re-originates after
+    # the adjacency reaches Up. A bare assert here races that reflood.
+    And show command "show isis database detail" in namespace "z2" should eventually contain "End.X (REP, PSP)"
     # The uSID peer's own SIDs are unchanged — z1 sees plain uN.
     And show command "show isis database detail" in namespace "z1" should eventually contain "Behavior: uN,"
     # Reachability across the adjacency proves the REPLACE codepoints


### PR DESCRIPTION
`isis_srv6_replace` failed a full c=16 run on a step that **cannot be satisfied at the moment it runs**.

## Diagnosis — a test bug, not a daemon bug

z1 originates its **first** LSP as soon as it has content — locator plus the `End` SID, with no `Extended IS Reachability` block — and only adds the `End.X` **adjacency** SID when it re-originates after the adjacency reaches Up. That two-stage origination is correct IS-IS behaviour; FRR and Cisco do the same.

Line 36 waits with `should eventually contain "End (REP, PSP, USD)"`, which legitimately matches on that first LSP. Line 37 then asserted the adjacency SID with a bare `should contain` and no retry, racing the reflood.

The captured LSDB at the failure is the proof — z1 at `SeqNumber 0x00000001`, `End` SID present, **no `Extended IS Reachability` at all**, while z2's own LSP already carried its `End.X ... uA`:

```
z1.00-00                         158  0x00000001  0xd4f6      1197  0/0/0
  SRv6 Locator: fcbb:bbbb:1:1::/64 (Metric: 0) Algo: SPF(0)
   SRv6 End SID: Behavior: End (REP, PSP, USD), SID value: fcbb:bbbb:1:1::
  IPv6 Reachability: 2001:db8::1/128 (Metric: 10)          <-- no Extended IS Reachability

z2.00-00                  *      197  0x00000001  0x80c0      1199  0/0/0
  Extended IS Reachability:
   SRv6 End.X SID: fcbb:bbbb:2:e000::, ... Behavior uA        <-- z2 already re-originated
```

## Changes

Two sites, both `should contain` → `should eventually contain`:

- **`isis_srv6_replace:37`** — the failure above. This is the *same* bug already fixed on `main` for the sibling feature `isis_srv6_flavor` (`uN` then `uA`); that sweep missed the `End`/`End.X` twin.
- **`isis_sr_switchover:209`** — identical signature (`eventually` on node SID `uN`, bare assert on adjacency SID `uA`). Latent; converted before it costs a red run.

Both are 60×1s polls that return immediately on the common case, so the healthy path costs nothing. Comments record *why* the state arrives late, so the polling isn't "simplified" back later.

## Deliberately narrow

A regex finds **~131** bare-`contain`-after-`eventually` sites across 51 features. Converting them wholesale would be wrong: the usual idiom asserts a second field that arrives **with** the awaited one, where a bare assert is correct and *stronger* — a polling version would mask an ordering bug. Only the two sites whose target is genuinely a **later event** are changed.

## Verification

Both features pass solo, and a full c=16 suite run passes both.

Worth stating plainly: these are roaming flakes that pass solo, so **a green run cannot prove the race is closed** — the proof is the mechanism and the LSP capture above. The runs are regression checks.

The four other failures in that run are unrelated pre-existing load-margin flakes, untouched by this change: `bgp_as_path_match` (BGP policy propagation) and the `ospfv2_spf_interval` / `min_ls_arrival` / `min_ls_interval` cluster (all three missing `10.0.0.2/32` from `show ospf route`). Test-only change — no source is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)