### PR TITLE
bgp: arm a 1 ms next-tick timer for adv-interval 0 instead of a bare spawn

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1012,14 +1012,6 @@ pub struct Peer {
     pub cache_evpn_rev: HashMap<EvpnRoute, Arc<BgpAttr>>,
     pub cache_vpnv4_timer: Option<Timer>,
     pub cache_evpn_timer: Option<Timer>,
-    /// Adv-interval-0 twins of the three timer fields above: set when
-    /// `send_vpnv4`/`send_vpnv6`/`send_evpn` (route.rs) queues an
-    /// immediate flush event with no timer armed. Gates re-queueing
-    /// within one synchronous advertise batch; cleared by
-    /// `fsm_adv_timer_*_expires` alongside the matching `cache_*_timer`.
-    pub immediate_flush_queued_vpnv4: bool,
-    pub immediate_flush_queued_vpnv6: bool,
-    pub immediate_flush_queued_evpn: bool,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
     // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
     // this peer. Needed because TCP_AO_DEL_KEY requires the exact
@@ -1175,9 +1167,6 @@ impl Peer {
             cache_evpn_rev: HashMap::default(),
             cache_vpnv4_timer: None,
             cache_evpn_timer: None,
-            immediate_flush_queued_vpnv4: false,
-            immediate_flush_queued_vpnv6: false,
-            immediate_flush_queued_evpn: false,
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
             adv_interval: timer::AdvInterval::default(),
@@ -1958,7 +1947,6 @@ pub fn fsm(
 
 pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {
     peer.cache_vpnv4_timer = None;
-    peer.immediate_flush_queued_vpnv4 = false;
     if peer.state.is_established() {
         peer.flush_vpnv4();
     }
@@ -1967,7 +1955,6 @@ pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {
 
 pub fn fsm_adv_timer_vpnv6_expires(peer: &mut Peer) -> State {
     peer.cache_vpnv6_timer = None;
-    peer.immediate_flush_queued_vpnv6 = false;
     if peer.state.is_established() {
         peer.flush_vpnv6();
     }
@@ -1976,7 +1963,6 @@ pub fn fsm_adv_timer_vpnv6_expires(peer: &mut Peer) -> State {
 
 pub fn fsm_adv_timer_evpn_expires(peer: &mut Peer) -> State {
     peer.cache_evpn_timer = None;
-    peer.immediate_flush_queued_evpn = false;
     if peer.state.is_established() {
         peer.flush_evpn();
     }
@@ -4575,13 +4561,14 @@ mod adv_timer_phantom_tests {
         (peer, rx)
     }
 
-    /// adv-interval 0 must behave like FRR's `bgp_adjust_routeadv`
-    /// `v_routeadv == 0` special case: no debounce timer at all — the
-    /// flush event is queued directly (`tokio::spawn`, no sleep) so it
-    /// must already be sitting on the channel well before the old
-    /// `Timer::once` 1 s floor could ever fire.
+    /// adv-interval 0 mirrors FRR's `bgp_adjust_routeadv`
+    /// `v_routeadv == 0` case: arm a *next-tick* (~1 ms) debounce timer
+    /// rather than the 1 s-clamped `Timer::once(0, …)`.
+    /// `duration_sec() == 0` is the regression guard (the old clamp
+    /// gave a 1 s timer); the flush event must also land on the channel
+    /// well before the old 1 s floor.
     #[tokio::test]
-    async fn send_vpnv4_zero_adv_interval_queues_flush_without_timer() {
+    async fn send_vpnv4_zero_adv_interval_flushes_under_one_second_floor() {
         let (mut peer, mut rx) = peer_with_channel();
         peer.adv_interval = timer::AdvInterval { ibgp: 0, ebgp: 0 };
         let nlri = Vpnv4Nlri {
@@ -4595,14 +4582,18 @@ mod adv_timer_phantom_tests {
 
         peer.send_vpnv4(nlri, Arc::new(BgpAttr::new()), true);
 
-        assert!(
-            peer.cache_vpnv4_timer.is_none(),
-            "adv-interval 0 must not arm a debounce timer"
+        let timer = peer
+            .cache_vpnv4_timer
+            .as_ref()
+            .expect("adv-interval 0 must still arm a debounce timer");
+        assert_eq!(
+            timer.duration_sec(),
+            0,
+            "adv-interval 0 must arm a sub-second timer, not the 1 s-clamped one"
         );
-        assert!(peer.immediate_flush_queued_vpnv4);
         let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
             .await
-            .expect("flush event must already be queued, no timer wait")
+            .expect("flush event must fire well under the old 1 s floor")
             .expect("channel open");
         match msg {
             Message::Event(ident, Event::AdvTimerVpnv4Expires) => assert_eq!(ident, peer.ident),
@@ -4611,7 +4602,8 @@ mod adv_timer_phantom_tests {
     }
 
     /// Non-zero adv-interval (the default) must keep debouncing via a
-    /// real timer exactly as before — no flush event before it fires.
+    /// multi-second timer exactly as before — no flush event before it
+    /// fires.
     #[tokio::test]
     async fn send_vpnv4_nonzero_adv_interval_still_arms_timer() {
         let (mut peer, mut rx) = peer_with_channel();
@@ -4627,11 +4619,14 @@ mod adv_timer_phantom_tests {
 
         peer.send_vpnv4(nlri, Arc::new(BgpAttr::new()), true);
 
+        let timer = peer
+            .cache_vpnv4_timer
+            .as_ref()
+            .expect("non-zero interval must debounce via a timer");
         assert!(
-            peer.cache_vpnv4_timer.is_some(),
-            "non-zero interval must debounce via a timer"
+            timer.duration_sec() >= 1,
+            "non-zero interval must arm a multi-second timer, not the next-tick one"
         );
-        assert!(!peer.immediate_flush_queued_vpnv4);
         assert!(
             rx.try_recv().is_err(),
             "flush must not fire before the debounce timer elapses"
@@ -4643,7 +4638,7 @@ mod adv_timer_phantom_tests {
     /// mirrored wiring (VPNv6 is identical in shape to VPNv4, so it
     /// isn't repeated here).
     #[tokio::test]
-    async fn send_evpn_zero_adv_interval_queues_flush_without_timer() {
+    async fn send_evpn_zero_adv_interval_flushes_under_one_second_floor() {
         let (mut peer, mut rx) = peer_with_channel();
         peer.adv_interval = timer::AdvInterval { ibgp: 0, ebgp: 0 };
         let route = EvpnRoute::EthernetAd(EvpnEthernetAd {
@@ -4656,11 +4651,14 @@ mod adv_timer_phantom_tests {
 
         peer.send_evpn(route, Arc::new(BgpAttr::new()), true);
 
-        assert!(peer.cache_evpn_timer.is_none());
-        assert!(peer.immediate_flush_queued_evpn);
+        let timer = peer
+            .cache_evpn_timer
+            .as_ref()
+            .expect("adv-interval 0 must still arm a debounce timer");
+        assert_eq!(timer.duration_sec(), 0);
         let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
             .await
-            .expect("flush event must already be queued, no timer wait")
+            .expect("flush event must fire well under the old 1 s floor")
             .expect("channel open");
         match msg {
             Message::Event(ident, Event::AdvTimerEvpnExpires) => assert_eq!(ident, peer.ident),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -10204,11 +10204,9 @@ pub fn route_clean(
     peer.cache_vpnv4.clear();
     peer.cache_vpnv4_rev.clear();
     peer.cache_vpnv4_timer = None;
-    peer.immediate_flush_queued_vpnv4 = false;
     peer.cache_vpnv6.clear();
     peer.cache_vpnv6_rev.clear();
     peer.cache_vpnv6_timer = None;
-    peer.immediate_flush_queued_vpnv6 = false;
 
     // IPv6 unicast. Same shape as the IPv4 block above — withdraw
     // every prefix the peer gave us from the Loc-RIB (which fans out
@@ -10729,7 +10727,6 @@ pub fn route_clean(
     peer.cache_evpn.clear();
     peer.cache_evpn_rev.clear();
     peer.cache_evpn_timer = None;
-    peer.immediate_flush_queued_evpn = false;
 
     // IPv4 / IPv6 Labeled-Unicast (SAFI 4). No LLGR handling yet —
     // withdraw every labeled route the peer gave us and clear the
@@ -12322,23 +12319,8 @@ impl Peer {
             .or_default()
             .insert(nlri.clone());
         self.cache_vpnv4_rev.insert(nlri, attr);
-        if timer && self.cache_vpnv4_timer.is_none() && !self.immediate_flush_queued_vpnv4 {
-            let secs = self.adv_interval.secs_for(self.peer_type);
-            if secs == 0 {
-                // See `update_group::send_ipv4` for why adv-interval 0
-                // queues the flush event directly instead of arming a
-                // timer.
-                self.immediate_flush_queued_vpnv4 = true;
-                let tx = self.tx.clone();
-                let ident = self.ident;
-                tokio::spawn(async move {
-                    let _ = tx
-                        .send(Message::Event(ident, Event::AdvTimerVpnv4Expires))
-                        .await;
-                });
-            } else {
-                self.cache_vpnv4_timer = Some(start_adv_timer_vpnv4(self));
-            }
+        if timer && self.cache_vpnv4_timer.is_none() {
+            self.cache_vpnv4_timer = Some(start_adv_timer_vpnv4(self));
         }
     }
 
@@ -12368,23 +12350,8 @@ impl Peer {
             .or_default()
             .insert(route.clone());
         self.cache_evpn_rev.insert(route, attr);
-        if timer && self.cache_evpn_timer.is_none() && !self.immediate_flush_queued_evpn {
-            let secs = self.adv_interval.secs_for(self.peer_type);
-            if secs == 0 {
-                // See `update_group::send_ipv4` for why adv-interval 0
-                // queues the flush event directly instead of arming a
-                // timer.
-                self.immediate_flush_queued_evpn = true;
-                let tx = self.tx.clone();
-                let ident = self.ident;
-                tokio::spawn(async move {
-                    let _ = tx
-                        .send(Message::Event(ident, Event::AdvTimerEvpnExpires))
-                        .await;
-                });
-            } else {
-                self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
-            }
+        if timer && self.cache_evpn_timer.is_none() {
+            self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
         }
     }
 
@@ -12460,23 +12427,8 @@ impl Peer {
             .or_default()
             .insert(nlri.clone());
         self.cache_vpnv6_rev.insert(nlri, attr);
-        if timer && self.cache_vpnv6_timer.is_none() && !self.immediate_flush_queued_vpnv6 {
-            let secs = self.adv_interval.secs_for(self.peer_type);
-            if secs == 0 {
-                // See `update_group::send_ipv4` for why adv-interval 0
-                // queues the flush event directly instead of arming a
-                // timer.
-                self.immediate_flush_queued_vpnv6 = true;
-                let tx = self.tx.clone();
-                let ident = self.ident;
-                tokio::spawn(async move {
-                    let _ = tx
-                        .send(Message::Event(ident, Event::AdvTimerVpnv6Expires))
-                        .await;
-                });
-            } else {
-                self.cache_vpnv6_timer = Some(start_adv_timer_vpnv6(self));
-            }
+        if timer && self.cache_vpnv6_timer.is_none() {
+            self.cache_vpnv6_timer = Some(start_adv_timer_vpnv6(self));
         }
     }
 

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -98,6 +98,32 @@ macro_rules! start_timer {
     }};
 }
 
+/// Advertise-debounce timer. Identical to `start_timer!` except an
+/// adv-interval of 0 arms a next-tick (~1 ms) timer instead of letting
+/// `Timer::once` clamp 0 s up to its 1 s floor. The one-timer-at-a-time
+/// gate (`cache_*_timer.is_none()`) still coalesces a same-batch burst
+/// into a single flush, so 0 means "flush as fast as the executor
+/// turns over" without the artificial second of latency.
+macro_rules! start_adv_timer {
+    ($peer:expr, $secs:expr, $ev:expr) => {{
+        let ident = $peer.ident;
+        let tx = $peer.tx.clone();
+        let secs = $secs;
+
+        let cb = move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::Event(ident, $ev)).await;
+            }
+        };
+        if secs == 0 {
+            Timer::once_ms(1, cb)
+        } else {
+            Timer::once(secs, cb)
+        }
+    }};
+}
+
 macro_rules! start_repeater {
     ($peer:expr, $time:expr, $ev:expr) => {{
         let ident = $peer.ident;
@@ -148,12 +174,12 @@ fn start_hold_timer(peer: &Peer) -> Timer {
 
 pub fn start_adv_timer_vpnv4(peer: &Peer) -> Timer {
     let secs = peer.adv_interval.secs_for(peer.peer_type);
-    start_timer!(peer, secs, Event::AdvTimerVpnv4Expires)
+    start_adv_timer!(peer, secs, Event::AdvTimerVpnv4Expires)
 }
 
 pub fn start_adv_timer_vpnv6(peer: &Peer) -> Timer {
     let secs = peer.adv_interval.secs_for(peer.peer_type);
-    start_timer!(peer, secs, Event::AdvTimerVpnv6Expires)
+    start_adv_timer!(peer, secs, Event::AdvTimerVpnv6Expires)
 }
 
 /// EVPN advertise debounce — same iBGP/eBGP cadence as the IPv4 /
@@ -161,7 +187,7 @@ pub fn start_adv_timer_vpnv6(peer: &Peer) -> Timer {
 /// UPDATE per attribute group.
 pub fn start_adv_timer_evpn(peer: &Peer) -> Timer {
     let secs = peer.adv_interval.secs_for(peer.peer_type);
-    start_timer!(peer, secs, Event::AdvTimerEvpnExpires)
+    start_adv_timer!(peer, secs, Event::AdvTimerEvpnExpires)
 }
 
 fn start_keepalive_timer(peer: &Peer) -> Timer {
@@ -303,7 +329,6 @@ pub fn update_timers(peer: &mut Peer) {
     }
     if peer.state != Established {
         peer.cache_vpnv4_timer = None;
-        peer.immediate_flush_queued_vpnv4 = false;
     }
 }
 

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -263,13 +263,9 @@ pub struct UpdateGroup {
     pub cache_ipv4_rev: HashMap<Ipv4Nlri, Arc<BgpAttr>>,
     /// Adv-debounce timer. Started on first send; on fire,
     /// `Bgp::serve` drains the cache and ships UPDATEs to members.
+    /// With `adv_interval` 0 this is a ~1 ms next-tick timer (see
+    /// `start_adv_timer_ipv4`) rather than the usual multi-second one.
     pub cache_ipv4_timer: Option<Timer>,
-    /// Set instead of `cache_ipv4_timer` when `adv_interval` is 0: no
-    /// timer is armed at all, a flush message is queued directly (see
-    /// `send_ipv4`). Gates re-queueing within one synchronous
-    /// advertise batch; cleared by `build_flush_job_ipv4` alongside
-    /// `cache_ipv4_timer`.
-    pub immediate_flush_queued_ipv4: bool,
 
     // ── IPv6 unicast pending advertisement cache ──
     //
@@ -279,8 +275,6 @@ pub struct UpdateGroup {
     pub cache_ipv6: HashMap<Arc<BgpAttr>, HashMap<Ipv6Nlri, usize>>,
     pub cache_ipv6_rev: HashMap<Ipv6Nlri, Arc<BgpAttr>>,
     pub cache_ipv6_timer: Option<Timer>,
-    /// IPv6 twin of `immediate_flush_queued_ipv4`.
-    pub immediate_flush_queued_ipv6: bool,
 
     /// Snapshot of `Bgp::adv_interval` captured at group creation
     /// (`attach`) and refreshed by the global config callback. Used
@@ -547,11 +541,9 @@ pub fn attach(
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
-                immediate_flush_queued_ipv4: false,
                 cache_ipv6: HashMap::new(),
                 cache_ipv6_rev: HashMap::new(),
                 cache_ipv6_timer: None,
-                immediate_flush_queued_ipv6: false,
                 adv_interval,
                 flush_inflight_ipv4: false,
                 flush_pending_ipv4: false,
@@ -662,28 +654,9 @@ pub fn send_ipv4(
         .or_default()
         .insert(nlri.clone(), source_ident);
     group.cache_ipv4_rev.insert(nlri, attr);
-    if kick_timer && group.cache_ipv4_timer.is_none() && !group.immediate_flush_queued_ipv4 {
+    if kick_timer && group.cache_ipv4_timer.is_none() {
         let secs = group.adv_interval.secs_for(group.sig.peer_type);
-        if secs == 0 {
-            // FRR's bgp_adjust_routeadv() treats v_routeadv==0 as "no
-            // timer, schedule update-group packet generation as a 0 ms
-            // event" rather than a fast timer. Mirror that: queue the
-            // flush directly instead of arming `Timer::once`, which
-            // clamps 0 secs to a 1 s floor. `tokio::spawn` doesn't
-            // sleep at all — it just runs on the next scheduler pass —
-            // so this can't fire before the current synchronous
-            // advertise batch returns control to the executor, which
-            // is what keeps same-batch sends coalescing into one
-            // flush.
-            group.immediate_flush_queued_ipv4 = true;
-            let tx = tx.clone();
-            let id = group.id.clone();
-            tokio::spawn(async move {
-                let _ = tx.send(Message::FlushUpdateGroupIpv4(id)).await;
-            });
-        } else {
-            group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, secs));
-        }
+        group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, secs));
     }
 }
 
@@ -709,13 +682,23 @@ pub fn cache_remove_ipv4(group: &mut UpdateGroup, prefix: ipnet::Ipv4Net, id: u3
 fn start_adv_timer_ipv4(tx: &mpsc::Sender<Message>, id: &UpdateGroupId, secs: u64) -> Timer {
     let tx = tx.clone();
     let id = id.clone();
-    Timer::once(secs, move || {
+    let cb = move || {
         let tx = tx.clone();
         let id = id.clone();
         async move {
             let _ = tx.send(Message::FlushUpdateGroupIpv4(id)).await;
         }
-    })
+    };
+    // adv-interval 0 fires on the next tick (~1 ms) instead of letting
+    // `Timer::once` clamp 0 s up to its 1 s floor. `cache_ipv4_timer`
+    // stays `Some` until the flush drains it, so a same-batch burst
+    // still coalesces into one flush. See `start_adv_timer!` in
+    // timer.rs for the per-peer twin of this.
+    if secs == 0 {
+        Timer::once_ms(1, cb)
+    } else {
+        Timer::once(secs, cb)
+    }
 }
 
 /// One member's send context, snapshotted out of `PeerMap` while
@@ -965,7 +948,6 @@ pub(super) fn build_flush_job_ipv4(
 ) -> Option<FlushJob<Ipv4Nlri>> {
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
     group.cache_ipv4_timer = None;
-    group.immediate_flush_queued_ipv4 = false;
     let buckets: Vec<(Arc<BgpAttr>, Vec<(Ipv4Nlri, usize)>)> = group
         .cache_ipv4
         .drain()
@@ -1206,20 +1188,9 @@ pub fn send_ipv6(
         .or_default()
         .insert(nlri.clone(), source_ident);
     group.cache_ipv6_rev.insert(nlri, attr);
-    if kick_timer && group.cache_ipv6_timer.is_none() && !group.immediate_flush_queued_ipv6 {
+    if kick_timer && group.cache_ipv6_timer.is_none() {
         let secs = group.adv_interval.secs_for(group.sig.peer_type);
-        if secs == 0 {
-            // See `send_ipv4` for why this queues directly instead of
-            // arming a timer.
-            group.immediate_flush_queued_ipv6 = true;
-            let tx = tx.clone();
-            let id = group.id.clone();
-            tokio::spawn(async move {
-                let _ = tx.send(Message::FlushUpdateGroupIpv6(id)).await;
-            });
-        } else {
-            group.cache_ipv6_timer = Some(start_adv_timer_ipv6(tx, &group.id, secs));
-        }
+        group.cache_ipv6_timer = Some(start_adv_timer_ipv6(tx, &group.id, secs));
     }
 }
 
@@ -1240,13 +1211,19 @@ pub fn cache_remove_ipv6(group: &mut UpdateGroup, prefix: ipnet::Ipv6Net, id: u3
 fn start_adv_timer_ipv6(tx: &mpsc::Sender<Message>, id: &UpdateGroupId, secs: u64) -> Timer {
     let tx = tx.clone();
     let id = id.clone();
-    Timer::once(secs, move || {
+    let cb = move || {
         let tx = tx.clone();
         let id = id.clone();
         async move {
             let _ = tx.send(Message::FlushUpdateGroupIpv6(id)).await;
         }
-    })
+    };
+    // See `start_adv_timer_ipv4` for why 0 fires on the next tick.
+    if secs == 0 {
+        Timer::once_ms(1, cb)
+    } else {
+        Timer::once(secs, cb)
+    }
 }
 
 /// IPv6 counterpart of [`build_flush_job_ipv4`]. No ENHE step — v6
@@ -1258,7 +1235,6 @@ pub(super) fn build_flush_job_ipv6(
 ) -> Option<FlushJob<Ipv6Nlri>> {
     let afi_safi = AfiSafi::new(Afi::Ip6, Safi::Unicast);
     group.cache_ipv6_timer = None;
-    group.immediate_flush_queued_ipv6 = false;
     let buckets: Vec<(Arc<BgpAttr>, Vec<(Ipv6Nlri, usize)>)> = group
         .cache_ipv6
         .drain()
@@ -1893,11 +1869,9 @@ mod tests {
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
-                immediate_flush_queued_ipv4: false,
                 cache_ipv6: HashMap::new(),
                 cache_ipv6_rev: HashMap::new(),
                 cache_ipv6_timer: None,
-                immediate_flush_queued_ipv6: false,
                 adv_interval: AdvInterval::default(),
                 flush_inflight_ipv4: false,
                 flush_pending_ipv4: false,
@@ -2244,11 +2218,9 @@ mod tests {
             cache_ipv4: HashMap::new(),
             cache_ipv4_rev: HashMap::new(),
             cache_ipv4_timer: None,
-            immediate_flush_queued_ipv4: false,
             cache_ipv6: HashMap::new(),
             cache_ipv6_rev: HashMap::new(),
             cache_ipv6_timer: None,
-            immediate_flush_queued_ipv6: false,
             adv_interval: AdvInterval::default(),
             flush_inflight_ipv4: false,
             flush_pending_ipv4: false,
@@ -2385,28 +2357,33 @@ mod tests {
         assert_eq!(group.counters.messages_formatted, 1);
     }
 
-    // ── adv-interval 0: immediate flush, no timer ──
+    // ── adv-interval 0: sub-second flush, no 1 s floor ──
 
-    /// adv-interval 0 must not arm `cache_ipv4_timer` at all — the
-    /// flush message is queued directly (`tokio::spawn`, no sleep), so
-    /// it must already be sitting on the channel well before the old
-    /// `Timer::once` 1 s floor could ever fire.
+    /// adv-interval 0 must arm a *next-tick* (~1 ms) timer, not the
+    /// 1 s-clamped `Timer::once(0, …)`. `duration_sec() == 0` is the
+    /// regression guard: the old clamp produced a 1 s timer
+    /// (`duration_sec() == 1`). The flush must also land on the channel
+    /// well under the old 1 s floor.
     #[tokio::test]
-    async fn send_ipv4_zero_adv_interval_queues_flush_without_timer() {
+    async fn send_ipv4_zero_adv_interval_flushes_under_one_second_floor() {
         let (id, mut group) = test_group(0);
         group.adv_interval = AdvInterval { ibgp: 0, ebgp: 0 };
         let (tx, mut rx) = mpsc::channel(8);
 
         send_ipv4(&mut group, nlri("10.0.0.1/32"), test_attr(0), 99, &tx, true);
 
-        assert!(
-            group.cache_ipv4_timer.is_none(),
-            "adv-interval 0 must not arm a debounce timer"
+        let timer = group
+            .cache_ipv4_timer
+            .as_ref()
+            .expect("adv-interval 0 must still arm a debounce timer");
+        assert_eq!(
+            timer.duration_sec(),
+            0,
+            "adv-interval 0 must arm a sub-second timer, not the 1 s-clamped one"
         );
-        assert!(group.immediate_flush_queued_ipv4);
         let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
             .await
-            .expect("flush must already be queued, no timer wait")
+            .expect("flush must fire well under the old 1 s floor")
             .expect("channel open");
         let Message::FlushUpdateGroupIpv4(got) = msg else {
             panic!("expected FlushUpdateGroupIpv4, got {msg:?}");
@@ -2415,9 +2392,9 @@ mod tests {
     }
 
     /// A burst of sends within one synchronous batch (before the
-    /// executor gets a chance to run the queued flush task) must still
-    /// coalesce into a single flush message — adv-interval 0 removes
-    /// the timer, not the batching.
+    /// executor runs the ~1 ms timer) must still coalesce into a single
+    /// flush message — adv-interval 0 shortens the debounce, it doesn't
+    /// remove the batching.
     #[tokio::test]
     async fn send_ipv4_zero_adv_interval_coalesces_batch_into_one_flush() {
         let (_id, mut group) = test_group(0);
@@ -2444,8 +2421,8 @@ mod tests {
     }
 
     /// Non-zero adv-interval (the default) must keep debouncing via a
-    /// real timer exactly as before — no flush message before it
-    /// fires.
+    /// multi-second timer exactly as before — no flush message before
+    /// it fires.
     #[tokio::test]
     async fn send_ipv4_nonzero_adv_interval_still_arms_timer() {
         let (_id, mut group) = test_group(0);
@@ -2454,21 +2431,24 @@ mod tests {
 
         send_ipv4(&mut group, nlri("10.0.0.1/32"), test_attr(0), 99, &tx, true);
 
+        let timer = group
+            .cache_ipv4_timer
+            .as_ref()
+            .expect("non-zero interval must debounce via a timer");
         assert!(
-            group.cache_ipv4_timer.is_some(),
-            "non-zero interval must debounce via a timer"
+            timer.duration_sec() >= 1,
+            "non-zero interval must arm a multi-second timer, not the next-tick one"
         );
-        assert!(!group.immediate_flush_queued_ipv4);
         assert!(
             rx.try_recv().is_err(),
             "flush must not fire before the debounce timer elapses"
         );
     }
 
-    /// IPv6 twin of `send_ipv4_zero_adv_interval_queues_flush_without_timer`
+    /// IPv6 twin of `send_ipv4_zero_adv_interval_flushes_under_one_second_floor`
     /// — catches a copy-paste mistake in the mirrored wiring.
     #[tokio::test]
-    async fn send_ipv6_zero_adv_interval_queues_flush_without_timer() {
+    async fn send_ipv6_zero_adv_interval_flushes_under_one_second_floor() {
         let (id, mut group) = test_group(0);
         group.adv_interval = AdvInterval { ibgp: 0, ebgp: 0 };
         let (tx, mut rx) = mpsc::channel(8);
@@ -2486,11 +2466,14 @@ mod tests {
 
         send_ipv6(&mut group, nlri6, attr, 99, &tx, true);
 
-        assert!(group.cache_ipv6_timer.is_none());
-        assert!(group.immediate_flush_queued_ipv6);
+        let timer = group
+            .cache_ipv6_timer
+            .as_ref()
+            .expect("adv-interval 0 must still arm a debounce timer");
+        assert_eq!(timer.duration_sec(), 0);
         let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
             .await
-            .expect("flush must already be queued, no timer wait")
+            .expect("flush must fire well under the old 1 s floor")
             .expect("channel open");
         let Message::FlushUpdateGroupIpv6(got) = msg else {
             panic!("expected FlushUpdateGroupIpv6, got {msg:?}");
@@ -2518,8 +2501,11 @@ mod tests {
 
         send_ipv6(&mut group, nlri6, attr, 99, &tx, true);
 
-        assert!(group.cache_ipv6_timer.is_some());
-        assert!(!group.immediate_flush_queued_ipv6);
+        let timer = group
+            .cache_ipv6_timer
+            .as_ref()
+            .expect("non-zero interval must debounce via a timer");
+        assert!(timer.duration_sec() >= 1);
         assert!(rx.try_recv().is_err());
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #2109. That PR removed the adv-interval-0 latency floor (`Timer::once` clamps `0 s → 1 s`, so every debounced flush waited a full second) by bypassing the timer entirely — it queued the flush directly via `tokio::spawn` and added an `immediate_flush_queued_*` flag at each of the five cache sites to gate re-queueing within one advertise batch.

This reworks that fix into a smaller shape with the same effect: for adv-interval 0, arm the debounce timer with **`Timer::once_ms(1)`** (which does **not** clamp) instead of `Timer::once(0)` (which clamps up to 1 s). The existing `cache_*_timer.is_some()` gate already coalesces a same-batch burst into a single flush, so the new flag and all six of its reset sites are no longer needed and are deleted.

**Net −39 lines** vs. #2109's approach.

## Behaviour

- adv-interval 0 → ~1 ms next-tick debounce (was ~0 ms with the bare spawn; both are far under the old 1 s floor and negligible against the ~20–40 ms convergence target that motivated #2109).
- Non-zero intervals: unchanged (`Timer::once(secs)` as before).
- All five sites (update-group IPv4/IPv6, per-peer VPNv4/VPNv6/EVPN) route through the single `secs == 0` branch in their timer starter — update-group via `start_adv_timer_ipv4/ipv6`, per-peer via a new `start_adv_timer!` macro (`start_timer!` is left untouched so other timers keep their semantics).

## Why simpler

The bare-spawn approach needed a companion boolean per cache (`immediate_flush_queued_ipv4/ipv6`, `immediate_flush_queued_vpnv4/vpnv6/evpn`) whose sole job was to reproduce the coalescing that `cache_*_timer.is_some()` already provides — and it had to be reset in lockstep at every site the timer field resets (`build_flush_job_*`, `fsm_adv_timer_*_expires`, `route_clean`, `update_timers`). Reusing the timer field for the 0 case collapses all of that back into the existing gate.

## Tests

The nine unit tests from #2109 are reworked: the zero-interval tests now assert the armed timer is **sub-second** (`duration_sec() == 0` — the regression guard against a re-clamp to `Timer::once(0)`) and that the flush still lands well under the old 1 s floor; the same-batch coalescing and non-zero-interval debounce tests are retained.

`cargo test -p zebra-rs` (714 bgp tests), `cargo clippy --workspace --all-targets`, and `cargo fmt --all --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)