### PR TITLE
bdd: don't let a feature clobber a sibling whose tag extends its own

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -50,6 +50,39 @@ impl World {
     fn pid_file(&self, logical: &str) -> String {
         format!("/tmp/{}.pid", self.ns(logical))
     }
+
+    /// Resource-name prefixes belonging to feature tags that *extend* this
+    /// one's — for `bgp_evpn_vpws`, those of `bgp_evpn_vpws_multihoming`.
+    ///
+    /// Every per-feature resource is named `<feature-tag>_<logical>`, so a
+    /// sibling whose tag extends this one's shares this feature's `<tag>_`
+    /// prefix. A bare prefix scan therefore mistakes the sibling's resources
+    /// for this feature's, and when the two run concurrently that does real
+    /// damage in three places: the startup liveness check aborts this feature
+    /// ("another run is in progress"), the startup sweep deletes the
+    /// sibling's *live* namespaces, and the clean-environment check reports
+    /// them as this feature's leaked ones. Bridges and host veths are
+    /// unaffected — they carry `short_id()`, a hash of the whole tag.
+    fn sibling_prefixes(&self) -> Vec<String> {
+        let own = format!("{}_", self.feature_tag);
+        let Ok(entries) = fs::read_dir("tests/features") else {
+            return Vec::new();
+        };
+        entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("feature"))
+            .filter_map(|p| p.file_stem()?.to_str().map(str::to_owned))
+            .filter(|stem| stem.len() > self.feature_tag.len() && stem.starts_with(&own))
+            .map(|stem| format!("{stem}_"))
+            .collect()
+    }
+}
+
+/// True when a `<feature-tag>_<logical>` resource name belongs to one of
+/// `siblings` rather than to the feature that scanned for it.
+fn owned_by_sibling(name: &str, siblings: &[String]) -> bool {
+    siblings.iter().any(|p| name.starts_with(p.as_str()))
 }
 
 #[given("a clean test environment")]
@@ -65,6 +98,9 @@ async fn clean_test_environment(world: &mut World) {
     let ns_prefix = format!("{}_", world.feature_tag);
     let pid_prefix = ns_prefix.clone();
     let bridge_name = world.bridge("");
+    // Resources of a feature whose tag extends ours share our prefix; never
+    // touch them (see `World::sibling_prefixes`).
+    let siblings = world.sibling_prefixes();
 
     // 1. Detect concurrent run of the same feature: if any pid file in
     // /tmp matching this feature points to a live process, abort. The
@@ -83,6 +119,13 @@ async fn clean_test_environment(world: &mut World) {
         .unwrap()
         .insert(world.feature_tag.clone());
     if let Ok(pidfiles) = netns::list_pidfiles(Path::new("/tmp"), &pid_prefix).await {
+        let pidfiles: Vec<PathBuf> = pidfiles
+            .into_iter()
+            .filter(|p| {
+                let name = p.file_name().unwrap_or_default().to_string_lossy();
+                !owned_by_sibling(&name, &siblings)
+            })
+            .collect();
         for path in &pidfiles {
             if first_clean_in_process && netns::pidfile_alive(path).await {
                 panic!(
@@ -104,6 +147,9 @@ async fn clean_test_environment(world: &mut World) {
     // step 4 below sweeps those separately.
     if let Ok(stale) = netns::list_netns_with_prefix(&ns_prefix).await {
         for ns in stale {
+            if owned_by_sibling(&ns, &siblings) {
+                continue; // a sibling feature's namespace, possibly live
+            }
             let _ = netns::delete_netns(&ns).await;
         }
     }
@@ -2749,9 +2795,15 @@ async fn verify_clean_environment(world: &mut World) {
         return;
     }
     let ns_prefix = format!("{}_", world.feature_tag);
-    let leftover_ns = netns::list_netns_with_prefix(&ns_prefix)
+    // A concurrently-running feature whose tag extends ours owns namespaces
+    // under our prefix; they are not our leak (see `World::sibling_prefixes`).
+    let siblings = world.sibling_prefixes();
+    let leftover_ns: Vec<String> = netns::list_netns_with_prefix(&ns_prefix)
         .await
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|ns| !owned_by_sibling(ns, &siblings))
+        .collect();
     assert!(
         leftover_ns.is_empty(),
         "Namespaces still exist: {:?}",
@@ -2768,9 +2820,15 @@ async fn verify_clean_environment(world: &mut World) {
         leftover_br
     );
 
-    let leftover_pid = netns::list_pidfiles(Path::new("/tmp"), &ns_prefix)
+    let leftover_pid: Vec<PathBuf> = netns::list_pidfiles(Path::new("/tmp"), &ns_prefix)
         .await
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|p| {
+            let name = p.file_name().unwrap_or_default().to_string_lossy();
+            !owned_by_sibling(&name, &siblings)
+        })
+        .collect();
     assert!(
         leftover_pid.is_empty(),
         "PID files still exist: {:?}",


### PR DESCRIPTION
## The bug

Every per-feature resource is named `<feature-tag>_<logical>`, and the harness
finds them by scanning for that bare prefix. A feature whose tag *extends*
another's therefore shares its prefix — `bgp_evpn_vpws_multihoming_z1` looks
exactly like a `bgp_evpn_vpws` resource.

When the two run concurrently that does real damage in **three** places:

1. the startup liveness check sees the sibling's live pid file and aborts this
   feature outright (*"another run of feature X is in progress"*);
2. the startup sweep **deletes the sibling's live namespaces** out from under
   it;
3. the clean-environment check reports them as this feature's leak.

## Scope

Six features, ten sibling relationships:

```
bgp_adv_interval_zero  <-  bgp_adv_interval_zero_v6, bgp_adv_interval_zero_vrf
bgp_evpn_vpws          <-  bgp_evpn_vpws_multihoming
isis_tilfa             <-  isis_tilfa_bfd, isis_tilfa_srv6, isis_tilfa_srv6_classic
isis_tilfa_srv6        <-  isis_tilfa_srv6_classic
ospfv3_tilfa           <-  ospfv3_tilfa_srv6, ospfv3_tilfa_srv6_classic
ospfv3_tilfa_srv6      <-  ospfv3_tilfa_srv6_classic
```

Note `isis_tilfa_srv6` and `ospfv3_tilfa_srv6` are each *both* a sibling and a
parent; the fix handles that by computing each feature's extenders
independently from the features directory, so it needs no maintenance as
features are added.

All four scans now skip names owned by a sibling. Bridges and host veths were
never affected — they carry `short_id()`, a hash of the whole tag.

## Why it matters

This is why a full-suite run reported `bgp_evpn_vpws` failing at
`--concurrency=8` while it passes serially. Beyond the false failure, it means
a full-suite result needs manual triage to tell a real regression from this
artifact — and the sweep can genuinely corrupt a concurrent sibling's run.

## Test plan

A/B on the pair that actually failed, same concurrency, same host:

```
WITHOUT fix:  ✗ bgp_evpn_vpws (1 step failed)   ✓ bgp_evpn_vpws_multihoming
WITH fix:     ✓ bgp_evpn_vpws                    ✓ bgp_evpn_vpws_multihoming
```

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings`, `cargo test --workspace --exclude bdd` — green.

Port of cradle-rs#160, which hit the identical bug with `cradle_evpn_mpls` /
`cradle_evpn_mpls_bum`.

Generated with [Claude Code](https://claude.com/claude-code)