### PR TITLE
bgp: per-neighbor advertisement-interval for ipv4/ipv6 unicast + adv-interval-0 BDD

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -15,6 +15,18 @@ rr:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_basic_rr"
 
+bgp_adv_interval_zero:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero"
+
+bgp_adv_interval_zero_v6:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero_v6"
+
+bgp_adv_interval_zero_vrf:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero_vrf"
+
 # IPv4 unicast announced inside MP_REACH_NLRI (RFC 4760 §3) by a scripted
 # speaker (tests/scripts/bgp_mp_reach_send.py) — zebra-rs/FRR/GoBGP all
 # emit traditional NLRI, so only the script can produce this encoding.

--- a/bdd/tests/configs/bgp_adv_interval_zero/z1-1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero/z1-1.yaml
@@ -1,0 +1,40 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 0
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: vpnv4
+        enabled: true
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_adv_interval_zero/z2-1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero/z2-1.yaml
@@ -1,0 +1,30 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 0
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: vpnv4
+        enabled: true
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/configs/bgp_adv_interval_zero_v6/z1-1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero_v6/z1-1.yaml
@@ -1,0 +1,36 @@
+vrf:
+- name: vrf-blue
+  ipv6:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 0
+    neighbor:
+    - remote-address: 2001:db8::2
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      - name: vpnv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:100::/64
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      afi-safi:
+        ipv6:
+          network:
+          - prefix: 2001:db8:a::/64

--- a/bdd/tests/configs/bgp_adv_interval_zero_v6/z2-1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero_v6/z2-1.yaml
@@ -1,0 +1,28 @@
+vrf:
+- name: vrf-blue
+  ipv6:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 0
+    neighbor:
+    - remote-address: 2001:db8::1
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      - name: vpnv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/configs/bgp_adv_interval_zero_vrf/ce1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero_vrf/ce1.yaml
@@ -1,0 +1,43 @@
+# CE (AS 65001). A plain global router (no VRF) peering with the PE over
+# IPv4 and IPv6 transport, each neighbor with `advertisement-interval 0`
+# — the global per-neighbor MRAI knob. It redistributes its connected
+# loopbacks so the PE's vrf-cust receives them; with adv-interval 0 the PE
+# must receive them without waiting out the stock MRAI.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+  ipv6:
+    address: 2001:db8:8::1/128
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.1.1
+    neighbor:
+    - remote-address: 10.1.0.1
+      remote-as: 65000
+      timers:
+        advertisement-interval: 0
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    - remote-address: 2001:db8:1::1
+      remote-as: 65000
+      timers:
+        advertisement-interval: 0
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/bgp_adv_interval_zero_vrf/pe1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero_vrf/pe1.yaml
@@ -1,0 +1,79 @@
+# PE (AS 65000). vrf-cust holds two PE-CE eBGP neighbors to the CE — one
+# over IPv4 transport (ipv4 unicast), one over IPv6 transport (ipv6
+# unicast) — each with `advertisement-interval 0`. This is the only way
+# to give a per-VRF neighbor a non-default MRAI: the instance-level
+# `router bgp timer adv-interval` snapshot never reaches the per-VRF task.
+#
+# The PE originates one prefix per family into vrf-cust via a static route
+# with a vrf-local next hop (the CE link address) + `redistribute static`
+# — a bare `network` statement in a VRF resolves its next hop to the
+# global router-id, which is unreachable inside the VRF and so is not
+# advertised. With adv-interval 0 the CE must receive both without waiting
+# out the stock 5s/30s MRAI.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  static:
+    vrf:
+    - name: vrf-cust
+      ipv4:
+        route:
+        - prefix: 10.9.0.0/24
+          nexthop:
+          - address: 10.1.0.2
+      ipv6:
+        route:
+        - prefix: 2001:db8:9::/64
+          nexthop:
+          - address: 2001:db8:1::2
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      - remote-address: 10.1.0.2
+        remote-as: 65001
+        timers:
+          advertisement-interval: 0
+        afi-safi:
+        - name: ipv4
+          enabled: true
+      - remote-address: 2001:db8:1::2
+        remote-as: 65001
+        timers:
+          advertisement-interval: 0
+        afi-safi:
+        - name: ipv6
+          enabled: true
+      afi-safi:
+        ipv4:
+          redistribute:
+            static: {}
+        ipv6:
+          redistribute:
+            static: {}

