### PR TITLE
rib: re-tee ILMs to cradle on reconnect, not just IP routes

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -954,6 +954,21 @@ impl FibHandle {
         false
     }
 
+    /// Re-tee one selected ILM into a freshly-(re)connected cradle engine.
+    ///
+    /// The cradle branch of [`Self::ilm_install`] is a no-op when the tee is
+    /// not up yet, and unlike IP routes an ILM does not churn afterwards — a
+    /// service label is programmed once, at config load, which is exactly
+    /// when the tee is still connecting. Without this the label FIB stays
+    /// permanently empty for anything installed in that window.
+    pub async fn cradle_ilm_resync(&self, label: u32, ilm: &IlmEntry) -> bool {
+        if self.cradle.is_none() {
+            return false;
+        }
+        self.cradle_ilm_program(label, ilm).await;
+        true
+    }
+
     /// v6 sibling of [`Self::cradle_route_resync_v4`].
     pub async fn cradle_route_resync_v6(
         &self,
@@ -3143,12 +3158,15 @@ impl FibHandle {
         self.ilm_install(label, ilm, true).await;
     }
 
-    async fn ilm_install(&self, label: u32, ilm: &IlmEntry, replace: bool) {
-        // Tee the ILM to the cradle eBPF data plane (mirrors the netlink
-        // install below). DecapVrf/ContextLabel decap to IP in a VRF; every
-        // other type is a swap whose out stack rides the nexthop — an empty
-        // stack is PHP, popped by the data plane on the packet's S bit.
-        // Multi-member ILM ECMP is not teed yet (first member only).
+    /// Tee an ILM to the cradle eBPF data plane. `DecapVrf`/`ContextLabel`
+    /// decap to IP in a VRF, `DecapBd` pops into a bridge domain, and every
+    /// other type is a swap whose out stack rides the nexthop — an empty
+    /// stack is PHP, popped by the data plane on the packet's S bit.
+    /// Multi-member ILM ECMP is not teed yet (first member only).
+    ///
+    /// Split out of [`Self::ilm_install`] so the post-connect resync can
+    /// replay it without re-running the netlink half.
+    async fn cradle_ilm_program(&self, label: u32, ilm: &IlmEntry) {
         if let Some(cradle) = &self.cradle {
             match &ilm.ilm_type {
                 IlmType::DecapVrf { table_id, .. } | IlmType::ContextLabel { table_id, .. } => {
@@ -3206,6 +3224,10 @@ impl FibHandle {
                 }
             }
         }
+    }
+
+    async fn ilm_install(&self, label: u32, ilm: &IlmEntry, replace: bool) {
+        self.cradle_ilm_program(label, ilm).await;
 
         // EVPN-over-MPLS decap is cradle-only. Linux has no action that pops
         // a label and hands the exposed Ethernet frame to a bridge, so there

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -4145,8 +4145,20 @@ impl Rib {
                 }
             }
         }
-        if v4 + v6 > 0 {
-            tracing::info!("rib: cradle resync walked {v4} v4 + {v6} v6 installed routes");
+        // ILMs too. Unlike an IP route these do not churn afterwards — a
+        // service label is programmed once, at config load, which is exactly
+        // when the tee is still connecting — so without this walk the label
+        // FIB stays permanently empty for anything installed in that window.
+        let mut ilms = 0usize;
+        for (label, entries) in self.ilm.iter() {
+            if let Some(entry) = entries.iter().find(|e| e.selected)
+                && self.fib_handle.cradle_ilm_resync(*label, entry).await
+            {
+                ilms += 1;
+            }
+        }
+        if v4 + v6 + ilms > 0 {
+            tracing::info!("rib: cradle resync walked {v4} v4 + {v6} v6 routes + {ilms} ILMs");
         }
     }
 


### PR DESCRIPTION
## The bug

`cradle_rib_walk` — the resync that runs when the cradle tee comes up or
reconnects — walks the global and per-VRF IPv4/IPv6 tables but **never the ILM
table**. Any ILM installed while the tee was still connecting is lost
permanently: the cradle branch of `ilm_install` is a no-op with no tee, and
unlike an IP route an ILM does not churn afterwards to give itself a second
chance.

## How it surfaced

End-to-end, while bringing up EVPN over MPLS. A PE allocates its EVI service
label and programs the bridge-domain decap **during config load** — exactly when
the tee is still connecting. So:

```
zebra:  *> B 20   16   Pop   EVPN Decap (bd 100 )    <- present
cradle: 16002 pop / 15000 pop / 16003 pop / 16001 swap   <- label 16 absent
```

Frames arrived at the egress PE with the right service label on top and were
silently dropped, while both control planes looked perfectly correct — the
label FIB was simply empty for that label.

## The fix

Walk `self.ilm` alongside the route tables and re-program each selected entry.
The cradle half of `ilm_install` is split into `cradle_ilm_program` so the
resync can replay it without re-running the netlink half (which would collide
with `NLM_F_EXCL`).

**This is not EVPN-specific.** A `DecapVrf` VPN label or an IS-IS SR ILM
installed in the same window had the same hole; it was just harder to hit,
because those are installed later (a VRF ILM waits on kernel VRF info) or
re-installed on the next SPF.

## Test plan

- cradle-rs `cradle_evpn_mpls_zebra` — **fails without this, passes with it**.
  That feature is the regression test: CE-to-CE ping across a fully dynamic
  EVPN-over-MPLS core.
- Regression on every other zebra-teed cradle feature: `cradle_mpls_zebra`,
  `cradle_l3vpn_zebra`, `cradle_evpn_srv6_zebra`, `cradle_evpn_vxlan_zebra` —
  4/4 pass.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo
  test --workspace --exclude bdd` — green.

Generated with [Claude Code](https://claude.com/claude-code)