### PR TITLE
bgp: VPWS remote selection — prefer the primary, fail over to the backup

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-novpws.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-novpws.yaml
@@ -1,0 +1,40 @@
+# z2 — same Ethernet Segment es1, but its eline1 service is removed, so z2
+# withdraws its per-EVI Type-1. z3 must then fail over to z1's SID (the
+# segment's backup) instead of tearing the E-Line down.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
@@ -158,6 +158,34 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     When I apply config "z2-1.yaml" to namespace "z2"
     Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
 
+  Scenario: The remote PE binds the primary of a multihomed pair
+    Given the test topology exists
+    # z1 and z2 both advertise service instance 101 under es1's ESI. Instance
+    # 101 carves to z2, so z2 sends P=1 and z1 sends B=1 — z3 must bind z2's
+    # SID (carved from LOC2), not simply the first route it happened to see.
+    Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "Remote SID: fcbb:bbbb:2:"
+    And show command "show bgp evpn vpws" in namespace "z3" should contain "(via 192.168.0.2)"
+    # Both ends are visible to z3, and it knows one is standing by.
+    And show command "show bgp evpn vpws" in namespace "z3" should contain "Remote endpoints: 2 (multihomed; 1 standing by)"
+    And show command "show bgp evpn vpws" in namespace "z3" should contain "State: up"
+
+  Scenario: Losing the primary fails the service over to the backup
+    Given the test topology exists
+    # Remove z2's service so it withdraws its per-EVI Type-1, leaving only
+    # z1's B=1 route. Before remote selection this unbound the AC and the
+    # E-Line went down; now it re-selects onto the backup.
+    When I apply config "z2-novpws.yaml" to namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "Remote SID: fcbb:bbbb:1:"
+    And show command "show bgp evpn vpws" in namespace "z3" should contain "(via 192.168.0.1, backup)"
+    # One endpoint left, so no standby line, and the service stays up.
+    And show command "show bgp evpn vpws" in namespace "z3" should not contain "standing by"
+    And show command "show bgp evpn vpws" in namespace "z3" should contain "State: up"
+    # Restoring the primary takes the service back — the re-selection is
+    # symmetric, and z3 changed no config in either direction.
+    When I apply config "z2-1.yaml" to namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "Remote SID: fcbb:bbbb:2:"
+    And show command "show bgp evpn vpws" in namespace "z3" should contain "(via 192.168.0.2)"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -4633,6 +4633,60 @@ mod adv_timer_phantom_tests {
         );
     }
 
+    /// A route re-advertised with a *changed* attribute must not stay
+    /// queued under its previous attribute group. `cache_evpn` groups
+    /// pending NLRIs by attribute and `flush_evpn` emits one UPDATE per
+    /// group, so a stale entry ships the route twice and the peer keeps
+    /// whichever attribute happened to be emitted last — arbitrary, because
+    /// the groups drain in `BTreeMap` key order.
+    ///
+    /// This is what made a DF-elected VPWS Type-1 flipping B -> P reach the
+    /// peer as B: the local Loc-RIB said primary while the peer still
+    /// believed backup.
+    #[tokio::test]
+    async fn send_evpn_readvertise_evicts_the_previous_attr_group() {
+        let (mut peer, _rx) = peer_with_channel();
+        let route = EvpnRoute::EthernetAd(EvpnEthernetAd {
+            id: 0,
+            rd: RouteDistinguisher::default(),
+            esi: [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99],
+            ether_tag: 101,
+            label: 0,
+        });
+
+        // Queue it under one attribute, then re-advertise under another
+        // before the debounce timer flushes.
+        let backup = Arc::new(BgpAttr::new());
+        let mut primary_attr = BgpAttr::new();
+        primary_attr.local_pref = Some(bgp_packet::LocalPref { local_pref: 200 });
+        let primary = Arc::new(primary_attr);
+
+        peer.send_evpn(route.clone(), backup.clone(), true);
+        peer.send_evpn(route.clone(), primary.clone(), true);
+
+        // Exactly one group holds it, and it is the newer one.
+        assert!(
+            !peer.cache_evpn.contains_key(&backup),
+            "the superseded attr group must be dropped, not emitted alongside"
+        );
+        assert!(
+            peer.cache_evpn
+                .get(&primary)
+                .is_some_and(|set| set.contains(&route)),
+            "the route must be queued under the attribute last advertised"
+        );
+        assert_eq!(peer.cache_evpn_rev.get(&route), Some(&primary));
+
+        // Re-advertising with the *same* attribute is idempotent.
+        peer.send_evpn(route.clone(), primary.clone(), true);
+        assert_eq!(peer.cache_evpn.len(), 1);
+        assert_eq!(
+            peer.cache_evpn.get(&primary).map(|s| s.len()),
+            Some(1),
+            "a repeat advertise must not duplicate the NLRI"
+        );
+    }
+
     /// EVPN twin of the VPNv4 zero-interval test above, using a
     /// distinct `EvpnRoute` shape to catch a copy-paste mistake in the
     /// mirrored wiring (VPNv6 is identical in shape to VPNv4, so it

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -20,6 +20,7 @@ use super::peer_map::PeerMap;
 use super::shard::msg::{ShardUpdateV4, ShardUpdateV6};
 use super::shard::{ShardMsg, ShardOut};
 use super::timer::{start_adv_timer_vpnv4, start_adv_timer_vpnv6};
