### PR TITLE
bgp: derive a VPWS service's Ethernet Segment from its attachment circuit

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-1.yaml
@@ -29,7 +29,6 @@ router:
         local-service-id: 101
         remote-service-id: 103
         interface: ce1
-        ethernet-segment: es1
     neighbor:
     - remote-address: 192.168.0.2
       enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-allactive.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-allactive.yaml
@@ -27,7 +27,6 @@ router:
         local-service-id: 101
         remote-service-id: 103
         interface: ce1
-        ethernet-segment: es1
     neighbor:
     - remote-address: 192.168.0.2
       enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-ambiguous.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-ambiguous.yaml
@@ -1,26 +1,28 @@
-# z2 — the other half of the dual-homed pair (RFC 8214 §5). Same Ethernet
-# Segment es1 and the same VPWS service instance id 101 as z1: the two PEs
-# are one logical endpoint of eline1. Single-active carving puts instance
-# 101 at ordinal 101 % 2 = 1, so z2 is the DF and advertises P=1 while z1
-# advertises B=1. Control-plane only — no cradle dataplane.
+# z1 — two Ethernet Segments both claim access port ce1, and eline1 names
+# neither. Inference cannot pick one, so the service stays single-homed and
+# `show bgp evpn vpws` reports both candidates instead of guessing an ESI.
 segment-routing:
   locator:
-  - name: LOC2
-    prefix: fcbb:bbbb:2::/48
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
     behavior: usid
 router:
   bgp:
     global:
       as: 65001
-      router-id: 192.168.0.2
+      router-id: 192.168.0.1
     segment-routing:
       srv6:
-        locator: LOC2
+        locator: LOC1
     afi-safi:
     - name: evpn
       ethernet-segment:
       - name: es1
         esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+      - name: es2
+        esi: "00:aa:bb:cc:dd:ee:ff:01:02:03"
         redundancy-mode: single-active
         interface: ce1
       vpws:
@@ -30,7 +32,7 @@ router:
         remote-service-id: 103
         interface: ce1
     neighbor:
-    - remote-address: 192.168.0.1
+    - remote-address: 192.168.0.2
       enabled: true
       remote-as: 65001
       afi-safi:

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-override.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-override.yaml
@@ -1,26 +1,29 @@
-# z2 — the other half of the dual-homed pair (RFC 8214 §5). Same Ethernet
-# Segment es1 and the same VPWS service instance id 101 as z1: the two PEs
-# are one logical endpoint of eline1. Single-active carving puts instance
-# 101 at ordinal 101 % 2 = 1, so z2 is the DF and advertises P=1 while z1
-# advertises B=1. Control-plane only — no cradle dataplane.
+# z1 — same ambiguous pair as z1-ambiguous.yaml, resolved by naming es2 on
+# the `ethernet-segment` leaf. The override wins over inference and the
+# Type-1 re-keys onto es2's ESI; z2 stays on es1, so z1 is now alone on its
+# segment and elects itself primary.
 segment-routing:
   locator:
-  - name: LOC2
-    prefix: fcbb:bbbb:2::/48
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
     behavior: usid
 router:
   bgp:
     global:
       as: 65001
-      router-id: 192.168.0.2
+      router-id: 192.168.0.1
     segment-routing:
       srv6:
-        locator: LOC2
+        locator: LOC1
     afi-safi:
     - name: evpn
       ethernet-segment:
       - name: es1
         esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+      - name: es2
+        esi: "00:aa:bb:cc:dd:ee:ff:01:02:03"
         redundancy-mode: single-active
         interface: ce1
       vpws:
@@ -29,8 +32,9 @@ router:
         local-service-id: 101
         remote-service-id: 103
         interface: ce1
+        ethernet-segment: es2
     neighbor:
-    - remote-address: 192.168.0.1
+    - remote-address: 192.168.0.2
       enabled: true
       remote-as: 65001
       afi-safi:

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-allactive.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-allactive.yaml
@@ -26,7 +26,6 @@ router:
         local-service-id: 101
         remote-service-id: 103
         interface: ce1
-        ethernet-segment: es1
     neighbor:
     - remote-address: 192.168.0.1
       enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
@@ -68,8 +68,10 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     # Instance 101 -> ordinal 1 -> z2 is DF. Both PEs agree on the winner.
     Then show command "show bgp evpn vpws" in namespace "z2" should eventually contain "Role: primary (DF 192.168.0.2)"
     And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