--- a/bdd/tests/features/bgp_adv_interval_zero.feature
+++ b/bdd/tests/features/bgp_adv_interval_zero.feature
@@ -1,0 +1,67 @@
+@serial
+@bgp_adv_interval_zero
+Feature: BGP zero adv-interval delivers routes across IPv4 families
+  As a network operator
+  I want `router bgp timer adv-interval ibgp 0` to disable the MRAI
+  debounce without stalling advertisement
+  Using a two-namespace iBGP topology that carries IPv4 unicast, VPNv4,
+  and EVPN over one session, all with adv-interval 0.
+
+  Regression guard for the adv-interval-0 fast-flush path (a 0-second
+  MRAI arms a ~1 ms next-tick debounce timer instead of the old
+  1 s-clamped one): each family's routes must still converge at the peer.
+
+  Test Topology:
+  ```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   iBGP AS65001 │     z2      │
+  │ 192.168.0.1 │ ◀────────────▶ │ 192.168.0.2 │
+  │ vrf-blue    │ ipv4/vpnv4/evpn│ vrf-blue    │
+  │  RD 65001:  │  adv-interval  │  RD 65001:  │
+  │   100       │    ibgp 0      │   200       │
+  │  RT 65001:100 imp/exp        │  RT 65001:100 imp/exp
+  └─────────────┘                └─────────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, adv-interval ibgp 0, neighbor 192.168.0.2 with
+    ipv4/vpnv4/evpn address families. Originates ipv4 unicast 10.0.0.1/32
+    and vrf-blue net 10.1.0.0/24 (exported to VPNv4 and, via
+    `evpn advertise-ipv4`, as an EVPN Type-5).
+  - z2-1.yaml: AS 65001, adv-interval ibgp 0, same address families,
+    vrf-blue RD 65001:200 with matching import RT.
+
+  Scenario: Setup topology and establish the multiprotocol session
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually be "Established"
+
+  Scenario: IPv4 unicast route converges with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp ipv4" in namespace "z2" should eventually contain "10.0.0.1/32"
+
+  Scenario: VPNv4 route converges with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp vpnv4" in namespace "z2" should eventually contain "10.1.0.0/24"
+    And show command "show bgp vpnv4" in namespace "z2" should eventually contain "65001:100"
+
+  Scenario: EVPN Type-5 route converges with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "[5]:"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "10.1.0.0"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_adv_interval_zero_v6.feature
+++ b/bdd/tests/features/bgp_adv_interval_zero_v6.feature
@@ -1,0 +1,62 @@
+@serial
+@bgp_adv_interval_zero_v6
+Feature: BGP zero adv-interval delivers routes across IPv6 families
+  As a network operator
+  I want `router bgp timer adv-interval ibgp 0` to disable the MRAI
+  debounce without stalling advertisement
+  Using a two-namespace iBGP topology over IPv6 transport that carries
+  IPv6 unicast and VPNv6, both with adv-interval 0.
+
+  IPv6 counterpart of @bgp_adv_interval_zero. Regression guard for the
+  adv-interval-0 fast-flush path (a 0-second MRAI arms a ~1 ms next-tick
+  debounce timer instead of the old 1 s-clamped one): each family's
+  routes must still converge at the peer.
+
+  Test Topology:
+  ```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   iBGP AS65001 │     z2      │
+  │ 2001:db8::1 │ ◀────────────▶ │ 2001:db8::2 │
+  │ vrf-blue    │   ipv6/vpnv6   │ vrf-blue    │
+  │  RD 65001:  │  adv-interval  │  RD 65001:  │
+  │   100       │    ibgp 0      │   200       │
+  │  RT 65001:100 imp/exp        │  RT 65001:100 imp/exp
+  └─────────────┘                └─────────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, adv-interval ibgp 0, neighbor 2001:db8::2 with
+    ipv6/vpnv6 address families. Originates ipv6 unicast 2001:db8:100::/64
+    and vrf-blue net 2001:db8:a::/64 (exported to VPNv6).
+  - z2-1.yaml: AS 65001, adv-interval ibgp 0, same address families,
+    vrf-blue RD 65001:200 with matching import RT.
+
+  Scenario: Setup topology and establish the multiprotocol session
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "2001:db8::1/64" on bridge "br0"
+    And I create namespace "z2" with IP "2001:db8::2/64" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    Then BGP session in "z1" to "2001:db8::2" should eventually be "Established"
+    And BGP session in "z2" to "2001:db8::1" should eventually be "Established"
+
+  Scenario: IPv6 unicast route converges with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp ipv6" in namespace "z2" should eventually contain "2001:db8:100::/64"
+
+  Scenario: VPNv6 route converges with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp vpnv6" in namespace "z2" should eventually contain "2001:db8:a::/64"
+    And show command "show bgp vpnv6" in namespace "z2" should eventually contain "65001:100"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_adv_interval_zero_vrf.feature
+++ b/bdd/tests/features/bgp_adv_interval_zero_vrf.feature
@@ -1,0 +1,69 @@
+@serial
+@bgp_adv_interval_zero_vrf
+Feature: Per-VRF BGP neighbor zero adv-interval delivers ipv4/ipv6 unicast
+  As an operator of an L3VPN PE
+  I want `router bgp vrf <name> neighbor <ce> timers advertisement-interval 0`
+  to disable the MRAI for a per-VRF CE neighbor
+  So that PE-CE ipv4/ipv6 unicast converges without waiting out the stock
+  MRAI — the instance-level `router bgp timer adv-interval` never reaches
+  the per-VRF task, so the per-neighbor knob is the only lever.
+
+  Regression guard for wiring the per-neighbor `advertisement-interval`
+  into the update-group signature (`adv_interval_override`) and arming
+  path: with 0 the per-VRF ipv4/ipv6-unicast advertise debounce arms a
+  ~1 ms next-tick timer instead of the stock 30s eBGP one. The CE side
+  uses the same knob as a plain global neighbor, so both directions are
+  covered.
+
+  Test Topology (2 namespaces, point-to-point, dual-stack):
+  ```
+   ce1 ───────────────── pe1
+   AS 65001            AS 65000
+   global              vrf-cust (RD 65000:1)
+   lo 10.0.1.1/32      net 10.9.0.0/24
+      2001:db8:8::1/128    2001:db8:9::/64
+        .2 ── .1   (10.1.0.0/30)
+        ::2 ── ::1 (2001:db8:1::/64)
+   adv-interval 0      adv-interval 0 (per VRF neighbor)
+  ```
+
+  Config files:
+  - pe1.yaml: AS 65000, vrf-cust with two CE neighbors (10.1.0.2 ipv4,
+    2001:db8:1::2 ipv6), each `timers advertisement-interval 0`. Originates
+    vrf-cust networks 10.9.0.0/24 and 2001:db8:9::/64.
+  - ce1.yaml: AS 65001, global neighbors to the PE (ipv4 + ipv6), each
+    `timers advertisement-interval 0`, redistributing connected loopbacks.
+
+  Scenario: Build the PE-CE dual-stack topology and establish sessions
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    Then show command "show bgp vrf" in namespace "pe1" should eventually contain "vrf-cust"
+    And BGP session in "ce1" to "10.1.0.1" should eventually be "Established"
+    And BGP session in "ce1" to "2001:db8:1::1" should eventually be "Established"
+
+  Scenario: PE advertises its vrf-cust ipv4 network to the CE with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp ipv4" in namespace "ce1" should eventually contain "10.9.0.0/24"
+
+  Scenario: PE advertises its vrf-cust ipv6 network to the CE with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp ipv6" in namespace "ce1" should eventually contain "2001:db8:9::/64"
+
+  Scenario: CE advertises its ipv4/ipv6 loopbacks to the PE vrf with adv-interval 0
+    Given the test topology exists
+    Then show command "show bgp vrf vrf-cust" in namespace "pe1" should eventually contain "10.0.1.1/32"
+    And show command "show bgp vrf vrf-cust ipv6" in namespace "pe1" should eventually contain "2001:db8:8::1/128"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    Then the test environment should be clean

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -254,6 +254,7 @@
 /router/bgp/vrf/neighbor/route-reflector/client
 /router/bgp/vrf/neighbor/tcp-ao/include-tcp-options
 /router/bgp/vrf/neighbor/tcp-ao/key-chain
