### PR TITLE
bgp: import EVPN Type-2/Type-3 over MPLS into the cradle datapath

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_com_type.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_type.rs
@@ -115,6 +115,11 @@ pub enum TunnelType {
     Vxlan = 8,
     #[strum(serialize = "NVGRE")]
     Nvgre = 9,
+    /// Plain MPLS (RFC 9012). Rarely seen on EVPN: RFC 8365 §5.1.3 makes MPLS
+    /// the default and signals it by omitting the Encapsulation extended
+    /// community entirely, but a peer may tag it explicitly.
+    #[strum(serialize = "MPLS")]
+    Mpls = 10,
     #[strum(serialize = "MPLS-in-GRE")]
     MplsGre = 11,
 }

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -167,8 +167,10 @@ message FdbRemote {
   string mac         = 1;
   uint32 bd          = 2;
   string remote_sid  = 3;   // SRv6: remote End.DT2U/DT2M service SID
-  uint32 nexthop_id  = 4;   // 0 = FIB lookup on the SID/VTEP in the datapath
-  string remote_vtep = 5;   // VXLAN: remote VTEP IPv4 (exactly one of sid/vtep)
+  uint32 nexthop_id  = 4;   // 0 = FIB lookup on the SID/VTEP/PE in the datapath
+  string remote_vtep = 5;   // VXLAN: remote VTEP IPv4
+  string remote_pe    = 6;  // MPLS: remote PE address (exactly one of sid/vtep/pe)
+  uint32 remote_label = 7;  // MPLS: that PE's EVI service label
 }
 
 message FdbRemoteDel {
@@ -213,6 +215,8 @@ message ReplSlot {
   uint32 bd          = 1;
   string remote_sid  = 2;   // SRv6: remote End.DT2M SID
   string remote_vtep = 3;   // VXLAN: remote VTEP IPv4 (VNI from the bd's SetVni)
+  string remote_pe    = 4;  // MPLS: remote PE address
+  uint32 remote_label = 5;  // MPLS: that PE's BUM (EVI) service label
 }
 
 // An RFC 9524 Replication segment: the local End.Replicate SID `sid` is an SR

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7276,6 +7276,12 @@ fn route_evpn_export_selected(
                             .rib_client
                             .send(rib::Message::CradleReplDel { vni, sid: dt2m });
                     }
+                    // Mirror the announce side's MPLS slot.
+                    if let Some((pe, _label)) = evpn_mpls_bum(wd) {
+                        let _ = bgp
+                            .rib_client
+                            .send(rib::Message::CradleReplDelMpls { bd: vni, pe });
+                    }
                     bgp.local_rib.evpn_flood.remove_remote(vni, *orig);
                     bgp.local_rib.evpn_flood.reconcile(vni, bgp.rib_client);
                 } else {
@@ -7397,6 +7403,11 @@ fn route_evpn_export_selected(
                     // RFC 9252: a remote End.DT2U SID selects the SRv6 L2
                     // data plane (cradle tee) over the kernel VXLAN FDB.
                     srv6_sid: evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2U),
+                    // RFC 7432: an MPLS service label likewise selects the
+                    // cradle tee — the kernel cannot pop a label into a
+                    // bridge. The next hop is the PE the transport LSP
+                    // resolves on (`tunnel_endpoint`).
+                    mpls_label: evpn_mpls_label(best),
                 };
                 let _ = bgp.rib_client.send(msg);
             } else {
@@ -7424,6 +7435,15 @@ fn route_evpn_export_selected(
                     let _ = bgp
                         .rib_client
                         .send(rib::Message::CradleReplAdd { vni, sid: dt2m });
+                }
+                // RFC 7432 ingress replication: an MPLS IMET advertises the
+                // BUM service label in its PMSI. Same shape as the SRv6 slot
+                // above — one slot per remote PE in the bridge domain's flood
+                // list, independent of the AR/PMSI role machinery.
+                if let Some((pe, label)) = evpn_mpls_bum(best) {
+                    let _ =
+                        bgp.rib_client
+                            .send(rib::Message::CradleReplAddMpls { bd: vni, pe, label });
                 }
                 let pmsi = best.attr.pmsi_tunnel.as_ref();
                 if let Some(p) = pmsi.filter(|p| p.is_sr_p2mp()) {
@@ -7936,6 +7956,18 @@ pub fn route_evpn_update(
     // Extract ESI from EVPN Type 2 route for multi-homing support.
     if let EvpnRoute::Mac(m) = route {
         rib.esi = Some(m.esi);
+        // The Type-2 service field: an MPLS service label under
+        // `encapsulation mpls`, the VNI under VXLAN/SRv6. Capture it either
+        // way — the MPLS import needs the label to impose toward this MAC,
+        // and for VXLAN it simply restates the VNI the route target already
+        // carries, so a reflected route re-emits exactly what arrived.
+        if m.vni != 0 {
+            rib.label = Some(bgp_packet::Label {
+                label: m.vni,
+                exp: 0,
+                bos: true,
+            });
+        }
     }
     // Type-5 (IP Prefix) carries an MPLS service label in its NLRI;
     // preserve it on the BgpRib so the VRF import (which reuses the
@@ -17205,6 +17237,71 @@ fn evpn_mac_mobility(seq: u32) -> ExtCommunityValue {
 /// two octets. Without this community a Type-2 receiver that
 /// understands EVPN but supports multiple data planes can't tell
 /// which encap to install, so RFC 8365 §5.1.2.4 makes it mandatory.
+/// True when the path carries a BGP Encapsulation extended community
+/// (RFC 9012 type 0x03 / sub 0x0c) — i.e. it names an overlay explicitly.
+pub(super) fn attr_has_encap_ec(attr: &BgpAttr) -> bool {
+    encap_ec_tunnel_type(attr).is_some()
+}
+
+/// The tunnel type in the path's Encapsulation extended community (RFC 9012
+/// type 0x03 / sub 0x0c), if it carries one. The type occupies the trailing
+/// two octets of the 6-byte value.
+fn encap_ec_tunnel_type(attr: &BgpAttr) -> Option<u16> {
+    attr.ecom.as_ref().and_then(|ecom| {
+        ecom.0
+            .iter()
+            .find(|ec| ec.high_type == 0x03 && ec.low_type == 0x0c)
+            .map(|ec| u16::from_be_bytes([ec.val[4], ec.val[5]]))
+    })
+}
+
+/// True when the path is MPLS-encapsulated: RFC 8365 §5.1.3 makes MPLS the
+/// default, signalled by the *absence* of an Encapsulation extended
+/// community — but accept an explicit tunnel type 10 (MPLS) too, since a
+/// peer is free to tag it.
+fn attr_encap_is_mpls(attr: &BgpAttr) -> bool {
+    match encap_ec_tunnel_type(attr) {
+        None => true,
+        Some(t) => t == TunnelType::Mpls as u16,
+    }
+}
+
+/// The MPLS service label a received EVPN L2 route asks us to impose toward
+/// it, or `None` when the route is not MPLS-encapsulated.
+///
+/// RFC 8365 §5.1.3: the *absence* of an Encapsulation extended community
+/// means plain MPLS — VXLAN and the other overlays name themselves. Combined
+/// with a non-zero service field that is an unambiguous read of the wire, and
+/// it works for a route reflector too, which has no local encapsulation
+/// config to consult. An SRv6 route is classified before this by its L2
+/// service SID.
+fn evpn_mpls_label(rib: &BgpRib) -> Option<u32> {
+    if !attr_encap_is_mpls(&rib.attr) {
+        return None;
+    }
+    rib.label.as_ref().map(|l| l.label).filter(|l| *l != 0)
+}
+
+/// The `(remote PE, BUM service label)` a received Type-3 IMET asks us to
+/// replicate toward, or `None` when it is not MPLS-encapsulated.
+///
+/// Same read as [`evpn_mpls_label`] — no Encapsulation EC means plain MPLS
+/// (RFC 8365 §5.1.3) — but the label comes from the PMSI Tunnel's label
+/// field, which is where RFC 7432 §11.2 puts the ingress-replication label,
+/// and the PE is the PMSI's tunnel endpoint.
+fn evpn_mpls_bum(rib: &BgpRib) -> Option<(IpAddr, u32)> {
+    if !attr_encap_is_mpls(&rib.attr) {
+        return None;
+    }
+    let pmsi = rib.attr.pmsi_tunnel.as_ref()?;
+    // SR-P2MP trees are not ingress replication: their label field is unused
+    // and BUM rides the tree, not a per-PE slot.
+    if pmsi.is_sr_p2mp() || pmsi.vni == 0 {
+        return None;
+    }
+    Some((pmsi.endpoint, pmsi.vni))
+}
+
 fn evpn_encap_vxlan() -> ExtCommunityValue {
     let mut encap = ExtCommunityValue {
         high_type: 0x03,
@@ -17214,6 +17311,47 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
     // Encapsulation type 8 = VXLAN, occupies the trailing 2 octets.
     encap.val[5] = 8;
     encap
+}
+
+/// Receive-side encapsulation classification: which overlay is a received
+/// EVPN L2 route asking us to use?
+#[cfg(test)]
+mod evpn_encap_classify_tests {
+    use super::*;
+
+    fn attr_with_encap(tunnel_type: Option<u16>) -> BgpAttr {
+        let mut attr = BgpAttr::new();
+        if let Some(t) = tunnel_type {
+            let mut ec = ExtCommunityValue {
+                high_type: 0x03,
+                low_type: 0x0c,
+                val: [0; 6],
+            };
+            ec.val[4..6].copy_from_slice(&t.to_be_bytes());
+            attr.ecom = Some(ExtCommunity::from([ec]));
+        }
+        attr
+    }
+
+    /// RFC 8365 §5.1.3: no Encapsulation EC means plain MPLS.
+    #[test]
+    fn absent_encap_ec_is_mpls() {
+        assert!(attr_encap_is_mpls(&attr_with_encap(None)));
+    }
+
+    /// A peer may tag MPLS explicitly (RFC 9012 tunnel type 10) rather than
+    /// signalling it by omission; both must read as MPLS.
+    #[test]
+    fn explicit_tunnel_type_10_is_mpls() {
+        assert!(attr_encap_is_mpls(&attr_with_encap(Some(10))));
+    }
+
+    /// VXLAN (8) is not MPLS — this is the case that keeps a VXLAN Type-2
+    /// out of the MPLS FDB install.
+    #[test]
+    fn vxlan_is_not_mpls() {
+        assert!(!attr_encap_is_mpls(&attr_with_encap(Some(8))));
+    }
 }
 
 /// The Type-2 service field: MPLS label vs RT-derived VNI.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4070,18 +4070,6 @@ fn show_evpn_ecom(attr: &BgpAttr) -> String {
 /// the T field, and the RFC 9574 Pruned-Flood-List (BM/U) and Leaf
 /// Information Required (L) flags are appended when set. SR P2MP trees per
 /// RFC 9524 carry a Root and Tree-ID instead of a plain endpoint and VNI.
-/// True when the path carries a BGP Encapsulation extended community
-/// (RFC 9012 type 0x03 / sub 0x0c). Its *absence* is how RFC 8365 §5.1.3
-/// signals plain MPLS, so the show path reads it to decide whether a
-/// 24-bit service field is a VNI or a label.
-fn has_encap_ec(attr: &BgpAttr) -> bool {
-    attr.ecom.as_ref().is_some_and(|ecom| {
-        ecom.0
-            .iter()
-            .any(|ec| ec.high_type == 0x03 && ec.low_type == 0x0c)
-    })
-}
-
 /// `mpls` names the 24-bit service field a label rather than a VNI: the PMSI
 /// carries one field whose meaning follows the encapsulation, and calling an
 /// MPLS service label "vni" reads as a bug to an operator.
@@ -4182,7 +4170,7 @@ fn write_evpn_path_attrs(buf: &mut String, attr: &BgpAttr, originated: bool) -> 
         writeln!(
             buf,
             "{PAD}PMSI: {}",
-            format_pmsi_tunnel(pmsi, !has_encap_ec(attr))
+            format_pmsi_tunnel(pmsi, !super::route::attr_has_encap_ec(attr))
         )?;
     }
     if let Some(com) = &attr.com {

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -99,6 +99,12 @@ struct CradleMirror {
     /// `fdb_vxlan` depending on the received route's encap.
     fdb_vxlan: HashMap<(u32, [u8; 6]), Ipv4Addr>,
     repl_slots_vxlan: HashSet<(u32, Ipv4Addr)>,
+    /// EVPN-over-MPLS counterparts: (bridge domain, mac) → (remote PE, that
+    /// PE's EVI service label), and the per-(bd, PE) BUM replication slots
+    /// with their BUM label. A `(vni, mac)` key lives in exactly one of
+    /// `fdb` / `fdb_vxlan` / `fdb_mpls`, per the received route's encap.
+    fdb_mpls: HashMap<(u32, [u8; 6]), (IpAddr, u32)>,
+    repl_slots_mpls: HashSet<(u32, IpAddr, u32)>,
     /// RFC 9524 Replication segments (operator `replication-segment` config):
     /// local End.Replicate SID → (hop-limit threshold, downstream branches
     /// `(sid, nexthop_id, local)`). Replayed as `SetReplSeg` on engine restart.
@@ -1454,6 +1460,8 @@ impl CradleFib {
                     remote_sid: sid.to_string(),
                     nexthop_id: 0,
                     remote_vtep: String::new(),
+                    remote_pe: String::new(),
+                    remote_label: 0,
                 })
                 .await?;
             anyhow::Ok(())
@@ -1483,6 +1491,8 @@ impl CradleFib {
                     remote_sid: String::new(),
                     nexthop_id: 0,
                     remote_vtep: vtep.to_string(),
+                    remote_pe: String::new(),
+                    remote_label: 0,
                 })
                 .await?;
             anyhow::Ok(())
@@ -1490,6 +1500,42 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle fdb_add_vxlan {mac_str} vni {vni} failed: {e}");
+        }
+    }
+
+    /// EVPN/MPLS overlay FDB entry (Type-2, RFC 7432): `mac` in bridge domain
+    /// `bd` sits behind PE `pe`, reached by imposing that PE's EVI service
+    /// `label`. `nexthop_id: 0` — cradle resolves the underlay adjacency with
+    /// a FIB lookup on the PE, which is also what supplies the transport LSP
+    /// label stack the service label rides under.
+    pub async fn fdb_add_mpls(&self, bd: u32, mac: [u8; 6], pe: IpAddr, label: u32) {
+        self.mirror
+            .lock()
+            .await
+            .fdb_mpls
+            .insert((bd, mac), (pe, label));
+        let mac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        );
+        let result = async {
+            self.client()
+                .await?
+                .add_fdb_remote(pb::FdbRemote {
+                    mac: mac_str.clone(),
+                    bd,
+                    remote_sid: String::new(),
+                    nexthop_id: 0,
+                    remote_vtep: String::new(),
+                    remote_pe: pe.to_string(),
+                    remote_label: label,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle fdb_add_mpls {mac_str} bd {bd} failed: {e}");
         }
     }
 
@@ -1639,6 +1685,8 @@ impl CradleFib {
                     bd: vni,
                     remote_sid: sid.to_string(),
                     remote_vtep: String::new(),
+                    remote_pe: String::new(),
+                    remote_label: 0,
                 })
                 .await?;
             anyhow::Ok(())
@@ -1788,6 +1836,8 @@ impl CradleFib {
                     bd: vni,
                     remote_sid: sid.to_string(),
                     remote_vtep: String::new(),
+                    remote_pe: String::new(),
+                    remote_label: 0,
                 })
                 .await?;
             anyhow::Ok(())
@@ -1815,6 +1865,8 @@ impl CradleFib {
                     bd: vni,
                     remote_sid: String::new(),
                     remote_vtep: vtep.to_string(),
+                    remote_pe: String::new(),
+                    remote_label: 0,
                 })
                 .await?;
             anyhow::Ok(())
