### PR TITLE
bdd: EVPN-over-MPLS control-plane coverage + book chapter

### DIFF
--- a/bdd/tests/configs/bgp_evpn_mpls/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_mpls/z1-1.yaml
@@ -1,0 +1,21 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      evi:
+      - id: 100
+        bridge: br100

--- a/bdd/tests/configs/bgp_evpn_mpls/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_mpls/z2-1.yaml
@@ -1,0 +1,21 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      evi:
+      - id: 100
+        bridge: br100

--- a/bdd/tests/features/bgp_evpn_mpls.feature
+++ b/bdd/tests/features/bgp_evpn_mpls.feature
@@ -1,0 +1,96 @@
+@serial
+@bgp_evpn_mpls
+Feature: EVPN over MPLS advertises a per-EVI service label (RFC 7432)
+  As a network operator running EVPN's L2 services over an MPLS core
+  I want each PE to advertise its EVI with an MPLS service label and to
+  program the matching decap, so a remote PE knows what to impose on frames
+  toward this one — the control plane behind the eBPF data path that
+  forwards it.
+
+  Test topology (control plane only — no CEs, no bridges, no forwarding):
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+   encapsulation mpls, evi 100 bridge br100 on both
+  ```
+
+  What distinguishes MPLS from the VXLAN and SRv6 encapsulations, and what
+  this feature pins:
+
+  - The EVI is *declared*, not inferred. VXLAN and SRv6 read a local VXLAN
+    device's VNI; an MPLS EVI has no VNI, so `evi 100 bridge br100` is what
+    tells the PE this L2 service exists at all.
+  - The Type-3 IMET carries an MPLS **label** in its PMSI, not a VNI, and
+    the label is a different number from the EVI id (it comes from the
+    dynamic block, so it is deliberately NOT asserted as a literal).
+  - The next hop and PMSI tunnel identifier are the router-id, not a VTEP.
+  - No Encapsulation extended community is attached: RFC 8365 section 5.1.3
+    makes MPLS the default and signals it by that EC's *absence*, so its
+    presence would be the bug.
+  - A decap ILM is programmed at the service label so a remote PE's frame
+    pops into bridge domain 100. It is cradle-only — the kernel has no
+    action that pops a label into a bridge — so `show mpls ilm` is the only
+    place it is observable without a data plane.
+
+  Type-2 (MAC/IP) needs a datapath MAC learn and is covered by the
+  cradle-rs `cradle_evpn_mpls_zebra` feature, which drives this same control
+  plane with a real eBPF data plane and CE-to-CE traffic.
+
+  Scenario: Setup topology and establish the EVPN session
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Each PE originates a Type-3 IMET for its declared EVI
+    Given the test topology exists
+    # RD is <router-id>:<evi> and the next hop is the router-id — there is no
+    # VTEP address in an MPLS EVPN.
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "192.168.0.1:100"
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "[3]:[0]:[32]:[192.168.0.1]"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "[3]:[0]:[32]:[192.168.0.2]"
+
+  Scenario: The IMET reaches the far PE with an MPLS label, not a VNI
+    Given the test topology exists
+    # `label:` (rather than `vni:`) is what the show path renders for a path
+    # with no Encapsulation EC — the MPLS signal itself.
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "[3]:[0]:[32]:[192.168.0.1]"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "ingress-replication endpoint:192.168.0.1 label:"
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "ingress-replication endpoint:192.168.0.2 label:"
+
+  Scenario: The route target carries the EVI and no encapsulation EC is set
+    Given the test topology exists
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "RT:65001:100"
+    # RFC 8365 5.1.3: MPLS is signalled by omitting the Encapsulation EC.
+    And show command "show bgp evpn" in namespace "z2" should not contain "VXLAN"
+
+  Scenario: Each PE programs a bridge-domain decap ILM for its EVI
+    Given the test topology exists
+    # Cradle-only by construction (the kernel has no MPLS-to-bridge action),
+    # so this is the RIB's view rather than the kernel LFIB's.
+    Then show command "show mpls ilm" in namespace "z1" should eventually contain "EVPN Decap (bd 100"
+    And show command "show mpls ilm" in namespace "z2" should eventually contain "EVPN Decap (bd 100"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -51,6 +51,7 @@
   - [EVPN BUM & Assisted Replication](ch-02-33-bgp-evpn-assisted-replication.md)
   - [EVPN BUM Tunnel Segmentation (RFC 9572)](ch-02-34-bgp-evpn-segmentation.md)
   - [EVPN VPWS (E-Line over SRv6)](ch-02-38-bgp-evpn-vpws.md)
+  - [EVPN over MPLS](ch-02-39-bgp-evpn-mpls.md)
   - [Mobile User Plane (MUP) & the MUP Controller](ch-02-35-bgp-mup.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)

--- a/book/src/appendix-b-supported-rfcs.md
+++ b/book/src/appendix-b-supported-rfcs.md
@@ -169,7 +169,7 @@ implementation; the corresponding features track the referenced draft revision.
 
 | RFC / Internet-Draft | Description |
 | --- | --- |
-| RFC 7432 | BGP MPLS-Based Ethernet VPN (EVPN) — the base control plane. |
+| RFC 7432 | BGP MPLS-Based Ethernet VPN (EVPN) — the base control plane, and MPLS-encapsulated L2 forwarding (Type-2 / Type-3) over the cradle eBPF data plane. |
 | RFC 8365 | A Network Virtualization Overlay Solution Using EVPN (EVPN over VXLAN). |
 | RFC 9136 | IP Prefix Advertisement in EVPN (Type-5 routes). |
 | RFC 8584 | Framework for EVPN Designated Forwarder (DF) Election Extensibility. |

--- a/book/src/ch-02-06-bgp-evpn-type5.md
+++ b/book/src/ch-02-06-bgp-evpn-type5.md
@@ -77,9 +77,11 @@ next-hop resolves over the underlay, and re-installs if that underlay
 reroutes.
 
 > **Note** — this is the **L3** EVPN service. EVPN's **L2** services
-> (Type-2 MAC/IP, Type-3 inclusive-multicast) run over VXLAN and are
-> documented separately; EVPN-over-MPLS *L2* is not supported (the Linux
-> kernel has no L2-over-MPLS data path).
+> (Type-2 MAC/IP, Type-3 inclusive-multicast) are documented separately and
+> run over VXLAN, SRv6, or MPLS. EVPN-over-MPLS *L2* is not forwardable by
+> the Linux kernel — it has no action that pops a label and hands the frame
+> to a bridge — so it needs the cradle eBPF data plane; see
+> [EVPN over MPLS](ch-02-39-bgp-evpn-mpls.md).
 
 ## Verification
 

--- a/book/src/ch-02-39-bgp-evpn-mpls.md
+++ b/book/src/ch-02-39-bgp-evpn-mpls.md
@@ -1,0 +1,127 @@
+# EVPN over MPLS (RFC 7432)
+
+EVPN's L2 services — Type-2 (MAC/IP) and Type-3 (Inclusive Multicast) — over
+plain MPLS: the encapsulation RFC 7432 was written for, and the one zebra-rs
+supported last. A CE frame is carried under a per-EVI **service label**,
+imposed beneath whatever transport LSP reaches the egress PE, which pops it
+and bridges the frame into that EVI's bridge domain.
+
+> **This needs the cradle eBPF data plane.** Linux has no action that pops an
+> MPLS label and hands the exposed Ethernet frame to a bridge — that gap is
+> precisely why EVPN-over-MPLS L2 was unsupported for so long. The control
+> plane here programs [cradle](ch-02-00-zebra-integration.md) directly and
+> deliberately skips netlink for the decap. VXLAN and SRv6 have kernel data
+> paths; this one does not.
+>
+> EVPN **Type-5** (IP Prefix) is a different story — it is an L3 service and
+> rides the ordinary VPNv4/VPNv6 MPLS data path, kernel included. See
+> [EVPN Type-5](ch-02-06-bgp-evpn-type5.md).
+
+## Configuration
+
+```
+router bgp 65001 {
+  global {
+    router-id 10.255.0.1;
+  }
+  neighbor 10.255.0.2 {
+    remote-as 65001;
+    afi-safi { name evpn; enabled true; }
+  }
+  afi-safi {
+    name evpn;
+    advertise-all-vni true;
+    encapsulation mpls;
+    evi 100 {
+      bridge br100;
+    }
+  }
+}
+```
+
+### Why the EVI must be declared
+
+Under `encapsulation vxlan` or `srv6`, zebra-rs works out which bridge domains
+to advertise by reading the kernel: each bridge's VXLAN slave supplies a VNI,
+and that VNI is the service identifier on the wire.
+
+An MPLS EVI has no VNI to read. So it is declared: `evi <id> { bridge <name> }`
+names the instance and the bridge whose L2 domain it carries. The id then does
+triple duty — it is the bridge domain, the low 24 bits of the auto-derived RD
+(`<router-id>:<id>`) and of the route target (`<local-AS>:<id>`) — which keeps
+it interchangeable with a VNI everywhere else in the EVPN path.
+
+The **service label is not the EVI id.** It is allocated from the same dynamic
+MPLS block the per-VRF L3VPN labels come from, so `evi 100` will advertise some
+label like 16 or 100017. That is the number a remote PE imposes; the EVI id is
+only the service's name.
+
+## What goes on the wire
+
+| | VXLAN / SRv6 | MPLS |
+|---|---|---|
+| Type-2 NLRI service field | VNI | **service label** |
+| Type-3 PMSI label field | VNI | **BUM service label** |
+| Next hop / PMSI tunnel id | local VTEP | **router-id** |
+| Encapsulation ext. community | VXLAN (8) | **absent** |
+
+That last row is the encapsulation signal itself: RFC 8365 §5.1.3 makes MPLS
+the default and marks it by *omitting* the Encapsulation extended community.
+zebra-rs reads a received route the same way (and also accepts an explicit
+tunnel type 10), so a route reflector — which has no `encapsulation` of its
+own — classifies traffic exactly as a PE does.
+
+## Forwarding
+
+**Ingress.** A frame from a CE port whose destination MAC resolves to a remote
+PE is imposed with `[transport LSP…][service label, S=1]` under an `0x8847`
+Ethernet header. The FDB row names only the remote PE; the data plane resolves
+the adjacency by a FIB lookup on it, which is also what supplies the transport
+labels — so the control plane advertises a *PE*, never a tunnel.
+
+**Egress.** The service label's ILM pops it and bridges the exposed frame in
+the EVI's bridge domain, reusing the same hand-off SRv6's `End.DT2U` decap
+uses — so split horizon, MAC learning and flooding all behave identically
+across the three encapsulations.
+
+**BUM** is ingress-replicated: each remote PE's Type-3 becomes a replication
+slot, and a flooded frame gets one copy per slot carrying that PE's BUM label.
+
+## Verification
+
+```
+zebra-rs# show bgp evpn
+Route Distinguisher: 10.255.0.1:100
+ *>  [3]:[0]:[32]:[10.255.0.1]
+                    10.255.0.1                 0         32768 i
+                    Extended community: RT:65001:100
+                    PMSI: ingress-replication endpoint:10.255.0.1 label:16
+```
+
+`label:` rather than `vni:` is the render for a path with no Encapsulation
+EC — one PMSI field, two meanings.
+
+```
+zebra-rs# show mpls ilm
+   P Dist Local  Outgoing    Prefix             Outgoing     Next Hop
+          Label  Label       or ID              Interface
+-- - ---- ------ ----------- ------------------ ------------ ---------------
+*> B 20   16     Pop         EVPN Decap (bd 100 ) -
+```
+
+The decap ILM at the service label. There is no outgoing interface because the
+pop delivers into a bridge domain rather than out a port — and no kernel LFIB
+entry to compare it against, since this one lives only in the data plane.
+
+## Limitations
+
+- **Requires cradle** (`system cradle grpc-endpoint`). Without it the routes
+  are advertised and received but nothing forwards.
+- **IPv4 underlay only** in the data plane today; an IPv6-underlay PE punts
+  rather than misforwarding.
+- **Single-homed.** Multihoming (Type-1/Type-4 and the ESI label's
+  split-horizon check) is not implemented for MPLS.
+- **No control word.** RFC 7432 leaves it optional and both ends must agree.
+  Its absence is only a hazard where a P router hashes deeply enough to
+  mistake a customer frame beginning with nibble 4 or 6 for an IP packet.
+- **EVPN-VPWS** (RFC 8214) over MPLS is not implemented; VPWS is SRv6-only.


### PR DESCRIPTION
## Summary

Closes out the zebra-rs side of EVPN's L2 services over MPLS (#2121, #2123,
#2125, #2127).

`bgp_evpn_mpls` pins what **distinguishes** MPLS from the VXLAN and SRv6
encapsulations, rather than re-testing EVPN generally:

- the EVI is *declared* — there is no VXLAN device to infer a VNI from;
- the Type-3 PMSI carries a **label**, not a VNI;
- the next hop and PMSI tunnel identifier are the **router-id**, not a VTEP;
- **no** Encapsulation extended community — RFC 8365 §5.1.3 signals MPLS by that
  EC's absence, so its presence would be the bug;
- a bridge-domain **decap ILM** is programmed at the service label.

The service label is deliberately *not* asserted as a literal: it comes from the
dynamic block, so pinning `16` would encode an allocator detail into the test.
The assertions check that `label:` is rendered at all — which is the
encapsulation signal — and that the ILM names bridge domain 100.

Type-2 needs a datapath MAC learn, so it stays with the cradle-rs end-to-end
feature, where a real eBPF data plane and CE traffic exist.

## Docs

New chapter, and a correction. `ch-02-06-bgp-evpn-type5.md` said:

> EVPN-over-MPLS *L2* is not supported (the Linux kernel has no L2-over-MPLS
> data path).

The kernel gap is real — it is exactly why this needs cradle, and why the decap
ILM skips netlink — but it is no longer a reason the feature does not exist. The
note now says so and points at the new chapter. RFC 7432's appendix entry moves
from "the base control plane" to naming the forwarding.

## Test plan

```
✓ bgp_evpn_mpls (6 scenario(s))
1 feature(s) ran, 1 passed, 0 failed
```

Run serially on a verified-idle host (no cucumber process, no leftover
namespaces, no stray daemons, installed binary md5-matched).

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo
test --workspace --exclude bdd` — green.

## Next

The last piece is in cradle-rs: `cradle_evpn_mpls_zebra` — two PEs over an IS-IS
SR-MPLS core, fully dynamic, where a CE-to-CE ping proves this control plane and
the eBPF data plane together for the first time.

Generated with [Claude Code](https://claude.com/claude-code)