+/router/bgp/vrf/neighbor/timers/advertisement-interval
 /router/bgp/vrf/neighbor/timers/connect-retry-time
 /router/bgp/vrf/neighbor/timers/hold-time
 /router/bgp/vrf/neighbor/timers/idle-hold-time

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -22,8 +22,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 318
-Handled: 304
+Total settable schema nodes: 319
+Handled: 305
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -94,19 +94,20 @@ registers each binding from materialize_peers AFTER the peer has its ident,
 and unregisters them all on shutdown -- the actor has no unsubscribe, and
 its per-name watch lists only shrink on Unregister.
 
-Note: /router/bgp/vrf/neighbor/timers exposes only connect-retry-time,
-hold-time and idle-hold-time — the three leaves crate::bgp::timer::Config
-is actually read for. It deliberately does NOT `uses neighbor-group-timers`
-the way the global neighbor's timers container does, because three leaves
-of that grouping (advertisement-interval, originate-interval,
+Note: /router/bgp/vrf/neighbor/timers exposes connect-retry-time,
+hold-time, idle-hold-time and advertisement-interval — the leaves
+crate::bgp::timer::Config is actually read for. It deliberately does NOT
+`uses neighbor-group-timers` the way the global neighbor's timers
+container does, because two leaves of that grouping (originate-interval,
 delay-open-time) are staged onto PeerConfig::timer and never consumed by
 any timer-arming path. They are counted as handled orphans-by-another-name
 on the global neighbor (they have callbacks, they just do nothing); adding
-them under the VRF neighbor would have shipped three more knobs that
-silently no-op. Note also that the advertisement interval (MRAI) is NOT in
-this container on either neighbor: it comes from the AdvInterval snapshot
-configured under /router/bgp/timer/adv-interval, which has no per-VRF
-plumbing, so a per-VRF session always runs the stock 30s eBGP / 5s iBGP
+them under the VRF neighbor would have shipped two more knobs that
+silently no-op. advertisement-interval IS modelled here (unlike on the
+inert list): it feeds the update-group signature's adv_interval_override
+and is the only MRAI lever for a per-VRF neighbor, since the AdvInterval
+snapshot configured under /router/bgp/timer/adv-interval has no per-VRF
+plumbing. Without it a per-VRF session runs the stock 30s eBGP / 5s iBGP
 cadence.
 
 == Handler paths with no schema node (stale/other) ==

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -347,6 +347,7 @@
 /router/bgp/vrf/neighbor/tcp-ao/include-tcp-options	leaf
 /router/bgp/vrf/neighbor/tcp-ao/key-chain	leaf
 /router/bgp/vrf/neighbor/timers	container
+/router/bgp/vrf/neighbor/timers/advertisement-interval	leaf
 /router/bgp/vrf/neighbor/timers/connect-retry-time	leaf
 /router/bgp/vrf/neighbor/timers/hold-time	leaf
 /router/bgp/vrf/neighbor/timers/idle-hold-time	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4423,6 +4423,10 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_idle_hold_time,
         );
         self.callback_add(
+            "/router/bgp/vrf/neighbor/timers/advertisement-interval",
+            super::vrf_config::config_vrf_neighbor_advertisement_interval,
+        );
+        self.callback_add(
             "/router/bgp/vrf/neighbor/afi-safi/enabled",
             super::vrf_config::config_vrf_neighbor_afi_safi_enabled,
         );

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -188,6 +188,17 @@ pub struct UpdateGroupSig {
     /// attributes (or only one attaching) must not share canonical
     /// bytes — fold it into the key. `None` when off (the common case).
     pub attach_unknown_attr: Option<UnknownAttr>,
+    /// Per-neighbor `advertisement-interval` override (MRAI in seconds),
+    /// or `None` to inherit the instance-level `router bgp timer
+    /// adv-interval` cadence via `adv_interval`. Unlike the fields
+    /// above it does NOT change the encoded UPDATE bytes — it only sets
+    /// how long the advertise debounce waits before flushing. It still
+    /// belongs in the signature: a group owns a single debounce timer,
+    /// so two peers with different advertise cadences must not share one
+    /// group (the slower peer's interval would otherwise pace the
+    /// faster one, or vice versa). `Some(0)` disables the MRAI — the
+    /// group flushes on the next tick (see `start_adv_timer_ipv4`).
+    pub adv_interval_override: Option<u16>,
     pub signature_version: u32,
 }
 