-    # The segment and its mode are reported alongside the role.
-    And show command "show bgp evpn vpws" in namespace "z1" should contain "Ethernet Segment: es1 (ESI 00:11:22:33:44:55:66:77:88:99, single-active)"
+    # Neither PE names a segment on its vpws service: es1 declares ce1 as its
+    # access port and the service's AC is ce1, so the binding is inferred —
+    # `(from ce1)` is the show reporting that it was derived, not configured.
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Ethernet Segment: es1 (from ce1) (ESI 00:11:22:33:44:55:66:77:88:99, single-active)"
     # The election reaches the wire: z3 receives one P and one B for the
     # same service instance.
     And show command "show bgp evpn" in namespace "z3" should eventually contain "l2-attr:P:mtu0"
@@ -83,7 +85,7 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     # and the backup bit disappears from the segment entirely.
     Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: primary"
     And show command "show bgp evpn vpws" in namespace "z2" should eventually contain "Role: primary"
-    And show command "show bgp evpn vpws" in namespace "z1" should contain "(ESI 00:11:22:33:44:55:66:77:88:99, all-active)"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "(from ce1) (ESI 00:11:22:33:44:55:66:77:88:99, all-active)"
     And show command "show bgp evpn" in namespace "z3" should eventually not contain "l2-attr:B:mtu0"
     # Back to single-active for the re-election scenario below.
     When I apply config "z1-1.yaml" to namespace "z1"
@@ -105,6 +107,31 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     # Put z2 back on the segment: z1 hands the DF role back, again with no
     # config change of its own.
     When I apply config "z2-1.yaml" to namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+
+  Scenario: An AC claimed by two segments is reported, not guessed; the leaf resolves it
+    Given the test topology exists
+    # Add a second segment es2 that also claims ce1. Inference now has two
+    # candidates and refuses both — picking one would silently move the
+    # service onto the wrong ESI.
+    When I apply config "z1-ambiguous.yaml" to namespace "z1"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Ethernet Segment: ambiguous"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "es1, es2 claim ce1"
+    # Ambiguous is not a segment: the service falls back to single-homed, so
+    # its Type-1 re-keys onto the all-zero ESI.
+    And show command "show bgp evpn" in namespace "z3" should eventually contain "[1]:[00:00:00:00:00:00:00:00:00:00]:[101]"
+    And show command "show bgp evpn vpws" in namespace "z1" should not contain "Role:"
+    # Naming one on the leaf is the documented way out. es2 wins over the
+    # inference that would have picked neither, and the Type-1 re-keys again
+    # — now onto es2's ESI, where z1 is the only PE and so elects itself.
+    When I apply config "z1-override.yaml" to namespace "z1"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Ethernet Segment: es2 (ESI 00:aa:bb:cc:dd:ee:ff:01:02:03, single-active)"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Role: primary (DF 192.168.0.1)"
+    # An overridden binding is not annotated `(from ...)` — it was configured.
+    And show command "show bgp evpn vpws" in namespace "z1" should not contain "es2 (from ce1)"
+    And show command "show bgp evpn" in namespace "z3" should eventually contain "[1]:[00:aa:bb:cc:dd:ee:ff:01:02:03]:[101]"
+    # Back to the inferred single-segment config for the scenarios that follow.
+    When I apply config "z1-1.yaml" to namespace "z1"
     Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
 
   Scenario: Teardown topology

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -84,10 +84,14 @@ the whole-port service.
 
 ### Multihoming (RFC 8214 §5)
 
-When the AC sits on a CE that is dual-homed to two PEs, both PEs name the
-same `ethernet-segment` (RFC 7432 — the shared ESI both advertise a Type-4
-under) and advertise the **same** VPWS service instance id: the pair is one
-logical endpoint of the E-Line.
+When the AC sits on a CE that is dual-homed to two PEs, both PEs configure
+the same `ethernet-segment` (RFC 7432 — the shared ESI both advertise a
+Type-4 under) and advertise the **same** VPWS service instance id: the pair
+is one logical endpoint of the E-Line.
+
+The service picks up the segment **from its attachment circuit** — the
+segment declares an `interface`, the service declares the same one, and that
+is the binding. Nothing else is needed:
 
 ```
 router bgp
@@ -95,14 +99,37 @@ router bgp
   ethernet-segment ES1
    esi 00:11:22:33:44:55:66:77:88:99
    redundancy-mode single-active
-   interface ce1
+   interface ce1              <-- the segment claims ce1 ...
   vpws eline1
    evi 100
    local-service-id 101
    remote-service-id 103
-   interface ce1
-   ethernet-segment ES1
+   interface ce1              <-- ... and this AC is ce1, so ES1 binds
 ```
