### PR TITLE
book: bring EVPN over MPLS up to date across the book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -51,7 +51,7 @@
   - [EVPN BUM & Assisted Replication](ch-02-33-bgp-evpn-assisted-replication.md)
   - [EVPN BUM Tunnel Segmentation (RFC 9572)](ch-02-34-bgp-evpn-segmentation.md)
   - [EVPN VPWS (E-Line over SRv6)](ch-02-38-bgp-evpn-vpws.md)
-  - [EVPN over MPLS](ch-02-39-bgp-evpn-mpls.md)
+  - [EVPN over MPLS](ch-02-40-bgp-evpn-mpls.md)
   - [Mobile User Plane (MUP) & the MUP Controller](ch-02-35-bgp-mup.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)

--- a/book/src/ch-00-04-bridge-configuration.md
+++ b/book/src/ch-00-04-bridge-configuration.md
@@ -7,10 +7,13 @@ attributes to an existing device — the top-level `bridge` list
 **creates** the kernel bridge netdevice (`ip link add <name> type
 bridge`) and tears it down when the entry is removed.
 
-A bridge is the L2 forwarding domain an EVPN deployment binds a
-[VXLAN](ch-00-03-vxlan-configuration.md) device into: the VXLAN tunnel
-and the local access ports are enslaved to the same bridge, and the
-control plane drives the forwarding database.
+A bridge is the L2 forwarding domain an EVPN deployment carries. Over
+[VXLAN](ch-00-03-vxlan-configuration.md) that means binding a VXLAN device
+into it — the tunnel and the local access ports are enslaved to the same
+bridge, and the control plane drives the forwarding database. Over
+[MPLS](ch-02-40-bgp-evpn-mpls.md) there is no tunnel device at all: the
+bridge is named directly by an `evi <id> { bridge <name> }` entry, and the
+transport is a service label rather than an enslaved netdevice.
 
 ## Configuration
 

--- a/book/src/ch-02-06-bgp-evpn-type5.md
+++ b/book/src/ch-02-06-bgp-evpn-type5.md
@@ -5,8 +5,9 @@ RFC 9136. Type-5 carries an IP prefix across an EVPN as an L3VPN-style
 service — it is, in effect, an alternative NLRI *encoding* of the same
 per-VRF IP routing that [VPNv4 / VPNv6 L3VPN](ch-02-04-bgp-l3vpn.md)
 provides. DC fabrics commonly prefer the EVPN encoding because one
-address family (`l2vpn evpn`) then carries both the L2 service
-(Type-2 / Type-3, see VXLAN EVPN) and the L3 service (Type-5).
+address family (`l2vpn evpn`) then carries both the L2 service (Type-2 /
+Type-3, over [VXLAN](ch-00-03-vxlan-configuration.md), SRv6 or
+[MPLS](ch-02-40-bgp-evpn-mpls.md)) and the L3 service (Type-5).
 
 Because Type-5 reuses the existing L3VPN control- and data-plane, the
 two ends of a VPN flow map exactly as they do for VPNv4 / VPNv6:
@@ -81,7 +82,7 @@ reroutes.
 > run over VXLAN, SRv6, or MPLS. EVPN-over-MPLS *L2* is not forwardable by
 > the Linux kernel — it has no action that pops a label and hands the frame
 > to a bridge — so it needs the cradle eBPF data plane; see
-> [EVPN over MPLS](ch-02-39-bgp-evpn-mpls.md).
+> [EVPN over MPLS](ch-02-40-bgp-evpn-mpls.md).
 
 ## Verification
 

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -188,10 +188,24 @@ the Type-1 if this PE's own role changed, with no local config change. A PE
 whose own Type-4 is not selected yet advertises primary rather than
 blackholing the service while the segment converges.
 
