### PR TITLE
bgp: flush adv-interval 0 immediately instead of via a timer

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1012,6 +1012,14 @@ pub struct Peer {
     pub cache_evpn_rev: HashMap<EvpnRoute, Arc<BgpAttr>>,
     pub cache_vpnv4_timer: Option<Timer>,
     pub cache_evpn_timer: Option<Timer>,
+    /// Adv-interval-0 twins of the three timer fields above: set when
+    /// `send_vpnv4`/`send_vpnv6`/`send_evpn` (route.rs) queues an
+    /// immediate flush event with no timer armed. Gates re-queueing
+    /// within one synchronous advertise batch; cleared by
+    /// `fsm_adv_timer_*_expires` alongside the matching `cache_*_timer`.
+    pub immediate_flush_queued_vpnv4: bool,
+    pub immediate_flush_queued_vpnv6: bool,
+    pub immediate_flush_queued_evpn: bool,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
     // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
     // this peer. Needed because TCP_AO_DEL_KEY requires the exact
@@ -1167,6 +1175,9 @@ impl Peer {
             cache_evpn_rev: HashMap::default(),
             cache_vpnv4_timer: None,
             cache_evpn_timer: None,
+            immediate_flush_queued_vpnv4: false,
+            immediate_flush_queued_vpnv6: false,
+            immediate_flush_queued_evpn: false,
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
             adv_interval: timer::AdvInterval::default(),
@@ -1947,6 +1958,7 @@ pub fn fsm(
 
 pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {
     peer.cache_vpnv4_timer = None;
+    peer.immediate_flush_queued_vpnv4 = false;
     if peer.state.is_established() {
         peer.flush_vpnv4();
     }
@@ -1955,6 +1967,7 @@ pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {
 
 pub fn fsm_adv_timer_vpnv6_expires(peer: &mut Peer) -> State {
     peer.cache_vpnv6_timer = None;
+    peer.immediate_flush_queued_vpnv6 = false;
     if peer.state.is_established() {
         peer.flush_vpnv6();
     }
@@ -1963,6 +1976,7 @@ pub fn fsm_adv_timer_vpnv6_expires(peer: &mut Peer) -> State {
 
 pub fn fsm_adv_timer_evpn_expires(peer: &mut Peer) -> State {
     peer.cache_evpn_timer = None;
+    peer.immediate_flush_queued_evpn = false;
     if peer.state.is_established() {
         peer.flush_evpn();
     }
@@ -4537,6 +4551,121 @@ mod adv_timer_phantom_tests {
             peer.cache_vpnv6_timer.is_none(),
             "route_clean must cancel the VPNv6 advertise timer"
         );
+    }
+
+    // ── adv-interval 0: immediate flush, no timer ──
+
+    /// `idle_peer()` leaks its receiver since the tests above only
+    /// care about `peer.state`; the tests below need to inspect what
+    /// actually lands on the channel, so build the peer inline keeping
+    /// `rx`.
+    fn peer_with_channel() -> (Peer, mpsc::Receiver<Message>) {
+        let (tx, rx) = mpsc::channel::<Message>(64);
+        let mut peer = Peer::new(
+            1,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65001,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = State::Idle;
+        (peer, rx)
+    }
+
+    /// adv-interval 0 must behave like FRR's `bgp_adjust_routeadv`
+    /// `v_routeadv == 0` special case: no debounce timer at all — the
+    /// flush event is queued directly (`tokio::spawn`, no sleep) so it
+    /// must already be sitting on the channel well before the old
+    /// `Timer::once` 1 s floor could ever fire.
+    #[tokio::test]
+    async fn send_vpnv4_zero_adv_interval_queues_flush_without_timer() {
+        let (mut peer, mut rx) = peer_with_channel();
+        peer.adv_interval = timer::AdvInterval { ibgp: 0, ebgp: 0 };
+        let nlri = Vpnv4Nlri {
+            label: Label::default(),
+            rd: RouteDistinguisher::default(),
+            nlri: Ipv4Nlri {
+                id: 0,
+                prefix: "10.0.0.0/24".parse().unwrap(),
+            },
+        };
+
+        peer.send_vpnv4(nlri, Arc::new(BgpAttr::new()), true);
+
+        assert!(
+            peer.cache_vpnv4_timer.is_none(),
+            "adv-interval 0 must not arm a debounce timer"
+        );
+        assert!(peer.immediate_flush_queued_vpnv4);
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("flush event must already be queued, no timer wait")
+            .expect("channel open");
+        match msg {
+            Message::Event(ident, Event::AdvTimerVpnv4Expires) => assert_eq!(ident, peer.ident),
+            other => panic!("expected AdvTimerVpnv4Expires, got {other:?}"),
+        }
+    }
+
+    /// Non-zero adv-interval (the default) must keep debouncing via a
+    /// real timer exactly as before — no flush event before it fires.
+    #[tokio::test]
+    async fn send_vpnv4_nonzero_adv_interval_still_arms_timer() {
+        let (mut peer, mut rx) = peer_with_channel();
+        assert_eq!(peer.adv_interval, timer::AdvInterval::default());
+        let nlri = Vpnv4Nlri {
+            label: Label::default(),
+            rd: RouteDistinguisher::default(),
+            nlri: Ipv4Nlri {
+                id: 0,
+                prefix: "10.0.0.0/24".parse().unwrap(),
+            },
+        };
+
+        peer.send_vpnv4(nlri, Arc::new(BgpAttr::new()), true);
+
+        assert!(
+            peer.cache_vpnv4_timer.is_some(),
+            "non-zero interval must debounce via a timer"
+        );
+        assert!(!peer.immediate_flush_queued_vpnv4);
+        assert!(
+            rx.try_recv().is_err(),
+            "flush must not fire before the debounce timer elapses"
+        );
+    }
+
+    /// EVPN twin of the VPNv4 zero-interval test above, using a
+    /// distinct `EvpnRoute` shape to catch a copy-paste mistake in the
+    /// mirrored wiring (VPNv6 is identical in shape to VPNv4, so it
+    /// isn't repeated here).
+    #[tokio::test]
+    async fn send_evpn_zero_adv_interval_queues_flush_without_timer() {
+        let (mut peer, mut rx) = peer_with_channel();
+        peer.adv_interval = timer::AdvInterval { ibgp: 0, ebgp: 0 };
+        let route = EvpnRoute::EthernetAd(EvpnEthernetAd {
+            id: 0,
+            rd: RouteDistinguisher::default(),
+            esi: [0; 10],
+            ether_tag: 0,
+            label: 0,
+        });
+
+        peer.send_evpn(route, Arc::new(BgpAttr::new()), true);
+
+        assert!(peer.cache_evpn_timer.is_none());
+        assert!(peer.immediate_flush_queued_evpn);
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("flush event must already be queued, no timer wait")
+            .expect("channel open");
+        match msg {
+            Message::Event(ident, Event::AdvTimerEvpnExpires) => assert_eq!(ident, peer.ident),
+            other => panic!("expected AdvTimerEvpnExpires, got {other:?}"),
+        }
     }
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -10204,9 +10204,11 @@ pub fn route_clean(
     peer.cache_vpnv4.clear();
     peer.cache_vpnv4_rev.clear();
     peer.cache_vpnv4_timer = None;
+    peer.immediate_flush_queued_vpnv4 = false;
     peer.cache_vpnv6.clear();
     peer.cache_vpnv6_rev.clear();
     peer.cache_vpnv6_timer = None;
+    peer.immediate_flush_queued_vpnv6 = false;
 
     // IPv6 unicast. Same shape as the IPv4 block above — withdraw
     // every prefix the peer gave us from the Loc-RIB (which fans out
@@ -10727,6 +10729,7 @@ pub fn route_clean(
     peer.cache_evpn.clear();
     peer.cache_evpn_rev.clear();
     peer.cache_evpn_timer = None;
+    peer.immediate_flush_queued_evpn = false;
 
     // IPv4 / IPv6 Labeled-Unicast (SAFI 4). No LLGR handling yet —
     // withdraw every labeled route the peer gave us and clear the
@@ -12319,8 +12322,23 @@ impl Peer {
             .or_default()
             .insert(nlri.clone());
         self.cache_vpnv4_rev.insert(nlri, attr);
-        if timer && self.cache_vpnv4_timer.is_none() {
-            self.cache_vpnv4_timer = Some(start_adv_timer_vpnv4(self));
+        if timer && self.cache_vpnv4_timer.is_none() && !self.immediate_flush_queued_vpnv4 {
+            let secs = self.adv_interval.secs_for(self.peer_type);
+            if secs == 0 {
+                // See `update_group::send_ipv4` for why adv-interval 0
+                // queues the flush event directly instead of arming a
+                // timer.
+                self.immediate_flush_queued_vpnv4 = true;
+                let tx = self.tx.clone();
+                let ident = self.ident;
+                tokio::spawn(async move {
+                    let _ = tx
+                        .send(Message::Event(ident, Event::AdvTimerVpnv4Expires))
+                        .await;
+                });
+            } else {
+                self.cache_vpnv4_timer = Some(start_adv_timer_vpnv4(self));
+            }
         }
     }
 
@@ -12350,8 +12368,23 @@ impl Peer {
             .or_default()
             .insert(route.clone());
         self.cache_evpn_rev.insert(route, attr);
-        if timer && self.cache_evpn_timer.is_none() {
-            self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
+        if timer && self.cache_evpn_timer.is_none() && !self.immediate_flush_queued_evpn {
+            let secs = self.adv_interval.secs_for(self.peer_type);
+            if secs == 0 {
+                // See `update_group::send_ipv4` for why adv-interval 0
+                // queues the flush event directly instead of arming a
+                // timer.
+                self.immediate_flush_queued_evpn = true;
+                let tx = self.tx.clone();
+                let ident = self.ident;
+                tokio::spawn(async move {
+                    let _ = tx
+                        .send(Message::Event(ident, Event::AdvTimerEvpnExpires))
+                        .await;
+                });
+            } else {
+                self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
+            }
         }
     }
 
@@ -12427,8 +12460,23 @@ impl Peer {
             .or_default()
             .insert(nlri.clone());
         self.cache_vpnv6_rev.insert(nlri, attr);
-        if timer && self.cache_vpnv6_timer.is_none() {
-            self.cache_vpnv6_timer = Some(start_adv_timer_vpnv6(self));
+        if timer && self.cache_vpnv6_timer.is_none() && !self.immediate_flush_queued_vpnv6 {
+            let secs = self.adv_interval.secs_for(self.peer_type);
+            if secs == 0 {
+                // See `update_group::send_ipv4` for why adv-interval 0
+                // queues the flush event directly instead of arming a
+                // timer.
+                self.immediate_flush_queued_vpnv6 = true;
+                let tx = self.tx.clone();
+                let ident = self.ident;
+                tokio::spawn(async move {
+                    let _ = tx
+                        .send(Message::Event(ident, Event::AdvTimerVpnv6Expires))
+                        .await;
+                });
+            } else {
+                self.cache_vpnv6_timer = Some(start_adv_timer_vpnv6(self));
+            }
         }
     }
 

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -303,6 +303,7 @@ pub fn update_timers(peer: &mut Peer) {
     }
     if peer.state != Established {
         peer.cache_vpnv4_timer = None;
+        peer.immediate_flush_queued_vpnv4 = false;
     }
 }
 

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -264,6 +264,12 @@ pub struct UpdateGroup {
     /// Adv-debounce timer. Started on first send; on fire,
     /// `Bgp::serve` drains the cache and ships UPDATEs to members.
     pub cache_ipv4_timer: Option<Timer>,
+    /// Set instead of `cache_ipv4_timer` when `adv_interval` is 0: no
+    /// timer is armed at all, a flush message is queued directly (see
+    /// `send_ipv4`). Gates re-queueing within one synchronous
+    /// advertise batch; cleared by `build_flush_job_ipv4` alongside
+    /// `cache_ipv4_timer`.
+    pub immediate_flush_queued_ipv4: bool,
 
     // ── IPv6 unicast pending advertisement cache ──
     //
@@ -273,6 +279,8 @@ pub struct UpdateGroup {
     pub cache_ipv6: HashMap<Arc<BgpAttr>, HashMap<Ipv6Nlri, usize>>,
     pub cache_ipv6_rev: HashMap<Ipv6Nlri, Arc<BgpAttr>>,
     pub cache_ipv6_timer: Option<Timer>,
+    /// IPv6 twin of `immediate_flush_queued_ipv4`.
+    pub immediate_flush_queued_ipv6: bool,
 
     /// Snapshot of `Bgp::adv_interval` captured at group creation
     /// (`attach`) and refreshed by the global config callback. Used
@@ -539,9 +547,11 @@ pub fn attach(
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
+                immediate_flush_queued_ipv4: false,
                 cache_ipv6: HashMap::new(),
                 cache_ipv6_rev: HashMap::new(),
                 cache_ipv6_timer: None,
+                immediate_flush_queued_ipv6: false,
                 adv_interval,
                 flush_inflight_ipv4: false,
                 flush_pending_ipv4: false,
@@ -652,9 +662,28 @@ pub fn send_ipv4(
         .or_default()
         .insert(nlri.clone(), source_ident);
     group.cache_ipv4_rev.insert(nlri, attr);
-    if kick_timer && group.cache_ipv4_timer.is_none() {
+    if kick_timer && group.cache_ipv4_timer.is_none() && !group.immediate_flush_queued_ipv4 {
         let secs = group.adv_interval.secs_for(group.sig.peer_type);
-        group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, secs));
+        if secs == 0 {
+            // FRR's bgp_adjust_routeadv() treats v_routeadv==0 as "no
+            // timer, schedule update-group packet generation as a 0 ms
+            // event" rather than a fast timer. Mirror that: queue the
+            // flush directly instead of arming `Timer::once`, which
+            // clamps 0 secs to a 1 s floor. `tokio::spawn` doesn't
+            // sleep at all — it just runs on the next scheduler pass —
+            // so this can't fire before the current synchronous
+            // advertise batch returns control to the executor, which
+            // is what keeps same-batch sends coalescing into one
+            // flush.
+            group.immediate_flush_queued_ipv4 = true;
+            let tx = tx.clone();
+            let id = group.id.clone();
+            tokio::spawn(async move {
+                let _ = tx.send(Message::FlushUpdateGroupIpv4(id)).await;
+            });
+        } else {
+            group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, secs));
+        }
     }
 }
 
@@ -936,6 +965,7 @@ pub(super) fn build_flush_job_ipv4(
 ) -> Option<FlushJob<Ipv4Nlri>> {
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
     group.cache_ipv4_timer = None;
+    group.immediate_flush_queued_ipv4 = false;
     let buckets: Vec<(Arc<BgpAttr>, Vec<(Ipv4Nlri, usize)>)> = group
         .cache_ipv4
         .drain()
@@ -1176,9 +1206,20 @@ pub fn send_ipv6(
         .or_default()
         .insert(nlri.clone(), source_ident);
     group.cache_ipv6_rev.insert(nlri, attr);
-    if kick_timer && group.cache_ipv6_timer.is_none() {
+    if kick_timer && group.cache_ipv6_timer.is_none() && !group.immediate_flush_queued_ipv6 {
         let secs = group.adv_interval.secs_for(group.sig.peer_type);
-        group.cache_ipv6_timer = Some(start_adv_timer_ipv6(tx, &group.id, secs));
+        if secs == 0 {
+            // See `send_ipv4` for why this queues directly instead of
+            // arming a timer.
+            group.immediate_flush_queued_ipv6 = true;
+            let tx = tx.clone();
+            let id = group.id.clone();
+            tokio::spawn(async move {
+                let _ = tx.send(Message::FlushUpdateGroupIpv6(id)).await;
+            });
+        } else {
+            group.cache_ipv6_timer = Some(start_adv_timer_ipv6(tx, &group.id, secs));
+        }
     }
 }
 
@@ -1217,6 +1258,7 @@ pub(super) fn build_flush_job_ipv6(
 ) -> Option<FlushJob<Ipv6Nlri>> {
     let afi_safi = AfiSafi::new(Afi::Ip6, Safi::Unicast);
     group.cache_ipv6_timer = None;
+    group.immediate_flush_queued_ipv6 = false;
     let buckets: Vec<(Arc<BgpAttr>, Vec<(Ipv6Nlri, usize)>)> = group
         .cache_ipv6
         .drain()
@@ -1851,9 +1893,11 @@ mod tests {
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
+                immediate_flush_queued_ipv4: false,
                 cache_ipv6: HashMap::new(),
                 cache_ipv6_rev: HashMap::new(),
                 cache_ipv6_timer: None,
+                immediate_flush_queued_ipv6: false,
                 adv_interval: AdvInterval::default(),
                 flush_inflight_ipv4: false,
                 flush_pending_ipv4: false,
@@ -2200,9 +2244,11 @@ mod tests {
             cache_ipv4: HashMap::new(),
             cache_ipv4_rev: HashMap::new(),
             cache_ipv4_timer: None,
+            immediate_flush_queued_ipv4: false,
             cache_ipv6: HashMap::new(),
             cache_ipv6_rev: HashMap::new(),
             cache_ipv6_timer: None,
+            immediate_flush_queued_ipv6: false,
             adv_interval: AdvInterval::default(),
             flush_inflight_ipv4: false,
             flush_pending_ipv4: false,
@@ -2337,6 +2383,144 @@ mod tests {
         let group = af.group_by_id_mut(&id).unwrap();
         assert!(!group.flush_inflight_ipv4);
         assert_eq!(group.counters.messages_formatted, 1);
+    }
+
+    // ── adv-interval 0: immediate flush, no timer ──
+
+    /// adv-interval 0 must not arm `cache_ipv4_timer` at all — the
+    /// flush message is queued directly (`tokio::spawn`, no sleep), so
+    /// it must already be sitting on the channel well before the old
+    /// `Timer::once` 1 s floor could ever fire.
+    #[tokio::test]
+    async fn send_ipv4_zero_adv_interval_queues_flush_without_timer() {
+        let (id, mut group) = test_group(0);
+        group.adv_interval = AdvInterval { ibgp: 0, ebgp: 0 };
+        let (tx, mut rx) = mpsc::channel(8);
+
+        send_ipv4(&mut group, nlri("10.0.0.1/32"), test_attr(0), 99, &tx, true);
+
+        assert!(
+            group.cache_ipv4_timer.is_none(),
+            "adv-interval 0 must not arm a debounce timer"
+        );
+        assert!(group.immediate_flush_queued_ipv4);
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("flush must already be queued, no timer wait")
+            .expect("channel open");
+        let Message::FlushUpdateGroupIpv4(got) = msg else {
+            panic!("expected FlushUpdateGroupIpv4, got {msg:?}");
+        };
+        assert_eq!(got, id);
+    }
+
+    /// A burst of sends within one synchronous batch (before the
+    /// executor gets a chance to run the queued flush task) must still
+    /// coalesce into a single flush message — adv-interval 0 removes
+    /// the timer, not the batching.
+    #[tokio::test]
+    async fn send_ipv4_zero_adv_interval_coalesces_batch_into_one_flush() {
+        let (_id, mut group) = test_group(0);
+        group.adv_interval = AdvInterval { ibgp: 0, ebgp: 0 };
+        let (tx, mut rx) = mpsc::channel(8);
+
+        send_ipv4(&mut group, nlri("10.0.0.1/32"), test_attr(0), 99, &tx, true);
+        send_ipv4(&mut group, nlri("10.0.0.2/32"), test_attr(0), 99, &tx, true);
+        send_ipv4(&mut group, nlri("10.0.0.3/32"), test_attr(1), 99, &tx, true);
+
+        assert_eq!(
+            group.cache_ipv4.values().map(|b| b.len()).sum::<usize>(),
+            3,
+            "all three sends must land in the cache"
+        );
+        tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("one flush message must be queued")
+            .expect("channel open");
+        assert!(
+            rx.try_recv().is_err(),
+            "a same-batch burst must coalesce into a single flush message"
+        );
+    }
+
+    /// Non-zero adv-interval (the default) must keep debouncing via a
+    /// real timer exactly as before — no flush message before it
+    /// fires.
+    #[tokio::test]
+    async fn send_ipv4_nonzero_adv_interval_still_arms_timer() {
+        let (_id, mut group) = test_group(0);
+        assert_eq!(group.adv_interval, AdvInterval::default());
+        let (tx, mut rx) = mpsc::channel(8);
+
+        send_ipv4(&mut group, nlri("10.0.0.1/32"), test_attr(0), 99, &tx, true);
+
+        assert!(
+            group.cache_ipv4_timer.is_some(),
+            "non-zero interval must debounce via a timer"
+        );
+        assert!(!group.immediate_flush_queued_ipv4);
+        assert!(
+            rx.try_recv().is_err(),
+            "flush must not fire before the debounce timer elapses"
+        );
+    }
+
+    /// IPv6 twin of `send_ipv4_zero_adv_interval_queues_flush_without_timer`
+    /// — catches a copy-paste mistake in the mirrored wiring.
+    #[tokio::test]
+    async fn send_ipv6_zero_adv_interval_queues_flush_without_timer() {
+        let (id, mut group) = test_group(0);
+        group.adv_interval = AdvInterval { ibgp: 0, ebgp: 0 };
+        let (tx, mut rx) = mpsc::channel(8);
+        let attr = {
+            let mut attr = BgpAttr::new();
+            attr.origin = Some(Origin::Igp);
+            attr.aspath = Some(As4Path::from(vec![65001]));
+            attr.nexthop = Some(BgpNexthop::Ipv6("2001:db8::1".parse().unwrap()));
+            Arc::new(attr)
+        };
+        let nlri6 = Ipv6Nlri {
+            id: 0,
+            prefix: "2001:db8:1::/48".parse().unwrap(),
+        };
+
+        send_ipv6(&mut group, nlri6, attr, 99, &tx, true);
+
+        assert!(group.cache_ipv6_timer.is_none());
+        assert!(group.immediate_flush_queued_ipv6);
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("flush must already be queued, no timer wait")
+            .expect("channel open");
+        let Message::FlushUpdateGroupIpv6(got) = msg else {
+            panic!("expected FlushUpdateGroupIpv6, got {msg:?}");
+        };
+        assert_eq!(got, id);
+    }
+
+    /// IPv6 twin of `send_ipv4_nonzero_adv_interval_still_arms_timer`.
+    #[tokio::test]
+    async fn send_ipv6_nonzero_adv_interval_still_arms_timer() {
+        let (_id, mut group) = test_group(0);
+        assert_eq!(group.adv_interval, AdvInterval::default());
+        let (tx, mut rx) = mpsc::channel(8);
+        let attr = {
+            let mut attr = BgpAttr::new();
+            attr.origin = Some(Origin::Igp);
+            attr.aspath = Some(As4Path::from(vec![65001]));
+            attr.nexthop = Some(BgpNexthop::Ipv6("2001:db8::1".parse().unwrap()));
+            Arc::new(attr)
+        };
+        let nlri6 = Ipv6Nlri {
+            id: 0,
+            prefix: "2001:db8:1::/48".parse().unwrap(),
+        };
+
+        send_ipv6(&mut group, nlri6, attr, 99, &tx, true);
+
+        assert!(group.cache_ipv6_timer.is_some());
+        assert!(!group.immediate_flush_queued_ipv6);
+        assert!(rx.try_recv().is_err());
     }
 
     /// Counter merge accumulates additive fields and overwrites the


### PR DESCRIPTION
## Summary

With `set router bgp timer adv-interval ebgp 0` the MRAI is supposed to be disabled, but announce-to-delivery latency never drops below ~1 s regardless of prefix count (measured p50 ~1017 ms for 1000 prefixes, ~1124 ms for 50k — the marginal cost of 49k extra prefixes is only ~100 ms, so the constant floor dominates). Found while benchmarking zebra-rs 26.7.7 as a DUT with xk6-bgp; gobgpd and RustyBGP converge the same 1000-prefix case in ~20–40 ms. For reference, FRR defaults advertisement-interval to 0 for both eBGP and iBGP, so 0 is a mainstream operating point rather than an edge case.

## Cause / fix

The advertise debounce timers (update-group IPv4/IPv6 flush, per-peer VPNv4/VPNv6/EVPN caches) were armed via `Timer::once`, whose constructor clamps 0 seconds to 1 second.

Mirror FRR's `bgp_adjust_routeadv()` handling of `v_routeadv == 0`: with adv-interval 0, arm no timer at all and queue the flush message directly via `tokio::spawn` (keeping the same `.send().await` backpressure as the timer path — `try_send` could silently drop the flush and wedge the cache). Since nothing spawned runs until the current synchronous advertise batch returns control to the executor, same-batch sends still coalesce into a single flush; batches across separate event-loop passes no longer wait out an artificial floor. A new `immediate_flush_queued_*` flag (paired with each existing `cache_*_timer` field) gates re-queueing within one batch and is reset wherever the timer field already resets. Non-zero intervals keep the existing timer path untouched.

## Tests

Nine unit tests across the five sites: adv-interval 0 delivers the flush without arming a timer (well under the old 1 s floor), multiple same-batch sends queue exactly one flush (coalescing), and non-zero intervals still debounce via the timer path.