+
+`show bgp evpn vpws` marks an inferred binding `(from ce1)`. This matches
+how every commercial implementation works — IOS-XR, Junos, Arista and FRR
+all configure the segment *on the interface*, so the AC is what identifies
+it and the two cannot contradict each other.
+
+The `ethernet-segment` leaf overrides that inference and is only needed in
+two cases: several segments claim the same access port, or the segment
+declares no `interface` of its own.
+
+```
+  vpws eline1
+   interface ce1
+   ethernet-segment ES2       <-- override; ES2 is used even if ES1 claims ce1
+```
+
+Two situations are reported rather than silently resolved:
+
+* **Ambiguous** — more than one segment claims the AC. The service stays
+  single-homed and `show` lists the candidates, because guessing would put
+  it on the wrong ESI. Naming one on the leaf resolves it.
+* **Interface mismatch** — the leaf names a segment whose `interface` is a
+  different port. The override still wins (explicit config is respected),
+  but `show` prints a `WARNING` line rather than swallowing the discrepancy.
 
 The segment supplies two things. Its **ESI** replaces the all-zero one in
 the service's Type-1, so the remote PE can tell that the routes it receives
@@ -148,17 +175,24 @@ VPWS service: eline1
   State: up
 ```
 
-A multihomed service adds its segment and elected role:
+A multihomed service adds its segment and elected role. `(from ce1)` marks a
+binding inferred from the AC; an overridden one is printed without it:
 
 ```
