### PR TITLE
bgp: advertise VRF self-originated `network` to CE neighbors

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -27,6 +27,10 @@ bgp_adv_interval_zero_vrf:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero_vrf"
 
+bgp_vrf_self_network:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_self_network"
+
 # IPv4 unicast announced inside MP_REACH_NLRI (RFC 4760 §3) by a scripted
 # speaker (tests/scripts/bgp_mp_reach_send.py) — zebra-rs/FRR/GoBGP all
 # emit traditional NLRI, so only the script can produce this encoding.

--- a/bdd/tests/configs/bgp_vrf_self_network/ce1.yaml
+++ b/bdd/tests/configs/bgp_vrf_self_network/ce1.yaml
@@ -1,0 +1,32 @@
+# CE (AS 65001). Plain global router peering with the PE over IPv4 and
+# IPv6 transport; it just needs the two sessions up to receive the PE's
+# vrf-cust self-originated networks.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.1.1
+    neighbor:
+    - remote-address: 10.1.0.1
+      remote-as: 65000
+      timers:
+        advertisement-interval: 0
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    - remote-address: 2001:db8:1::1
+      remote-as: 65000
+      timers:
+        advertisement-interval: 0
+      afi-safi:
+      - name: ipv6
+        enabled: true

--- a/bdd/tests/configs/bgp_vrf_self_network/pe1.yaml
+++ b/bdd/tests/configs/bgp_vrf_self_network/pe1.yaml
@@ -1,0 +1,64 @@
+# PE (AS 65000). vrf-cust originates one prefix per family with a bare
+# `network` statement and peers with the CE over IPv4 and IPv6 transport.
+#
+# Regression guard: a self-originated `network` row must reach the CE. It
+# previously did not for the family whose CE neighbor held ident 0 (the
+# first peer enrolled in the VRF PeerMap) — the row's ident (0) aliased
+# that peer, so the egress split-horizon dropped it. The ipv4 neighbor is
+# listed first so it takes ident 0 and exercises that exact collision.
+#
+# advertisement-interval 0 keeps the runtime-add scenario prompt.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      - remote-address: 10.1.0.2
+        remote-as: 65001
+        timers:
+          advertisement-interval: 0
+        afi-safi:
+        - name: ipv4
+          enabled: true
+      - remote-address: 2001:db8:1::2
+        remote-as: 65001
+        timers:
+          advertisement-interval: 0
+        afi-safi:
+        - name: ipv6
+          enabled: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.9.0.0/24
+        ipv6:
+          network:
+          - prefix: 2001:db8:9::/64

