### PR TITLE
bdd: drop the static+redistribute workaround from bgp_adv_interval_zero_vrf

### DIFF
--- a/bdd/tests/configs/bgp_adv_interval_zero_vrf/pe1.yaml
+++ b/bdd/tests/configs/bgp_adv_interval_zero_vrf/pe1.yaml
@@ -4,12 +4,9 @@
 # to give a per-VRF neighbor a non-default MRAI: the instance-level
 # `router bgp timer adv-interval` snapshot never reaches the per-VRF task.
 #
-# The PE originates one prefix per family into vrf-cust via a static route
-# with a vrf-local next hop (the CE link address) + `redistribute static`
-# — a bare `network` statement in a VRF resolves its next hop to the
-# global router-id, which is unreachable inside the VRF and so is not
-# advertised. With adv-interval 0 the CE must receive both without waiting
-# out the stock 5s/30s MRAI.
+# The PE originates one prefix per family into vrf-cust with a plain
+# `network` statement. With adv-interval 0 the CE must receive both
+# without waiting out the stock 5s/30s MRAI.
 vrf:
 - name: vrf-cust
   ipv4:
@@ -35,19 +32,6 @@ interface:
   ipv6:
     address: 2001:db8:1::1/64
 router:
-  static:
-    vrf:
-    - name: vrf-cust
-      ipv4:
-        route:
-        - prefix: 10.9.0.0/24
-          nexthop:
-          - address: 10.1.0.2
-      ipv6:
-        route:
-        - prefix: 2001:db8:9::/64
-          nexthop:
-          - address: 2001:db8:1::2
   bgp:
     global:
       as: 65000
@@ -72,8 +56,8 @@ router:
           enabled: true
       afi-safi:
         ipv4:
-          redistribute:
-            static: {}
+          network:
+          - prefix: 10.9.0.0/24
         ipv6:
-          redistribute:
-            static: {}
+          network:
+          - prefix: 2001:db8:9::/64


### PR DESCRIPTION
## Summary

Cleanup after #2112 / #2113.

The `@bgp_adv_interval_zero_vrf` PE config (added in #2111) originated its two test prefixes via a per-VRF static route + `redistribute static`, with a comment explaining that a bare `network` in a VRF *"resolves its next hop to the global router-id, which is unreachable inside the VRF and so is not advertised"*.

**That explanation was wrong.** The real cause, found while investigating afterwards, was two separate bugs:

- **#2112** — the self-originated row carried `ident: 0`, which aliased the first CE enrolled in the VRF `PeerMap`, so the egress split-horizon (`rib.ident == ctx.ident`) dropped it to exactly that peer.
- **#2113** — runtime `network` edits were never advertised at all; only the session-up sync delivered them.

The next-hop is irrelevant: `route_update_ipv4` rewrites it regardless, and substituting `UNSPECIFIED` for the router-id was tried during the investigation and changed nothing.

Both bugs are fixed on `main`, so this switches the config to a plain `network` and corrects the comment. Net −16 lines.

A pleasant side effect: the feature now becomes an incidental second guard for those fixes, since the config shape it uses is exactly the one that used to fail.

## Tests

`make -C bdd bgp_adv_interval_zero_vrf` — 5 scenarios, 24 steps, all pass. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)