### PR TITLE
bdd: give every namespace-creating feature a standalone teardown scenario

### DIFF
--- a/bdd/tests/features/isis_bfd_ipv4_lan.feature
+++ b/bdd/tests/features/isis_bfd_ipv4_lan.feature
@@ -120,6 +120,10 @@ Feature: IS-IS BFD over an IPv4 LAN (broadcast) link
     Then bfd session in namespace "z1" on interface "vz1ns" should be up
     And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
     And ping from "z1" to "10.255.0.2" should succeed
+
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I delete namespace "z1"

--- a/bdd/tests/features/isis_bfd_ipv4_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv4_p2p.feature
@@ -181,6 +181,10 @@ Feature: IS-IS BFD over an IPv4 point-to-point link
     Then bfd session in namespace "z1" on interface "i1" should be up
     And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
     And ping from "z1" to "10.255.0.2" should succeed
+
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I delete namespace "z1"

--- a/bdd/tests/features/isis_bfd_ipv6_lan.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_lan.feature
@@ -120,6 +120,10 @@ Feature: IS-IS BFD over an IPv6-only LAN (broadcast) link
     Then bfd session in namespace "z1" on interface "vz1ns" should be up
     And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
     And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I delete namespace "z1"

--- a/bdd/tests/features/isis_bfd_ipv6_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_p2p.feature
@@ -112,6 +112,10 @@ Feature: IS-IS BFD over an IPv6-only point-to-point link
     Then bfd session in namespace "z1" on interface "i1" should be up
     And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
     And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I delete namespace "z1"

--- a/bdd/tests/features/ospf_clear_neighbor.feature
+++ b/bdd/tests/features/ospf_clear_neighbor.feature
@@ -61,7 +61,9 @@ Feature: clear ospf neighbor resets an OSPFv2 adjacency
     Then show command "show ospf neighbor" in namespace "o1" should contain "Full"
     And ping from "o1" to "10.0.0.2" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "o1"
     And I stop zebra-rs in namespace "o2"
     And I delete namespace "o1"

--- a/bdd/tests/features/ospfv2_area_range.feature
+++ b/bdd/tests/features/ospfv2_area_range.feature
@@ -97,7 +97,9 @@ Feature: OSPFv2 area ranges aggregate Type-3 summaries at the ABR
     # protection for the range's gaps.
     And kernel route "10.1.0.0/16" in namespace "a" should eventually contain "blackhole"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_as_external.feature
+++ b/bdd/tests/features/ospfv2_as_external.feature
@@ -141,7 +141,9 @@ Feature: OSPFv2 AS-External (Type-5) LSA origination with E1 and E2 metric types
     And show command "show ospf route" in namespace "f" should contain "192.168.1.0/24"
     And show command "show ospf route" in namespace "f" should contain "[40]"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_auth.feature
+++ b/bdd/tests/features/ospfv2_auth.feature
@@ -132,7 +132,9 @@ Feature: OSPFv2 per-interface authentication gates adjacency formation
     Then show command "show ospf neighbor" in namespace "a" should not contain "10.0.0.2"
     And show command "show ospf neighbor" in namespace "b" should not contain "10.0.0.1"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv2_default_originate.feature
+++ b/bdd/tests/features/ospfv2_default_originate.feature
@@ -61,7 +61,9 @@ Feature: OSPFv2 default-information originate advertises a Type-5 default
     When I apply command "delete router static ipv4 route 0.0.0.0/0" in namespace "b"
     Then show command "show ospf route" in namespace "a" should eventually not contain "0.0.0.0/0"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv2_graceful_restart.feature
+++ b/bdd/tests/features/ospfv2_graceful_restart.feature
@@ -120,7 +120,11 @@ Feature: OSPFv2 graceful restart keeps forwarding through a daemon restart
     And show command "show ospf route" in namespace "a" should eventually contain "10.0.0.2/32"
     And ping from "a" to "10.0.0.2" should eventually succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only). The