-  Ethernet Segment: ES1 (ESI 00:11:22:33:44:55:66:77:88:99, single-active)
+  Ethernet Segment: ES1 (from ce1) (ESI 00:11:22:33:44:55:66:77:88:99, single-active)
   Role: backup (DF 192.168.0.2)
 ```
 
-A segment name that resolves to nothing — no such `ethernet-segment`, or one
-whose `esi` is not set — shows as `(unresolved)` and the service stays
-single-homed, which distinguishes a typo from a deliberately single-homed
-service.
+The problem cases each print distinctly, so none of them can be mistaken for
+a deliberately single-homed service:
+
+```
+  Ethernet Segment: ES9 (no such segment)
+  Ethernet Segment: ambiguous — ES1, ES2 claim ce1; name one explicitly
+  Ethernet Segment: ES1 (ESI unset)
+  Ethernet Segment: ES2 (ESI …, single-active)
+  WARNING: segment interface ce7 differs from AC ce1
+```
 
 `json` is supported. The state progresses `partial-config` (mandatory
 leaves missing) → `pending` (config complete, no router-id / locator

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1898,7 +1898,9 @@ fn config_ethernet_segment_redundancy_mode(
 }
 
 /// `router bgp afi-safi evpn ethernet-segment <name> interface <name>` — the
-/// CE-facing access port bound to this ES.
+/// CE-facing access port bound to this ES. This is also what a VPWS service
+/// matches its AC against to infer its segment, so setting it can bind (or
+/// unbind) services that name no segment of their own.
 fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
@@ -1911,6 +1913,7 @@ fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp
         None
     };
     bgp.ethernet_segments.entry(name).or_default().interface = interface;
+    bgp.vpws_resync_es();
     Some(())
 }
 
@@ -2084,6 +2087,9 @@ fn config_vpws_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
         });
     }
     bgp.vpws_reconcile(&name);
+    // The AC is what infers the segment, so moving it can move the service
+    // onto (or off) one — even though no `ethernet-segment` leaf changed.
+    bgp.vpws_resync_es();
     Some(())
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -16120,27 +16120,41 @@ impl Bgp {
     /// than a bare re-originate) is what withdraws the route under the old
     /// segment before advertising it under the new one.
     pub fn vpws_resync_es(&mut self) {
-        let resolved: Vec<(String, Option<[u8; 10]>, bool)> = self
+        use super::vpws::EsBinding;
+        type Resolved = (String, EsBinding, Option<[u8; 10]>, bool, Option<String>);
+        let resolved: Vec<Resolved> = self
             .local_rib
             .evpn_vpws
             .services
             .iter()
             .map(|(name, svc)| {
-                let es = svc
-                    .ethernet_segment
-                    .as_ref()
-                    .and_then(|es_name| self.ethernet_segments.get(es_name));
+                let binding = self.vpws_bind_es(svc);
+                let es = binding.name().and_then(|n| self.ethernet_segments.get(n));
+                // The segment's own `interface`, when it names one that is
+                // not this AC. Only reachable through the explicit leaf —
+                // inference matches on that very field.
+                let mismatch = es
+                    .and_then(|e| e.interface.as_ref())
+                    .filter(|es_if| Some(*es_if) != svc.interface.as_ref())
+                    .cloned();
                 (
                     name.clone(),
+                    binding,
                     es.and_then(|e| e.esi),
                     es.is_some_and(|e| e.redundancy_mode.single_active()),
+                    mismatch,
                 )
             })
             .collect();
-        for (name, esi, single_active) in resolved {
+        for (name, binding, esi, single_active, mismatch) in resolved {
             let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(&name) else {
                 continue;
             };
+            // The binding and the mismatch note are display state — record
+            // them either way, but only an ESI or mode move is a wire event
+            // worth reconciling for.
+            svc.es = binding;
+            svc.es_if_mismatch = mismatch;
             if svc.esi == esi && svc.single_active == single_active {
                 continue;
             }
@@ -16148,6 +16162,17 @@ impl Bgp {
             svc.single_active = single_active;
             self.vpws_reconcile(&name);
         }
+    }
+
+    /// Resolve which Ethernet Segment VPWS service `svc` sits on. Thin
+    /// wrapper over [`super::vpws::bind_es`], which holds the rules (and the
+    /// unit tests) without needing a whole `Bgp`.
+    fn vpws_bind_es(&self, svc: &super::vpws::VpwsService) -> super::vpws::EsBinding {
+        super::vpws::bind_es(
+            svc.ethernet_segment.as_ref(),
+            svc.interface.as_ref(),
+            &self.ethernet_segments,
+        )
     }
 
     /// Re-run DF election for the services marked by a Type-4 install or

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2623,6 +2623,9 @@ struct VpwsServiceJson {
     remote_sid: Option<String>,
     remote_mtu_mismatch: Option<u16>,
     ethernet_segment: Option<String>,
+    ethernet_segment_binding: Option<String>,
+    ethernet_segment_candidates: Option<Vec<String>>,
+    ethernet_segment_if_mismatch: Option<String>,
     esi: Option<String>,
     redundancy_mode: Option<String>,
     role: Option<String>,
@@ -2667,7 +2670,21 @@ fn show_bgp_evpn_vpws(
                 local_sid: vpws.sids.get(name).map(|(addr, _)| addr.to_string()),
                 remote_sid: svc.remote_sid.map(|sid| sid.to_string()),
                 remote_mtu_mismatch: svc.remote_mtu_mismatch,
-                ethernet_segment: svc.ethernet_segment.clone(),
+                // The *effective* segment, however it was bound — a JSON
+                // consumer wants what the service is on, not what was typed.
+                ethernet_segment: svc.es.name().map(str::to_string),
+                ethernet_segment_binding: match &svc.es {
+                    super::vpws::EsBinding::None => None,
+                    super::vpws::EsBinding::Explicit(_) => Some("explicit".to_string()),
+                    super::vpws::EsBinding::Derived(_) => Some("derived".to_string()),
+                    super::vpws::EsBinding::Ambiguous(_) => Some("ambiguous".to_string()),
+                    super::vpws::EsBinding::Unresolved(_) => Some("unresolved".to_string()),
+                },
+                ethernet_segment_candidates: match &svc.es {
+                    super::vpws::EsBinding::Ambiguous(names) => Some(names.clone()),
+                    _ => None,
+                },
+                ethernet_segment_if_mismatch: svc.es_if_mismatch.clone(),
                 esi: svc.esi.map(|esi| bgp_packet::esi_display(&esi)),
                 redundancy_mode: svc.esi.map(|_| {
                     if svc.single_active {
@@ -2713,26 +2730,53 @@ fn show_bgp_evpn_vpws(
         if let Some(mtu) = svc.mtu.filter(|m| *m != 0) {
             writeln!(buf, "  MTU: {mtu}")?;
         }
-        // RFC 8214 §5 multihoming. The segment name shows even when it
-        // resolves to nothing (no such ES, or its ESI unset) — that is the
-        // difference between "single-homed" and "misconfigured".
-        if let Some(es_name) = &svc.ethernet_segment {
-            match svc.esi {
-                Some(esi) => {
-                    let mode = if svc.single_active {
-                        "single-active"
-                    } else {
-                        "all-active"
-                    };
+        // RFC 8214 §5 multihoming. Both failure states print — a typo'd
+        // segment name and an AC claimed by several segments must not look
+        // like a deliberately single-homed service.
+        match &svc.es {
+            super::vpws::EsBinding::None => {}
+            super::vpws::EsBinding::Unresolved(es_name) => {
+                writeln!(buf, "  Ethernet Segment: {es_name} (no such segment)")?;
+            }
+            super::vpws::EsBinding::Ambiguous(names) => {
+                writeln!(
+                    buf,
+                    "  Ethernet Segment: ambiguous — {} claim {}; name one explicitly",
+                    names.join(", "),
+                    svc.interface.as_deref().unwrap_or("this AC"),
+                )?;
+            }
+            binding @ (super::vpws::EsBinding::Explicit(es_name)
+            | super::vpws::EsBinding::Derived(es_name)) => {
+                let how = if matches!(binding, super::vpws::EsBinding::Derived(_)) {
+                    format!(" (from {})", svc.interface.as_deref().unwrap_or("AC"))
+                } else {
+                    String::new()
+                };
+                match svc.esi {
+                    Some(esi) => {
+                        let mode = if svc.single_active {
+                            "single-active"
+                        } else {
+                            "all-active"
+                        };
+                        writeln!(
+                            buf,
+                            "  Ethernet Segment: {es_name}{how} (ESI {}, {mode})",
+                            bgp_packet::esi_display(&esi)
+                        )?;
+                        let df = svc.df.map_or("(none)".to_string(), |df| df.to_string());
+                        writeln!(buf, "  Role: {} (DF {df})", svc.role.as_str())?;
+                    }
+                    None => writeln!(buf, "  Ethernet Segment: {es_name}{how} (ESI unset)")?,
+                }
+                if let Some(es_if) = &svc.es_if_mismatch {
                     writeln!(
                         buf,
-                        "  Ethernet Segment: {es_name} (ESI {}, {mode})",
-                        bgp_packet::esi_display(&esi)
+                        "  WARNING: segment interface {es_if} differs from AC {}",
+                        svc.interface.as_deref().unwrap_or("(unset)")
                     )?;
-                    let df = svc.df.map_or("(none)".to_string(), |df| df.to_string());
-                    writeln!(buf, "  Role: {} (DF {df})", svc.role.as_str())?;
                 }
-                None => writeln!(buf, "  Ethernet Segment: {es_name} (unresolved)")?,
             }
         }
         if let Some((sid, _)) = vpws.sids.get(name) {

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -10,12 +10,14 @@
 //! → cradle `AddXconnect`, which programs both the ingress XCONNECT map and
 //! the local `End.DX2` decap).
 //!
-//! A service whose AC sits on a multihomed Ethernet Segment names it with
-//! `ethernet-segment <name>`: the segment's ESI replaces the all-zero one in
-//! the Type-1, and Designated-Forwarder election over the PEs advertising
-//! that segment's Type-4 — run per `<ESI, VPWS service instance>` (RFC 8214
-//! §5) — drives the P/B bits. Single-homed services keep the all-zero ESI
-//! and advertise as primary.
+//! A service whose AC sits on a multihomed Ethernet Segment picks it up from
+//! that AC — an `ethernet-segment` whose `interface` is this service's
+//! `interface` binds automatically ([`bind_es`]), with the
+//! `ethernet-segment` leaf available to override. The segment's ESI replaces
+//! the all-zero one in the Type-1, and Designated-Forwarder election over
+//! the PEs advertising that segment's Type-4 — run per `<ESI, VPWS service
+//! instance>` (RFC 8214 §5) — drives the P/B bits. Single-homed services
+//! keep the all-zero ESI and advertise as primary.
 //!
 //! The Type-1 carries the RFC 8214 §3.1 Layer-2 Attributes extended
 //! community (P/B plus the configured L2 MTU); a remote whose non-zero MTU
