### PR TITLE
bgp: preference-based DF election for Ethernet Segments (Alg 2)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-pref.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-pref.yaml
@@ -1,0 +1,50 @@
+# z1 — es1 switched to preference-based DF election (Alg 2,
+# draft-ietf-bess-evpn-pref-df) with preference 300. z1 bids 300 and z2
+# bids 100, so z1 wins every service instance — note that under carving
+# instance 101 elected z2, so this config flips the DF purely by
+# preference, which is what proves Alg 2 is in effect.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+        df-election:
+          preference: 300
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: ce1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-pref.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-pref.yaml
@@ -1,0 +1,50 @@
+# z2 — es1 switched to preference-based DF election (Alg 2,
+# draft-ietf-bess-evpn-pref-df) with preference 100. z1 bids 300 and z2
+# bids 100, so z1 wins every service instance — note that under carving
+# instance 101 elected z2, so this config flips the DF purely by
+# preference, which is what proves Alg 2 is in effect.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+        df-election:
+          preference: 100
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: ce1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
@@ -134,6 +134,30 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     When I apply config "z1-1.yaml" to namespace "z1"
     Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
 
+  Scenario: Preference-based DF election overrides the carving ordinal
+    Given the test topology exists
+    # Switch es1 to Alg 2 with z1 bidding 300 and z2 bidding 100. Under
+    # carving, instance 101 elected z2 (ordinal 101 % 2 = 1); preference is
+    # per-segment, so the higher bid now wins every instance — the DF flips
+    # to z1 with no change to the service ids.
+    When I apply config "z1-pref.yaml" to namespace "z1"
+    And I apply config "z2-pref.yaml" to namespace "z2"
+    Then show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "DF algorithm: preference-based (local pref 300)"
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: primary (DF 192.168.0.1)"
+    And show command "show bgp evpn vpws" in namespace "z2" should eventually contain "Role: backup (DF 192.168.0.1)"
+    # Each PE's bid rides its Type-4's DF Election EC, so the peer sees it.
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "df-election:alg2:pref300"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "192.168.0.2 pref 100"
+    # Raising z2 above z1 hands the DF back — the election is re-run from the
+    # peer's Type-4 alone, with no config change on z1.
+    When I apply config "z1-1.yaml" to namespace "z1"
+    Then show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "DF algorithm: service-carving (default)"
+    # One PE back on Alg 0 means the segment cannot agree, so RFC 8584
+    # negotiation drops both to carving — and instance 101 carves to z2 again.
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+    When I apply config "z2-1.yaml" to namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -143,12 +143,43 @@ community:
 | `all-active` | *every* attached PE is primary — `P=1 B=0` |
 | `single-active` | the elected DF is `P=1 B=0`, its successor in the carving order is `P=0 B=1`, any further PE is `P=0 B=0` |
 
-The election runs per `<ESI, VPWS service instance>`: the PEs advertising
-the segment's Type-4 are ordered by ascending VTEP address and the DF is
-ordinal `service-id mod N` (RFC 7432 §8.5 service carving). Keying on the
-service instance rather than a fixed ordinal is what spreads different
-E-Lines on one segment across both PEs instead of piling them all onto the
-lowest address.
+By default the election runs per `<ESI, VPWS service instance>`: the PEs
+advertising the segment's Type-4 are ordered by ascending VTEP address and
+the DF is ordinal `service-id mod N` (RFC 7432 §8.5 service carving). Keying
+on the service instance rather than a fixed ordinal is what spreads
+different E-Lines on one segment across both PEs instead of piling them all
+onto the lowest address.
+
+**Preference-based election** (Alg 2, draft-ietf-bess-evpn-pref-df) replaces
+that hash with an explicit choice — set a preference on the segment and the
+highest bid wins, ties broken by the lowest originating address:
+
+```
+  ethernet-segment ES1
+   esi 00:11:22:33:44:55:66:77:88:99
+   redundancy-mode single-active
+   interface ce1
+   df-election
+    preference 300
+    ac-df           # optional: advertise the AC-Influenced DF capability
+```
+
+Preference is per-*segment*, so one PE wins every service instance on it —
+that is the trade against carving, and the reason to use it: the operator
+pins the DF instead of accepting a hash. The value rides each PE's Type-4 in
+the DF Election extended community, so `show bgp evpn` on a peer renders
+`df-election:alg2:pref300`.
+
+Every PE on the segment must advertise the same algorithm. RFC 8584
+negotiation drops the whole segment back to service carving if any one of
+them disagrees, so a half-configured segment silently reverts rather than
+splitting the election — `show bgp evpn ethernet-segment` reports the
+negotiated algorithm and each PE's bid.
+
+This interoperates with IOS-XR `service-carving preference-based`, Junos
+`df-election-type preference`, Arista
+`designated-forwarder election algorithm preference` and FRR
+`evpn mh es-df-pref`.
 
 Because the candidate set comes from the Type-4 routes in the Loc-RIB, the
 role is re-elected whenever a PE joins or leaves the segment — a peer's

--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -166,6 +166,7 @@ impl ExtCommunityValue {
         Some(DfElectionEc {
             df_alg: self.val[0] & DfElectionEc::DF_ALG_MASK,
             bitmap: u16::from_be_bytes([self.val[1], self.val[2]]),
+            pref: u16::from_be_bytes([self.val[4], self.val[5]]),
         })
     }
 