-> **Note:** which of a multihomed pair the *remote* PE binds is remote
-> selection, tracked separately — a remote today binds a single end and does
-> not yet prefer `P` over `B` or fail over to the backup. All-active
-> therefore signals correctly but is not load-balanced: one end is used.
+**Remote selection** — which of a multihomed pair this PE binds — ranks the
+advertised remotes per RFC 8214 §5: primary over backup, non-designated
+(`P=0 B=0`) dropped, lowest originator breaking a tie so both ends agree.
+Losing the primary re-selects rather than tearing the E-Line down. Two
+details matter in practice:
+
+* **MTU is filtered before the ranking**, so a primary whose MTU clashes
+  steps aside for a compatible backup instead of wedging the service.
+* **The per-ES Ethernet A-D route is the liveness gate**: a candidate on a
+  non-zero ESI is usable only while its PE advertises one, which is how
+  RFC 7432 §8.2 mass withdraw takes effect.
+
+A single-homed remote (all-zero ESI) is always usable regardless of the
+bits — an implementation that omits the Layer-2 Attributes EC decodes as
+`P=0 B=0`, and excluding those would break every plain point-to-point peer.
+
+> **Note:** all-active signals correctly but is not load-balanced — one end
+> is selected and used, with the other standing by.
 
 ## Show command
 
@@ -241,11 +255,12 @@ configured (or re-pointed) is found without waiting for a route churn.
 
 ## Scope
 
-Multihoming covers origination: the Type-1 carries the segment's ESI and
-DF-elected P/B bits. Not yet implemented — remote selection over a
-multihomed pair (prefer `P`, fail over to `B`, honour the per-ES A-D mass
-withdraw), all-active load balancing across both remote SIDs, and the
+Multihoming covers both directions: the Type-1 carries the segment's ESI and
+DF-elected P/B bits, and remote selection honours them (prefer `P`, fail over
+to `B`, per-ES A-D mass withdraw). Not yet implemented — all-active load
+balancing across both remote SIDs, and the
 control word (`C` is always 0). Forwarding requires the
 [eBPF data plane](ch-16-00-ebpf.md)
-(`system ebpf enabled`); the kernel has no End.DX2/DX2V seg6local action, so
-these SIDs are never installed via netlink.
+(`system ebpf enabled` to run the engine, `system cradle enabled` to tee the
+service into it); the kernel has no End.DX2/DX2V seg6local action, so these
+SIDs are never installed via netlink.

--- a/book/src/ch-02-40-bgp-evpn-mpls.md
+++ b/book/src/ch-02-40-bgp-evpn-mpls.md
@@ -9,7 +9,7 @@ and bridges the frame into that EVI's bridge domain.
 > **This needs the cradle eBPF data plane.** Linux has no action that pops an
 > MPLS label and hands the exposed Ethernet frame to a bridge — that gap is
 > precisely why EVPN-over-MPLS L2 was unsupported for so long. The control
-> plane here programs [cradle](ch-02-00-zebra-integration.md) directly and
+> plane here programs [cradle](ch-16-00-ebpf.md) directly and
 > deliberately skips netlink for the decap. VXLAN and SRv6 have kernel data
 > paths; this one does not.
 >
@@ -87,6 +87,48 @@ across the three encapsulations.
 **BUM** is ingress-replicated: each remote PE's Type-3 becomes a replication
 slot, and a flooded frame gets one copy per slot carrying that PE's BUM label.
 