+    # checkpoint removal belongs here too: a leftover ospf.cbor is exactly
+    # what a failed GR scenario would strand.
     When I execute "rm -f /var/lib/zebra-rs/checkpoint/ospf.cbor" in namespace "a"
     And I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"

--- a/bdd/tests/features/ospfv2_min_ls_interval.feature
+++ b/bdd/tests/features/ospfv2_min_ls_interval.feature
@@ -34,7 +34,9 @@ Feature: OSPFv2 MinLSInterval self-LSA re-origination throttle
     And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
     And ping from "a" to "10.0.0.2" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv2_multi_area.feature
+++ b/bdd/tests/features/ospfv2_multi_area.feature
@@ -118,7 +118,9 @@ Feature: OSPFv2 multi-area routing across two Area Border Routers
     # Mirror proof for the cost-20 c-d link (d's c-d address 10.0.34.2).
     And show command "show ospf route" in namespace "c" should contain "[20] via 10.0.34.2"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_nssa_base.feature
+++ b/bdd/tests/features/ospfv2_nssa_base.feature
@@ -258,6 +258,9 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And show command "show ospf route" in namespace "b" should contain "192.168.1.0/24"
     And show command "show ospf route" in namespace "b" should contain "[40]"
 
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_nssa_fa.feature
+++ b/bdd/tests/features/ospfv2_nssa_fa.feature
@@ -73,7 +73,9 @@ Feature: NSSA Type-7 forwarding address is originated, translated, and resolved
     Then show command "show ospf route" in namespace "b" should eventually contain "10.9.9.0/24"
     And ping from "b" to "10.9.9.1" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_passive.feature
+++ b/bdd/tests/features/ospfv2_passive.feature
@@ -48,7 +48,9 @@ Feature: OSPFv2 passive interfaces advertise their prefix without forming adjace
     # The passive interface reports its state.
     And show command "show ospf interface" in namespace "b" should contain "No Hellos (Passive interface)"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_redist_table.feature
+++ b/bdd/tests/features/ospfv2_redist_table.feature
@@ -47,7 +47,9 @@ Feature: OSPFv2 redistributes routes from a kernel routing table
     Then show command "show ospf route" in namespace "r1" should eventually not contain "10.55.1.0/24"
     And show command "show ospf route" in namespace "r1" should contain "10.55.2.0/24"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "r1"
     And I stop zebra-rs in namespace "r2"
     And I delete namespace "r1"

--- a/bdd/tests/features/ospfv2_redistribute_static.feature
+++ b/bdd/tests/features/ospfv2_redistribute_static.feature
@@ -47,7 +47,9 @@ Feature: OSPFv2 instance-level redistribute static originates Type-5 AS-External
     # b itself must not self-install its own external.
     And show command "show ospf route" in namespace "b" should not contain "192.168.50.0/24"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv2_stub_base.feature
+++ b/bdd/tests/features/ospfv2_stub_base.feature
@@ -75,7 +75,9 @@ Feature: OSPFv2 stub area drops Type-5 AS-External while keeping inter-area rout
     And ping from "c" to "10.0.0.2" should succeed
     And ping from "a" to "192.168.1.1" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv2_stub_router.feature
+++ b/bdd/tests/features/ospfv2_stub_router.feature
@@ -91,7 +91,9 @@ Feature: OSPFv2 stub-router advertisement (RFC 6987 max-metric router-lsa)
     And show command "show ospf route" in namespace "r1" should eventually contain "10.0.0.3/32          [20] via 10.0.12.2"
     And ping from "r1" to "10.0.0.3" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "r1"
     And I stop zebra-rs in namespace "r2"
     And I stop zebra-rs in namespace "r3"

--- a/bdd/tests/features/ospfv3_adjacency.feature
+++ b/bdd/tests/features/ospfv3_adjacency.feature
@@ -46,7 +46,9 @@ Feature: OSPFv3 two-router adjacency forms over a point-to-point link
     And show command "show ospfv3 neighbor" in namespace "o2" should contain "10.0.0.1"
     And show command "show ospfv3 neighbor" in namespace "o2" should contain "Full"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "o1"
     And I stop zebra-rs in namespace "o2"
     And I delete namespace "o1"