@@ -308,6 +319,21 @@ pub struct UpdateGroup {
     /// created, dropped (abort-on-drop) when it empties. For now it is idle —
     /// it tracks the member set and routes no egress yet.
     pub task: Option<super::group_egress::GroupEgressTask>,
+}
+
+impl UpdateGroup {
+    /// Seconds the advertise debounce should wait before flushing this
+    /// group's cache. A per-neighbor `advertisement-interval` override
+    /// (folded into the signature, so every member shares it) wins over
+    /// the instance-level `router bgp timer adv-interval` cadence held
+    /// in `adv_interval`. `0` disables the MRAI — `start_adv_timer_*`
+    /// arms a next-tick (~1 ms) timer rather than the multi-second one.
+    pub fn effective_adv_interval_secs(&self) -> u64 {
+        match self.sig.adv_interval_override {
+            Some(secs) => secs as u64,
+            None => self.adv_interval.secs_for(self.sig.peer_type),
+        }
+    }
 }
 
 /// Per-AFI/SAFI bookkeeping: the active groups plus a monotonic seq
@@ -441,6 +467,10 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         // onto every advertised route, so peers with different attach
         // specs encode different bytes and must shard the group.
         attach_unknown_attr: peer.config.attach_unknown_attr.clone(),
+        // Per-neighbor `advertisement-interval` (all AFI/SAFIs — a
+        // timing knob, not a per-family transform). `None` inherits the
+        // instance-level `router bgp timer adv-interval` cadence.
+        adv_interval_override: peer.config.timer.min_adv_interval,
         signature_version: SIGNATURE_VERSION,
     })
 }