@@ -1822,6 +1874,61 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle repl_slot_add_vxlan vni {vni} {vtep} failed: {e}");
+        }
+    }
+
+    /// EVPN/MPLS BUM replication slot (RFC 7432 ingress replication): each
+    /// copy flooded in bridge domain `bd` is MPLS-encapsulated toward PE `pe`
+    /// with that PE's BUM service `label`.
+    pub async fn repl_slot_add_mpls(&self, bd: u32, pe: IpAddr, label: u32) {
+        self.mirror
+            .lock()
+            .await
+            .repl_slots_mpls
+            .insert((bd, pe, label));
+        let result = async {
+            self.client()
+                .await?
+                .add_repl_slot(pb::ReplSlot {
+                    bd,
+                    remote_sid: String::new(),
+                    remote_vtep: String::new(),
+                    remote_pe: pe.to_string(),
+                    remote_label: label,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_slot_add_mpls bd {bd} {pe} failed: {e}");
+        }
+    }
+
+    /// Remove a `(bd, pe)` MPLS replication slot. cradle keys the slot on
+    /// `(bd, PE)`, so the label is not needed to find it.
+    pub async fn repl_slot_del_mpls(&self, bd: u32, pe: IpAddr) {
+        self.mirror
+            .lock()
+            .await
+            .repl_slots_mpls
+            .retain(|(b, p, _)| !(*b == bd && *p == pe));
+        let result = async {
+            self.client()
+                .await?
+                .del_repl_slot(pb::ReplSlot {
+                    bd,
+                    remote_sid: String::new(),
+                    remote_vtep: String::new(),
+                    remote_pe: pe.to_string(),
+                    remote_label: 0,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_slot_del_mpls bd {bd} {pe} failed: {e}");
         }
     }
 
@@ -1839,6 +1946,8 @@ impl CradleFib {
                     bd: vni,
                     remote_sid: String::new(),
                     remote_vtep: vtep.to_string(),
+                    remote_pe: String::new(),
+                    remote_label: 0,
                 })
                 .await?;
             anyhow::Ok(())

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -605,6 +605,20 @@ impl FibHandle {
         }
     }
 
+    /// The MPLS flavor (RFC 7432 ingress replication): a BUM replication slot
+    /// toward PE `pe`, whose copies carry that PE's `label`.
+    pub async fn cradle_repl_add_mpls(&self, bd: u32, pe: IpAddr, label: u32) {
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_slot_add_mpls(bd, pe, label).await;
+        }
+    }
+
+    pub async fn cradle_repl_del_mpls(&self, bd: u32, pe: IpAddr) {
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_slot_del_mpls(bd, pe).await;
+        }
+    }
+
     /// Tee an RFC 9524 Replication segment (operator `replication-segment`
     /// config) to cradle: the local End.Replicate SID and its downstream
     /// branches. No kernel counterpart — cradle's `REPL_SEG` is the SR-P2MP