+use super::vpws::{VpwsRemote, VpwsSelection, ZERO_ESI};
 use super::{AssistedReplicationRole, Bgp, EvpnBumTunnel, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
@@ -7167,6 +7168,200 @@ fn evpn_vpws_sid(attr: &BgpAttr) -> Option<std::net::Ipv6Addr> {
         .or_else(|| evpn_srv6_sid(attr, bgp_packet::SRV6_BEHAVIOR_END_DX2V))
 }
 
+/// The PEs currently advertising a live per-ES Ethernet A-D route
+/// (`[1]:[esi]:[MAX-ET]`) for `esi` — the RFC 7432 §8.2 liveness signal a
+/// multihomed PE keeps up for as long as its segment is usable.
+///
+/// Withdrawing that one route is the **mass withdraw**: it invalidates every
+/// per-EVI Type-1 that PE advertised on the segment at once, without waiting
+/// for each to be withdrawn individually. Because selection re-derives this
+/// set from the Loc-RIB on every pass, honouring the mass withdraw needs no
+/// state of its own — the routes simply stop being candidates.
+fn vpws_es_live_pes(local_rib: &LocalRib, esi: &[u8; 10]) -> BTreeSet<IpAddr> {
+    let mut live = BTreeSet::new();
+    for table in local_rib.evpn.values() {
+        for (prefix, rib) in table.selected.iter() {
+            if let EvpnPrefix::EthernetAd { esi: e, eth_tag } = prefix
+                && eth_tag == &MAX_ET
+                && e == esi
+                && rib.typ != BgpRibType::Originated
+                && let Some(BgpNexthop::Evpn(nh)) = rib.attr.nexthop
+            {
+                live.insert(nh);
+            }
+        }
+    }
+    live
+}
+
+/// Every remote endpoint advertised for VPWS service instance `remote_id`
+/// within `evi`: the non-originated per-EVI Type-1s carrying an
+/// `End.DX2`/`End.DX2V` SID, with their ESI, advertising PE and RFC 8214
+/// §3.1 P/B bits.
+///
+/// A candidate on a **non-zero** ESI is dropped unless its PE also has a
+/// live per-ES A-D for that segment — that is the mass-withdraw gate. A
+/// single-homed (all-zero ESI) remote has no per-ES A-D to check, so it is
+/// never gated: requiring one would break every plain point-to-point peer.
+fn vpws_gather_remotes(local_rib: &LocalRib, evi: u32, remote_id: u32) -> Vec<VpwsRemote> {
+    if remote_id == MAX_ET {
+        // MAX-ET tags per-ES A-D routes, never a VPWS service instance.
+        return Vec::new();
+    }
+    let mut out: Vec<VpwsRemote> = Vec::new();
+    let mut live_cache: BTreeMap<[u8; 10], BTreeSet<IpAddr>> = BTreeMap::new();
+    for table in local_rib.evpn.values() {
+        for (prefix, rib) in table.selected.iter() {
+            let EvpnPrefix::EthernetAd { esi, eth_tag } = prefix else {
+                continue;
+            };
+            if *eth_tag != remote_id
+                || rib.typ == BgpRibType::Originated
+                || extract_vni_from_attr(&rib.attr) != Some(evi)
+            {
+                continue;
+            }
+            let Some(sid) = evpn_vpws_sid(&rib.attr) else {
+                // A Type-1 without an End.DX2/DX2V L2-Service SID (e.g. an
+                // RFC 9572 A-D form) has no SRv6 dataplane binding.
+                continue;
+            };
+            let Some(BgpNexthop::Evpn(originator)) = rib.attr.nexthop else {
+                continue;
+            };
+            if *esi != ZERO_ESI {
+                let live = live_cache
+                    .entry(*esi)
+                    .or_insert_with(|| vpws_es_live_pes(local_rib, esi));
+                if !live.contains(&originator) {
+                    continue;
+                }
+            }
+            let l2 = rib
+                .attr
+                .ecom
+                .as_ref()
+                .and_then(|ecom| ecom.0.iter().find_map(|v| v.as_l2_attr()));
+            out.push(VpwsRemote {
+                sid,
+                mtu: l2.map(|a| a.mtu).unwrap_or(0),
+                esi: *esi,
+                originator,
+                primary: l2.is_some_and(|a| a.primary),
+                backup: l2.is_some_and(|a| a.backup),
+            });
+        }
+    }
+    out
+}
+
+/// Re-select and re-bind the remote end of every named VPWS service.
+///
+/// This is the single place a service's AC binding is decided. The receive
+/// path (a Type-1 arriving or being withdrawn), the per-ES A-D mass
+/// withdraw, and the config path all funnel through it, so an event that
+/// removes the current remote *re-selects* rather than merely unbinding —
+/// which is what makes primary→backup failover work. It needs only
+/// `LocalRib` and the RIB client, so it runs unchanged from the `BgpTop`
+/// receive path and from the full `Bgp`.
+fn vpws_rebind(local_rib: &mut LocalRib, rib_client: &crate::rib::client::RibClient, name: &str) {
+    let Some(svc) = local_rib.evpn_vpws.services.get(name) else {
+        return;
+    };
+    let cached = svc.remote_sid;
+    let ifname = svc.interface.clone();
+    let (vid, table) = svc.vid_table();
+    let local_mtu = svc.mtu;
+    let selection = match svc.params() {
+        Some((evi, _, remote_id, _)) => {
+            super::vpws::select_remote(vpws_gather_remotes(local_rib, evi, remote_id), local_mtu)
+        }
+        None => VpwsSelection::None,
+    };
+    let local_sid = local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
+
+    let Some(svc) = local_rib.evpn_vpws.services.get_mut(name) else {
+        return;
+    };
+    match selection {
+        VpwsSelection::Bound { remote, usable } => {
+            svc.remote_sid = Some(remote.sid);
+            svc.remote_mtu_mismatch = None;
+            svc.remote_pe = Some(remote.originator);
+            svc.remote_is_backup = remote.esi != ZERO_ESI && !remote.primary && remote.backup;
+            svc.remote_count = usable;
+            if let Some(ifname) = ifname {
+                let _ = rib_client.send(rib::Message::XconnectAdd {
+                    ifname,
+                    remote_sid: remote.sid,
+                    local_sid,
+                    vid,
+                    table,
+                });
+            }
+        }
+        VpwsSelection::MtuMismatch(mtu) => {
+            svc.remote_sid = None;
+            svc.remote_mtu_mismatch = Some(mtu);
+            svc.remote_pe = None;
+            svc.remote_is_backup = false;
+            svc.remote_count = 0;
+            if cached.is_some()
+                && let Some(ifname) = ifname
+            {
+                let _ = rib_client.send(rib::Message::XconnectDel {
+                    ifname,
+                    local_sid,
+                    vid,
+                    table,
+                });
+            }
+        }
+        VpwsSelection::None => {
+            svc.remote_sid = None;
+            svc.remote_mtu_mismatch = None;
+            svc.remote_pe = None;
+            svc.remote_is_backup = false;
+            svc.remote_count = 0;
+            if cached.is_some()
+                && let Some(ifname) = ifname
+            {
+                let _ = rib_client.send(rib::Message::XconnectDel {
+                    ifname,
+                    local_sid,
+                    vid,
+                    table,
+                });
+            }
+        }
+    }
+}
+
+/// Re-select every VPWS service whose remote candidates could have moved.
+///
+/// `scope` limits the sweep: a per-EVI Type-1 event only affects services
+/// with that `(evi, service instance)`, while a per-ES A-D event can
+/// invalidate candidates for any service, so it re-selects all of them.
+fn vpws_rebind_scope(
+    local_rib: &mut LocalRib,
+    rib_client: &crate::rib::client::RibClient,
+    scope: Option<(u32, u32)>,
+) {
+    let names: Vec<String> = local_rib
+        .evpn_vpws
+        .services
+        .iter()
+        .filter(|(_, svc)| match scope {
+            Some((evi, eth_tag)) => svc.evi == Some(evi) && svc.remote_service_id == Some(eth_tag),
+            None => true,
+        })
+        .map(|(name, _)| name.clone())
+        .collect();
+    for name in names {
+        vpws_rebind(local_rib, rib_client, &name);
+    }
+}
+
 /// Mark every VPWS service sitting on Ethernet Segment `esi` as needing a DF
 /// re-election, for `Bgp::vpws_df_drain` to pick up. Called from the Type-4
 /// install and withdraw arms, which see only `LocalRib`.
@@ -7179,16 +7374,6 @@ pub(super) fn vpws_mark_df_dirty(local_rib: &mut LocalRib, esi: &[u8; 10]) {
         .map(|(name, _)| name.clone())
         .collect();
     local_rib.evpn_vpws.df_dirty.extend(names);
-}
-
-/// The L2 MTU from an EVPN route's Layer-2 Attributes EC (RFC 8214 §3.1).
-/// 0 when the EC is absent or carries no MTU — either way, no MTU check.
-fn evpn_l2_attr_mtu(attr: &BgpAttr) -> u16 {
-    attr.ecom
-        .as_ref()
-        .and_then(|ecom| ecom.0.iter().find_map(|v| v.as_l2_attr()))
-        .map(|a| a.mtu)
-        .unwrap_or(0)
 }
 
 /// The Router's MAC of a received EVPN route (RFC 9135 §6): the advertising
@@ -7313,33 +7498,23 @@ fn route_evpn_export_selected(
                     });
                 }
             }