--- a/bdd/tests/features/ospfv3_area_range.feature
+++ b/bdd/tests/features/ospfv3_area_range.feature
@@ -83,7 +83,9 @@ Feature: OSPFv3 area ranges aggregate Inter-Area-Prefix-LSAs at the ABR
     # The discard route is installed even with not-advertise.
     And kernel route "2001:db8:1::/48" in namespace "a" should eventually contain "blackhole"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv3_auth.feature
+++ b/bdd/tests/features/ospfv3_auth.feature
@@ -79,7 +79,9 @@ Feature: OSPFv3 native authentication config drives the RFC 7166 trailer
     Then show command "show ospfv3 neighbor" in namespace "a" should not contain "10.0.0.2"
     And show command "show ospfv3 neighbor" in namespace "b" should not contain "10.0.0.1"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv3_default_originate.feature
+++ b/bdd/tests/features/ospfv3_default_originate.feature
@@ -54,7 +54,9 @@ Feature: OSPFv3 default-information originate advertises an AS-External default
     When I apply command "delete router static ipv6 route ::/0" in namespace "b"
     Then show command "show ospfv3 route" in namespace "a" should eventually not contain "::/0"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv3_graceful_restart.feature
+++ b/bdd/tests/features/ospfv3_graceful_restart.feature
@@ -94,7 +94,11 @@ Feature: OSPFv3 graceful restart keeps forwarding through a daemon restart
     And show command "show ospfv3 route" in namespace "a" should eventually contain "2001:db8::2/128"
     And ping from "a" to "2001:db8::2" should eventually succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only). The
+    # checkpoint removal belongs here too: a leftover ospfv3.cbor is
+    # exactly what a failed GR scenario would strand.
     When I execute "rm -f /var/lib/zebra-rs/checkpoint/ospfv3.cbor" in namespace "a"
     And I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"

--- a/bdd/tests/features/ospfv3_instance_id.feature
+++ b/bdd/tests/features/ospfv3_instance_id.feature
@@ -55,7 +55,9 @@ Feature: OSPFv3 Instance ID separates instances on a link (RFC 5340)
     And show command "show ospfv3 neighbor" in namespace "b" should not contain "10.0.0.1"
     And show command "show ospfv3 route" in namespace "a" should not contain "2001:db8::2/128"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv3_multi_area.feature
+++ b/bdd/tests/features/ospfv3_multi_area.feature
@@ -94,7 +94,9 @@ Feature: OSPFv3 ABR originates Inter-Area-Prefix-LSAs across three areas
     And show command "show ospfv3 route" in namespace "a" should contain "2001:db8::4/128 metric 20"
     And show command "show ospfv3 route" in namespace "c" should contain "2001:db8::4/128 metric 20"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv3_nssa.feature
+++ b/bdd/tests/features/ospfv3_nssa.feature
@@ -126,6 +126,9 @@ Feature: OSPFv3 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     #     backbone: b must NOT contain it. ---
     And show command "show ospfv3 route" in namespace "b" should not contain "2001:db8:dead::/64"
 
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv3_passive.feature
+++ b/bdd/tests/features/ospfv3_passive.feature
@@ -36,7 +36,9 @@ Feature: OSPFv3 passive interfaces advertise their prefix without forming adjace
     And show command "show ospfv3 neighbor" in namespace "b" should not contain "10.0.0.3"
     And show command "show ospfv3 neighbor" in namespace "c" should not contain "10.0.0.2"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I stop zebra-rs in namespace "c"

--- a/bdd/tests/features/ospfv3_redistribute.feature
+++ b/bdd/tests/features/ospfv3_redistribute.feature
@@ -46,7 +46,9 @@ Feature: OSPFv3 instance-level redistribute originates AS-External LSAs
     And show command "show ospfv3 route" in namespace "a" should contain "2001:db8:99::/64"
     And show command "show ospfv3 database" in namespace "a" should contain "AS-External-LSA"
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
     And I delete namespace "a"