@@ -24,7 +26,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv6Addr};
 
-use super::ethernet_segment::VpwsRole;
+use super::ethernet_segment::{EthernetSegment, VpwsRole};
 
 /// One configured VPWS service (`router bgp afi-safi evpn vpws <name>`).
 #[derive(Debug, Default, Clone)]
@@ -58,9 +60,19 @@ pub struct VpwsService {
     /// The remote's L2 MTU when a matching Type-1 was **rejected** for an
     /// MTU mismatch — the service shows `mtu-mismatch` instead of `up`.
     pub remote_mtu_mismatch: Option<u16>,
-    /// Name of the `ethernet-segment` this AC belongs to (RFC 8214 §5
-    /// multihoming). `None` = single-homed.
+    /// Name configured on the `ethernet-segment` leaf, if any. Usually
+    /// absent: every commercial implementation derives the segment from the
+    /// attachment circuit, so this is the override for the cases inference
+    /// cannot settle, not the normal way to bind one. The *effective*
+    /// binding — configured or inferred — is [`VpwsService::es`].
     pub ethernet_segment: Option<String>,
+    /// How this service ended up on a segment (or why it did not).
+    pub es: EsBinding,
+    /// The referenced segment's own `interface`, when it names one and it is
+    /// **not** this service's AC. Display-only: the explicit leaf still
+    /// wins, but a segment describing a different port than the AC it is
+    /// bound to is a config error worth showing rather than swallowing.
+    pub es_if_mismatch: Option<String>,
     /// The referenced segment's ESI, resolved from `Bgp::ethernet_segments`.
     /// Denormalized so the route paths — which see `LocalRib`, not the ES
     /// config map — can key the Type-1 without another borrow. Kept in step
@@ -77,6 +89,87 @@ pub struct VpwsService {
     /// The elected Designated Forwarder for `<esi, local_service_id>`, or
     /// `None` when the service is single-homed or no Type-4 is selected.
     pub df: Option<IpAddr>,
+}
+
+/// How a VPWS service is bound to an Ethernet Segment.
+///
+/// IOS-XR, Junos, Arista and FRR all configure the segment *on the access
+/// interface*, so the attachment circuit is what identifies it and the two
+/// can never contradict each other. zebra-rs keeps segments in a named list
+/// under `router bgp` — which is what lets a service reference one by name —
+/// so it recovers the same property by inference: the AC picks the segment,
+/// and the `ethernet-segment` leaf is only needed when inference cannot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum EsBinding {
+    /// Single-homed: no `ethernet-segment` leaf and no segment claims the AC.
+    #[default]
+    None,
+    /// Bound by the `ethernet-segment` leaf.
+    Explicit(String),
+    /// Inferred: exactly one segment names this service's AC as its
+    /// `interface`.
+    Derived(String),
+    /// The AC is claimed by more than one segment, so inference cannot pick
+    /// one. Treated as single-homed — guessing here would silently put the
+    /// service on the wrong ESI. Naming one on the `ethernet-segment` leaf
+    /// resolves it.
+    Ambiguous(Vec<String>),
+    /// The `ethernet-segment` leaf names a segment that does not exist.
+    /// Distinct from `None` so a typo does not look like a deliberately
+    /// single-homed service.
+    Unresolved(String),
+}
+
+impl EsBinding {
+    /// The effective segment name, or `None` when the service is not on one.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            EsBinding::Explicit(name) | EsBinding::Derived(name) => Some(name),
+            EsBinding::None | EsBinding::Ambiguous(_) | EsBinding::Unresolved(_) => None,
+        }
+    }
+}
+
+/// Resolve which Ethernet Segment a VPWS service sits on, from its
+/// `ethernet-segment` leaf (`explicit`), its attachment circuit (`ac`) and
+/// the configured segments.
+///
+/// An explicit name always wins — it is the operator overriding inference,
+/// and ignoring it would be worse than any mismatch it creates (the mismatch
+/// is surfaced separately). With no leaf, the AC picks the segment: exactly
+/// one segment naming it as its `interface` binds. That is the property
+/// IOS-XR / Junos / Arista / FRR get for free by configuring the segment on
+/// the interface in the first place.
+///
+/// Two or more segments claiming one AC resolves to [`EsBinding::Ambiguous`]
+/// rather than an arbitrary tie-break (first match, lowest name): the wrong
+/// guess puts the service on the wrong ESI, which becomes a silent blackhole
+/// once a remote starts choosing between P and B.
+pub fn bind_es(
+    explicit: Option<&String>,
+    ac: Option<&String>,
+    segments: &BTreeMap<String, EthernetSegment>,
+) -> EsBinding {
+    if let Some(name) = explicit {
+        return if segments.contains_key(name) {
+            EsBinding::Explicit(name.clone())
+        } else {
+            EsBinding::Unresolved(name.clone())
+        };
+    }
+    let Some(ac) = ac else {
+        return EsBinding::None;
+    };
+    let claims: Vec<String> = segments
+        .iter()
+        .filter(|(_, es)| es.interface.as_ref() == Some(ac))
+        .map(|(name, _)| name.clone())
+        .collect();
+    match claims.len() {
+        0 => EsBinding::None,
+        1 => EsBinding::Derived(claims.into_iter().next().expect("len 1")),
+        _ => EsBinding::Ambiguous(claims),
+    }
 }
 
 impl VpwsService {
@@ -125,4 +218,119 @@ pub struct VpwsState {
     /// pool, peers), so it marks here and `Bgp::vpws_df_drain` re-elects
     /// once the `BgpTop` borrow has ended.
     pub df_dirty: BTreeSet<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A segment claiming access port `interface`.
+    fn seg(interface: Option<&str>) -> EthernetSegment {
+        EthernetSegment {
+            esi: Some([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99]),
+            interface: interface.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn segments(entries: &[(&str, Option<&str>)]) -> BTreeMap<String, EthernetSegment> {
+        entries
+            .iter()
+            .map(|(name, iface)| (name.to_string(), seg(*iface)))
+            .collect()
+    }
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    #[test]
+    fn ac_infers_its_segment() {
+        let segs = segments(&[("es1", Some("ce1")), ("es2", Some("ce2"))]);
+        // The AC picks its own segment — no `ethernet-segment` leaf needed,
+        // which is what every vendor gets by configuring the ES on the port.
+        assert_eq!(
+            bind_es(None, Some(&s("ce1")), &segs),
+            EsBinding::Derived(s("es1"))
+        );
+        assert_eq!(
+            bind_es(None, Some(&s("ce2")), &segs),
+            EsBinding::Derived(s("es2"))
+        );
+    }
+
+    #[test]
+    fn unclaimed_ac_is_single_homed() {
+        let segs = segments(&[("es1", Some("ce1"))]);
+        // No segment names this port, and a segment with no interface at all
+        // claims nothing — both leave the service single-homed.
+        assert_eq!(bind_es(None, Some(&s("ce9")), &segs), EsBinding::None);
+        assert_eq!(
+            bind_es(None, Some(&s("ce1")), &segments(&[("es1", None)])),
+            EsBinding::None
+        );
+        // No AC configured yet: nothing to infer from.
+        assert_eq!(bind_es(None, None, &segs), EsBinding::None);
+        // No segments configured at all.
+        assert_eq!(
+            bind_es(None, Some(&s("ce1")), &BTreeMap::new()),
+            EsBinding::None
+        );
+    }
+
+    #[test]
+    fn two_segments_on_one_ac_is_ambiguous_not_a_guess() {
+        let segs = segments(&[("es1", Some("ce1")), ("es2", Some("ce1")), ("es3", None)]);
+        // Picking either one would silently put the service on the wrong ESI,
+        // so refuse — and report both so the operator knows what to name.
+        assert_eq!(
+            bind_es(None, Some(&s("ce1")), &segs),
+            EsBinding::Ambiguous(vec![s("es1"), s("es2")])
+        );
+        // Ambiguity is not a segment: the service stays single-homed.
+        assert_eq!(bind_es(None, Some(&s("ce1")), &segs).name(), None);
+        // Naming one explicitly is the documented way out.
+        assert_eq!(
+            bind_es(Some(&s("es2")), Some(&s("ce1")), &segs),
+            EsBinding::Explicit(s("es2"))
+        );
+    }
+
+    #[test]
+    fn explicit_leaf_overrides_inference() {
+        let segs = segments(&[("es1", Some("ce1")), ("es2", Some("ce2"))]);
+        // The AC would infer es1; the leaf says es2 and wins. The caller
+        // reports the interface discrepancy separately rather than silently
+        // preferring one or the other.
+        assert_eq!(
+            bind_es(Some(&s("es2")), Some(&s("ce1")), &segs),
+            EsBinding::Explicit(s("es2"))
+        );
+    }
+
+    #[test]
+    fn explicit_leaf_naming_nothing_is_distinct_from_single_homed() {
+        let segs = segments(&[("es1", Some("ce1"))]);
+        // A typo must not read as "deliberately single-homed" — and it must
+        // not silently fall back to the segment the AC would have inferred,
+        // which would hide the typo completely.
+        assert_eq!(
+            bind_es(Some(&s("nosuch")), Some(&s("ce1")), &segs),
+            EsBinding::Unresolved(s("nosuch"))
+        );
+        assert_eq!(
+            bind_es(Some(&s("nosuch")), Some(&s("ce1")), &segs).name(),
+            None
+        );
+    }
+
+    #[test]
+    fn binding_name_is_the_effective_segment() {
+        assert_eq!(EsBinding::Explicit(s("es1")).name(), Some("es1"));
+        assert_eq!(EsBinding::Derived(s("es1")).name(), Some("es1"));
+        assert_eq!(EsBinding::None.name(), None);
+        // The default must stay single-homed: a service that has never been
+        // resolved advertises the all-zero ESI.
+        assert_eq!(EsBinding::default(), EsBinding::None);
+    }
 }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -245,7 +245,7 @@ module zebra-bgp-evpn {
            Absent = whole-port service (End.DX2).";
       }
       leaf ethernet-segment {
-        ext:help "Ethernet Segment this AC belongs to (multihoming)";
+        ext:help "Override the Ethernet Segment inferred from the AC";
         type string;
         description
           "Name of an `ethernet-segment` this service's attachment circuit
@@ -253,8 +253,20 @@ module zebra-bgp-evpn {
            supplies the ESI carried in this service's Type-1 route and the
            redundancy mode that drives Designated-Forwarder election, run
            per <ESI, VPWS service instance> over the PEs advertising the
-           segment's Type-4. Absent = single-homed: the Type-1 carries the
-           all-zero ESI and is always advertised as primary.";
+           segment's Type-4.
+
+           Normally this is NOT needed: the segment is inferred from the
+           attachment circuit, so an `ethernet-segment` whose `interface` is
+           this service's `interface` binds automatically. Set this leaf
+           only to override that — when several segments name the same
+           access port, or when the segment declares no interface of its
+           own. It always wins over inference; if it names a segment whose
+           `interface` is some other port, the service still uses it and
+           `show bgp evpn vpws` reports the discrepancy.
+
+           No segment configured and none claiming the AC = single-homed:
+           the Type-1 carries the all-zero ESI and is advertised as
+           primary.";
       }
     }
     leaf bum-tunnel-type {


### PR DESCRIPTION
> **Stacked on #2116** — base is `bgp-evpn-vpws-multihoming`, not `main`.
> It edits code that only exists there. Merge #2116 first; if its branch is
> deleted on merge, re-target this PR to `main` before merging (a deleted base
> can close the child).

## Summary

#2116 gave a `vpws` service an `ethernet-segment <name>` leaf. That left the
access port specifiable **twice** — as `interface` on the service and as
`interface` on the segment — with nothing reconciling them.

Every commercial implementation avoids this by construction:

| | Where the segment is configured |
|---|---|
| IOS-XR | `evpn interface <if> ethernet-segment` |
| Junos | `interfaces <ae> esi { … }` |
| Arista | `interface <po> evpn ethernet-segment` |
| FRR | `interface <if> evpn mh es-id …` |

All four hang it off the access interface, so the AC *is* the identifier and
the two cannot disagree. zebra-rs keeps segments in a named list under
`router bgp` — which is what lets a VPWS service reference one at all, and
which I'd keep — so this recovers the same property by **inference** rather
than by location: a segment whose `interface` is the service's AC binds
automatically.

```
  ethernet-segment ES1
   esi 00:11:22:33:44:55:66:77:88:99
   redundancy-mode single-active
   interface ce1              <-- the segment claims ce1 ...
  vpws eline1
   interface ce1              <-- ... and this AC is ce1, so ES1 binds
```

The leaf stays, demoted to an override for what inference cannot settle:
several segments claiming one port, or a segment declaring no interface. It
always wins — that is the operator overriding us, and ignoring it would be
worse than any mismatch it creates.

## Two things reported rather than resolved

* **Ambiguous** — two or more segments claiming one AC is not tie-broken. A
  first-match or lowest-name rule would put the service on the wrong ESI:
  silent today, a blackhole once a remote starts choosing between P and B.
  The service stays single-homed and `show` lists the candidates.
* **Interface mismatch** — an explicit leaf naming a segment whose
  `interface` is a different port still binds, but `show` prints a `WARNING`.
  Falling back to the inferred segment instead would hide the typo entirely.

`EsBinding` records which case applied, so `show bgp evpn vpws` can finally
tell *inferred*, *overridden*, *typo* and *deliberately single-homed* apart —
before this they all rendered identically. JSON gains
`ethernet_segment_binding`, `ethernet_segment_candidates` and
`ethernet_segment_if_mismatch`; `ethernet_segment` now reports the
**effective** segment, not the string that was typed.

## Notes for review

* The rules live in `vpws::bind_es` — a pure function over the segment map,
  so they are unit-testable without constructing a whole `Bgp`.
  `Bgp::vpws_bind_es` is a three-line delegation.
* **Two new sync points**, both of which could previously go stale: the
  service's own `interface` (it is the inference input) and the segment's
  `interface`. That brings `vpws_resync_es` to six call sites — the growth I
  flagged as the likely source of a future stale-state bug when we discussed
  #2116.

## Test plan

* 6 new unit tests on `bind_es`: AC infers its segment; unclaimed AC /
  interface-less segment / no AC / no segments all stay single-homed; two
  segments on one AC is `Ambiguous` and carries both names; explicit leaf
  beats inference; a leaf naming nothing is `Unresolved`, distinct from
  single-homed and *not* silently falling back to inference.
* **BDD**: z1/z2 drop the explicit leaf, so the existing multihoming
  scenarios now prove inference end to end (`(from ce1)` in `show`). New
  scenario adds a second segment claiming ce1 — asserts the service falls
  back to the all-zero ESI with both candidates listed and no role — then
  resolves it with the leaf and watches the Type-1 re-key onto es2's ESI with
  z1 electing itself primary.
* `@bgp_evpn_vpws_multihoming` + `@bgp_evpn_vpws`: **2 features ran, 2
  passed**.
* `cargo fmt --all`, workspace clippy clean, `cargo test --workspace
  --exclude bdd` green.

Generated with [Claude Code](https://claude.com/claude-code)