+### Enabling the data plane
+
+Because none of this forwarding exists in the kernel, the EVI's label, its
+decap and every remote MAC are programmed **only** into cradle. Three
+separate things have to be true — the control plane will happily advertise
+and receive routes with any of them missing:
+
+```
+system {
+  ebpf {
+    enabled true;
+  }
+  cradle {
+    enabled true;
+  }
+}
+interface enp0s6 {
+  ebpf {
+    enabled true;
+  }
+}
+interface enp0s7 {
+  ebpf {
+    enabled true;
+  }
+}
+```
+
+- **`system ebpf enabled`** supervises the engine as a child process. On its
+  own it yields a plain eBPF L2 switch with nothing programmed into it.
+- **`system cradle enabled`** is the FIB tee — the switch that actually
+  carries the service label, the decap ILM and the EVPN FDB across. An
+  externally-run cradle is teed to with this leaf alone (point it with
+  `system cradle grpc-endpoint`; that leaf is an endpoint override and
+  enables nothing by itself).
+- **`interface <name> ebpf enabled`** attaches a port. Both the core-facing
+  port (where labelled frames arrive) and the CE-facing port (where the
+  bridge's access traffic arrives) must be attached.
+
+See the [eBPF data plane](ch-16-00-ebpf.md) chapter for the engine's
+lifecycle and full command set.
+
 ## Verification
 
 ```
@@ -113,9 +155,35 @@ The decap ILM at the service label. There is no outgoing interface because the
 pop delivers into a bridge domain rather than out a port — and no kernel LFIB
 entry to compare it against, since this one lives only in the data plane.
 
+### Check the data-plane side too
+
+`show mpls ilm` and `show bgp evpn` are the RIB's and BGP's *intent*. Because
+there is no kernel LFIB row to cross-check, a correct-looking control plane on
+both PEs is not evidence that anything forwards — the frames arrive with the
+right service label on top and get dropped. Two commands read the engine
+itself and close that gap:
+
+- **`show ebpf mpls`** dumps the engine's incoming-label map. Every label
+  `show mpls ilm` lists must appear here. A service label present in
+  `show mpls ilm` and absent from `show ebpf mpls` means the tee never
+  carried it — check `show ebpf` for `FIB tee: enabled`.
+- **`show ebpf l2`** dumps the L2 FDB: MACs learned from remote Type-2
+  routes alongside the ones the data plane learned locally on the CE ports.
+
+An empty table prints nothing at all, which for this service is itself the
+diagnosis rather than a quiet success.
+
+> The state is **replayed** on reconnect: when the tee comes up — or comes
+> back after an engine restart — the routes, ILMs and EVPN state are
+> re-programmed from the RIB with no operator action. This matters at
+> startup in particular, since a PE allocates its EVI label and programs the
+> decap during config load, which is typically while the tee is still
+> connecting.
+
 ## Limitations
 
-- **Requires cradle** (`system cradle grpc-endpoint`). Without it the routes
+- **Requires cradle** (`system cradle enabled` plus an engine — see
+  [Enabling the data plane](#enabling-the-data-plane)). Without it the routes
   are advertised and received but nothing forwards.
 - **IPv4 underlay only** in the data plane today; an IPv6-underlay PE punts
   rather than misforwarding.

--- a/book/src/ch-16-00-ebpf.md
+++ b/book/src/ch-16-00-ebpf.md
@@ -10,16 +10,22 @@ Type-2 origination.
 
 Some forwarding behaviours have **no mainline-kernel equivalent** and are
 only available on the eBPF data plane — notably real GTP-U for
-[MUP](ch-02-35-bgp-mup.md) (`dataplane gtp`) and
-[EVPN VPWS](ch-02-38-bgp-evpn-vpws.md) E-Line egress.
+[MUP](ch-02-35-bgp-mup.md) (`dataplane gtp`),
+[EVPN VPWS](ch-02-38-bgp-evpn-vpws.md) E-Line egress, and the
+bridge-domain decap that [EVPN over MPLS](ch-02-40-bgp-evpn-mpls.md) needs —
+the kernel has no action that pops an MPLS label and hands the exposed frame
+to a bridge, so that service is cradle-only end to end.
 
 ## Configuration
 
-Two knobs, both runtime toggles:
+Three knobs, all runtime toggles:
 
 ```
 system {
   ebpf {
+    enabled true;
+  }
+  cradle {
     enabled true;
   }
 }
@@ -30,9 +36,17 @@ interface enp0s6 {
 }
 ```
 
-- **`system ebpf enabled true`** turns the data plane on: zebra-rs launches
-  the engine as a managed child process, keeps it healthy, and programs the
-  eBPF FIB from the RIB.
+- **`system ebpf enabled true`** runs the data plane: zebra-rs launches the
+  engine as a managed child process and keeps it healthy. On its own it is a
+  pure eBPF L2 switch — no routing state is programmed into it.
+- **`system cradle enabled true`** is the **FIB tee**: every route zebra-rs
+  installs — plus ILMs, SRv6 SIDs and EVPN state — is programmed into the
+  engine in addition to the kernel, and the data plane's MAC learning is fed
+  back into EVPN Type-2 origination. This is the switch that turns the
+  switch into a forwarder for zebra-rs's routing state, and it is
+  independent of `system ebpf`: an externally-run cradle is teed to with
+  this leaf alone, and `system cradle grpc-endpoint` only overrides the
+  endpoint (default `unix:cradle/grpc`) — it enables nothing by itself.
 - **`interface <name> ebpf enabled true`** makes that interface a data-plane
   port: the forwarding programs attach to it and it participates in eBPF
   forwarding. The port follows the interface's VRF binding
@@ -41,7 +55,9 @@ interface enp0s6 {
 
 | YANG leaf | Type | Default | Notes |
 |---|---|---|---|
-| `/system/ebpf/enabled` | `boolean` | `false` | The data-plane switch: engine + FIB programming. |
+| `/system/ebpf/enabled` | `boolean` | `false` | Engine lifecycle: spawn and supervise the data plane. |
+| `/system/cradle/enabled` | `boolean` | `false` | The FIB tee: program routes / ILM / SRv6 / EVPN into the engine. |
+| `/system/cradle/grpc-endpoint` | `string` | `unix:cradle/grpc` | Endpoint override, shared by the tee and the managed engine. Does not enable the tee. |
 | `/interface/ebpf/enabled` | `boolean` | `false` | Per-interface port membership. |
 
 Port membership is **reconciled**: enabling `ebpf` on an interface that does
@@ -172,3 +188,7 @@ zebra> show ebpf stats json
   real GTP-U on the eBPF data plane.
 - [EVPN VPWS](ch-02-38-bgp-evpn-vpws.md) — E-Line egress runs on the eBPF
   data plane.
+- [EVPN over MPLS](ch-02-40-bgp-evpn-mpls.md) — the per-EVI service label,
+  its bridge-domain decap and every remote MAC exist only here;
+  `show ebpf mpls` and `show ebpf l2` are the only place to confirm the
+  service is actually programmed.


### PR DESCRIPTION
The EVPN-over-MPLS chapter landed with #2128 — before the ILM resync fix (#2129), and before anyone had followed its own instructions end to end. Several things did not hold up.

## The chapter itself

**The enablement knob was wrong.** It said *Requires cradle (`system cradle grpc-endpoint`)*, which names a leaf that enables nothing — it is an endpoint override. The FIB tee is `system cradle enabled`, and that is what carries the service label, the decap ILM and the EVPN FDB into the engine at all. A new **Enabling the data plane** section spells out all three requirements (run the engine, enable the tee, attach both the core- and CE-facing ports), because the control plane advertises and receives perfectly happily with any of them missing.

**There was no way to check the data plane.** With no kernel LFIB row to compare against, a correct-looking `show mpls ilm` on both PEs is not evidence that anything forwards — which is exactly the failure #2129 hit: ILM in the RIB, absent from cradle, frames arriving with the right service label and being dropped. Verification now points at `show ebpf mpls` / `show ebpf l2` as the authority, states the invariant (every label in `show mpls ilm` must appear in `show ebpf mpls`), and records the reconnect replay.

**A broken link** — `ch-02-00-zebra-integration.md` does not exist; the eBPF data plane is `ch-16-00-ebpf.md`.

**A filename collision** — the chapter was `ch-02-39`, already taken by `ch-02-39-bgp-as-sets-withdraw.md`. Renamed to `ch-02-40`.

## Elsewhere in the book

- **`ch-16-00-ebpf`** documented `system ebpf` and `interface ebpf` but never `system cradle enabled`. The tee appeared only as a `FIB tee: enabled` line in sample `show ebpf` output, so the book described a data plane with no documented way to feed it. Added to the config section and the YANG table, along with EVPN-over-MPLS in the no-mainline-kernel-equivalent list and in Related.
- **`ch-02-06-bgp-evpn-type5`** sent the reader to "VXLAN EVPN" — not a chapter, and no longer the only L2 encapsulation.
- **`ch-00-04-bridge-configuration`** framed a bridge as the thing an EVPN deployment binds a VXLAN device into; an MPLS EVI names a bridge with no tunnel device at all.
- **`ch-02-38-bgp-evpn-vpws`** still said remote selection over a multihomed pair was unimplemented — #2126 implemented it. Now describes the RFC 8214 §5 ranking, MTU filtering ahead of ranking, and the per-ES A-D liveness gate; all-active load balancing and the control word remain the open items.

Docs only — no code changes. `mdbook build` is clean and no internal link dangles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)