-            // A withdrawn per-EVI Type-1 (RFC 8214): the remote end of a
-            // VPWS E-Line went away — unbind the AC cross-connect of every
-            // service that had matched it. Per-ES A-D (eth-tag MAX-ET) and
-            // our own originations don't bind anything.
+            // A withdrawn Ethernet A-D route. For a **per-EVI** one the
+            // remote end of an E-Line went away; for a **per-ES** one
+            // (MAX-ET) the RFC 7432 §8.2 mass withdraw just invalidated
+            // every endpoint that PE advertised on the segment at once.
+            //
+            // Both re-select rather than unbind: if the far end is
+            // multihomed, losing the primary must fail the service over to
+            // the backup, not tear it down. `vpws_rebind` unbinds only when
+            // the re-scan genuinely finds nothing usable.
             EvpnPrefix::EthernetAd { eth_tag, .. } => {
-                if *eth_tag != MAX_ET
-                    && wd.typ != BgpRibType::Originated
-                    && let Some(evi) = extract_vni_from_attr(&wd.attr)
-                {
-                    let vpws = &mut bgp.local_rib.evpn_vpws;
-                    for (name, svc) in vpws.services.iter_mut() {
-                        if svc.remote_service_id != Some(*eth_tag) || svc.evi != Some(evi) {
-                            continue;
-                        }
-                        svc.remote_sid = None;
-                        svc.remote_mtu_mismatch = None;
-                        if let Some(ifname) = svc.interface.clone() {
-                            let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
-                            let (vid, table) = svc.vid_table();
-                            let _ = bgp.rib_client.send(rib::Message::XconnectDel {
-                                ifname,
-                                local_sid,
-                                vid,
-                                table,
-                            });
-                        }
-                    }
+                let scope = if *eth_tag == MAX_ET {
+                    None
+                } else {
+                    extract_vni_from_attr(&wd.attr).map(|evi| (evi, *eth_tag))
+                };
+                if *eth_tag == MAX_ET || scope.is_some() {
+                    vpws_rebind_scope(bgp.local_rib, bgp.rib_client, scope);
                 }
             }
             // A withdrawn Type-4: a PE left the Ethernet Segment, so every
@@ -7499,61 +7674,24 @@ fn route_evpn_export_selected(
                 });
             }
         }
