### PR TITLE
bgp: originate EVPN Type-2 and Type-3 over MPLS

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2346,8 +2346,16 @@ pub(super) fn reoriginate_all_imet(bgp: &mut Bgp) {
     if !bgp.advertise_all_vni {
         return;
     }
-    let vxlans: Vec<(u32, IpAddr)> = bgp.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect();
-    for (vni, vtep_local) in vxlans {
+    // Under MPLS there is no VXLAN device to enumerate: the configured EVIs
+    // are the local L2 services, and the router-id stands in for the VTEP
+    // (it is the BGP next hop the transport LSP resolves on).
+    let services: Vec<(u32, IpAddr)> = if bgp.evpn_encap.is_mpls() {
+        let orig = IpAddr::V4(bgp.router_id);
+        bgp.evpn_evis.keys().map(|evi| (*evi, orig)).collect()
+    } else {
+        bgp.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect()
+    };
+    for (vni, vtep_local) in services {
         bgp.evpn_originate_imet(vni, vtep_local);
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4458,6 +4458,7 @@ impl Bgp {
         let evis: Vec<u32> = self.evpn_evis.keys().copied().collect();
         let mut freed = Vec::new();
         let mut short = false;
+        let mut changed = false;
         for evi in evis {
             let current = self.evpn_evis.get(&evi).and_then(|e| e.label);
             match (want_labels, current) {
@@ -4472,6 +4473,7 @@ impl Bgp {
                         cfg.label = Some(label);
                     }
                     self.evi_ilm_install(evi, label);
+                    changed = true;
                 }
                 (false, Some(label)) => {
                     if let Some(cfg) = self.evpn_evis.get_mut(&evi) {
@@ -4479,6 +4481,7 @@ impl Bgp {
                     }
                     self.evi_ilm_uninstall(evi, label);
                     freed.push(label);
+                    changed = true;
                 }
                 _ => {}
             }
@@ -4487,6 +4490,28 @@ impl Bgp {
         if short {
             self.request_label_block();
         }
+        // A label that just appeared (or went away) changes what every L2
+        // route for that EVI puts on the wire, so re-originate. Routes
+        // originated before the block landed carry label 0; this is what
+        // replaces them.
+        if changed {
+            self.evpn_reoriginate_l2();
+        }
+    }
+
+    /// Re-originate every locally-originated EVPN L2 route (Type-2 from the
+    /// local FDB, Type-3 per service) so they pick up the current
+    /// encapsulation's service identifier. No-op while `advertise-all-vni`
+    /// is off — nothing was originated to refresh.
+    pub(super) fn evpn_reoriginate_l2(&mut self) {
+        if !self.advertise_all_vni {
+            return;
+        }
+        let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+        for entry in entries {
+            self.evpn_originate_macip(&entry);
+        }
+        super::config::reoriginate_all_imet(self);
     }
 
     /// Drop one EVI's label and decap ILM — the config handler's delete path.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5152,7 +5152,7 @@ pub fn route_update_evpn(
             orig: *orig,
         }),
         EvpnPrefix::MacIp { eth_tag, mac, .. } => {
-            let vni = extract_vni_from_attr(&rib.attr).unwrap_or(0);
+            let vni = macip_service_field(rib);
             EvpnRoute::Mac(EvpnMac {
                 id,
                 rd: *rd,
@@ -5374,6 +5374,29 @@ pub fn route_withdraw_evpn_to_peers(
 /// inbound attr to consult and the VNI is recovered from the RD's
 /// trailing 2 bytes (Type-1 form). ESI defaults to zero, eth-tag
 /// passes through.
+/// The 24-bit service field a Type-2 (MAC/IP) route puts on the wire.
+///
+/// It is an MPLS service label under `encapsulation mpls` (RFC 7432) and a
+/// VNI under VXLAN / SRv6 (RFC 8365, which encodes the VNI redundantly in the
+/// route target — historically this field was read back from there).
+///
+/// The path's own label wins whenever it has one: that is the faithful value
+/// both for a locally-originated MPLS route and for a route being reflected
+/// (whose label came off the wire). Only a VXLAN-originated path, which
+/// carries no label, falls back to the route-target derivation.
+///
+/// Announce and withdraw must agree — a withdraw carrying a different service
+/// field would not match its announce at the receiver — so both emit sites
+/// call this.
+fn macip_service_field(rib: &BgpRib) -> u32 {
+    rib.label
+        .as_ref()
+        .map(|l| l.label)
+        .filter(|l| *l != 0)
+        .or_else(|| extract_vni_from_attr(&rib.attr))
+        .unwrap_or(0)
+}
+
 fn evpn_route_from_prefix(rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32) -> EvpnRoute {
     match prefix {
         // Type-1/4: reconstructed from the key for a withdraw (label/RD are
@@ -7718,6 +7741,9 @@ fn evpn_reoriginate_per_region(
         None,
         IpAddr::V4(*bgp.router_id),
         vni,
+        // RFC 9572 segmentation is a VXLAN/SRv6 feature: identity and
+        // service field are both the VNI.
+        vni,
     );
     // RFC 9572 §6.3: set the L (Leaf Information Required) flag so in-region
     // tunnel leaves answer with a Leaf A-D (Type-11), letting the RBR learn the
@@ -7778,6 +7804,9 @@ fn evpn_reoriginate_spmsi(
         AssistedReplicationRole::None,
         None,
         IpAddr::V4(*bgp.router_id),
+        vni,
+        // RFC 9572 segmentation is a VXLAN/SRv6 feature: identity and
+        // service field are both the VNI.
         vni,
     );
     pmsi.set_leaf_info_required(true);
@@ -10909,7 +10938,7 @@ fn build_evpn_route(
             orig: *orig,
         })),
         EvpnPrefix::MacIp { eth_tag, mac, .. } => {
-            let vni = extract_vni_from_attr(&rib.attr).unwrap_or(0);
+            let vni = macip_service_field(rib);
             Some(EvpnRoute::Mac(EvpnMac {
                 id: rib.remote_id,
                 rd: *rd,
@@ -15260,8 +15289,14 @@ impl Bgp {
         // 16-byte nexthop). Per-peer NEXT_HOP rewrite for eBGP
         // still happens inside `route_update_evpn`.
         let mut attr = BgpAttr::new();
-        let mut ecom =
-            ExtCommunity::from([evpn_route_target(self.asn, entry.vni), evpn_encap_vxlan()]);
+        // RFC 8365 §5.1.2.4 wants the Encapsulation EC so the receiver knows
+        // which data plane to use. MPLS is the *default* encapsulation
+        // (RFC 8365 §5.1.3) and is signalled by its absence, so only the
+        // overlay encapsulations tag themselves.
+        let mut ecom = ExtCommunity::from([evpn_route_target(self.asn, entry.vni)]);
+        if !self.evpn_encap.is_mpls() {
+            ecom.0.insert(evpn_encap_vxlan());
+        }
         // RFC 7432 §7.7 MAC Mobility: a MAC that is (or was) advertised by
         // a remote PE makes this origination a MOVE — carry sequence
         // `max_remote + 1` so every PE (including the previous owner)
@@ -15293,7 +15328,13 @@ impl Bgp {
             .copied()
             .or(entry.vxlan_local)
             .unwrap_or(IpAddr::V4(self.router_id));
-        if !self.local_vxlans.contains_key(&entry.vni) && entry.vxlan_local.is_none() {
+        // Under MPLS the router-id IS the next hop — there is no VTEP to
+        // resolve, and the transport LSP is looked up on it — so the fallback
+        // is the intended answer rather than a degraded one.
+        if !self.evpn_encap.is_mpls()
+            && !self.local_vxlans.contains_key(&entry.vni)
+            && entry.vxlan_local.is_none()
+        {
             tracing::warn!(
                 "evpn_originate_macip: VXLAN for VNI {} has no local IP; \
                  falling back to router-id {} as nexthop",
@@ -15308,6 +15349,16 @@ impl Bgp {
         if self.evpn_encap.is_srv6() {
             attr.prefix_sid = self.vni_dt2u_prefix_sid(entry.vni);
         }
+        // RFC 7432: under `encapsulation mpls` the Type-2 carries this PE's
+        // per-EVI service label in the NLRI's label field, which is what the
+        // remote PE imposes on frames toward this MAC. An EVI still waiting
+        // for its label (no dynamic block granted yet) originates without
+        // one; `evi_reconcile` re-originates when the grant lands.
+        let evi_label = self
+            .evpn_encap
+            .is_mpls()
+            .then(|| self.evpn_evis.get(&entry.vni).and_then(|cfg| cfg.label))
+            .flatten();
 
         let mut rib = BgpRib::new(
             ORIGINATED_PEER,
@@ -15317,7 +15368,11 @@ impl Bgp {
             // withdraw path matches against the same value.
             32768,
             &attr,
-            None,
+            evi_label.map(|label| bgp_packet::Label {
+                label,
+                exp: 0,
+                bos: true,
+            }),
             None,
             false,
         );
@@ -15512,6 +15567,13 @@ impl Bgp {
     ///     mechanism to use and will reject the route.
     ///   - Nexthop = local VTEP IP. Same as Type-2 origination.
     ///
+    /// Under `encapsulation mpls` (RFC 7432 §11.2) the same shape carries
+    /// MPLS values instead: the PMSI Label is this PE's per-EVI service
+    /// label — what a remote PE imposes on BUM toward us — the Tunnel
+    /// Identifier and next hop are the router-id, and the Encapsulation EC
+    /// is omitted (MPLS is the default). `vtep_local` is the router-id in
+    /// that mode.
+    ///
     /// Same gates as `evpn_originate_macip`: `advertise_all_vni` on
     /// AND a valid router-id. RD = `<router-id>:<VNI>`.
     pub fn evpn_originate_imet(&mut self, vni: u32, vtep_local: IpAddr) {
@@ -15533,7 +15595,12 @@ impl Bgp {
             orig: vtep_local,
         };
         let mut attr = BgpAttr::new();
-        let mut ecom = ExtCommunity::from([evpn_route_target(self.asn, vni), evpn_encap_vxlan()]);
+        // As on Type-2: MPLS is signalled by the absence of the
+        // Encapsulation EC (RFC 8365 §5.1.3).
+        let mut ecom = ExtCommunity::from([evpn_route_target(self.asn, vni)]);
+        if !self.evpn_encap.is_mpls() {
+            ecom.0.insert(evpn_encap_vxlan());
+        }
         // RFC 9251 §6 / RFC 9572 §8: advertise IGMP/MLD proxy capability
         // and/or BUM tunnel-segmentation support on the IMET route via the
         // Multicast Flags EC, so peers and Regional Border Routers learn
@@ -15560,7 +15627,20 @@ impl Bgp {
         let prune_bm = self.local_rib.evpn_flood.prune_bm;
         let prune_unknown = self.local_rib.evpn_flood.prune_unknown;
         let selective = self.local_rib.evpn_flood.selective;
-        let (mut pmsi, nexthop) = imet_pmsi_tunnel(bum, role, ar_ip, vtep_local, vni);
+        // The PMSI's 24-bit service field: the VNI under VXLAN/SRv6, this
+        // PE's per-EVI service label under MPLS (RFC 7432 §11.2 — it is what
+        // a remote PE imposes on BUM toward us, so it must be the label, not
+        // the EVI id). An EVI still awaiting its label advertises 0 and is
+        // re-originated by `evi_reconcile` when the block lands.
+        let service = if self.evpn_encap.is_mpls() {
+            self.evpn_evis
+                .get(&vni)
+                .and_then(|cfg| cfg.label)
+                .unwrap_or(0)
+        } else {
+            vni
+        };
+        let (mut pmsi, nexthop) = imet_pmsi_tunnel(bum, role, ar_ip, vtep_local, vni, service);
         // RFC 9574 Pruned-Flood-List: advertise our prune preferences so
         // remote PEs can drop us from the BM / unknown-unicast flood lists.
         pmsi.set_prune_bm(prune_bm);
@@ -16791,12 +16871,17 @@ fn imet_whole_vtep_prune(pmsi: Option<&PmsiTunnel>) -> bool {
         .unwrap_or(false)
 }
 
+///
+/// `service` is the PMSI's 24-bit label field — the VNI under VXLAN/SRv6, the
+/// PE's per-EVI MPLS service label under `encapsulation mpls`. `vni` remains
+/// the EVI/VNI identity itself, which the SR-P2MP form uses as its Tree-ID.
 fn imet_pmsi_tunnel(
     bum: EvpnBumTunnel,
     role: AssistedReplicationRole,
     ar_ip: Option<IpAddr>,
     vtep_local: IpAddr,
     vni: u32,
+    service: u32,
 ) -> (PmsiTunnel, IpAddr) {
     // SR P2MP replication trees ignore the AR role. The MPLS Label field
     // stays 0 (shared-tunnel upstream label / SRv6 transposition is a
@@ -16817,7 +16902,7 @@ fn imet_pmsi_tunnel(
             PmsiTunnel {
                 flags: 0,
                 tunnel_type: PmsiTunnel::TUNNEL_ASSISTED_REPLICATION,
-                vni,
+                vni: service,
                 endpoint: ar,
                 tree_id: None,
             }
@@ -16828,7 +16913,7 @@ fn imet_pmsi_tunnel(
             PmsiTunnel {
                 flags: 0,
                 tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
-                vni,
+                vni: service,
                 endpoint: vtep_local,
                 tree_id: None,
             }
@@ -16839,7 +16924,7 @@ fn imet_pmsi_tunnel(
             PmsiTunnel {
                 flags: 0,
                 tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
-                vni,
+                vni: service,
                 endpoint: vtep_local,
                 tree_id: None,
             },
@@ -17108,6 +17193,61 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
     // Encapsulation type 8 = VXLAN, occupies the trailing 2 octets.
     encap.val[5] = 8;
     encap
+}
+
+/// The Type-2 service field: MPLS label vs RT-derived VNI.
+#[cfg(test)]
+mod macip_service_field_tests {
+    use super::*;
+
+    fn rib_with(label: Option<u32>, rt_vni: Option<u32>) -> BgpRib {
+        let mut attr = BgpAttr::new();
+        if let Some(vni) = rt_vni {
+            attr.ecom = Some(ExtCommunity::from([evpn_route_target(65001, vni)]));
+        }
+        BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            label.map(|label| bgp_packet::Label {
+                label,
+                exp: 0,
+                bos: true,
+            }),
+            None,
+            false,
+        )
+    }
+
+    /// EVPN over MPLS: the EVI service label is what goes on the wire, even
+    /// though the route target names a different number (the EVI id).
+    #[test]
+    fn mpls_label_wins_over_the_route_target() {
+        assert_eq!(macip_service_field(&rib_with(Some(16), Some(100))), 16);
+    }
+
+    /// EVPN over VXLAN: a locally-originated path carries no label, so the
+    /// VNI is recovered from the route target (RFC 8365 §5.1.2.4).
+    #[test]
+    fn vxlan_falls_back_to_the_route_target() {
+        assert_eq!(macip_service_field(&rib_with(None, Some(100))), 100);
+    }
+
+    /// A zero label is "no label", not a service id of 0 — an EVI whose
+    /// dynamic block has not landed yet must not shadow the RT derivation.
+    #[test]
+    fn zero_label_is_not_a_service_id() {
+        assert_eq!(macip_service_field(&rib_with(Some(0), Some(100))), 100);
+    }
+
+    /// Neither source: 0, the same value the pre-refactor code emitted.
+    #[test]
+    fn no_label_and_no_route_target_is_zero() {
+        assert_eq!(macip_service_field(&rib_with(None, None)), 0);
+    }
 }
 
 #[cfg(test)]
@@ -17550,6 +17690,7 @@ mod evpn_imet_ar_tests {
             Some(ar_ip()),
             ir_ip(),
             100,
+            100,
         );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
         assert_eq!(pmsi.ar_type(), AssistedReplicationType::Rnve);
@@ -17568,6 +17709,7 @@ mod evpn_imet_ar_tests {
             Some(ar_ip()),
             ir_ip(),
             100,
+            100,
         );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_ASSISTED_REPLICATION);
         assert_eq!(pmsi.ar_type(), AssistedReplicationType::Replicator);
@@ -17584,6 +17726,7 @@ mod evpn_imet_ar_tests {
             AssistedReplicationRole::Leaf,
             None,
             ir_ip(),
+            100,
             100,
         );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
@@ -17603,6 +17746,7 @@ mod evpn_imet_ar_tests {
             None,
             ir_ip(),
             100,
+            100,
         );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
         assert_eq!(pmsi.ar_type(), AssistedReplicationType::Rnve);
@@ -17620,6 +17764,7 @@ mod evpn_imet_ar_tests {
             Some(ar_ip()),
             ir_ip(),
             100,
+            100,
         );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_SR_MPLS_P2MP);
         assert!(pmsi.is_sr_p2mp());
@@ -17636,6 +17781,7 @@ mod evpn_imet_ar_tests {
             AssistedReplicationRole::None,
             None,
             ir_ip(),
+            4242,
             4242,
         );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_SRV6_P2MP);

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4070,7 +4070,22 @@ fn show_evpn_ecom(attr: &BgpAttr) -> String {
 /// the T field, and the RFC 9574 Pruned-Flood-List (BM/U) and Leaf
 /// Information Required (L) flags are appended when set. SR P2MP trees per
 /// RFC 9524 carry a Root and Tree-ID instead of a plain endpoint and VNI.
-fn format_pmsi_tunnel(p: &PmsiTunnel) -> String {
+/// True when the path carries a BGP Encapsulation extended community
+/// (RFC 9012 type 0x03 / sub 0x0c). Its *absence* is how RFC 8365 §5.1.3
+/// signals plain MPLS, so the show path reads it to decide whether a
+/// 24-bit service field is a VNI or a label.
+fn has_encap_ec(attr: &BgpAttr) -> bool {
+    attr.ecom.as_ref().is_some_and(|ecom| {
+        ecom.0
+            .iter()
+            .any(|ec| ec.high_type == 0x03 && ec.low_type == 0x0c)
+    })
+}
+
+/// `mpls` names the 24-bit service field a label rather than a VNI: the PMSI
+/// carries one field whose meaning follows the encapsulation, and calling an
+/// MPLS service label "vni" reads as a bug to an operator.
+fn format_pmsi_tunnel(p: &PmsiTunnel, mpls: bool) -> String {
     let mut s = String::new();
     let type_name = match p.tunnel_type {
         PmsiTunnel::TUNNEL_INGRESS_REPLICATION => "ingress-replication".to_string(),
@@ -4098,7 +4113,8 @@ fn format_pmsi_tunnel(p: &PmsiTunnel) -> String {
             let _ = write!(s, " tree-id:{tree_id}");
         }
     } else {
-        let _ = write!(s, " endpoint:{} vni:{}", p.endpoint, p.vni);
+        let field = if mpls { "label" } else { "vni" };
+        let _ = write!(s, " endpoint:{} {field}:{}", p.endpoint, p.vni);
     }
     // RFC 9574 flags: BM/U prune requests and the L (Leaf Information
     // Required) selective-AR solicitation.
@@ -4163,7 +4179,11 @@ fn write_evpn_path_attrs(buf: &mut String, attr: &BgpAttr, originated: bool) -> 
     // IMET route — ingress vs assisted replication, the AR role, prune flags,
     // or an SR P2MP tree binding.
     if let Some(pmsi) = &attr.pmsi_tunnel {
-        writeln!(buf, "{PAD}PMSI: {}", format_pmsi_tunnel(pmsi))?;
+        writeln!(
+            buf,
+            "{PAD}PMSI: {}",
+            format_pmsi_tunnel(pmsi, !has_encap_ec(attr))
+        )?;
     }
     if let Some(com) = &attr.com {
         let s = com.to_string();
@@ -7791,7 +7811,7 @@ mod pmsi_render_tests {
             tree_id: None,
         };
         assert_eq!(
-            format_pmsi_tunnel(&p),
+            format_pmsi_tunnel(&p, false),
             "ingress-replication endpoint:10.0.0.1 vni:550"
         );
     }
@@ -7809,7 +7829,7 @@ mod pmsi_render_tests {
         }
         .with_ar_type(AssistedReplicationType::Replicator);
         assert_eq!(
-            format_pmsi_tunnel(&p),
+            format_pmsi_tunnel(&p, false),
             "assisted-replication(replicator) endpoint:10.0.0.254 vni:550"
         );
     }
@@ -7828,7 +7848,7 @@ mod pmsi_render_tests {
         .with_ar_type(AssistedReplicationType::Replicator);
         p.set_leaf_info_required(true);
         assert_eq!(
-            format_pmsi_tunnel(&p),
+            format_pmsi_tunnel(&p, false),
             "assisted-replication(replicator) endpoint:10.0.0.254 vni:10 flags:leaf-info-required"
         );
     }
@@ -7848,7 +7868,7 @@ mod pmsi_render_tests {
         p.set_prune_bm(true);
         p.set_prune_unknown(true);
         assert_eq!(
-            format_pmsi_tunnel(&p),
+            format_pmsi_tunnel(&p, false),
             "ingress-replication endpoint:10.0.0.2 vni:10 flags:prune-bm,prune-u"
         );
     }
@@ -7858,6 +7878,30 @@ mod pmsi_render_tests {
     #[test]
     fn sr_p2mp_tree() {
         let p = PmsiTunnel::sr_p2mp(PmsiTunnel::TUNNEL_SRV6_P2MP, 0, 10, ip(10, 0, 0, 1));
-        assert_eq!(format_pmsi_tunnel(&p), "srv6-p2mp root:10.0.0.1 tree-id:10");
+        assert_eq!(
+            format_pmsi_tunnel(&p, false),
+            "srv6-p2mp root:10.0.0.1 tree-id:10"
+        );
+    }
+
+    /// The PMSI's one 24-bit field means different things per
+    /// encapsulation; calling an MPLS service label "vni" reads as a bug.
+    #[test]
+    fn mpls_names_the_service_field_a_label() {
+        let p = PmsiTunnel {
+            flags: 0,
+            tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
+            vni: 16,
+            endpoint: "10.255.0.1".parse().unwrap(),
+            tree_id: None,
+        };
+        assert_eq!(
+            format_pmsi_tunnel(&p, true),
+            "ingress-replication endpoint:10.255.0.1 label:16"
+        );
+        assert_eq!(
+            format_pmsi_tunnel(&p, false),
+            "ingress-replication endpoint:10.255.0.1 vni:16"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Third step of EVPN's L2 services over MPLS (after #2121, #2123). With a label
and a decap ILM per EVI in place, the routes now carry them.

Type-2 puts the EVI's service label in the NLRI's 24-bit field; Type-3's PMSI
Tunnel carries it as the ingress-replication label — what a remote PE imposes on
BUM toward us — with the router-id as both tunnel identifier and next hop.
Neither attaches the Encapsulation extended community: RFC 8365 §5.1.3 makes
MPLS the default and signals it by that EC's *absence*. (It was previously
attached unconditionally, which also mislabelled SRv6 routes as VXLAN; now
encapsulation-dependent.)

## The surgical change

The Type-2 wire emit sourced its service field from `extract_vni_from_attr` —
i.e. **re-derived it from the route target**. That is a VXLAN-ism that cannot
express an MPLS label, since the RT carries the EVI id and the label is a
different number entirely.

Both emit sites — announce and withdraw, which must agree or the withdraw will
not match at the receiver — now share `macip_service_field`: the path's own
label wins, else the RT derivation. This is also strictly more faithful for
**reflection**: a reflected route re-emits the label it arrived with rather than
one re-derived from an attribute.

## Other bits

- IMET origination is driven by local VXLAN devices, of which MPLS has none, so
  `reoriginate_all_imet` enumerates the configured EVIs instead.
- `imet_pmsi_tunnel` gains a `service` parameter distinct from `vni`: the SR
  P2MP form uses the identity as its **Tree-ID** while ingress replication uses
  the service field as a **label**. Conflating them would have put a label in a
  Tree-ID. The two RFC 9572 segmentation callers pass the VNI for both, which is
  what they meant all along.
- `show bgp evpn` renders that field as `label:` rather than `vni:` when the path
  carries no Encapsulation EC — one PMSI field means different things per
  encapsulation, and printing an MPLS label as "vni" reads as a bug.

## Test plan

**Live**, a PE with `encapsulation mpls` and `evi 100 bridge br100`:

```
Route Distinguisher: 10.255.0.1:100
 *>  [3]:[0]:[32]:[10.255.0.1]
                    10.255.0.1                 0         32768 i
                    Extended community: RT:65001:100
                    PMSI: ingress-replication endpoint:10.255.0.1 label:16
```

Next hop is the router-id (not a VTEP), the PMSI carries the service label, and
there is no Encapsulation EC.

**Unit tests** pin the service-field rule in all four combinations — label wins
over RT, RT fallback when unlabelled, a *zero* label means "no label" rather
than service id 0, and neither source gives 0 — plus the PMSI rendering both
ways. Type-2 needs a datapath MAC learn, so it is covered by the BDD in the
final PR.

**Regression** (EVPN BDD): `bgp_evpn_capability`, `bgp_vrf_evpn_type5`,
`bgp_evpn_rr_withdraw`, `bgp_evpn_ar`, `bgp_evpn_smet` all pass.

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo
test --workspace --exclude bdd` — green.

## Unrelated pre-existing failure

`bgp_evpn_df_election` fails — its z3 daemon never takes its config
(`unix:zebra-rs/vty: transport error` on every show). **It fails identically on
unmodified main**, so it is not from this change; flagging it because nightly
should be catching it. Happy to look at it separately.

Generated with [Claude Code](https://claude.com/claude-code)