--- a/bdd/tests/features/bgp_vrf_self_network.feature
+++ b/bdd/tests/features/bgp_vrf_self_network.feature
@@ -1,0 +1,62 @@
+@serial
+@bgp_vrf_self_network
+Feature: Per-VRF self-originated `network` reaches CE neighbors
+  As an operator of an L3VPN PE
+  I want a `network` under `router bgp vrf X afi-safi {ipv4,ipv6}` to be
+  advertised to the VRF's CE (unicast) neighbors
+  So that a PE can originate a prefix into a customer VRF without a
+  static route + redistribute workaround.
+
+  Regression guard for the self-originated split-horizon bug: the
+  self-originated Loc-RIB row carried ident 0, which aliased the first CE
+  enrolled in the VRF PeerMap (also ident 0), so the egress split-horizon
+  (`route_update_ipv4`: `rib.ident == ctx.ident`) dropped the route to
+  that peer. The row now carries `ORIGINATED_PEER`, like the redistribute
+  path. The ipv4 neighbor is enrolled first (ident 0) so scenario 2
+  exercises the exact collision that used to fail.
+
+  Test Topology (2 namespaces, point-to-point, dual-stack):
+  ```
+   ce1 ───────────────── pe1
+   AS 65001            AS 65000
+   global              vrf-cust (RD 65000:1)
+                        network 10.9.0.0/24
+                        network 2001:db8:9::/64
+        .2 ── .1   (10.1.0.0/30)
+        ::2 ── ::1 (2001:db8:1::/64)
+  ```
+
+  Config files:
+  - pe1.yaml: AS 65000, vrf-cust with ipv4 (10.1.0.2) + ipv6 (2001:db8:1::2)
+    CE neighbors, originating `network 10.9.0.0/24` and
+    `network 2001:db8:9::/64`.
+  - ce1.yaml: AS 65001, global neighbors to the PE (ipv4 + ipv6).
+
+  Scenario: Build the PE-CE dual-stack topology and establish sessions
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    Then show command "show bgp vrf" in namespace "pe1" should eventually contain "vrf-cust"
+    And BGP session in "ce1" to "10.1.0.1" should eventually be "Established"
+    And BGP session in "ce1" to "2001:db8:1::1" should eventually be "Established"
+
+  Scenario: CE receives the PE's self-originated ipv4 network (ident-0 peer)
+    Given the test topology exists
+    Then show command "show bgp ipv4" in namespace "ce1" should eventually contain "10.9.0.0/24"
+
+  Scenario: CE receives the PE's self-originated ipv6 network
+    Given the test topology exists
+    Then show command "show bgp ipv6" in namespace "ce1" should eventually contain "2001:db8:9::/64"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -2593,7 +2593,11 @@ impl BgpVrf {
     /// prefix. Driven by [`BgpVrfMsg::WithdrawNetwork`] when a
     /// `network` is removed from a running VRF.
     pub fn withdraw_self_network_v4(&mut self, prefix: ipnet::Ipv4Net) {
-        let removed = self.shard.remove(None, prefix, 0, 0);
+        // ident `ORIGINATED_PEER` — must match `originate_self_network_v4`
+        // (see `self_originated_rib`), else the row is never found.
+        let removed = self
+            .shard
+            .remove(None, prefix, 0, super::super::route::ORIGINATED_PEER);
         if removed.is_empty() {
             return;
         }
@@ -2628,7 +2632,10 @@ impl BgpVrf {
 
     /// IPv6 counterpart of [`Self::withdraw_self_network_v4`].
     pub fn withdraw_self_network_v6(&mut self, prefix: ipnet::Ipv6Net) {
-        let removed = self.shard.remove_v6(prefix, 0, 0);
+        // ident `ORIGINATED_PEER` — see `withdraw_self_network_v4`.
+        let removed = self
+            .shard
+            .remove_v6(prefix, 0, super::super::route::ORIGINATED_PEER);
         if removed.is_empty() {
             return;
         }
@@ -2819,7 +2826,14 @@ impl BgpVrf {
             remote_id: 0,
             local_id: 0,
             attr,
-            ident: 0,
+            // `ORIGINATED_PEER`, not 0: a self-originated row must not
+            // alias any real peer's ident, or the egress split-horizon
+            // (`route_update_ipv4`: `rib.ident == ctx.ident`) drops the
+            // route when advertising to the peer that happens to hold
+            // ident 0 (the first CE enrolled in this VRF's PeerMap). The
+            // redistribute path already uses `ORIGINATED_PEER` for the
+            // same reason; the withdraw paths key on it too.
+            ident: super::super::route::ORIGINATED_PEER,
             router_id: self.router_id,
             weight: 32768,
             typ: super::super::route::BgpRibType::Originated,
@@ -3663,6 +3677,54 @@ mod tests {
         Box::leak(Box::new(inbound_rx));
         let rib = RibClient::new(inbound_tx, ProtoId::from_raw(0));
         ProtoContext::for_vrf(rib, table_id, ifname.to_string())
+    }
+
+    /// Regression guard: a self-originated `network` row must carry
+    /// `ORIGINATED_PEER`, not ident 0. Ident 0 aliases the first CE
+    /// enrolled in the VRF PeerMap (also ident 0), so the egress
+    /// split-horizon (`route_update_ipv4`: `rib.ident == ctx.ident`)
+    /// dropped the route to that peer — a bare `network` never reached
+    /// the CE. `redist_inject_v4` already used `ORIGINATED_PEER`.
+    #[tokio::test]
+    async fn self_originated_network_uses_originated_peer_ident() {
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(51, "vrf-selforig");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-selforig".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let prefix: ipnet::Ipv4Net = "10.9.0.0/24".parse().unwrap();
+        vrf.originate_self_network_v4(prefix);
+        let row = vrf.shard.select_best_path(prefix);
+        let rib = row.first().expect("self-originated v4 row present");
+        assert_eq!(
+            rib.ident,
+            crate::bgp::route::ORIGINATED_PEER,
+            "self-originated v4 ident must be ORIGINATED_PEER, not 0 (split-horizon)"
+        );
+
+        let prefix6: ipnet::Ipv6Net = "2001:db8:9::/64".parse().unwrap();
+        vrf.originate_self_network_v6(prefix6);
+        let row6 = vrf.shard.select_best_path_v6(prefix6);
+        assert_eq!(
+            row6.first().expect("self-originated v6 row present").ident,
+            crate::bgp::route::ORIGINATED_PEER,
+            "self-originated v6 ident must be ORIGINATED_PEER, not 0"
+        );
+
+        // And the withdraw must find and remove the row by that ident.
+        vrf.withdraw_self_network_v4(prefix);
+        assert!(
+            vrf.shard.select_best_path(prefix).is_empty(),
+            "withdraw must remove the self-originated row (matching ident)"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

A `network` under `router bgp vrf X afi-safi {ipv4,ipv6}` is accepted and shows as `*>` best in `show bgp vrf X`, but is **silently not advertised to the VRF's CE (unicast) neighbors** — while `redistribute` and VPNv4 import are. The ipv6 case appeared to work, but only by accident of peer ordering.

## Root cause

`self_originated_rib` built the Loc-RIB row with **`ident: 0`**. The first CE enrolled in a VRF's `PeerMap` also gets ident `0` (`insert_with_key` assigns `peers.len()`), so the egress split-horizon in `route_update_ipv4` (`if rib.ident == ctx.ident { return None }`) treated the self-originated route as "learned from that peer" and dropped it. The route still reached any *other* peer (ident ≠ 0) — which is why a second-enrolled neighbor (e.g. the ipv6 one in a v4-first config) saw it and the v4 one didn't.

## Fix

Give self-originated rows **`ORIGINATED_PEER`** (`usize::MAX`) — the same sentinel `redist_inject_v4` already uses, and the identity the VPNv4 export path documents (`inst.rs`: "VRF-originated routes always carry `ident == ORIGINATED_PEER`"). The two `withdraw_self_network_*` paths are updated to key on it so the row is still found and removed. One line in `self_originated_rib` + the two withdraws.

## Scope / follow-up

This fixes origination applied **at spawn** (delivered to the CE via the session-up sync). A `network` added at **runtime** to an already-established CE still isn't re-advertised — `originate_self_network_*` doesn't call `route_advertise_to_peers` the way the import path does; that (plus the matching runtime withdraw) is a separate, larger follow-up and is intentionally out of scope here to keep this focused on the reported bug.

## Tests

- Unit guard `self_originated_network_uses_originated_peer_ident` (CI-visible, since BDD is excluded from CI) pins the ident and that withdraw still matches.
- BDD `@bgp_vrf_self_network`: a PE originates an ipv4 `network` (to the ident-0 CE neighbor — the exact case that used to fail) and an ipv6 `network`, asserting both reach the CE.
- `cargo test --workspace --exclude bdd` (39 suites) green; `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean. BDD feature passes locally (4 scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)