-        // A per-EVI Type-1 (RFC 8214): a remote VPWS endpoint. Match its
-        // Ethernet Tag against each configured service's remote-service-id
-        // (within the same EVI, via the RT) and cross-connect the service's
-        // AC to the route's End.DX2 SID through the cradle tee — the
-        // XconnectAdd carries our own End.DX2 SID too, so one message
-        // programs both the ingress encap and the egress decap. Per-ES A-D
-        // (eth-tag MAX-ET) and our own originations bind nothing.
+        // An Ethernet A-D route (RFC 8214 / RFC 7432 §8.2). A **per-EVI**
+        // one (eth-tag = a service instance) is a remote VPWS endpoint, so
+        // re-select the services that could bind it. A **per-ES** one
+        // (MAX-ET) is the segment's liveness signal: its arrival can make a
+        // whole segment's endpoints usable again, so every service
+        // re-selects. Either way the decision itself lives in
+        // `vpws_rebind` — arrival never binds directly, because the route
+        // that just arrived may lose to one already in the Loc-RIB.
         EvpnPrefix::EthernetAd { eth_tag, .. } => {
-            if *eth_tag != MAX_ET
-                && best.typ != BgpRibType::Originated
-                && let Some(evi) = extract_vni_from_attr(&best.attr)
-            {
-                let Some(remote_sid) = evpn_vpws_sid(&best.attr) else {
-                    // A Type-1 without an End.DX2/DX2V L2-Service SID (e.g.
-                    // an RFC 9572 A-D form) has no SRv6 dataplane binding.
-                    return;
-                };
-                let remote_mtu = evpn_l2_attr_mtu(&best.attr);
-                let vpws = &mut bgp.local_rib.evpn_vpws;
-                for (name, svc) in vpws.services.iter_mut() {
-                    if svc.remote_service_id != Some(*eth_tag) || svc.evi != Some(evi) {
-                        continue;
-                    }
-                    let (vid, table) = svc.vid_table();
-                    // RFC 8214 §3.1: both ends non-zero and different —
-                    // the remote MUST NOT be used. Unbind if it had been.
-                    if !svc.mtu_compatible(remote_mtu) {
-                        svc.remote_mtu_mismatch = Some(remote_mtu);
-                        if svc.remote_sid.take().is_some()
-                            && let Some(ifname) = svc.interface.clone()
-                        {
-                            let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
-                            let _ = bgp.rib_client.send(rib::Message::XconnectDel {
-                                ifname,
-                                local_sid,
-                                vid,
-                                table,
-                            });
-                        }
-                        continue;
-                    }
-                    svc.remote_mtu_mismatch = None;
-                    svc.remote_sid = Some(remote_sid);
-                    if let Some(ifname) = svc.interface.clone() {
-                        let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
-                        let _ = bgp.rib_client.send(rib::Message::XconnectAdd {
-                            ifname,
-                            remote_sid,
-                            local_sid,
-                            vid,
-                            table,
-                        });
-                    }
+            let scope = if *eth_tag == MAX_ET {
+                None
+            } else {
+                match extract_vni_from_attr(&best.attr) {
+                    Some(evi) => Some((evi, *eth_tag)),
+                    None => return,
                 }
-            }
+            };
+            vpws_rebind_scope(bgp.local_rib, bgp.rib_client, scope);
         }
         // A Type-4: a PE joined the Ethernet Segment (or re-advertised on
         // it). Its VTEP enters the DF-election candidate set, shifting every
@@ -12417,11 +12555,26 @@ impl Peer {
     /// per-attribute batching so a single MP_REACH UPDATE can carry
     /// every route that shares an attribute set.
     pub fn send_evpn(&mut self, route: EvpnRoute, attr: Arc<BgpAttr>, timer: bool) {
-        self.cache_evpn
-            .entry(attr.clone())
-            .or_default()
-            .insert(route.clone());
-        self.cache_evpn_rev.insert(route, attr);
+        // Re-advertising a route whose *attribute* changed must first evict
+        // it from the attr group it was queued under. `cache_evpn` groups
+        // pending NLRIs by attribute and `flush_evpn` emits one UPDATE per
+        // group, so leaving the stale entry ships the route twice — once
+        // with each attribute — and which one the peer ends up believing
+        // depends on `BTreeMap` iteration order over the attr keys. That is
+        // arbitrary, so the peer intermittently keeps the *old* attribute.
+        //
+        // `evpn_withdraw_one` already evicts this way for the withdraw case;
+        // this is the same eviction for the re-advertise case.
+        if let Some(old) = self.cache_evpn_rev.insert(route.clone(), attr.clone())
+            && old != attr
+            && let Some(set) = self.cache_evpn.get_mut(&old)
+        {
+            set.remove(&route);
+            if set.is_empty() {
+                self.cache_evpn.remove(&old);
+            }
+        }
+        self.cache_evpn.entry(attr).or_default().insert(route);
         if timer && self.cache_evpn_timer.is_none() {
             self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
         }
@@ -16104,95 +16257,20 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
-    /// Find the currently-selected remote end of a VPWS service in the EVPN
-    /// Loc-RIB: a non-originated per-EVI Type-1 (RFC 8214) whose Ethernet Tag
-    /// is the service's `remote-service-id` within the same EVI, carrying an
-    /// `End.DX2` L2-Service SID. Returns the SID plus the route's Layer-2
-    /// Attributes MTU (0 = none signalled); `None` while no such route is
-    /// selected.
-    fn vpws_lookup_remote_sid(
-        &self,
-        evi: u32,
-        remote_id: u32,
-    ) -> Option<(std::net::Ipv6Addr, u16)> {
-        if remote_id == MAX_ET {
-            // MAX-ET tags per-ES A-D routes, never a VPWS service instance.
-            return None;
-        }
-        for table in self.local_rib.evpn.values() {
-            for (prefix, rib) in table.selected.iter() {
-                let EvpnPrefix::EthernetAd { eth_tag, .. } = prefix else {
-                    continue;
-                };
-                if *eth_tag != remote_id
-                    || rib.typ == BgpRibType::Originated
-                    || extract_vni_from_attr(&rib.attr) != Some(evi)
-                {
-                    continue;
-                }
-                if let Some(sid) = evpn_vpws_sid(&rib.attr) {
-                    return Some((sid, evpn_l2_attr_mtu(&rib.attr)));
-                }
-            }
-        }
-        None
-    }
-
     /// Re-sync VPWS service `name` after a config or locator change:
-    /// withdraw the stale Type-1 (if any), originate afresh when the
-    /// config is complete, and re-derive the AC cross-connect from the
-    /// Loc-RIB — the matching remote Type-1 may have arrived before this
-    /// service was (fully) configured, or a re-pointed `remote-service-id`
-    /// / `evi` may now select a different remote, or none at all.
+    /// withdraw the stale Type-1 (if any), originate afresh when the config
+    /// is complete, and re-select the remote end from the Loc-RIB.
+    ///
+    /// The selection is the same `vpws_rebind` the receive path uses, so a
+    /// config edit and a route event can never disagree about which remote
+    /// wins. The Loc-RIB rescan also means ordering does not matter: a
+    /// remote Type-1 that arrived *before* this service was (fully)
+    /// configured is found without waiting for a route churn, and a
+    /// re-pointed `remote-service-id` / `evi` re-selects immediately.
     pub fn vpws_reconcile(&mut self, name: &str) {
         self.evpn_withdraw_vpws(name);
         self.evpn_originate_vpws(name);
-        let Some(svc) = self.local_rib.evpn_vpws.services.get(name) else {
-            return;
-        };
-        let cached = svc.remote_sid;
-        let ifname = svc.interface.clone();
-        // The RFC 8214 §3.1 MTU gate: a found remote whose non-zero MTU
-        // differs from our non-zero MTU is unusable — treated as no match,
-        // remembered for `show` as mtu-mismatch.
-        let found = svc
-            .params()
-            .and_then(|(evi, _, remote_id, _)| self.vpws_lookup_remote_sid(evi, remote_id));
-        let (remote, mismatch) = match found {
-            Some((sid, remote_mtu)) if svc.mtu_compatible(remote_mtu) => (Some(sid), None),
-            Some((_, remote_mtu)) => (None, Some(remote_mtu)),
-            None => (None, None),
-        };
-        let (vid, table) = svc.vid_table();
-        if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
-            svc.remote_sid = remote;
-            svc.remote_mtu_mismatch = mismatch;
-        }
-        let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
-        match (remote, ifname) {
-            (Some(remote_sid), Some(ifname)) => {
-                let _ = self.ctx.rib.send(crate::rib::Message::XconnectAdd {
-                    ifname,
-                    remote_sid,
-                    local_sid,
-                    vid,
-                    table,
-                });
-            }
-            // A previously-bound AC whose remote no longer matches (config
-            // re-pointed, MTU now clashing, or partial config): unbind.
-            // Interface *changes* are unbound by `config_vpws_interface`,
-            // which still knows the old AC name.
-            (None, Some(ifname)) if cached.is_some() => {
-                let _ = self.ctx.rib.send(crate::rib::Message::XconnectDel {
-                    ifname,
-                    local_sid,
-                    vid,
-                    table,
-                });
-            }
-            _ => {}
-        }
+        vpws_rebind(&mut self.local_rib, &self.ctx.rib, name);
     }
 
     /// Full teardown for a deleted VPWS service: withdraw the Type-1,

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2642,6 +2642,9 @@ struct VpwsServiceJson {
     mtu: Option<u16>,
     local_sid: Option<String>,
     remote_sid: Option<String>,
+    remote_pe: Option<String>,
+    remote_is_backup: bool,
+    remote_count: usize,
     remote_mtu_mismatch: Option<u16>,
     ethernet_segment: Option<String>,
     ethernet_segment_binding: Option<String>,
@@ -2690,6 +2693,9 @@ fn show_bgp_evpn_vpws(
                 mtu: svc.mtu,
                 local_sid: vpws.sids.get(name).map(|(addr, _)| addr.to_string()),
                 remote_sid: svc.remote_sid.map(|sid| sid.to_string()),
+                remote_pe: svc.remote_pe.map(|pe| pe.to_string()),
+                remote_is_backup: svc.remote_is_backup,
+                remote_count: svc.remote_count,
                 remote_mtu_mismatch: svc.remote_mtu_mismatch,
                 // The *effective* segment, however it was bound — a JSON
                 // consumer wants what the service is on, not what was typed.
@@ -2809,7 +2815,24 @@ fn show_bgp_evpn_vpws(
             writeln!(buf, "  Local SID ({behavior}): {sid}")?;
         }
         if let Some(sid) = svc.remote_sid {
-            writeln!(buf, "  Remote SID: {sid}")?;
+            // Which PE won, and whether the service is running on the
+            // segment's standby rather than its primary — on a multihomed
+            // far end that is the difference between converged and failed
+            // over.
+            let via = match svc.remote_pe {
+                Some(pe) if svc.remote_is_backup => format!(" (via {pe}, backup)"),
+                Some(pe) => format!(" (via {pe})"),
+                None => String::new(),
+            };
+            writeln!(buf, "  Remote SID: {sid}{via}")?;
+            if svc.remote_count > 1 {
+                writeln!(
+                    buf,
+                    "  Remote endpoints: {} (multihomed; {} standing by)",
+                    svc.remote_count,
+                    svc.remote_count - 1
+                )?;
+            }
         }
         if let Some(remote_mtu) = svc.remote_mtu_mismatch {
             writeln!(buf, "  Remote MTU (mismatch): {remote_mtu}")?;

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -60,6 +60,16 @@ pub struct VpwsService {
     /// The remote's L2 MTU when a matching Type-1 was **rejected** for an
     /// MTU mismatch — the service shows `mtu-mismatch` instead of `up`.
     pub remote_mtu_mismatch: Option<u16>,
+    /// The PE whose SID is currently bound, and whether it was chosen as the
+    /// segment's backup rather than its primary. Display state: on a
+    /// multihomed far end this is the difference between "converged" and
+    /// "running on the standby".
+    pub remote_pe: Option<IpAddr>,
+    /// True when the bound remote advertised `B=1` rather than `P=1`.
+    pub remote_is_backup: bool,
+    /// How many usable remotes were advertised for this service instance —
+    /// 2 or more means the far end is multihomed and one is standing by.
+    pub remote_count: usize,
     /// Name configured on the `ethernet-segment` leaf, if any. Usually
     /// absent: every commercial implementation derives the segment from the
     /// attachment circuit, so this is the override for the cases inference
@@ -130,6 +140,105 @@ impl EsBinding {
     }
 }
 
+/// The all-zero ESI a single-homed service advertises.
+pub const ZERO_ESI: [u8; 10] = [0; 10];
+
+/// One remote endpoint advertised for a VPWS service instance — a per-EVI
+/// Type-1 that matched this service's `remote-service-id` within its EVI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VpwsRemote {
+    /// The advertised `End.DX2` / `End.DX2V` L2-Service SID.
+    pub sid: Ipv6Addr,
+    /// L2 MTU from the route's Layer-2 Attributes EC; 0 = none signalled.
+    pub mtu: u16,
+    /// The route's ESI. All-zero means the far end is single-homed.
+    pub esi: [u8; 10],
+    /// The advertising PE (the route's BGP next-hop) — the tie-break, and
+    /// what the per-ES A-D liveness check keys on.
+    pub originator: IpAddr,
+    /// RFC 8214 §3.1 P bit: this PE forwards for the service instance.
+    pub primary: bool,
+    /// RFC 8214 §3.1 B bit: this PE is the standby.
+    pub backup: bool,
+}
+
+impl VpwsRemote {
+    /// Preference rank, lower is better; `None` means the remote must not be
+    /// used at all.
+    ///
+    /// A single-homed remote (all-zero ESI) is always usable regardless of
+    /// the bits — an implementation that omits the Layer-2 Attributes EC
+    /// entirely decodes as `P=0 B=0`, and refusing those would break every
+    /// plain point-to-point peer. Only on a *multihomed* remote do the bits
+    /// carry an election result: primary beats backup, and a PE that claims
+    /// neither has lost the election and must not be forwarded to.
+    fn rank(&self) -> Option<u8> {
+        match (self.esi == ZERO_ESI, self.primary, self.backup) {
+            (true, _, _) => Some(0),
+            (false, true, _) => Some(0),
+            (false, false, true) => Some(1),
+            (false, false, false) => None,
+        }
+    }
+}
+
+/// The outcome of choosing among the remotes advertised for one service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VpwsSelection {
+    /// Bind this remote's SID to the attachment circuit. `usable` counts
+    /// every remote that survived filtering, so a caller can tell a
+    /// multihomed far end (2+) from a plain one without re-scanning.
+    Bound { remote: VpwsRemote, usable: usize },
+    /// Remotes exist but every one clashes on L2 MTU (RFC 8214 §3.1), so
+    /// none may be bound. Carries one clashing MTU for `show`.
+    MtuMismatch(u16),
+    /// Nothing usable: no matching route, or every candidate lost its
+    /// election / was mass-withdrawn.
+    None,
+}
+
+/// Choose which advertised remote a VPWS service binds.
+///
+/// MTU is filtered first, so a primary with a clashing MTU steps aside for a
+/// compatible backup rather than wedging the service. Then the RFC 8214 §5
+/// roles rank the survivors — primary over backup, non-designated dropped —
+/// with the lowest originating address breaking a tie so both ends of a
+/// segment make the same choice.
+///
+/// Under all-active every attached PE advertises `P=1`, so this picks the
+/// lowest-addressed of them: correct, since any of them can deliver, but not
+/// load-balanced. Spreading flows across several remote SIDs needs an
+/// xconnect that can hold more than one, which is a data-plane change.
+pub fn select_remote(candidates: Vec<VpwsRemote>, local_mtu: Option<u16>) -> VpwsSelection {
+    if candidates.is_empty() {
+        return VpwsSelection::None;
+    }
+    let mtu_ok = |remote_mtu: u16| match local_mtu {
+        Some(local) if local != 0 && remote_mtu != 0 => local == remote_mtu,
+        _ => true,
+    };
+    let clash = candidates.iter().find(|c| !mtu_ok(c.mtu)).map(|c| c.mtu);
+    let mut usable: Vec<(u8, VpwsRemote)> = candidates
+        .into_iter()
+        .filter(|c| mtu_ok(c.mtu))
+        .filter_map(|c| c.rank().map(|r| (r, c)))
+        .collect();
+    if usable.is_empty() {
+        // Report the MTU clash only when that is what removed everything —
+        // a lost election is not an MTU problem.
+        return match clash {
+            Some(mtu) => VpwsSelection::MtuMismatch(mtu),
+            None => VpwsSelection::None,
+        };
+    }
+    usable.sort_by(|(ra, a), (rb, b)| ra.cmp(rb).then_with(|| a.originator.cmp(&b.originator)));
+    let count = usable.len();
+    VpwsSelection::Bound {
+        remote: usable.remove(0).1,
+        usable: count,
+    }
+}
+
 /// Resolve which Ethernet Segment a VPWS service sits on, from its
 /// `ethernet-segment` leaf (`explicit`), its attachment circuit (`ac`) and
 /// the configured segments.
@@ -184,15 +293,6 @@ impl VpwsService {
         ))
     }
 
-    /// RFC 8214 §3.1 MTU check: a remote is usable unless **both** ends
-    /// signal a non-zero L2 MTU and they differ.
-    pub fn mtu_compatible(&self, remote_mtu: u16) -> bool {
-        match self.mtu {
-            Some(local) if local != 0 && remote_mtu != 0 => local == remote_mtu,
-            _ => true,
-        }
-    }
-
     /// The cradle xconnect scoping pair `(802.1Q VID, End.DX2V VLAN-table
     /// id — the EVI)`; `(0, 0)` for a whole-port `End.DX2` service.
     pub fn vid_table(&self) -> (u16, u32) {
@@ -242,6 +342,142 @@ mod tests {
 
     fn s(v: &str) -> String {
         v.to_string()
+    }
+
+    const ES1: [u8; 10] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99];
+
+    fn pe(last: u8) -> IpAddr {
+        use std::net::Ipv4Addr;
+        IpAddr::V4(Ipv4Addr::new(192, 168, 0, last))
+    }
+
+    fn sid(last: u16) -> Ipv6Addr {
+        Ipv6Addr::new(0xfcbb, 0xbbbb, last, 0, 0, 0, 0, 0)
+    }
+
+    /// A remote on ES1 advertising the given role bits.
+    fn mh(last: u8, primary: bool, backup: bool) -> VpwsRemote {
+        VpwsRemote {
+            sid: sid(last as u16),
+            mtu: 0,
+            esi: ES1,
+            originator: pe(last),
+            primary,
+            backup,
+        }
+    }
+
+    /// A single-homed remote — all-zero ESI, no role bits at all (the shape
+    /// a peer that omits the Layer-2 Attributes EC produces).
+    fn sh(last: u8) -> VpwsRemote {
+        VpwsRemote {
+            sid: sid(last as u16),
+            mtu: 0,
+            esi: ZERO_ESI,
+            originator: pe(last),
+            primary: false,
+            backup: false,
+        }
+    }
+
+    fn bound(sel: &VpwsSelection) -> &VpwsRemote {
+        match sel {
+            VpwsSelection::Bound { remote, .. } => remote,
+            other => panic!("expected a bound remote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn primary_beats_backup() {
+        // z2 advertises P, z3 advertises B: the primary is bound even though
+        // it is the higher address, so role beats the tie-break.
+        let sel = select_remote(vec![mh(3, false, true), mh(2, true, false)], None);
+        assert_eq!(bound(&sel).originator, pe(2));
+        assert!(matches!(sel, VpwsSelection::Bound { usable: 2, .. }));
+    }
+
+    #[test]
+    fn losing_the_primary_fails_over_to_the_backup() {
+        // The primary's route is gone (mass withdraw, or its own withdraw):
+        // what remains is the backup, and it binds rather than the service
+        // going down. This is the whole point of remote selection.
+        let sel = select_remote(vec![mh(3, false, true)], None);
+        assert_eq!(bound(&sel).originator, pe(3));
+        assert!(bound(&sel).backup);
+    }
+
+    #[test]
+    fn non_designated_is_never_used() {
+        // P=0 B=0 on a multihomed remote means that PE lost the election —
+        // forwarding to it blackholes. With only such remotes there is no
+        // usable endpoint at all.
+        assert_eq!(
+            select_remote(vec![mh(2, false, false), mh(3, false, false)], None),
+            VpwsSelection::None
+        );
+        // ... and it is skipped in favour of a usable peer.
+        let sel = select_remote(vec![mh(2, false, false), mh(3, false, true)], None);
+        assert_eq!(bound(&sel).originator, pe(3));
+        assert!(matches!(sel, VpwsSelection::Bound { usable: 1, .. }));
+    }
+
+    #[test]
+    fn single_homed_remote_ignores_the_role_bits() {
+        // A plain point-to-point peer may not send the Layer-2 Attributes EC
+        // at all, which decodes as P=0 B=0. Excluding those would break every
+        // pre-multihoming deployment, so an all-zero ESI is always usable.
+        let sel = select_remote(vec![sh(2)], None);
+        assert_eq!(bound(&sel).originator, pe(2));
+        assert!(!bound(&sel).backup);
+    }
+
+    #[test]
+    fn equal_rank_breaks_on_lowest_originator() {
+        // All-active: every attached PE advertises P=1, so pick deterministically
+        // — both ends of the segment must reach the same answer.
+        let sel = select_remote(vec![mh(4, true, false), mh(2, true, false)], None);
+        assert_eq!(bound(&sel).originator, pe(2));
+        assert!(matches!(sel, VpwsSelection::Bound { usable: 2, .. }));
+    }
+
+    #[test]
+    fn mtu_is_filtered_before_the_role_ranking() {
+        // The primary clashes on MTU but the backup agrees: bind the backup
+        // rather than wedging the service on the unusable primary.
+        let mut primary = mh(2, true, false);
+        primary.mtu = 9000;
+        let mut backup = mh(3, false, true);
+        backup.mtu = 1500;
+        let sel = select_remote(vec![primary, backup], Some(1500));
+        assert_eq!(bound(&sel).originator, pe(3));
+    }
+
+    #[test]
+    fn mtu_mismatch_only_when_that_is_what_removed_everything() {
+        // Every candidate clashes -> mtu-mismatch, carrying the remote value.
+        let mut clash = sh(2);
+        clash.mtu = 9000;
+        assert_eq!(
+            select_remote(vec![clash], Some(1500)),
+            VpwsSelection::MtuMismatch(9000)
+        );
+        // Removed by the election instead -> plain None, not an MTU story.
+        assert_eq!(
+            select_remote(vec![mh(2, false, false)], Some(1500)),
+            VpwsSelection::None
+        );
+        // A zero MTU on either side disables the check (RFC 8214 §3.1).
+        let mut zero = sh(2);
+        zero.mtu = 0;
+        assert!(matches!(
+            select_remote(vec![zero], Some(1500)),
+            VpwsSelection::Bound { .. }
+        ));
+    }
+
+    #[test]
+    fn no_candidates_is_none() {
+        assert_eq!(select_remote(vec![], Some(1500)), VpwsSelection::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The P/B bits a multihomed pair advertises had no effect on the receiving side.
A VPWS service bound whichever matching Type-1 the install path happened to
process, and the **withdraw path unbound the AC outright instead of
re-selecting** — so losing the primary tore the E-Line down even with a usable
backup sitting in the Loc-RIB.

Selection now ranks the advertised remotes (RFC 8214 §5):

* **primary over backup**, non-designated dropped entirely (that PE lost the
  election; forwarding to it blackholes), lowest originator breaking a tie so
  both ends agree.
* **MTU is filtered before the ranking**, so a primary with a clashing MTU
  steps aside for a compatible backup instead of wedging the service.
* A **single-homed** remote (all-zero ESI) is always usable regardless of the
  bits — a peer that omits the Layer-2 Attributes EC decodes as `P=0 B=0`, and
  excluding those would break every plain point-to-point deployment.
* The **per-ES A-D route is the liveness gate**: a candidate on a non-zero ESI
  is usable only while its PE advertises one. That is RFC 7432 §8.2 mass
  withdraw, and since selection re-derives the set from the Loc-RIB each pass
  it needs no state of its own.

The three copies of the bind logic (install arm, withdraw arm,
`vpws_reconcile`) collapse into one `vpws_rebind`. That unification *is* the
failover fix: every event re-selects, and unbinds only when the re-scan
genuinely finds nothing usable.

## This uncovered a pre-existing EVPN send bug, also fixed here

`send_evpn` groups pending NLRIs by attribute and `flush_evpn` emits one
UPDATE per group — but re-advertising a route whose **attribute** changed left
it queued under the *old* group as well. Both UPDATEs went out, and the peer
kept whichever drained last: arbitrary, because the groups iterate in
`BTreeMap` key order.

So a DF-elected Type-1 flipping `B` → `P` reached the peer as `B` roughly half
the time. The originator's own Loc-RIB said `primary` while its peer still
believed `backup` — I caught exactly that divergence live:

```
z2 (originator) show bgp evpn:  ... l2-attr:P:mtu0     <- correct
z3 (peer)       show bgp evpn:  ... l2-attr:B:mtu0     <- stale
```

`evpn_withdraw_one` already evicted this way via `cache_evpn_rev`; the
re-advertise path now does the same. It was invisible before this PR because
nothing consumed the P/B bits.

**This is arguably separable** — it is a pre-existing bug in the #2116 code
path, not in remote selection. I bundled it because the feature is not
testable end-to-end without it, but I'm happy to split it out if you'd rather
review it on its own.

## Test plan

* **9 new unit tests** on `select_remote`: primary beats backup; losing the
  primary falls over to the backup; non-designated never used (alone → nothing
  usable, and skipped in favour of a usable peer); single-homed ignores the
  role bits; equal rank breaks on lowest originator; MTU filtered before
  ranking; `MtuMismatch` only when MTU is what removed everything (a lost
  election reports plain `None`); empty input.
* **1 new unit test** on `send_evpn` eviction, **verified with a negative
  control** — reverting the fix makes it fail on the exact assertion.
* **BDD**: new scenarios where z3 binds the primary of the z1/z2 pair
  (asserting `(via 192.168.0.2)` and `Remote endpoints: 2`), then z2's service
  is removed and z3 **fails over to the backup** (`(via 192.168.0.1, backup)`,
  still `State: up`), then restores. Before this PR the failover step left no
  Remote SID at all.
* `@bgp_evpn_vpws_multihoming` + `@bgp_evpn_vpws` + `@bgp_evpn_es`:
  **3 runs, 3 features each, all passed**, with `/usr/bin/zebra-rs` verified
  by md5 against this build before *and* after every run (another worktree was
  installing concurrently and silently replaced it during earlier attempts).
* `cargo fmt --all`, and clippy + test run under `RUSTFLAGS="-D warnings"` to
  mirror CI.

## Not in scope

All-active load balancing: every attached PE advertises `P=1`, so this picks
the lowest-addressed one — correct, since any of them can deliver, but not
load-balanced. Spreading flows needs a cradle xconnect that can hold more than
one remote SID.

Generated with [Claude Code](https://claude.com/claude-code)