### PR TITLE
bgp: per-EVI MPLS label + bridge-decap ILM for EVPN over MPLS

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1748,6 +1748,10 @@ fn config_evpn_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
         return Some(());
     }
     bgp.evpn_encap = encap;
+    // Entering MPLS mode gives every EVI a service label + decap ILM;
+    // leaving it hands them back (the routes now carry a VNI or an SRv6 SID,
+    // and a stale ILM would decap traffic the label no longer owns).
+    bgp.evi_reconcile();
     // Re-originate under the new encapsulation (no-op when
     // advertise-all-vni is off; the config-load gate replay covers
     // cold boot, where this leaf lands before the FdbAdds arrive).
@@ -1933,9 +1937,12 @@ fn config_evi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     match op {
         ConfigOp::Set => {
             bgp.evpn_evis.entry(evi).or_default();
+            // Give it a service label + decap ILM if we are in MPLS mode.
+            bgp.evi_reconcile();
         }
         ConfigOp::Delete => {
-            bgp.evpn_evis.remove(&evi);
+            let label = bgp.evpn_evis.remove(&evi).and_then(|cfg| cfg.label);
+            bgp.evi_release(evi, label);
         }
         _ => {}
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4417,6 +4417,9 @@ impl Bgp {
         for name in unlabelled {
             self.relabel_vrf(&name);
         }
+        // EVPN-over-MPLS instances draw from the same block, and an EVI
+        // configured before the grant is sitting label-less too.
+        self.evi_reconcile();
         // The reconcile may have outgrown this block too (a large VRF
         // fleet). If any VRF is still label-less, ask for another.
         if self.vrf_registry.values().any(|h| h.label == 0) {
@@ -4434,6 +4437,106 @@ impl Bgp {
         self.vrf_label_request_pending = true;
         self.rib_subscriber
             .send_label_block_request("bgp", VRF_LABEL_BLOCK_SIZE);
+    }
+
+    /// Bring every configured EVPN Instance's MPLS service label and decap
+    /// ILM in line with the current encapsulation.
+    ///
+    /// Under `encapsulation mpls` each EVI takes one label from the same
+    /// dynamic block the per-VRF labels come from — labels are unique in one
+    /// platform label space, so a second allocator would buy nothing — and
+    /// installs a [`IlmType::DecapBd`] ILM at it, so a remote PE's frame with
+    /// that label pops into the EVI's bridge domain. Under any other
+    /// encapsulation the labels are handed back: an EVI's routes carry a VNI
+    /// or an SRv6 SID instead, and a stale ILM would decap traffic the label
+    /// no longer belongs to.
+    ///
+    /// Idempotent, so it can be called from the config handlers, from a
+    /// label-block grant, and from an encapsulation change alike.
+    pub(super) fn evi_reconcile(&mut self) {
+        let want_labels = self.evpn_encap.is_mpls();
+        let evis: Vec<u32> = self.evpn_evis.keys().copied().collect();
+        let mut freed = Vec::new();
+        let mut short = false;
+        for evi in evis {
+            let current = self.evpn_evis.get(&evi).and_then(|e| e.label);
+            match (want_labels, current) {
+                (true, None) => {
+                    let Some(label) = self.vrf_label_alloc.as_mut().and_then(|a| a.alloc()) else {
+                        // No block bound yet, or this one is spent. Ask for
+                        // (more) space; `label_block_arrived` calls us back.
+                        short = true;
+                        continue;
+                    };
+                    if let Some(cfg) = self.evpn_evis.get_mut(&evi) {
+                        cfg.label = Some(label);
+                    }
+                    self.evi_ilm_install(evi, label);
+                }
+                (false, Some(label)) => {
+                    if let Some(cfg) = self.evpn_evis.get_mut(&evi) {
+                        cfg.label = None;
+                    }
+                    self.evi_ilm_uninstall(evi, label);
+                    freed.push(label);
+                }
+                _ => {}
+            }
+        }
+        self.free_evi_labels(freed);
+        if short {
+            self.request_label_block();
+        }
+    }
+
+    /// Drop one EVI's label and decap ILM — the config handler's delete path.
+    pub(super) fn evi_release(&mut self, evi: u32, label: Option<u32>) {
+        let Some(label) = label else {
+            return;
+        };
+        self.evi_ilm_uninstall(evi, label);
+        self.free_evi_labels(vec![label]);
+    }
+
+    /// Return EVI labels to the shared pool, releasing any block that fully
+    /// empties (mirrors the per-VRF despawn path).
+    fn free_evi_labels(&mut self, labels: Vec<u32>) {
+        if labels.is_empty() {
+            return;
+        }
+        let released: Vec<(u32, u32)> = if let Some(alloc) = self.vrf_label_alloc.as_mut() {
+            for label in labels {
+                alloc.free(label);
+            }
+            alloc.reclaim_free_blocks()
+        } else {
+            Vec::new()
+        };
+        for (start, end) in released {
+            self.rib_subscriber
+                .send_label_block_release("bgp", start, end - start);
+        }
+    }
+
+    /// Install the EVI's bridge-decap ILM. Cradle-only by construction — the
+    /// RIB's FIB handle skips netlink for `DecapBd`, since Linux has no
+    /// action that pops a label into a bridge.
+    fn evi_ilm_install(&self, evi: u32, label: u32) {
+        let entry = crate::rib::inst::IlmEntry {
+            ilm_type: crate::rib::inst::IlmType::DecapBd { bd: evi },
+            nexthop: crate::rib::Nexthop::default(),
+            ..crate::rib::inst::IlmEntry::new(crate::rib::RibType::Bgp)
+        };
+        self.rib_subscriber.send_ilm_add(label, entry);
+    }
+
+    fn evi_ilm_uninstall(&self, evi: u32, label: u32) {
+        let entry = crate::rib::inst::IlmEntry {
+            ilm_type: crate::rib::inst::IlmType::DecapBd { bd: evi },
+            nexthop: crate::rib::Nexthop::default(),
+            ..crate::rib::inst::IlmEntry::new(crate::rib::RibType::Bgp)
+        };
+        self.rib_subscriber.send_ilm_del(label, entry);
     }
 
     /// Allocate a per-VRF label from the dynamic block(s). When no block

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -153,6 +153,12 @@ pub struct Cradle {
     /// Stable auto-allocated bd ids, keyed by bridge name so a bridge
     /// keeps its id across ifindex churn.
     bd_alloc: BTreeMap<String, u16>,
+    /// Bridge name → EVI id, from `router bgp afi-safi evpn evi <id>
+    /// bridge <name>` (EVPN over MPLS). Takes precedence over both the
+    /// VXLAN-slave VNI and the auto-allocated id in [`Self::recompute_bds`]:
+    /// the EVI id *is* the bridge domain, so the control plane's `(mac, bd)`
+    /// and the datapath's agree.
+    evi_by_bridge: BTreeMap<String, u16>,
     engine: Option<Engine>,
     /// Last observed engine availability (from [`EngineEvent`]s).
     status: EngineStatus,
@@ -195,6 +201,7 @@ impl Cradle {
             links: HashMap::new(),
             bd_by_ifindex: HashMap::new(),
             bd_alloc: BTreeMap::new(),
+            evi_by_bridge: BTreeMap::new(),
             engine: None,
             status: EngineStatus::default(),
             applied: HashMap::new(),
@@ -257,6 +264,41 @@ impl Cradle {
                         } else {
                             self.if_ebpf.remove(&if_name);
                         }
+                    }
+                    // `router bgp afi-safi evpn evi <id> bridge <name>` — an
+                    // EVPN-over-MPLS instance. Config is broadcast to every
+                    // subscriber, so this arrives here directly and pins the
+                    // bridge's domain id to the EVI, exactly as a VXLAN
+                    // slave's VNI does for the vxlan/srv6 overlays. Without
+                    // it the bridge would take an auto-allocated bd and the
+                    // EVPN tee's `(mac, bd)` would not match the datapath's.
+                    "/router/bgp/afi-safi/evi/bridge" => {
+                        let Some(afi_safi) = args.string() else {
+                            return;
+                        };
+                        if afi_safi != "evpn" {
+                            return;
+                        }
+                        let Some(evi) = args.u32() else { return };
+                        let Some(bridge) = args.string() else { return };
+                        // EVI ids run to 2^24; a bridge domain is a u16. A
+                        // wider EVI simply keeps its auto-allocated bd.
+                        match (msg.op.is_set(), u16::try_from(evi)) {
+                            (true, Ok(bd)) => {
+                                self.evi_by_bridge.insert(bridge, bd);
+                            }
+                            (true, Err(_)) => {
+                                warn!(
+                                    "cradle: evi {evi} on {bridge} exceeds the bridge-domain range; \
+                                     using an auto-allocated id"
+                                );
+                                self.evi_by_bridge.remove(&bridge);
+                            }
+                            (false, _) => {
+                                self.evi_by_bridge.remove(&bridge);
+                            }
+                        }
+                        self.recompute_bds();
                     }
                     _ => {}
                 }
@@ -345,10 +387,12 @@ impl Cradle {
     }
 
     /// Re-derive every bridge's domain id from link state. Preference
-    /// order per bridge: the VNI of a VXLAN slave when it fits a u16
-    /// (EVPN — the ports must land in the same bd the EVPN FDB tee
-    /// programs), else a stable auto-allocated id (smallest unused,
-    /// per bridge name, skipping ids claimed by any known VNI).
+    /// order per bridge: a configured EVI id (EVPN over MPLS — the operator
+    /// named this bridge's instance), else the VNI of a VXLAN slave when it
+    /// fits a u16 (EVPN over VXLAN/SRv6), else a stable auto-allocated id
+    /// (smallest unused, per bridge name, skipping ids claimed by any known
+    /// VNI). The first two exist for the same reason: the ports must land in
+    /// the same bd the EVPN FDB tee programs.
     fn recompute_bds(&mut self) {
         self.bd_by_ifindex.clear();
         let vni_claimed: std::collections::HashSet<u16> = self
@@ -370,7 +414,7 @@ impl Cradle {
                 .find(|l| l.master == Some(ifindex) && l.vni.is_some())
                 .and_then(|l| l.vni)
                 .and_then(|v| u16::try_from(v).ok());
-            let bd = match vni_bd {
+            let bd = match self.evi_by_bridge.get(&name).copied().or(vni_bd) {
                 Some(bd) => bd,
                 None => match self.bd_alloc.get(&name) {
                     Some(bd) => *bd,

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -28,6 +28,10 @@ const FIB_F_ECMP: u32 = 1 << 3;
 /// Mirrors `cradle_common::MPLS_OP_*` — the ILM `action` values.
 pub const MPLS_OP_SWAP: u32 = 0;
 pub const MPLS_OP_POP_L3: u32 = 1;
+/// Pop an EVPN-over-MPLS EVI service label and bridge the exposed Ethernet
+/// frame; the ILM's `vrf_table_id` carries the bridge domain rather than a
+/// VRF table (the same field reuse cradle applies to `End.DT2U`).
+pub const MPLS_OP_POP_L2: u32 = 3;
 
 /// An EVPN symmetric-IRB VXLAN L3 encap leg: `(remote VTEP, L3VNI, remote
 /// router MAC)`. `Some` on a member marks it a VXLAN-encapsulated nexthop

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -3149,6 +3149,12 @@ impl FibHandle {
                         )
                         .await;
                 }
+                // EVPN-over-MPLS EVI service label: pop and bridge in `bd`.
+                IlmType::DecapBd { bd } => {
+                    cradle
+                        .ilm_install(label, crate::fib::cradle::MPLS_OP_POP_L2, *bd, None, 0, &[])
+                        .await;
+                }
                 // Self prefix-SID (UHP local pop): the loopback nexthop is
                 // for the kernel LFIB only — teeing it would make the eBPF
                 // pop-and-forward resolve an L2 neighbor on `lo` and punt.
@@ -3185,6 +3191,15 @@ impl FibHandle {
                     }
                 }
             }
+        }
+
+        // EVPN-over-MPLS decap is cradle-only. Linux has no action that pops
+        // a label and hands the exposed Ethernet frame to a bridge, so there
+        // is nothing to program here — and falling through would install a
+        // bogus pure-swap route at the EVI's service label. Mirrors
+        // `route_sid_install` skipping netlink for the End.DT2U/DT2M SIDs.
+        if matches!(ilm.ilm_type, IlmType::DecapBd { .. }) {
+            return;
         }
 
         let create_flags = if replace {
@@ -3347,6 +3362,11 @@ impl FibHandle {
     pub async fn ilm_del(&self, label: u32, ilm: &IlmEntry) {
         if let Some(cradle) = &self.cradle {
             cradle.ilm_uninstall(label).await;
+        }
+        // Never installed into the kernel (see `ilm_install`), so there is
+        // nothing to delete — and asking would log a spurious ESRCH.
+        if matches!(ilm.ilm_type, IlmType::DecapBd { .. }) {
+            return;
         }
 
         let mut msg = RouteMessage::default();

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -1957,6 +1957,7 @@ fn fmt_ilm_type(t: &crate::rib::inst::IlmType) -> String {
             format!("Pop Mirror Ctx (table {})", table_id)
         }
         crate::rib::inst::IlmType::Swap => "Swap LU".to_string(),
+        crate::rib::inst::IlmType::DecapBd { bd } => format!("Pop DecapBd (bd {})", bd),
     }
 }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -625,6 +625,20 @@ pub enum IlmType {
     /// swap (same path as Node/Adjacency); this variant only labels the
     /// owner for show output and ILM selection.
     Swap,
+    /// EVPN-over-MPLS per-EVI decap (RFC 7432): pop the EVI service label
+    /// and **bridge** the exposed Ethernet frame in bridge domain `bd`. The
+    /// L2 counterpart of [`IlmType::DecapVrf`].
+    ///
+    /// Unlike every other variant this one is **never programmed into the
+    /// kernel** — Linux has no action that pops an MPLS label and hands the
+    /// frame to a bridge, which is exactly why EVPN-over-MPLS L2 was
+    /// previously unsupported. It exists only to be teed to the cradle eBPF
+    /// data plane (`MPLS_OP_POP_L2`), the same way the SRv6 `End.DT2U` /
+    /// `End.DT2M` local SIDs skip netlink because the kernel has no
+    /// seg6local action for them.
+    DecapBd {
+        bd: u32,
+    },
 }
 
 /// All ILM candidates competing for a single incoming label. Mirrors

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1662,19 +1662,29 @@ pub fn ilm_show(rib: &Rib, _args: Args, json: bool) -> String {
 /// just a VRF the popped packet is routed into. Other no-nexthop types
 /// are skipped.
 fn write_ilm_decap_entry(buf: &mut String, rib: &Rib, label: u32, ilm: &super::inst::IlmEntry) {
-    let (prefix_or_id, vrf_ifindex) = match &ilm.ilm_type {
+    let (prefix_or_id, interface) = match &ilm.ilm_type {
         super::inst::IlmType::DecapVrf {
             table_id,
             vrf_ifindex,
-        } => (format!("VPN Decap (tbl {:<3})", table_id), *vrf_ifindex),
+        } => (
+            format!("VPN Decap (tbl {:<3})", table_id),
+            rib.link_name(*vrf_ifindex),
+        ),
         super::inst::IlmType::ContextLabel {
             table_id,
             vrf_ifindex,
-        } => (format!("Mirror Ctx (tbl {:<3})", table_id), *vrf_ifindex),
+        } => (
+            format!("Mirror Ctx (tbl {:<3})", table_id),
+            rib.link_name(*vrf_ifindex),
+        ),
+        // EVPN-over-MPLS: the pop delivers into a bridge domain, not a VRF
+        // device, so there is no egress interface to name.
+        super::inst::IlmType::DecapBd { bd } => {
+            (format!("EVPN Decap (bd {:<4})", bd), "-".to_string())
+        }
         _ => return,
     };
     let marker = if ilm.selected { "*>" } else { "" };
-    let interface = rib.link_name(vrf_ifindex);
     // No forwarding next-hop column — the popped packet is routed in the VRF.
     writeln!(
         buf,
@@ -1727,6 +1737,7 @@ fn write_ilm_entry(
             vrf_ifindex: _,
         } => format!("Mirror Ctx (tbl {:<3})", table_id),
         super::inst::IlmType::Swap => "LU Swap".to_string(),
+        super::inst::IlmType::DecapBd { bd } => format!("EVPN Decap (bd {:<4})", bd),
         // A static ILM (`router static mpls label ...`) is keyed by its
         // incoming label and has no prefix or SID identity to show.
         // (Guessing one from the RIB — any route sharing the gateway —
@@ -1783,6 +1794,7 @@ fn ilm_to_json(
             vrf_ifindex: _,
         } => format!("Mirror Ctx (tbl {})", table_id),
         super::inst::IlmType::Swap => "LU Swap".to_string(),
+        super::inst::IlmType::DecapBd { bd } => format!("EVPN Decap (bd {:<4})", bd),
         // See `write_ilm_entry`: no prefix/SID identity to show.
         super::inst::IlmType::None => "-".to_string(),
     };


### PR DESCRIPTION
## Summary

Second step of EVPN's L2 services over MPLS (after #2121). Under
`encapsulation mpls` each configured EVI now takes a service label and programs
the decap that makes a remote PE's frame land in the right bridge domain.

**Labels** come from the same dynamic block the per-VRF labels use — one
platform label space, so a second allocator would buy nothing — and follow the
same deferral: an EVI configured before the RIB grants a block waits, and
`label_block_arrived` reconciles it. `evi_reconcile` is idempotent and runs from
the EVI handler, an encapsulation change, and a block grant alike. Leaving MPLS
mode hands the labels back and tears the ILMs down; a stale one would decap
traffic the label no longer owns.

**The decap** is a new `IlmType::DecapBd { bd }` — the L2 counterpart of
`DecapVrf`, and the first ILM variant that is *never* programmed into the
kernel. Linux has no action that pops a label and hands the frame to a bridge,
which is exactly why EVPN-over-MPLS L2 was unsupported; the entry exists to be
teed to cradle as `MPLS_OP_POP_L2`, mirroring how the SRv6 `End.DT2U`/`DT2M`
local SIDs skip netlink. Both `ilm_install` and `ilm_del` return before touching
netlink for it — without that the generic path would install a bogus pure-swap
route at the service label, and the delete would log a spurious ESRCH.

**Binding the bridge domain** needed no new plumbing. Config is broadcast to
every subscriber, so the cradle port supervisor reads `evi <id> bridge <name>`
directly and pins that bridge's domain id to the EVI. This replaces the
RIB round-trip I had planned, and puts the EVI on exactly the footing a VXLAN
slave's VNI already has in `recompute_bds` — which is what makes the control
plane's `(mac, bd)` and the datapath's agree.

## Drive-by fix

`write_ilm_decap_entry` ends in `_ => return`, so any no-nexthop ILM type it did
not know about was stored correctly but **silently omitted from `show mpls
ilm`**. That cost a debugging cycle here — the ILMs were installed right the
whole time — and would have hidden the next such variant too.

## Test plan

Verified live end to end on a throwaway daemon, since none of this is reachable
from a unit test:

```
*> B 20   16     Pop         EVPN Decap (bd 100 ) -
*> B 20   17     Pop         EVPN Decap (bd 200 ) -
```

- Two EVIs take labels 16/17 and render as `EVPN Decap (bd …)`.
- Switching `encapsulation` to vxlan withdraws both ILMs and returns the labels.
- Switching back re-acquires **the same two** labels — proving the free actually
  returned them to the pool rather than leaking.
- Deleting one EVI drops just its own label and ILM.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace --exclude bdd` — all green.

## Next

Type-2 / Type-3 origination carrying the label, then the receive tee
(`fdb_add_mpls` / `repl_slot_add_mpls`) against the cradle datapath that already
forwards this (cradle-rs#159, #160).

Generated with [Claude Code](https://claude.com/claude-code)