--- a/bdd/tests/features/ospfv3_stub_router.feature
+++ b/bdd/tests/features/ospfv3_stub_router.feature
@@ -88,7 +88,9 @@ Feature: OSPFv3 stub-router advertisement (RFC 5340 R-bit clear)
     And show command "show ospfv3 route" in namespace "r1" should eventually contain "2001:db8::3/128 metric 20 via"
     And ping from "r1" to "2001:db8::3" should succeed
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "r1"
     And I stop zebra-rs in namespace "r2"
     And I stop zebra-rs in namespace "r3"

--- a/bdd/tests/features/static_blackhole.feature
+++ b/bdd/tests/features/static_blackhole.feature
@@ -25,7 +25,9 @@ Feature: Static blackhole routes install RTN_BLACKHOLE discard entries
     When I apply command "delete router static ipv4 route 10.9.9.0/24 nexthop blackhole" in namespace "r"
     Then kernel route "10.9.9.0/24" in namespace "r" should eventually be gone
 
-    # Teardown.
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
     When I stop zebra-rs in namespace "r"
     And I delete namespace "r"
     Then the test environment should be clean


### PR DESCRIPTION
A c=16 run left **two namespaces and two daemons** behind after `ospfv2_min_ls_interval` failed.

## Root cause, confirmed by a natural experiment

Its cleanup steps lived at the end of the **same scenario** as the assertions. Cucumber abandons the rest of a scenario at the first failed step, so the failure skipped all four teardown steps.

Its siblings `ospfv2_min_ls_arrival` and `ospfv2_spf_interval` failed the **identical** assert in that same run and did **not** leak — because each keeps cleanup in a separate `Scenario: Teardown topology`.

Sweeping for the pattern found **31 features** with cleanup inline: every one leaks namespaces and daemons the moment it fails. That is not cosmetic — leaked daemons have previously cascaded into *fake* failures in unrelated features.

## Fix

Promote each feature's **final** teardown into its own scenario. Only the final one, deliberately:

- `Given a clean test environment` scopes its sweep to `<feature_tag>_`, so it only ever cleans its own feature. *Within* a feature it does sweep an earlier scenario's leftovers (its own comment says so) — so the only escape path is **the last scenario failing**, since nothing runs after it.
- `delete_namespace` calls `.expect("Failed to delete namespace")` and so panics on an already-deleted namespace. A blanket teardown scenario appended to a feature whose last scenario already cleaned up would fail on the **happy** path.

Intermediate scenarios therefore keep their inline teardown, and every feature now ends with the standalone scenario the project convention requires.

## One hand fix the automation would have got wrong

Both `graceful_restart` features began their teardown with `I execute "rm -f .../checkpoint/*.cbor"`, which the mechanical promotion did not recognise as a teardown step and stranded in the failing scenario. A leftover checkpoint is *exactly* what a failed GR scenario strands, and a stale one has poisoned unrelated daemons before — so it moves into the teardown scenario as its first step, with a comment saying why.

## Verification — by injecting a real failure, not by a passing run

| feature | injected failure | teardown ran | leaks after |
|---|---|---|---|
| `ospfv2_min_ls_interval` (1 scenario) | ✔ | 2 deletes ✔ | netns=0 daemons=0 |
| `ospfv2_auth` (5 scenarios) | ✔ | 10 deletes ✔, 5 clean-asserts | netns=0 daemons=0 |

Before this change the same injected failure leaked 2 namespaces and 2 daemons. Injections were reverted and the diff confirmed to contain only the teardown promotion.

Full c=16 suite: **256/257, zero leaks**, all 31 reworked features pass. The lone failure (`ospfv3_tilfa_srv6_classic`, a pre-existing TI-LFA convergence flake) is untouched by this PR and — having had a standalone teardown all along — left nothing behind, which is precisely the behaviour this PR gives the other 31.

## Known follow-up, deliberately not bundled

`delete_namespace`'s `.expect(...)` means teardown is not idempotent. Making it tolerate an already-absent namespace would let the pattern be applied uniformly, but it is a harness behaviour change that could mask genuine delete failures, so it is left out of this test-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)