@@ -3458,6 +3472,7 @@ impl FibHandle {
         _seq: u32,
         esi: Option<[u8; 10]>,
         srv6_sid: Option<std::net::Ipv6Addr>,
+        mpls_label: Option<u32>,
     ) {
         // EVPN over SRv6 (RFC 9252): the MAC sits behind a remote L2 service
         // SID (End.DT2U; the all-ones BUM sentinel behind End.DT2M). The
@@ -3466,6 +3481,18 @@ impl FibHandle {
         if let Some(sid) = srv6_sid {
             if let Some(cradle) = &self.cradle {
                 cradle.fdb_add(vni, mac.octets(), sid).await;
+            }
+            return;
+        }
+        // EVPN over MPLS (RFC 7432): the MAC sits behind a remote PE, reached
+        // by imposing that PE's EVI service label under the transport LSP.
+        // cradle-only for the same reason the decap ILM is — the kernel has
+        // no MPLS-to-bridge data path — so a label with no cradle tee means
+        // this MAC simply is not forwardable, and installing a kernel VXLAN
+        // row for it would be worse than doing nothing.
+        if let Some(label) = mpls_label {
+            if let (Some(cradle), Some(pe)) = (&self.cradle, tunnel_endpoint) {
+                cradle.fdb_add_mpls(vni, mac.octets(), pe, label).await;
             }
             return;
         }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -339,6 +339,11 @@ pub enum Message {
         /// all-ones BUM sentinel. `Some` selects the cradle L2 tee over the
         /// kernel VXLAN FDB.
         srv6_sid: Option<std::net::Ipv6Addr>,
+        /// EVPN-over-MPLS (RFC 7432): the remote PE's EVI service label,
+        /// imposed on frames toward this MAC under the transport LSP that
+        /// reaches `tunnel_endpoint`. `Some` selects the cradle L2 tee — the
+        /// kernel has no MPLS-to-bridge data path.
+        mpls_label: Option<u32>,
     },
     MacDel {
         vni: u32,
@@ -354,6 +359,19 @@ pub enum Message {
     CradleReplDel {
         vni: u32,
         sid: std::net::Ipv6Addr,
+    },
+    /// The MPLS flavor (RFC 7432): a remote PE joined/left a bridge domain's
+    /// BUM flood set, advertising `label` as the service label to impose on
+    /// BUM toward it (the Type-3 PMSI's label field). Teed to cradle as a
+    /// replication slot — per-copy MPLS encap in the flood list.
+    CradleReplAddMpls {
+        bd: u32,
+        pe: IpAddr,
+        label: u32,
+    },
+    CradleReplDelMpls {
+        bd: u32,
+        pe: IpAddr,
     },
     /// MUP `dataplane gtp` uplink decap (`H.M.GTP4.D`): a GTP-U decap PDR teed
     /// to cradle — a G-PDU on (`dst`, `teid`) is stripped and its inner packet
@@ -3442,9 +3460,19 @@ impl Rib {
                 seq,
                 esi,
                 srv6_sid,
+                mpls_label,
             } => {
-                self.mac_add(vni, mac, tunnel_endpoint, flags, seq, esi, srv6_sid)
-                    .await;
+                self.mac_add(
+                    vni,
+                    mac,
+                    tunnel_endpoint,
+                    flags,
+                    seq,
+                    esi,
+                    srv6_sid,
+                    mpls_label,
+                )
+                .await;
             }
             Message::MacDel { vni, mac } => {
                 self.mac_del(vni, mac).await;
@@ -3468,6 +3496,12 @@ impl Rib {
             }
             Message::CradleReplDel { vni, sid } => {
                 self.fib_handle.cradle_repl_del(vni, sid).await;
+            }
+            Message::CradleReplAddMpls { bd, pe, label } => {
+                self.fib_handle.cradle_repl_add_mpls(bd, pe, label).await;
+            }
+            Message::CradleReplDelMpls { bd, pe } => {
+                self.fib_handle.cradle_repl_del_mpls(bd, pe).await;
             }
             Message::CradleGtpPdrAdd {
                 dst,
@@ -4361,6 +4395,7 @@ impl Rib {
         seq: u32,
         esi: Option<[u8; 10]>,
         srv6_sid: Option<std::net::Ipv6Addr>,
+        mpls_label: Option<u32>,
     ) {
         // MAC Mobility: ignore stale duplicates (lower sequence number)
         if let Some(existing) = self.mac_table.get(&(vni, mac))
@@ -4382,7 +4417,16 @@ impl Rib {
         // Forward to kernel FIB (or, with an SRv6 L2 service SID, the
         // cradle eBPF tee).
         self.fib_handle
-            .mac_add(vni, &mac, tunnel_endpoint, flags, seq, esi, srv6_sid)
+            .mac_add(
+                vni,
+                &mac,
+                tunnel_endpoint,
+                flags,
+                seq,
+                esi,
+                srv6_sid,
+                mpls_label,
+            )
             .await;
     }
 


### PR DESCRIPTION
## Summary

Fourth step of EVPN's L2 services over MPLS (after #2121, #2123, #2125): the
receive side. A remote PE's Type-2 now installs an FDB entry that imposes that
PE's service label, and its Type-3 a BUM replication slot that does the same for
flooded copies — both into the cradle eBPF datapath, which already forwards this
(cradle-rs#159, #160).

**The service field was being dropped on receive.** Type-5 and Type-1 captured
theirs onto `rib.label`; Type-2 did not, because the VXLAN path re-derives the
VNI from the route target and never needed it. Capturing it unconditionally also
makes a reflected Type-2 re-emit exactly what arrived rather than a value
recomputed from an attribute.

**Encapsulation is classified from the route, not local config**, so a route
reflector — which has no `encapsulation` of its own — reads it the same way a PE
does. RFC 8365 §5.1.3 makes MPLS the default and signals it by the *absence* of
an Encapsulation extended community; an explicit tunnel type 10 is accepted too,
since a peer is free to tag it (`TunnelType` gained the variant). SRv6 is still
classified first, by its L2 service SID.

**The install is cradle-only**, like the decap ILM in #2123: a labelled MAC with
no cradle tee is simply not forwardable, and installing a kernel VXLAN row for it
would be worse than doing nothing.

**Type-3 mirrors the SRv6 slot tee**, not the VXLAN flood-list reconcile — the
label rides the PMSI, and the SRv6 path already establishes that a slot is
programmed straight from the IMET, independent of the AR/PMSI role machinery.
SR-P2MP IMETs are excluded: BUM rides the tree there, not a per-PE slot.

The Type-2 withdraw needs nothing new (`MacDel` keys on `(vni, mac)` and
cradle's FDB delete is flavor-agnostic); the Type-3 withdraw mirrors its
announce.

Also removes the duplicate encap-EC predicate the show path grew in #2125 —
both now read `attr_has_encap_ec`.

## Test plan

- Unit tests pin the classification: absent EC → MPLS, explicit tunnel type 10 →
  MPLS, and VXLAN (8) → **not** MPLS (the case that keeps a VXLAN Type-2 out of
  the MPLS install path).
- **Regression (the real check here** — `mac_add` is shared by all three
  encapsulations): `bgp_evpn_capability`, `bgp_vrf_evpn_type5`,
  `bgp_evpn_rr_withdraw`, `bgp_evpn_ar`, `bgp_evpn_smet`, `bgp_evpn_es` — 6/6
  pass.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo
  test --workspace --exclude bdd` — green.

End-to-end forwarding lands with the BDD in the final PR: two PEs over an IS-IS
SR-MPLS core, CE-to-CE ping with no static forwarding state anywhere.

Generated with [Claude Code](https://claude.com/claude-code)