@@ -655,7 +685,7 @@ pub fn send_ipv4(
         .insert(nlri.clone(), source_ident);
     group.cache_ipv4_rev.insert(nlri, attr);
     if kick_timer && group.cache_ipv4_timer.is_none() {
-        let secs = group.adv_interval.secs_for(group.sig.peer_type);
+        let secs = group.effective_adv_interval_secs();
         group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, secs));
     }
 }
@@ -1189,7 +1219,7 @@ pub fn send_ipv6(
         .insert(nlri.clone(), source_ident);
     group.cache_ipv6_rev.insert(nlri, attr);
     if kick_timer && group.cache_ipv6_timer.is_none() {
-        let secs = group.adv_interval.secs_for(group.sig.peer_type);
+        let secs = group.effective_adv_interval_secs();
         group.cache_ipv6_timer = Some(start_adv_timer_ipv6(tx, &group.id, secs));
     }
 }
@@ -1461,6 +1491,7 @@ mod tests {
             vpnv4_next_hop_unchanged: false,
             egress_script: None,
             attach_unknown_attr: None,
+            adv_interval_override: None,
             signature_version: SIGNATURE_VERSION,
         }
     }
@@ -2507,6 +2538,55 @@ mod tests {
             .expect("non-zero interval must debounce via a timer");
         assert!(timer.duration_sec() >= 1);
         assert!(rx.try_recv().is_err());
+    }
+
+    // ── per-neighbor advertisement-interval override ──
+
+    /// `effective_adv_interval_secs` prefers the signature override
+    /// (per-neighbor `advertisement-interval`) over the instance-level
+    /// `adv_interval` snapshot.
+    #[test]
+    fn effective_adv_interval_prefers_the_signature_override() {
+        let (_id, mut group) = test_group(0);
+        // Instance default is non-zero (30s eBGP for the test sig).
+        assert!(group.effective_adv_interval_secs() >= 1);
+        group.sig.adv_interval_override = Some(0);
+        assert_eq!(group.effective_adv_interval_secs(), 0);
+        group.sig.adv_interval_override = Some(7);
+        assert_eq!(group.effective_adv_interval_secs(), 7);
+    }
+
+    /// A per-neighbor `advertisement-interval 0` override (as a VRF CE
+    /// neighbor sets) must arm the next-tick (~1 ms) debounce even when
+    /// the instance-level `adv_interval` is the multi-second default —
+    /// this is the VRF-neighbor path, where the instance knob never
+    /// reaches the peer.
+    #[tokio::test]
+    async fn send_ipv4_neighbor_override_zero_flushes_under_one_second_floor() {
+        let (id, mut group) = test_group(0);
+        assert_eq!(group.adv_interval, AdvInterval::default());
+        group.sig.adv_interval_override = Some(0);
+        let (tx, mut rx) = mpsc::channel(8);
+
+        send_ipv4(&mut group, nlri("10.0.0.1/32"), test_attr(0), 99, &tx, true);
+
+        let timer = group
+            .cache_ipv4_timer
+            .as_ref()
+            .expect("override 0 must still arm a debounce timer");
+        assert_eq!(
+            timer.duration_sec(),
+            0,
+            "per-neighbor advertisement-interval 0 must arm a sub-second timer"
+        );
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("flush must fire well under the old 1 s floor")
+            .expect("channel open");
+        let Message::FlushUpdateGroupIpv4(got) = msg else {
+            panic!("expected FlushUpdateGroupIpv4, got {msg:?}");
+        };
+        assert_eq!(got, id);
     }
 
     /// Counter merge accumulates additive fields and overwrites the

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -787,6 +787,34 @@ pub fn config_vrf_neighbor_idle_hold_time(
     Some(())
 }
 
