### PR TITLE
bgp: add `encapsulation mpls` and the EVI list to EVPN config

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -13,6 +13,8 @@
 /router/bgp/afi-safi/ethernet-segment/esi
 /router/bgp/afi-safi/ethernet-segment/interface
 /router/bgp/afi-safi/ethernet-segment/redundancy-mode
+/router/bgp/afi-safi/evi
+/router/bgp/afi-safi/evi/bridge
 /router/bgp/afi-safi/igmp-mld-proxy
 /router/bgp/afi-safi/network
 /router/bgp/afi-safi/pruned-flood-list/broadcast-multicast

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -22,8 +22,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 320
-Handled: 306
+Total settable schema nodes: 322
+Handled: 308
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -10,6 +10,8 @@
 /router/bgp/afi-safi/ethernet-segment/esi	leaf
 /router/bgp/afi-safi/ethernet-segment/interface	leaf
 /router/bgp/afi-safi/ethernet-segment/redundancy-mode	leaf
+/router/bgp/afi-safi/evi	list keys=id
+/router/bgp/afi-safi/evi/bridge	leaf
 /router/bgp/afi-safi/igmp-mld-proxy	leaf
 /router/bgp/afi-safi/network	list keys=prefix
 /router/bgp/afi-safi/pruned-flood-list	container

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -17,7 +17,7 @@ use super::peer::BgpTop;
 use super::route_clean;
 use super::{
     AssistedReplicationRole, BGP_PORT, Bgp, EvpnBumTunnel,
-    inst::Callback,
+    inst::{Callback, EvpnEncap},
     peer::{AllowAsIn, LocalAs, PasswordEncoding, Peer, PeerType, RemovePrivateAs},
     timer,
 };
@@ -1726,26 +1726,28 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
-/// `router bgp afi-safi evpn encapsulation {vxlan|srv6}` (RFC 9252).
-/// With `srv6`, Type-2 routes carry a per-VNI End.DT2U SID and Type-3
-/// IMETs an End.DT2M SID (SRv6 L2 Service TLVs), both carved from the
-/// BGP SRv6 locator; received MACs install against the peer's SIDs.
-/// Toggling re-originates the local FDB and IMETs so the SIDs are
+/// `router bgp afi-safi evpn encapsulation {vxlan|srv6|mpls}`.
+/// With `srv6` (RFC 9252), Type-2 routes carry a per-VNI End.DT2U SID and
+/// Type-3 IMETs an End.DT2M SID (SRv6 L2 Service TLVs), both carved from
+/// the BGP SRv6 locator; received MACs install against the peer's SIDs.
+/// With `mpls` (RFC 7432) they carry a per-EVI MPLS service label instead.
+/// Toggling re-originates the local FDB and IMETs so the SIDs / labels are
 /// attached/dropped in place.
 fn config_evpn_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
         return None;
     }