@@ -528,6 +529,10 @@ pub struct DfElectionEc {
     pub df_alg: u8,
     /// Capability Bitmap (16 bits, RFC MSB-0 numbering: Bit 0 = `0x8000`).
     pub bitmap: u16,
+    /// DF Preference, in the last two octets of the value
+    /// (draft-ietf-bess-evpn-pref-df). Only meaningful under
+    /// [`ALG_PREF`](Self::ALG_PREF); zero and ignored otherwise.
+    pub pref: u16,
 }
 
 impl DfElectionEc {
@@ -538,6 +543,18 @@ impl DfElectionEc {
     pub const ALG_DEFAULT: u8 = 0;
     /// DF Alg 1 — Highest Random Weight (HRW, RFC 8584 §3).
     pub const ALG_HRW: u8 = 1;
+    /// DF Alg 2 — Preference-based (draft-ietf-bess-evpn-pref-df). The
+    /// highest [`pref`](Self::pref) wins, ties broken by lowest IP. This is
+    /// what IOS-XR (`service-carving preference-based`), Junos
+    /// (`df-election-type preference`), Arista
+    /// (`designated-forwarder election algorithm preference`) and FRR
+    /// (`evpn mh es-df-pref`) all expose.
+    pub const ALG_PREF: u8 = 2;
+
+    /// The preference every implementation defaults to when the algorithm
+    /// is selected but no value is configured (FRR
+    /// `EVPN_MH_DF_PREF_DEFAULT`).
+    pub const PREF_DEFAULT: u16 = 32767;
 
     /// Bitmap Bit 1 (RFC 8584 §2.2): AC-DF Capability (AC-Influenced DF
     /// election). MSB-0 within the 16-bit Bitmap → `0x4000`.
@@ -571,6 +588,9 @@ impl From<DfElectionEc> for ExtCommunityValue {
         // RSV (high 3 bits of val[0]) stays 0; only the low 5 bits carry DF Alg.
         val[0] = df.df_alg & DfElectionEc::DF_ALG_MASK;
         val[1..3].copy_from_slice(&df.bitmap.to_be_bytes());
+        // val[3] stays reserved; the DF Preference occupies the last two
+        // octets (EC bytes 6..8 counting the two type octets).
+        val[4..6].copy_from_slice(&df.pref.to_be_bytes());
         ExtCommunityValue {
             high_type: ExtCommunityType::Evpn as u8,
             low_type: EVPN_DF_ELECTION_SUB_TYPE,
@@ -699,6 +719,9 @@ impl fmt::Display for ExtCommunityValue {
             // DF Election EC (RFC 8584 §2.2): render the algorithm and append
             // `+ac-df` when the AC-Influenced DF election bit is set.
             write!(f, "df-election:alg{}", df.df_alg)?;
+            if df.df_alg == DfElectionEc::ALG_PREF {
+                write!(f, ":pref{}", df.pref)?;
+            }
             if df.ac_df() {
                 write!(f, "+ac-df")?;
             }
@@ -1156,6 +1179,7 @@ mod tests {
         let ec: ExtCommunityValue = DfElectionEc {
             df_alg: DfElectionEc::ALG_HRW,
             bitmap: DfElectionEc::CAP_AC_DF,
+            pref: 0,
         }
         .into();
         assert_eq!(ec.high_type, 0x06);
@@ -1167,12 +1191,69 @@ mod tests {
     }
 
     #[test]
+    fn df_election_pref_wire_layout_matches_frr() {
+        // draft-ietf-bess-evpn-pref-df: the DF Preference is the LAST two
+        // octets of the 8-octet EC, i.e. val[4..6], with val[3] still
+        // reserved. Pinned against FRR's `encode_df_elect_extcomm`
+        // (bgp_evpn_private.h), which writes eval->val[6]/val[7], and its
+        // decoder (bgp_attr_df_pref_from_ec), which skips 3 octets after the
+        // alg byte before reading a BE16 — interop depends on this offset.
+        let ec: ExtCommunityValue = DfElectionEc {
+            df_alg: DfElectionEc::ALG_PREF,
+            bitmap: 0,
+            pref: DfElectionEc::PREF_DEFAULT,
+        }
+        .into();
+        let mut buf = BytesMut::new();
+        ec.encode(&mut buf);
+        // 32767 = 0x7FFF in the final two octets.
+        assert_eq!(&buf[..], &[0x06, 0x06, 0x02, 0x00, 0x00, 0x00, 0x7f, 0xff]);
+        // And it survives the round trip.
+        let back = ec.as_df_election().expect("decodes");
+        assert_eq!(back.df_alg, DfElectionEc::ALG_PREF);
+        assert_eq!(back.pref, 32767);
+
+        // A non-preference EC leaves the field zero, so an Alg-0 speaker is
+        // byte-identical to what it emitted before preference existed.
+        let carving: ExtCommunityValue = DfElectionEc {
+            df_alg: DfElectionEc::ALG_DEFAULT,
+            bitmap: 0,
+            pref: 0,
+        }
+        .into();
+        assert_eq!(carving.val, [0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn df_election_pref_renders_only_for_alg_two() {
+        let pref: ExtCommunityValue = DfElectionEc {
+            df_alg: DfElectionEc::ALG_PREF,
+            bitmap: DfElectionEc::CAP_AC_DF,
+            pref: 200,
+        }
+        .into();
+        assert_eq!(pref.to_string(), "df-election:alg2:pref200+ac-df");
+        // Under carving the field is meaningless, so it is not rendered even
+        // if a peer sent a stale non-zero value.
+        let mut carving: ExtCommunityValue = DfElectionEc {
+            df_alg: DfElectionEc::ALG_DEFAULT,
+            bitmap: 0,
+            pref: 0,
+        }
+        .into();
+        carving.val[4] = 0x00;
+        carving.val[5] = 0x64;
+        assert_eq!(carving.to_string(), "df-election:alg0");
+    }
+
+    #[test]
     fn df_election_df_alg_is_low_five_bits() {
         // Only the low 5 bits of val[0] carry DF Alg; the high 3 (RSV) stay 0.
         // A 5-bit value of 31 (max) must round-trip without bleeding into RSV.
         let ec: ExtCommunityValue = DfElectionEc {
             df_alg: 31,
             bitmap: 0,
+            pref: 0,
         }
         .into();
         assert_eq!(ec.val[0], 0x1F, "DF Alg in low 5 bits, RSV clear");
@@ -1184,6 +1265,7 @@ mod tests {
         let wide: ExtCommunityValue = DfElectionEc {
             df_alg: 0xFF,
             bitmap: 0,
+            pref: 0,
         }
         .into();
         assert_eq!(wide.val[0], 0x1F);
@@ -1194,6 +1276,7 @@ mod tests {
         let mut df = DfElectionEc {
             df_alg: DfElectionEc::ALG_DEFAULT,
             bitmap: 0,
+            pref: 0,
         };
         assert!(!df.ac_df());
         df.set_ac_df(true);
@@ -1211,6 +1294,7 @@ mod tests {
         let original: ExtCommunityValue = DfElectionEc {
             df_alg: DfElectionEc::ALG_HRW,
             bitmap: DfElectionEc::CAP_AC_DF,
+            pref: 0,
         }
         .into();
         let mut buf = BytesMut::new();
@@ -1228,12 +1312,14 @@ mod tests {
         let hrw_ac: ExtCommunityValue = DfElectionEc {
             df_alg: DfElectionEc::ALG_HRW,
             bitmap: DfElectionEc::CAP_AC_DF,
+            pref: 0,
         }
         .into();
         assert_eq!(hrw_ac.to_string(), "df-election:alg1+ac-df");
         let default_only: ExtCommunityValue = DfElectionEc {
             df_alg: DfElectionEc::ALG_DEFAULT,
             bitmap: 0,
+            pref: 0,
         }
         .into();
         assert_eq!(default_only.to_string(), "df-election:alg0");

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -10,6 +10,8 @@
 /router/bgp/afi-safi/bum-tunnel-type
 /router/bgp/afi-safi/encapsulation
 /router/bgp/afi-safi/ethernet-segment
+/router/bgp/afi-safi/ethernet-segment/df-election/ac-df
+/router/bgp/afi-safi/ethernet-segment/df-election/preference
 /router/bgp/afi-safi/ethernet-segment/esi
 /router/bgp/afi-safi/ethernet-segment/interface
 /router/bgp/afi-safi/ethernet-segment/redundancy-mode

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -15,6 +15,7 @@ ORPHAN leaf         /router/bgp/sharding/peer-sharding
   /router/bgp/sr-policy  [p-container]
   /router/bgp/vrf/neighbor/afi-safi  [list]
   /router/bgp/vrf/neighbor/tcp-ao  [p-container]
+  /router/bgp/afi-safi/ethernet-segment/df-election  [p-container]
 
 Note: the bare /router/bgp/neighbor list path is deliberately absent
 here — it IS handled, registered as `callback_peer("", config_peer)`
@@ -22,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 322
-Handled: 308
+Total settable schema nodes: 325
+Handled: 310
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -7,6 +7,9 @@
 /router/bgp/afi-safi/bum-tunnel-type	leaf
 /router/bgp/afi-safi/encapsulation	leaf
 /router/bgp/afi-safi/ethernet-segment	list keys=name
+/router/bgp/afi-safi/ethernet-segment/df-election	p-container
+/router/bgp/afi-safi/ethernet-segment/df-election/ac-df	leaf
+/router/bgp/afi-safi/ethernet-segment/df-election/preference	leaf
 /router/bgp/afi-safi/ethernet-segment/esi	leaf
 /router/bgp/afi-safi/ethernet-segment/interface	leaf
 /router/bgp/afi-safi/ethernet-segment/redundancy-mode	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1899,6 +1899,64 @@ fn config_ethernet_segment_redundancy_mode(
     Some(())
 }
 
+/// `router bgp afi-safi evpn ethernet-segment <name> df-election preference
+/// <1..65535>` — switch the segment to preference-based DF election (Alg 2,
+/// draft-ietf-bess-evpn-pref-df) and set this PE's preference. Clearing it
+/// reverts to service carving. Either way the Type-4 is re-originated so
+/// peers see the new algorithm, and the VPWS services on the segment
+/// re-elect against it.
+fn config_es_df_preference(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let pref = if op.is_set() {
+        Some(args.u32()? as u16)
+    } else {
+        None
+    };
+    let es = bgp.ethernet_segments.entry(name).or_default();
+    es.df_preference = pref;
+    es_df_election_changed(bgp);
+    Some(())
+}
+
+/// `router bgp afi-safi evpn ethernet-segment <name> df-election ac-df` —
+/// advertise the RFC 8584 §2.2 AC-Influenced DF election capability bit.
+fn config_es_ac_df(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let es = bgp.ethernet_segments.entry(name).or_default();
+    es.ac_df = op.is_set();
+    es_df_election_changed(bgp);
+    Some(())
+}
+
+/// Re-originate every configured segment's ES routes and re-elect the VPWS
+/// services sitting on them. The DF Election EC rides the Type-4, so any
+/// change to the algorithm or preference has to reach peers *and* re-run the
+/// local election — our own Type-4 is one of the election's candidates.
+fn es_df_election_changed(bgp: &mut Bgp) {
+    let vtep = IpAddr::V4(bgp.router_id);
+    let segments: Vec<([u8; 10], bool)> = bgp
+        .ethernet_segments
+        .values()
+        .filter_map(|es| Some((es.esi?, es.redundancy_mode.single_active())))
+        .collect();
+    for (esi, single_active) in segments {
+        bgp.evpn_originate_es_routes(esi, vtep, single_active);
+        // The candidate set did not change, but its contents did: mark the
+        // services on this ESI so the drain re-elects against the new
+        // preference / algorithm.
+        super::route::vpws_mark_df_dirty(&mut bgp.local_rib, &esi);
+    }
+    bgp.vpws_df_drain();
+}
+
 /// `router bgp afi-safi evpn ethernet-segment <name> interface <name>` — the
 /// CE-facing access port bound to this ES. This is also what a VPWS service
 /// matches its AC against to infer its segment, so setting it can bind (or
@@ -4838,6 +4896,14 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/ethernet-segment/interface",
             config_ethernet_segment_interface,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment/df-election/preference",
+            config_es_df_preference,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment/df-election/ac-df",
+            config_es_ac_df,
         );
 
         // EVPN VPWS E-Line services (RFC 8214), under

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -57,9 +57,37 @@ pub struct EthernetSegment {
     pub redundancy_mode: EsRedundancyMode,
     /// Access interface bound to this ES (the multihomed CE-facing port).
     pub interface: Option<String>,
+    /// DF Preference (draft-ietf-bess-evpn-pref-df). `Some` switches this
+    /// segment to Alg 2, where the highest preference wins and ties break on
+    /// the lowest address, instead of the RFC 7432 §8.5 carving modulus.
+    /// `None` = service carving (Alg 0), the default.
+    pub df_preference: Option<u16>,
+    /// Advertise the RFC 8584 §2.2 AC-DF (AC-Influenced DF election)
+    /// capability on this segment's Type-4.
+    pub ac_df: bool,
 }
 
 impl EthernetSegment {
+    /// The DF Election extended community this segment advertises on its
+    /// Type-4: Alg 2 with the configured preference when one is set,
+    /// otherwise the default carving algorithm.
+    pub fn df_election_ec(&self) -> DfElectionEc {
+        let mut ec = match self.df_preference {
+            Some(pref) => DfElectionEc {
+                df_alg: DfElectionEc::ALG_PREF,
+                bitmap: 0,
+                pref,
+            },
+            None => DfElectionEc {
+                df_alg: DfElectionEc::ALG_DEFAULT,
+                bitmap: 0,
+                pref: 0,
+            },
+        };
+        ec.set_ac_df(self.ac_df);
+        ec
+    }
+
     /// Auto-derive the ES-Import Route Target (RFC 7432 §7.6) from the ESI —
     /// the high-order 6 octets of the ESI value. `None` until the ESI is set.
     /// Used (in a later phase) to scope the Type-4 ES route to the PEs on this
@@ -105,6 +133,53 @@ pub fn backup_forwarder(candidates: &[IpAddr], tag: u32) -> Option<IpAddr> {
     }
     let idx = (tag as usize).wrapping_add(1) % candidates.len();
     Some(candidates[idx])
+}
+
+/// One PE's advertised DF-election parameters, read off its Type-4's DF
+/// Election extended community: `(VTEP, algorithm, preference)`.
+pub type DfCandidate = (IpAddr, u8, u16);
+
+/// Order two preference-based candidates by who wins
+/// (draft-ietf-bess-evpn-pref-df): the higher preference, and on a tie the
+/// **lower** IP address. Matches FRR's comparison in
+/// `zebra_evpn_es_run_df_election`, so the two agree on a shared segment —
+/// disagreement here means two PEs both forward and the CE sees duplicates.
+fn pref_wins(a: &DfCandidate, b: &DfCandidate) -> std::cmp::Ordering {
+    // Higher pref first, then lower IP first.
+    b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0))
+}
+
+/// The candidates ordered best-DF-first under preference-based election.
+fn pref_ranked(candidates: &[DfCandidate]) -> Vec<IpAddr> {
+    let mut ranked = candidates.to_vec();
+    ranked.sort_by(pref_wins);
+    ranked.into_iter().map(|(ip, _, _)| ip).collect()
+}
+
+/// Elect the Designated Forwarder and its backup for one service instance,
+/// dispatching on the algorithm the segment's PEs agreed on.
+///
+/// Alg 2 (preference) ranks by preference then address, so the DF is the
+/// winner and the backup is the runner-up. Anything else falls back to
+/// service carving, where the ordinal is `tag mod N` and the backup is the
+/// next ordinal — the RFC 8584 fallback for a disagreed algorithm, which
+/// [`negotiate_df_alg`] already resolves to Alg 0.
+///
+/// `candidates` need not be sorted; carving sorts by address internally so
+/// the ordinal is stable across PEs.
+pub fn elect_forwarders(candidates: &[DfCandidate], tag: u32) -> (Option<IpAddr>, Option<IpAddr>) {
+    let algs: Vec<u8> = candidates.iter().map(|(_, alg, _)| *alg).collect();
+    if negotiate_df_alg(&algs) == DfElectionEc::ALG_PREF {
+        let ranked = pref_ranked(candidates);
+        return (ranked.first().copied(), ranked.get(1).copied());
+    }
+    let mut vteps: Vec<IpAddr> = candidates.iter().map(|(ip, _, _)| *ip).collect();
+    vteps.sort();
+    vteps.dedup();
+    (
+        designated_forwarder(&vteps, tag),
+        backup_forwarder(&vteps, tag),
+    )
 }
 
 /// The role a PE advertises for one VPWS service instance on an Ethernet
@@ -159,16 +234,18 @@ impl VpwsRole {
 /// service while the segment converges.
 pub fn vpws_role(
     mode: EsRedundancyMode,
-    candidates: &[IpAddr],
+    candidates: &[DfCandidate],
     me: IpAddr,
     service_id: u32,
 ) -> VpwsRole {
-    if !matches!(mode, EsRedundancyMode::SingleActive) || !candidates.contains(&me) {
+    let on_segment = candidates.iter().any(|(ip, _, _)| *ip == me);
+    if !matches!(mode, EsRedundancyMode::SingleActive) || !on_segment {
         return VpwsRole::Primary;
     }
-    if designated_forwarder(candidates, service_id) == Some(me) {
+    let (df, backup) = elect_forwarders(candidates, service_id);
+    if df == Some(me) {
         VpwsRole::Primary
-    } else if backup_forwarder(candidates, service_id) == Some(me) {
+    } else if backup == Some(me) {
         VpwsRole::Backup
     } else {
         VpwsRole::NonDesignated
@@ -273,10 +350,25 @@ mod tests {
         assert_eq!(backup_forwarder(&[], 0), None);
     }
 
+    /// Carving candidates: every PE advertising Alg 0 with no preference.
+    fn carving(ips: &[IpAddr]) -> Vec<DfCandidate> {
+        ips.iter()
+            .map(|ip| (*ip, DfElectionEc::ALG_DEFAULT, 0))
+            .collect()
+    }
+
+    /// Preference candidates: every PE advertising Alg 2 with its own value.
+    fn prefs(entries: &[(IpAddr, u16)]) -> Vec<DfCandidate> {
+        entries
+            .iter()
+            .map(|(ip, p)| (*ip, DfElectionEc::ALG_PREF, *p))
+            .collect()
+    }
+
     #[test]
     fn all_active_makes_every_pe_primary() {
         let [a, b, c] = pes();
-        let cands = [a, b, c];
+        let cands = carving(&[a, b, c]);
         // RFC 8214 §5: under all-active every attached PE forwards, so each
         // advertises P=1 regardless of its carving ordinal.
         for me in [a, b, c] {
@@ -292,7 +384,7 @@ mod tests {
     #[test]
     fn single_active_carves_one_primary_and_one_backup() {
         let [a, b, c] = pes();
-        let cands = [a, b, c];
+        let cands = carving(&[a, b, c]);
         let mode = EsRedundancyMode::SingleActive;
         // Service instance 0 carves to ordinal 0: a is DF, b backs it up,
         // c must not be used for this instance.
@@ -312,10 +404,98 @@ mod tests {
         let mode = EsRedundancyMode::SingleActive;
         // Our own Type-4 not selected yet (or no segment at all): advertise
         // primary rather than blackhole the service while it converges.
-        assert_eq!(vpws_role(mode, &[a, b], c, 0), VpwsRole::Primary);
+        assert_eq!(vpws_role(mode, &carving(&[a, b]), c, 0), VpwsRole::Primary);
         assert_eq!(vpws_role(mode, &[], a, 0), VpwsRole::Primary);
         // Sole PE on the segment is the DF.
-        assert_eq!(vpws_role(mode, &[a], a, 3), VpwsRole::Primary);
+        assert_eq!(vpws_role(mode, &carving(&[a]), a, 3), VpwsRole::Primary);
+    }
+
+    #[test]
+    fn preference_beats_address_order() {
+        let [a, b, c] = pes();
+        // a is the lowest address but the lowest preference, so under Alg 2
+        // it loses to both — the whole point of preference over carving.
+        let cands = prefs(&[(a, 10), (b, 300), (c, 200)]);
+        assert_eq!(elect_forwarders(&cands, 0), (Some(b), Some(c)));
+        // ... and the service instance no longer shifts the winner, unlike
+        // carving: preference is per-segment, not per-service.
+        for tag in 0..5u32 {
+            assert_eq!(elect_forwarders(&cands, tag).0, Some(b));
+        }
+    }
+
+    #[test]
+    fn equal_preference_breaks_on_lowest_address() {
+        let [a, b, c] = pes();
+        // draft-ietf-bess-evpn-pref-df, and FRR's comparison: equal pref ->
+        // lowest IP wins. Both PEs must agree or they both forward.
+        let cands = prefs(&[(c, 100), (a, 100), (b, 100)]);
+        assert_eq!(elect_forwarders(&cands, 0), (Some(a), Some(b)));
+    }
+
+    #[test]
+    fn mixed_algorithms_fall_back_to_carving() {
+        let [a, b, c] = pes();
+        // One PE still on Alg 0 means the segment cannot agree, so RFC 8584
+        // negotiation drops everyone to carving — preference is ignored even
+        // though two PEs advertised it.
+        let mut cands = prefs(&[(a, 10), (b, 300)]);
+        cands.push((c, DfElectionEc::ALG_DEFAULT, 0));
+        // Carving on the address-sorted list [a, b, c], tag 1 -> ordinal 1.
+        assert_eq!(elect_forwarders(&cands, 1), (Some(b), Some(c)));
+        // Whereas all-Alg-2 would have given b (highest pref) for every tag.
+        let agreed = prefs(&[(a, 10), (b, 300), (c, 0)]);
+        assert_eq!(elect_forwarders(&agreed, 1).0, Some(b));
+    }
+
+    #[test]
+    fn preference_drives_the_vpws_role() {
+        let [a, b, c] = pes();
+        let mode = EsRedundancyMode::SingleActive;
+        let cands = prefs(&[(a, 10), (b, 300), (c, 200)]);
+        // Highest preference is primary, runner-up is the backup, the rest
+        // must not be used — and unlike carving this holds for every
+        // service instance.
+        for tag in 0..4u32 {
+            assert_eq!(vpws_role(mode, &cands, b, tag), VpwsRole::Primary);
+            assert_eq!(vpws_role(mode, &cands, c, tag), VpwsRole::Backup);
+            assert_eq!(vpws_role(mode, &cands, a, tag), VpwsRole::NonDesignated);
+        }
+        // All-active still overrides the election entirely.
+        for me in [a, b, c] {
+            assert_eq!(
+                vpws_role(EsRedundancyMode::AllActive, &cands, me, 0),
+                VpwsRole::Primary
+            );
+        }
+    }
+
+    #[test]
+    fn single_pe_wins_and_empty_elects_nobody() {
+        let [a, _, _] = pes();
+        assert_eq!(elect_forwarders(&prefs(&[(a, 1)]), 0), (Some(a), None));
+        assert_eq!(elect_forwarders(&[], 0), (None, None));
+    }
+
+    #[test]
+    fn segment_advertises_the_configured_algorithm() {
+        // No preference configured: Alg 0, byte-identical to what the
+        // segment advertised before preference existed.
+        let carving_es = EthernetSegment::default();
+        let ec = carving_es.df_election_ec();
+        assert_eq!(ec.df_alg, DfElectionEc::ALG_DEFAULT);
+        assert_eq!(ec.pref, 0);
+        assert!(!ec.ac_df());
+        // A preference switches the segment to Alg 2 and carries the value.
+        let pref_es = EthernetSegment {
+            df_preference: Some(200),
+            ac_df: true,
+            ..Default::default()
+        };
+        let ec = pref_es.df_election_ec();
+        assert_eq!(ec.df_alg, DfElectionEc::ALG_PREF);
+        assert_eq!(ec.pref, 200);
+        assert!(ec.ac_df());
     }
 
     #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7126,7 +7126,7 @@ fn evpn_vpws_sid(attr: &BgpAttr) -> Option<std::net::Ipv6Addr> {
 /// Mark every VPWS service sitting on Ethernet Segment `esi` as needing a DF
 /// re-election, for `Bgp::vpws_df_drain` to pick up. Called from the Type-4
 /// install and withdraw arms, which see only `LocalRib`.
-fn vpws_mark_df_dirty(local_rib: &mut LocalRib, esi: &[u8; 10]) {
+pub(super) fn vpws_mark_df_dirty(local_rib: &mut LocalRib, esi: &[u8; 10]) {
     let names: Vec<String> = local_rib
         .evpn_vpws
         .services
@@ -7700,6 +7700,7 @@ fn evpn_reoriginate_per_region(
     let df_ec: ExtCommunityValue = DfElectionEc {
         df_alg: DfElectionEc::ALG_DEFAULT,
         bitmap: 0,
+        pref: 0,
     }
     .into();
     attr.ecom
@@ -15779,10 +15780,20 @@ impl Bgp {
             orig: vtep_local,
         };
         let mut attr = BgpAttr::new();
-        let df = bgp_packet::DfElectionEc {
-            df_alg: bgp_packet::DfElectionEc::ALG_DEFAULT,
-            bitmap: 0,
-        };
+        // The segment's configured DF Election EC: Alg 2 + preference when
+        // one is set, otherwise the default carving algorithm, plus the
+        // AC-DF capability bit. Falls back to a bare default for an ESI with
+        // no matching `ethernet-segment` entry (replay before config).
+        let df = self
+            .ethernet_segments
+            .values()
+            .find(|es| es.esi == Some(esi))
+            .map(|es| es.df_election_ec())
+            .unwrap_or(bgp_packet::DfElectionEc {
+                df_alg: bgp_packet::DfElectionEc::ALG_DEFAULT,
+                bitmap: 0,
+                pref: 0,
+            });
         attr.ecom = Some(ExtCommunity::from([
             ExtCommunityValue::es_import_rt(&esi),
             df.into(),
@@ -15952,9 +15963,7 @@ impl Bgp {
         name: &str,
         local_id: u32,
     ) -> ([u8; 10], super::ethernet_segment::VpwsRole, Option<IpAddr>) {
-        use super::ethernet_segment::{
-            EsRedundancyMode, VpwsRole, designated_forwarder, vpws_role,
-        };
+        use super::ethernet_segment::{EsRedundancyMode, VpwsRole, elect_forwarders, vpws_role};
 
         let Some(svc) = self.local_rib.evpn_vpws.services.get(name) else {
             return ([0; 10], VpwsRole::Primary, None);
@@ -15967,14 +15976,11 @@ impl Bgp {
         } else {
             EsRedundancyMode::AllActive
         };
-        let vteps: Vec<IpAddr> = self
-            .es_df_candidates(&esi)
-            .into_iter()
-            .map(|(vtep, _alg)| vtep)
-            .collect();
+        let cands = self.es_df_candidates(&esi);
         let me = IpAddr::V4(self.router_id);
-        let role = vpws_role(mode, &vteps, me, local_id);
-        (esi, role, designated_forwarder(&vteps, local_id))
+        let role = vpws_role(mode, &cands, me, local_id);
+        let (df, _backup) = elect_forwarders(&cands, local_id);
+        (esi, role, df)
     }
 
     /// Withdraw VPWS service `name`'s Type-1 — keyed by what was actually
@@ -16229,31 +16235,35 @@ impl Bgp {
     }
 
     /// The DF-election candidates for an ES, computed from the EVPN Loc-RIB:
-    /// the `(VTEP, advertised DF algorithm)` of every Type-4 route with this
-    /// ESI (our own originated one included), **sorted by ascending VTEP** so
-    /// the index is the RFC 7432 §8.5 service-carving ordinal. The algorithm
-    /// is read from each Type-4's DF Election EC (RFC 8584), defaulting to
-    /// service-carving (Alg 0) when absent. The ESI is in the Type-4 NLRI key,
-    /// so candidates match on it directly rather than on the ES-Import RT.
-    pub fn es_df_candidates(&self, esi: &[u8; 10]) -> Vec<(IpAddr, u8)> {
-        let mut cands: Vec<(IpAddr, u8)> = Vec::new();
+    /// the `(VTEP, advertised DF algorithm, DF preference)` of every Type-4
+    /// route with this ESI (our own originated one included), **sorted by
+    /// ascending VTEP** so the index is the RFC 7432 §8.5 service-carving
+    /// ordinal. Algorithm and preference are read from each Type-4's DF
+    /// Election EC (RFC 8584 / draft-ietf-bess-evpn-pref-df), defaulting to
+    /// service-carving (Alg 0) with preference 0 when absent. The ESI is in
+    /// the Type-4 NLRI key, so candidates match on it directly rather than on
+    /// the ES-Import RT.
+    pub fn es_df_candidates(&self, esi: &[u8; 10]) -> Vec<super::ethernet_segment::DfCandidate> {
+        let mut cands: Vec<super::ethernet_segment::DfCandidate> = Vec::new();
         for table in self.local_rib.evpn.values() {
             for (prefix, rib) in table.selected.iter() {
                 if let EvpnPrefix::EthernetSeg { esi: e, orig } = prefix
                     && e == esi
                 {
-                    let alg = rib
+                    let df = rib
                         .attr
                         .ecom
                         .as_ref()
-                        .and_then(|ec| ec.0.iter().find_map(|v| v.as_df_election()))
-                        .map(|df| df.df_alg)
+                        .and_then(|ec| ec.0.iter().find_map(|v| v.as_df_election()));
+                    let alg = df
+                        .map(|d| d.df_alg)
                         .unwrap_or(bgp_packet::DfElectionEc::ALG_DEFAULT);
-                    cands.push((*orig, alg));
+                    let pref = df.map(|d| d.pref).unwrap_or(0);
+                    cands.push((*orig, alg, pref));
                 }
             }
         }
-        cands.sort_by_key(|(ip, _)| *ip);
+        cands.sort_by_key(|(ip, _, _)| *ip);
         cands
     }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2489,6 +2489,8 @@ struct EthernetSegmentJson {
     esi: Option<String>,
     redundancy_mode: String,
     interface: Option<String>,
+    df_preference: Option<u16>,
+    ac_df: bool,
     es_import_rt: Option<String>,
     member_vteps: Vec<EsMemberVtepJson>,
     df_algorithm: Option<String>,
@@ -2511,25 +2513,25 @@ fn show_bgp_evpn_ethernet_segment(
             let mut designated_forwarder = None;
             if let Some(esi) = es.esi {
                 let cands = bgp.es_df_candidates(&esi);
-                let vteps: Vec<std::net::IpAddr> = cands.iter().map(|(ip, _)| *ip).collect();
-                for (ordinal, (vtep, _)) in cands.iter().enumerate() {
+                for (ordinal, (vtep, _, _)) in cands.iter().enumerate() {
                     member_vteps.push(EsMemberVtepJson {
                         ordinal,
                         vtep: vtep.to_string(),
                         local: *vtep == local,
                     });
                 }
-                let algs: Vec<u8> = cands.iter().map(|(_, a)| *a).collect();
+                let algs: Vec<u8> = cands.iter().map(|(_, a, _)| *a).collect();
                 let alg = super::ethernet_segment::negotiate_df_alg(&algs);
                 df_algorithm = Some(
-                    if alg == bgp_packet::DfElectionEc::ALG_DEFAULT {
-                        "service-carving (default)"
-                    } else {
-                        "negotiated (non-default; carving fallback)"
+                    match alg {
+                        bgp_packet::DfElectionEc::ALG_DEFAULT => "service-carving",
+                        bgp_packet::DfElectionEc::ALG_PREF => "preference-based",
+                        _ => "unsupported (carving fallback)",
                     }
                     .to_string(),
                 );
-                designated_forwarder = super::ethernet_segment::designated_forwarder(&vteps, 0)
+                designated_forwarder = super::ethernet_segment::elect_forwarders(&cands, 0)
+                    .0
                     .map(|df| df.to_string());
             }
             list.push(EthernetSegmentJson {
@@ -2537,6 +2539,8 @@ fn show_bgp_evpn_ethernet_segment(
                 esi: es.esi.map(|esi| bgp_packet::esi_display(&esi)),
                 redundancy_mode: es.redundancy_mode.as_str().to_string(),
                 interface: es.interface.clone(),
+                df_preference: es.df_preference,
+                ac_df: es.ac_df,
                 es_import_rt: es.es_import_rt().map(|rt| format_evpn_ecom_value(&rt)),
                 member_vteps,
                 df_algorithm,
@@ -2571,22 +2575,39 @@ fn show_bgp_evpn_ethernet_segment(
         // §8.5 service-carving ordinal.
         if let Some(esi) = es.esi {
             let cands = bgp.es_df_candidates(&esi);
-            let vteps: Vec<std::net::IpAddr> = cands.iter().map(|(ip, _)| *ip).collect();
+            let vteps: Vec<std::net::IpAddr> = cands.iter().map(|(ip, _, _)| *ip).collect();
             writeln!(buf, "  Member VTEPs ({}):", vteps.len())?;
-            for (ordinal, (vtep, _)) in cands.iter().enumerate() {
+            for (ordinal, (vtep, valg, vpref)) in cands.iter().enumerate() {
                 let tag = if *vtep == local { " (local)" } else { "" };
-                writeln!(buf, "    [{ordinal}] {vtep}{tag}")?;
+                // Each PE's own bid, so a disagreement is visible per-PE
+                // rather than only as the segment-wide carving fallback.
+                let bid = if *valg == bgp_packet::DfElectionEc::ALG_PREF {
+                    format!(" pref {vpref}")
+                } else {
+                    String::new()
+                };
+                writeln!(buf, "    [{ordinal}] {vtep}{bid}{tag}")?;
             }
-            // RFC 8584 algorithm negotiation, then RFC 7432 §8.5 carving.
-            let algs: Vec<u8> = cands.iter().map(|(_, a)| *a).collect();
+            // RFC 8584 algorithm negotiation, then the elected DF.
+            let algs: Vec<u8> = cands.iter().map(|(_, a, _)| *a).collect();
             let alg = super::ethernet_segment::negotiate_df_alg(&algs);
-            let alg_name = if alg == bgp_packet::DfElectionEc::ALG_DEFAULT {
-                "service-carving (default)"
-            } else {
-                "negotiated (non-default; carving fallback)"
+            let alg_name = match alg {
+                bgp_packet::DfElectionEc::ALG_DEFAULT => "service-carving (default)".to_string(),
+                bgp_packet::DfElectionEc::ALG_PREF => {
+                    // Under Alg 2 the local preference is what this PE is
+                    // bidding with, so show it next to the algorithm.
+                    match es.df_preference {
+                        Some(pref) => format!("preference-based (local pref {pref})"),
+                        None => "preference-based".to_string(),
+                    }
+                }
+                other => format!("alg {other} (unsupported; carving fallback)"),
             };
             writeln!(buf, "  DF algorithm: {alg_name}")?;
-            if let Some(df) = super::ethernet_segment::designated_forwarder(&vteps, 0) {
+            if es.ac_df {
+                writeln!(buf, "  AC-DF capability: advertised")?;
+            }
+            if let Some(df) = super::ethernet_segment::elect_forwarders(&cands, 0).0 {
                 let tag = if df == local { " (this node)" } else { "" };
                 writeln!(buf, "  Designated Forwarder (tag 0): {df}{tag}")?;
             }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -221,6 +221,50 @@ module zebra-bgp-evpn {
         type string;
         description "Access interface (CE-facing port) bound to this ES.";
       }
+      container df-election {
+        presence "Designated-Forwarder election tuning";
+        ext:help "Designated-Forwarder election tuning";
+        description
+          "Designated-Forwarder election parameters advertised in this
+           segment's Type-4 DF Election extended community (RFC 8584 §2.2).
+           Absent = the RFC 7432 §8.5 default: service carving, no
+           capabilities.";
+        leaf preference {
+          ext:help "DF preference; highest wins (selects Alg 2)";
+          type uint16 {
+            range "1..65535";
+          }
+          description
+            "Setting a preference switches this segment to preference-based
+             DF election (Alg 2, draft-ietf-bess-evpn-pref-df): the PE with
+             the **highest** preference becomes the Designated Forwarder,
+             ties broken by the lowest originating address. Unset = service
+             carving (Alg 0), where the DF is `service-id mod N` over the
+             address-ordered PEs.
+
+             Preference is per-segment, so one PE wins every service
+             instance on it — which is the point: it lets the operator pin
+             the DF instead of accepting a hash. Carving instead spreads
+             instances across the PEs.
+
+             All PEs on the segment must advertise the same algorithm; RFC
+             8584 negotiation falls the whole segment back to carving if any
+             one of them disagrees. Interoperates with IOS-XR
+             `service-carving preference-based`, Junos
+             `df-election-type preference`, Arista
+             `designated-forwarder election algorithm preference` and FRR
+             `evpn mh es-df-pref`.";
+        }
+        leaf ac-df {
+          ext:help "Advertise the AC-Influenced DF election capability";
+          type empty;
+          description
+            "Advertise the AC-DF (AC-Influenced DF election) capability bit
+             in the DF Election extended community (RFC 8584 §2.2), telling
+             the other PEs on the segment that this PE excludes itself from
+             the election while its attachment circuit is down.";
+        }
+      }
     }
     list vpws {
       ext:help "EVPN VPWS point-to-point E-Line service (RFC 8214)";


### PR DESCRIPTION
## Summary

Segments always advertised DF Alg 0 and elected by the RFC 7432 §8.5 carving
modulus, so which PE forwards was a hash of the service instance id — not
something an operator could choose. Preference-based election
(draft-ietf-bess-evpn-pref-df) is the knob every commercial implementation
exposes, and it is what makes the DF *placeable*:

| | Command |
|---|---|
| IOS-XR | `service-carving preference-based weight <n>` |
| Junos | `df-election-type preference { value <n>; }` |
| Arista | `designated-forwarder election algorithm preference <n>` |
| FRR | `evpn mh es-df-pref <n>` |

```
  ethernet-segment ES1
   esi 00:11:22:33:44:55:66:77:88:99
   redundancy-mode single-active
   interface ce1
   df-election
    preference 300
    ac-df
```

Setting a preference switches the segment to **Alg 2**: highest preference
wins, ties broken by the lowest originating address. Preference is
per-*segment*, so one PE wins every service instance on it — the deliberate
trade against carving, which spreads instances across PEs.

## Wire format is pinned against FRR, not the draft

The preference occupies the **last two octets** of the extended community
(`val[4..6]`, with `val[3]` still reserved). I took that from FRR's
`encode_df_elect_extcomm` (`bgp_evpn_private.h`, writes `val[6]`/`val[7]`)
and its decoder `bgp_attr_df_pref_from_ec` (skips 3 octets after the alg byte,
then reads a BE16) rather than from prose, and there is a unit test asserting
the exact 8 bytes `06 06 02 00 00 00 7f ff`.

The winner comparison likewise matches `zebra_evpn_es_run_df_election`. This
matters more than usual: if two PEs on one segment disagree about who won,
**both** forward and the CE sees duplicate traffic.

## Notes for review

* `elect_forwarders` now dispatches on the negotiated algorithm and returns
  the DF **and** its backup, so the VPWS role election (primary / backup /
  non-designated) is identical under either algorithm.
* `es_df_candidates` carries each PE's `(VTEP, alg, pref)`, so `show bgp evpn
  ethernet-segment` lists a per-PE bid — a disagreement is visible directly,
  not only as the segment-wide carving fallback.
* `ac-df` is bundled because it was one line: `set_ac_df()` already existed
  and origination hardcoded `bitmap: 0`.
* **HRW (Alg 1) is deliberately still absent.** No vendor leads with it, and
  a YANG keyword that parses and elects nothing is worse than no keyword.
* Alg-0 output is byte-identical to before (`pref: 0`, unit-tested), so
  nothing changes for segments that don't opt in.

## Test plan

* **New unit tests** — wire layout pinned to FRR's offsets; display renders
  `pref` only under Alg 2; preference beats address order; equal preference
  breaks on lowest address; **mixed algorithms fall back to carving** (RFC
  8584 negotiation); preference drives the VPWS role for every service
  instance; single-PE and empty candidate sets; the segment advertises the
  configured algorithm. 15 tests in `ethernet_segment`, 8 in `ext_com`.
* **BDD** — new scenario flips es1 to Alg 2 with z1 bidding 300 against z2's
  100. Under carving instance 101 elected **z2**, so the DF moving to **z1**
  with no change to any service id is what proves Alg 2 is in effect. Asserts
  the bid on the wire (`df-election:alg2:pref300`) and the per-PE bid in
  `show`, then reverts one PE to Alg 0 and watches negotiation fall the
  segment back to carving.
* `@bgp_evpn_vpws_multihoming` + `@bgp_evpn_es`: **2 features ran, 2 passed**.
* `cargo fmt --all`, workspace clippy clean, `cargo test --workspace
  --exclude bdd` green (audit docs regenerated: +3 settable nodes, +2
  handlers, and the `df-election` presence container added to the bare list).

## Not in scope

`dont-preempt` / non-revertive (Junos and Arista have it; FRR does not).
Trimmed from what I originally sketched because its Bitmap bit position is
not verifiable against any implementation I have here — shipping an
unverifiable wire bit next to a verified one risks a silent interop bug.
Worth adding once the bit can be checked against a real box.

Generated with [Claude Code](https://claude.com/claude-code)