+/// `set router bgp vrf <NAME> neighbor <addr> timers
+/// advertisement-interval <SECS>`.
+///
+/// Per-neighbor MinRouteAdvertisementInterval (MRAI). Staged onto
+/// `min_adv_interval` and carried onto the VRF peer by
+/// `materialize_peers`; the update-group folds it into its signature
+/// (`signature_of`) and `effective_adv_interval_secs` consults it when
+/// arming the ipv4/ipv6-unicast advertise debounce. This is the only
+/// way to give a per-VRF neighbor an MRAI other than the stock default:
+/// the instance-level `router bgp timer adv-interval` never reaches the
+/// per-VRF task. `0` disables the debounce (next-tick flush).
+pub fn config_vrf_neighbor_advertisement_interval(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, name, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    match op {
+        ConfigOp::Set => nbr.config.timer.min_adv_interval = Some(args.u16()?),
+        ConfigOp::Delete => nbr.config.timer.min_adv_interval = None,
+        _ => {}
+    }
+    Some(())
+}
+
 /// Generate a `… afi-safi <af> {policy,prefix-set} {in,out} <name>`
 /// callback. Unlike the `vrf_afi_knob!` family these do not go through a
 /// shared `afi_knob` setter: the value is not a `PeerConfig` field but a
@@ -1872,21 +1900,53 @@ mod tests {
 
     #[test]
     fn neighbor_timers_leave_the_inert_leaves_unset() {
-        // The schema deliberately omits advertisement-interval /
-        // originate-interval / delay-open-time: they are staged onto
-        // `PeerConfig::timer` and never read by any arming path, even for
-        // a global neighbor. Sharing `timer::Config` with the peer means
-        // they exist as fields, so pin that they stay `None` — if one is
-        // ever wired up, this test should fail and prompt exposing it
-        // here too.
+        // The schema still omits originate-interval / delay-open-time:
+        // they are staged onto `PeerConfig::timer` and never read by any
+        // arming path, even for a global neighbor. Sharing `timer::Config`
+        // with the peer means they exist as fields, so pin that they stay
+        // `None` — if one is ever wired up, this test should fail and
+        // prompt exposing it here too. `min_adv_interval` is now wired
+        // (advertisement-interval), so it is no longer pinned here — see
+        // `neighbor_advertisement_interval_stages_min_adv_interval`.
         let address: IpAddr = "192.0.2.1".parse().unwrap();
         let mut cfg = BgpVrfConfig::default();
         let nbr = neighbor_entry(&mut cfg, address, ConfigOp::Set).unwrap();
         nbr.config.timer.connect_retry_time = Some(3);
 
-        assert!(nbr.config.timer.min_adv_interval.is_none());
         assert!(nbr.config.timer.orig_interval.is_none());
         assert!(nbr.config.timer.delay_open_time.is_none());
+    }
+
+    /// `timers advertisement-interval <secs>` on a VRF neighbor stages
+    /// `min_adv_interval`; a delete clears it. This is what
+    /// `signature_of` reads into the update-group's
+    /// `adv_interval_override`, so a VRF neighbor can run an MRAI other
+    /// than the stock default (the instance-level knob never reaches the
+    /// per-VRF task).
+    #[test]
+    fn neighbor_advertisement_interval_stages_min_adv_interval() {
+        let address: IpAddr = "192.0.2.1".parse().unwrap();
+        let mut cfg = BgpVrfConfig::default();
+        let nbr = neighbor_entry(&mut cfg, address, ConfigOp::Set).unwrap();
+        nbr.config.timer.min_adv_interval = Some(0);
+        assert_eq!(
+            cfg.neighbors[&address].config.timer.min_adv_interval,
+            Some(0)
+        );
+
+        cfg.neighbors
+            .get_mut(&address)
+            .unwrap()
+            .config
+            .timer
+            .min_adv_interval = None;
+        assert!(
+            cfg.neighbors[&address]
+                .config
+                .timer
+                .min_adv_interval
+                .is_none()
+        );
     }
 
     #[test]

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -198,24 +198,38 @@ module zebra-bgp-vrf {
         description
           "Session timers for this CE peer. Deliberately NOT `uses
            neighbor-group-timers` (the grouping the global neighbor
-           takes): three of that grouping's leaves
-           (advertisement-interval, originate-interval,
+           takes): two of that grouping's leaves (originate-interval,
            delay-open-time) are staged onto `PeerConfig::timer` and
            never read by any timer-arming path, so mirroring it here
-           would expose knobs that silently do nothing. Only the three
-           leaves `crate::bgp::timer::Config` actually consumes are
-           modelled.
+           would expose knobs that silently do nothing. Only the leaves
+           `crate::bgp::timer::Config` actually consumes are modelled.
 
            These are applied by `materialize_peers` when the peer is
            built, so an edit takes effect on the next VRF respawn or
            `clear bgp` rather than on the live session.
 
-           Note this container does NOT cover the advertisement
-           interval (MRAI): that is paced by the `AdvInterval`
-           snapshot on the peer, configured under the instance-level
-           `router bgp timer adv-interval`, which does not reach
-           per-VRF tasks. A per-VRF session therefore still runs the
-           stock 30s eBGP / 5s iBGP MRAI.";
+           `advertisement-interval` IS modelled here (unlike
+           originate-interval / delay-open-time): it is the only way to
+           set a per-VRF neighbor's MRAI, since the instance-level
+           `router bgp timer adv-interval` snapshot does not reach
+           per-VRF tasks. Without it a per-VRF session runs the stock
+           30s eBGP / 5s iBGP MRAI.";
+        leaf advertisement-interval {
+          ext:help "MinRouteAdvertisementInterval (MRAI) in seconds";
+          type uint16;
+          units "seconds";
+          description
+            "Per-neighbor MRAI: how long the ipv4/ipv6-unicast
+             advertise debounce coalesces burst route changes before
+             flushing to this CE. `0` disables the debounce (the group
+             flushes on the next event-loop tick). When unset the peer
+             uses the stock default (30s eBGP / 5s iBGP), as the
+             instance-level `router bgp timer adv-interval` does not
+             reach the per-VRF task.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+             Section 9.2.1.1.";
+        }
         leaf connect-retry-time {
           ext:help "ConnectRetry timer (seconds)";
           type uint16 {


### PR DESCRIPTION
## Summary

Follow-up to the adv-interval-0 fast-flush fix (#2109 / #2110). Two parts:

### 1. Wire the per-neighbor `advertisement-interval` knob (code)

`advertisement-interval` was staged onto `PeerConfig::timer.min_adv_interval` but **never read** — a dead knob on the global neighbor. And a **per-VRF neighbor had no MRAI lever at all**: the instance-level `router bgp timer adv-interval` snapshot is only propagated to the global instance's peers/update-groups, never to a per-VRF task, so VRF neighbors were stuck on the stock 5 s iBGP / 30 s eBGP MRAI.

This wires it for ipv4/ipv6 unicast (which advertise via update-groups):

- **`UpdateGroupSig` gains `adv_interval_override: Option<u16>`**, sourced from `min_adv_interval` in `signature_of`. It is a timing knob (not a byte-affecting transform), but still belongs in the signature: a group owns a single debounce timer, so two peers with different advertise cadences must not share one group.
- **`UpdateGroup::effective_adv_interval_secs()`** prefers the override over the instance `adv_interval` snapshot; `send_ipv4`/`send_ipv6` arm the debounce with it. `0` disables the MRAI (next-tick ~1 ms flush).
- **VRF neighbor exposes `timers advertisement-interval`** (`zebra-bgp-vrf.yang`), parsed into `min_adv_interval` (`config_vrf_neighbor_advertisement_interval`); `materialize_peers` already copies the whole timer config onto the VRF peer. This is the only way to give a per-VRF neighbor a non-default MRAI.

The global-neighbor `advertisement-interval` (previously inert) now also takes effect for unicast. VPNv4/VPNv6/EVPN (per-peer, not update-group) are unchanged and follow the instance cadence. Config-audit docs regenerated for the new handled leaf.

### 2. adv-interval-0 BDD coverage (tests)

Three new features, each ending in a Teardown scenario:

| Feature | Covers |
|---|---|
| `@bgp_adv_interval_zero` | instance `timer adv-interval ibgp 0`: ipv4 unicast + VPNv4 + EVPN Type-5 |
| `@bgp_adv_interval_zero_v6` | IPv6 transport: ipv6 unicast + VPNv6 |
| `@bgp_adv_interval_zero_vrf` | per-VRF CE neighbor `timers advertisement-interval 0` + global-neighbor knob: ipv4 & ipv6 unicast, both directions |

Assertions poll (`should eventually contain`) rather than asserting latency, so they verify convergence without a timing race. The VRF PE originates via a per-VRF static route + `redistribute` (a bare `network` in a VRF resolves its next hop to the unreachable global router-id and isn't advertised).

## Tests

- `cargo test --workspace --exclude bdd` — 39 suites green (incl. regenerated `bgp_config_audit`), plus new unit tests for `effective_adv_interval_secs` and the VRF `advertisement-interval` parse.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean.
- All three BDD features pass locally (`make install` first): `@bgp_adv_interval_zero` (5 scenarios), `@bgp_adv_interval_zero_v6` (4), `@bgp_adv_interval_zero_vrf` (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)