-    let srv6 = if op.is_set() {
-        args.string()?.as_str() == "srv6"
+    // Delete falls back to the YANG default rather than to "not SRv6".
+    let encap = if op.is_set() {
+        EvpnEncap::parse(args.string()?.as_str())?
     } else {
-        false
+        EvpnEncap::default()
     };
-    if bgp.evpn_encap_srv6 == srv6 {
+    if bgp.evpn_encap == encap {
         return Some(());
     }
-    bgp.evpn_encap_srv6 = srv6;
+    bgp.evpn_encap = encap;
     // Re-originate under the new encapsulation (no-op when
     // advertise-all-vni is off; the config-load gate replay covers
     // cold boot, where this leaf lands before the FdbAdds arrive).
@@ -1911,6 +1913,50 @@ fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp
         None
     };
     bgp.ethernet_segments.entry(name).or_default().interface = interface;
+    Some(())
+}
+
+/// `router bgp afi-safi evpn evi <id>` — declare or remove an EVPN Instance.
+///
+/// The VXLAN and SRv6 paths read a local VXLAN device's VNI to learn which
+/// bridge domains to advertise; an MPLS EVI has no VNI, so the operator names
+/// it here. See [`EviConfig`].
+fn config_evi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let evi: u32 = args.u32()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.evpn_evis.entry(evi).or_default();
+        }
+        ConfigOp::Delete => {
+            bgp.evpn_evis.remove(&evi);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `router bgp afi-safi evpn evi <id> bridge <ifname>` — the bridge interface
+/// whose L2 domain this EVI carries.
+fn config_evi_bridge(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let evi: u32 = args.u32()?;
+    let bridge = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    let entry = bgp.evpn_evis.entry(evi).or_default();
+    if entry.bridge == bridge {
+        return Some(());
+    }
+    entry.bridge = bridge;
     Some(())
 }
 
@@ -4791,6 +4837,8 @@ impl Bgp {
         // EVPN VPWS E-Line services (RFC 8214), under
         // `router bgp afi-safi evpn vpws <name> …`. Augmented in by
         // zebra-bgp-evpn.yang.
+        self.callback_add("/router/bgp/afi-safi/evi", config_evi);
+        self.callback_add("/router/bgp/afi-safi/evi/bridge", config_evi_bridge);
         self.callback_add("/router/bgp/afi-safi/vpws", config_vpws);
         self.callback_add("/router/bgp/afi-safi/vpws/evi", config_vpws_evi);
         self.callback_add(

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -659,6 +659,72 @@ pub enum EvpnBumTunnel {
     SrV6P2mp,
 }
 
+/// Overlay encapsulation for EVPN's L2 services (Type-2 MAC/IP, Type-3
+/// Inclusive Multicast), configured under `router bgp afi-safi evpn
+/// encapsulation`. Type-5 (IP Prefix) is unaffected — it is an L3 service and
+/// takes its encapsulation from the VRF's own `encapsulation` leaf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EvpnEncap {
+    /// VXLAN tunnels (RFC 8365) — the kernel bridge/VXLAN FDB data plane, and
+    /// the default. The service identifier on the wire is the VNI, derived
+    /// from the route target.
+    #[default]
+    Vxlan,
+    /// SRv6 (RFC 9252) — a per-VNI `End.DT2U` SID on Type-2 and an `End.DT2M`
+    /// SID on Type-3, carved from the BGP SRv6 locator.
+    Srv6,
+    /// MPLS (RFC 7432) — the base encapsulation: routes carry a per-EVI MPLS
+    /// service label and the egress PE pops it into a bridge domain. The L2
+    /// data plane is the cradle eBPF tee; the kernel has no MPLS-to-bridge
+    /// action.
+    Mpls,
+}
+
+impl EvpnEncap {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "vxlan" => Some(Self::Vxlan),
+            "srv6" => Some(Self::Srv6),
+            "mpls" => Some(Self::Mpls),
+            _ => None,
+        }
+    }
+
+    /// True when locally originated L2 routes carry an SRv6 L2 service SID.
+    pub fn is_srv6(&self) -> bool {
+        matches!(self, Self::Srv6)
+    }
+
+    /// True when locally originated L2 routes carry an MPLS service label.
+    // Consumed by the Type-2/Type-3 originate path, which lands with the
+    // label allocator; the config surface is separated out to keep the
+    // encapsulation refactor reviewable on its own.
+    #[allow(dead_code)]
+    pub fn is_mpls(&self) -> bool {
+        matches!(self, Self::Mpls)
+    }
+}
+
+/// One EVPN Instance declared under `router bgp afi-safi evpn evi <id>`.
+///
+/// Only meaningful with `encapsulation mpls`: the VXLAN and SRv6 paths infer
+/// the service identifier from a local VXLAN device's VNI, but an MPLS EVI has
+/// no VNI to read, so the operator names the bridge and the EVI id explicitly.
+/// The EVI id doubles as the bridge domain and as the low 24 bits of the
+/// auto-derived RD (`<router-id>:<evi>`) and RT (`<as>:<evi>`), keeping it
+/// interchangeable with a VNI everywhere else in the EVPN path.
+#[derive(Debug, Clone, Default)]
+pub struct EviConfig {
+    /// Bridge interface whose L2 domain this EVI carries.
+    pub bridge: Option<String>,
+    /// MPLS service label advertised for this EVI, allocated from the BGP
+    /// dynamic label block. `None` until the block arrives.
+    // Filled in by the label allocator in the follow-up; declared here so the
+    // EVI's shape is settled in one place.
+    #[allow(dead_code)]
+    pub label: Option<u32>,
+}
+
 pub struct Bgp {
     pub asn: u32,
     /// Effective BGP Identifier — what OPENs, EVPN RDs and the show
@@ -1027,10 +1093,14 @@ pub struct Bgp {
     /// advertised on every Type-2 the VNI originates when
     /// [`Self::evpn_encap_srv6`] is set.
     pub evpn_dt2u_sids: BTreeMap<u32, (std::net::Ipv6Addr, u16)>,
-    /// `router bgp afi-safi evpn encapsulation srv6` (RFC 9252): EVPN rides
-    /// SRv6 L2 service SIDs (End.DT2U on Type-2, End.DT2M on Type-3) instead
-    /// of VXLAN. The L2 data plane is the cradle eBPF tee.
-    pub evpn_encap_srv6: bool,
+    /// `router bgp afi-safi evpn encapsulation {vxlan|srv6|mpls}` — the
+    /// overlay locally originated and received L2 routes ride.
+    pub evpn_encap: EvpnEncap,
+    /// EVPN Instances declared under `router bgp afi-safi evpn evi <id>`,
+    /// keyed by EVI id. Populated only for `encapsulation mpls`, where there
+    /// is no VXLAN device to infer a service identifier from. See
+    /// [`EviConfig`].
+    pub evpn_evis: BTreeMap<u32, EviConfig>,
     /// Precomputed advertise-time data derived from
     /// [`Self::srv6_ipv6_sid`] and the locator, borrowed into
     /// [`super::peer::BgpTop`] so the egress path stamps
@@ -1276,7 +1346,8 @@ impl Bgp {
             srv6_ipv6_sid: None,
             evpn_dt2m_sids: BTreeMap::new(),
             evpn_dt2u_sids: BTreeMap::new(),
-            evpn_encap_srv6: false,
+            evpn_encap: EvpnEncap::default(),
+            evpn_evis: BTreeMap::new(),
             srv6_ipv6_export: None,
             networks_v6: std::collections::BTreeSet::new(),
             peer_index: BTreeMap::new(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15304,7 +15304,7 @@ impl Bgp {
         // RFC 9252 §6.1/§6.2: under `encapsulation srv6` the Type-2 carries
         // this PE's per-VNI End.DT2U SID (SRv6 L2 Service TLV) so receivers
         // install the MAC against the SID instead of a VXLAN VTEP.
-        if self.evpn_encap_srv6 {
+        if self.evpn_encap.is_srv6() {
             attr.prefix_sid = self.vni_dt2u_prefix_sid(entry.vni);
         }
 
@@ -15575,7 +15575,7 @@ impl Bgp {
         // for the VNI on the IMET route (SRv6 L2 Service TLV in the Prefix-SID
         // attribute) so remote roots fan replicated BUM to it. SID-less when no
         // locator has resolved yet (reconciled on the next locator update).
-        if matches!(bum, EvpnBumTunnel::SrV6P2mp) || self.evpn_encap_srv6 {
+        if matches!(bum, EvpnBumTunnel::SrV6P2mp) || self.evpn_encap.is_srv6() {
             attr.prefix_sid = self.vni_dt2m_prefix_sid(vni);
         }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4315,6 +4315,38 @@ mod yang_load_tests {
         }
     }
 
+    /// `encapsulation mpls` (RFC 7432) and the `evi` list it needs — an MPLS
+    /// EVI has no VXLAN device to read a VNI from, so the bridge domain is
+    /// named explicitly. The two pre-existing encapsulations are asserted
+    /// alongside so a future enum edit can't silently drop one.
+    #[test]
+    fn bgp_evpn_mpls_encapsulation_and_evi_are_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn encapsulation vxlan",
+            "set router bgp afi-safi evpn encapsulation srv6",
+            "set router bgp afi-safi evpn encapsulation mpls",
+            "set router bgp afi-safi evpn evi 100",
+            "set router bgp afi-safi evpn evi 100 bridge br100",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
+
     #[test]
     fn bgp_evpn_pruned_flood_list_is_settable() {
         use crate::config::ExecCode;

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -80,7 +80,7 @@ module zebra-bgp-evpn {
          `address-family l2vpn evpn`.";
     }
     leaf encapsulation {
-      ext:help "EVPN overlay encapsulation (vxlan or srv6)";
+      ext:help "EVPN overlay encapsulation (vxlan, srv6 or mpls)";
       type enumeration {
         enum vxlan {
           description
@@ -97,11 +97,60 @@ module zebra-bgp-evpn {
              plane is the cradle eBPF tee (`system cradle grpc-endpoint`) —
              the kernel has no End.DT2U/DT2M seg6local actions.";
         }
+        enum mpls {
+          description
+            "MPLS (RFC 7432) — EVPN's base encapsulation. Type-2 and
+             Type-3 routes carry a per-EVI MPLS service label, imposed
+             under whatever transport LSP reaches the egress PE, which
+             pops it into the EVI's bridge domain. Bridge domains are
+             declared explicitly with the `evi` list (there is no VXLAN
+             device to read a VNI from). The L2 data plane is the
+             cradle eBPF tee (`system cradle grpc-endpoint`) — the
+             kernel has no action that pops a label into a bridge.";
+        }
       }
       default vxlan;
       description
         "EVPN overlay encapsulation for locally originated and
-         received MAC routes.";
+         received MAC routes. This is the L2 (Type-2 / Type-3) service;
+         Type-5 (IP Prefix) is an L3 service and takes its
+         encapsulation from the VRF's own `encapsulation` leaf.";
+    }
+    list evi {
+      ext:help "EVPN Instance (bridge domain) for `encapsulation mpls`";
+      key "id";
+      description
+        "An EVPN Instance — one bridge domain advertised into EVPN.
+
+         Only needed with `encapsulation mpls`. The vxlan and srv6
+         paths infer which bridge domains to advertise, and their
+         service identifier, from a local VXLAN device's VNI; an MPLS
+         EVI has no VNI, so the operator names the bridge and the
+         instance id here.
+
+         The id doubles as the bridge domain and as the low 24 bits of
+         the auto-derived RD (<router-id>:<id>) and route target
+         (<local-AS>:<id>), so it is interchangeable with a VNI
+         everywhere else in the EVPN path — matching the `evi` leaf
+         the vpws list already uses.";
+      leaf id {
+        ext:help "EVPN Instance id";
+        type uint32 {
+          range "1..16777215";
+        }
+        description
+          "EVPN Instance identifier (the list key). Both PEs of a
+           service must agree on it.";
+      }
+      leaf bridge {
+        ext:help "Bridge interface carrying this EVI's L2 domain";
+        type string;
+        description
+          "Name of the bridge interface whose L2 domain this EVI
+           carries — its CE-facing ports are the attachment circuits,
+           and MACs learned there are advertised as Type-2 routes
+           under this EVI's RD and route target.";
+      }
     }
     leaf igmp-mld-proxy {
       ext:help "Advertise IGMP/MLD proxy capability (RFC 9251)";


### PR DESCRIPTION
## Summary

Groundwork for EVPN's **L2** services over MPLS (RFC 7432). No wire behaviour
changes here — this lands the config surface and the internal shape the
originate/import paths need next.

EVPN Type-5 already rides MPLS (it reuses the VPNv4/VPNv6 label dataplane), but
Type-2/Type-3 were VXLAN- or SRv6-only. The cradle-rs side now forwards
EVPN-over-MPLS end to end (cradle-rs#159, #160), so the control plane can
follow.

**`encapsulation mpls`** joins vxlan and srv6, and the `bool evpn_encap_srv6`
behind it becomes a three-valued `EvpnEncap` enum — a bool cannot express a
third overlay. The delete path now falls back to the YANG default rather than
to "not SRv6".

**The `evi` list.** The vxlan and srv6 paths infer which bridge domains to
advertise, and their service identifier, from a local VXLAN device's VNI. An
MPLS EVI has no VNI, so it needs declaring:

```
router bgp 65001 {
  afi-safi {
    name evpn;
    encapsulation mpls;
    evi 100 { bridge br100; }
  }
}
```

The id doubles as the bridge domain and as the low 24 bits of the auto-derived
RD (`<router-id>:<id>`) and route target (`<as>:<id>`). That keeps it
interchangeable with a VNI everywhere else in the EVPN path — which is what
makes the follow-up mostly reuse rather than a parallel code path — and matches
the `evi` leaf the `vpws` list already uses.

`EviConfig::label` is declared here so the EVI's shape is settled in one place;
it is filled in by the label allocator in the follow-up (hence the `#[allow(dead_code)]`
with a pointer, rather than leaving CI's `-D warnings` to trip).

## Test plan

- **Live, not just schema**: a throwaway daemon accepts `encapsulation mpls`
  plus two `evi` entries via `vtyctl apply` and renders them back correctly in
  `show running-config` — the handler actually fires and stores the EVI, which
  a parse-only test would not prove.
- New settable-path unit test pins all three encapsulation values and both EVI
  paths, so a future enum edit cannot silently drop one.
- Config-audit docs regenerated for the two new handler paths; orphan-report
  counts move 320 → 322 settable / 306 → 308 handled, orphans unchanged (both
  new paths are handled).
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
  warnings`, `cargo test --workspace --exclude bdd` — all green.

## Next

Per-EVI label allocation from the BGP dynamic block plus the `DecapBd` ILM
(cradle-only — the kernel has no MPLS-to-bridge action), then Type-2/Type-3
origination and the receive tee.

Generated with [Claude Code](https://claude.com/claude-code)