### PR TITLE
bdd: regenerate the feature docs from the current feature set

### DIFF
--- a/bdd/docs/bgp_adv_interval_zero.md
+++ b/bdd/docs/bgp_adv_interval_zero.md
@@ -1,0 +1,40 @@
+# BGP zero adv-interval delivers routes across IPv4 families
+
+## Overview
+
+As a network operator
+I want `router bgp timer adv-interval ibgp 0` to disable the MRAI
+debounce without stalling advertisement
+Using a two-namespace iBGP topology that carries IPv4 unicast, VPNv4,
+and EVPN over one session, all with adv-interval 0.
+Regression guard for the adv-interval-0 fast-flush path (a 0-second
+MRAI arms a ~1 ms next-tick debounce timer instead of the old
+1 s-clamped one): each family's routes must still converge at the peer.
+
+## Test Topology
+
+```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   iBGP AS65001 │     z2      │
+  │ 192.168.0.1 │ ◀────────────▶ │ 192.168.0.2 │
+  │ vrf-blue    │ ipv4/vpnv4/evpn│ vrf-blue    │
+  │  RD 65001:  │  adv-interval  │  RD 65001:  │
+  │   100       │    ibgp 0      │   200       │
+  │  RT 65001:100 imp/exp        │  RT 65001:100 imp/exp
+  └─────────────┘                └─────────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, adv-interval ibgp 0, neighbor 192.168.0.2 with
+- z2-1.yaml: AS 65001, adv-interval ibgp 0, same address families,
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the multiprotocol session | |
+| IPv4 unicast route converges with adv-interval 0 | |
+| VPNv4 route converges with adv-interval 0 | |
+| EVPN Type-5 route converges with adv-interval 0 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_adv_interval_zero_v6.md
+++ b/bdd/docs/bgp_adv_interval_zero_v6.md
@@ -1,0 +1,40 @@
+# BGP zero adv-interval delivers routes across IPv6 families
+
+## Overview
+
+As a network operator
+I want `router bgp timer adv-interval ibgp 0` to disable the MRAI
+debounce without stalling advertisement
+Using a two-namespace iBGP topology over IPv6 transport that carries
+IPv6 unicast and VPNv6, both with adv-interval 0.
+IPv6 counterpart of @bgp_adv_interval_zero. Regression guard for the
+adv-interval-0 fast-flush path (a 0-second MRAI arms a ~1 ms next-tick
+debounce timer instead of the old 1 s-clamped one): each family's
+routes must still converge at the peer.
+
+## Test Topology
+
+```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   iBGP AS65001 │     z2      │
+  │ 2001:db8::1 │ ◀────────────▶ │ 2001:db8::2 │
+  │ vrf-blue    │   ipv6/vpnv6   │ vrf-blue    │
+  │  RD 65001:  │  adv-interval  │  RD 65001:  │
+  │   100       │    ibgp 0      │   200       │
+  │  RT 65001:100 imp/exp        │  RT 65001:100 imp/exp
+  └─────────────┘                └─────────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, adv-interval ibgp 0, neighbor 2001:db8::2 with
+- z2-1.yaml: AS 65001, adv-interval ibgp 0, same address families,
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the multiprotocol session | |
+| IPv6 unicast route converges with adv-interval 0 | |
+| VPNv6 route converges with adv-interval 0 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_adv_interval_zero_vrf.md
+++ b/bdd/docs/bgp_adv_interval_zero_vrf.md
@@ -1,0 +1,44 @@
+# Per-VRF BGP neighbor zero adv-interval delivers ipv4/ipv6 unicast
+
+## Overview
+
+As an operator of an L3VPN PE
+I want `router bgp vrf <name> neighbor <ce> timers advertisement-interval 0`
+to disable the MRAI for a per-VRF CE neighbor
+So that PE-CE ipv4/ipv6 unicast converges without waiting out the stock
+MRAI — the instance-level `router bgp timer adv-interval` never reaches
+the per-VRF task, so the per-neighbor knob is the only lever.
+Regression guard for wiring the per-neighbor `advertisement-interval`
+into the update-group signature (`adv_interval_override`) and arming
+path: with 0 the per-VRF ipv4/ipv6-unicast advertise debounce arms a
+~1 ms next-tick timer instead of the stock 30s eBGP one. The CE side
+uses the same knob as a plain global neighbor, so both directions are
+covered.
+
+## Test Topology
+
+```
+   ce1 ───────────────── pe1
+   AS 65001            AS 65000
+   global              vrf-cust (RD 65000:1)
+   lo 10.0.1.1/32      net 10.9.0.0/24
+      2001:db8:8::1/128    2001:db8:9::/64
+        .2 ── .1   (10.1.0.0/30)
+        ::2 ── ::1 (2001:db8:1::/64)
+   adv-interval 0      adv-interval 0 (per VRF neighbor)
+```
+
+## Config Files
+
+- pe1.yaml: AS 65000, vrf-cust with two CE neighbors (10.1.0.2 ipv4,
+- ce1.yaml: AS 65001, global neighbors to the PE (ipv4 + ipv6), each
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the PE-CE dual-stack topology and establish sessions | |
+| PE advertises its vrf-cust ipv4 network to the CE with adv-interval 0 | |
+| PE advertises its vrf-cust ipv6 network to the CE with adv-interval 0 | |
+| CE advertises its ipv4/ipv6 loopbacks to the PE vrf with adv-interval 0 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_as4.md
+++ b/bdd/docs/bgp_as4.md
@@ -1,0 +1,39 @@
+# BGP 4-octet AS support (RFC 6793)
+
+## Overview
+
+As a network operator
+I want sessions with 4-byte-ASN routers to establish and carry real AS paths,
+including toward legacy 2-octet (OLD) speakers via AS_TRANS + AS4_PATH.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS70000 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 70000 (4-byte), peer to 192.168.0.2, network 10.0.0.1/32
+- z2-1.yaml: AS 65002, peer to 192.168.0.1, network 10.1.0.1/32
+- z2-2.yaml: z2-1 plus `capability four-octet false` — z2 presents
+
+AS 70000 renders as "1.4464" in asdot notation (RFC 5396).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| A 4-byte-ASN neighbor establishes via AS_TRANS + AS4 capability | |
+| Routes carry the real 4-byte AS path on an AS4 session | |
+| OLD speaker recovers the 4-byte AS path via AS4_PATH | |
+| Teardown topology | |

--- a/bdd/docs/bgp_as_path_match.md
+++ b/bdd/docs/bgp_as_path_match.md
@@ -6,7 +6,6 @@ As a network operator
 I want zebra-rs `match as-path` to accept the same AS-path regular
 expressions as FRR's `bgp as-path access-list`, so that policies port
 between the two routers unchanged.
-
 The AS-path regex engine mirrors FRR's `bgp_regcomp`
 (bgpd/bgp_regex.c): the `_` magic character expands to
 `(^|[,{}() ]|$)`, matching a separator, the start, or the end of the
@@ -16,15 +15,7 @@ This feature exercises exact anchored matching plus the three classic
 `_` idioms — neighbor-is (`^ASN_`), originates-from (`_ASN$`), and
 transits (`_ASN_`).
 
-Re-evaluation rides the policy-change trigger (PolicyRx -> soft-in):
-applying a config whose as-path-set/policy changed re-runs the inbound
-policy over the Adj-RIB-In — no `clear` needed.
-
 ## Test Topology
-
-Linear eBGP chain, all three routers on one L2 segment. z1 and z3 are
-never peered, so z1's prefixes reach z3 only via the transit AS z2 and
-arrive with AS_PATH `65002 65001`.
 
 ```
   ┌──────────────────────────────────────────────────┐
@@ -37,6 +28,16 @@ arrive with AS_PATH `65002 65001`.
      │ .0.1/24 │     │ .0.2/24 │     │ .0.3/24 │
      └─────────┘     └─────────┘     └─────────┘
 ```
+
+## Notes
+
+z1 originates 10.0.0.1/32 + 10.0.0.2/32 and peers only z2. z2 is a
+transit AS with no policy, peering z1 and z3. z3 peers only z2, so the
+two prefixes reach z3 with AS_PATH `65002 65001`. Each scenario swaps
+z3's inbound policy and asserts which prefixes survive in z3's RIB.
+Re-evaluation rides the policy-change trigger (PolicyRx -> soft-in):
+applying a config whose as-path-set/policy changed re-runs the inbound
+policy over the Adj-RIB-In — no `clear` needed.
 
 ## Config Files
 

--- a/bdd/docs/bgp_dynamic_nbr_ao.md
+++ b/bdd/docs/bgp_dynamic_nbr_ao.md
@@ -1,0 +1,46 @@
+# A dynamic (listen-range) peer authenticates with TCP-AO (RFC 5925)
+
+## Overview
+
+As a network operator
+I want the tcp-ao key-chain on a listen-range's neighbor-group to protect the range
+So unconfigured sources cannot open a session just by being in the prefix.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+```
+
+## Notes
+
+Requires Linux kernel >= 6.7 on both peers.
+The DUT (z1) has no static neighbors: z2 arrives through the
+listen-range and inherits SENDERS, which carries the tcp-ao
+key-chain. Like the MD5 case, the MKT must be scoped to the whole
+prefix — the peer is materialized only after its SYN is accepted,
+while the kernel verifies the AO MAC during the handshake.
+
+## Config Files
+
+- z1.yaml:        DUT — SENDERS carries `tcp-ao key-chain BGP-AO`, listen-range 192.168.0.0/24
+- z1-noao.yaml:   same DUT with the group's tcp-ao removed
+- z1-rotated.yaml: DUT whose BGP-AO chain holds a rotated key-string (same IDs)
+- z2.yaml:        client, matching key-chain
+- z2-wrong.yaml:  client, mismatched key-string
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Establish a TCP-AO authenticated dynamic session | |
+| A mismatched key-string never materializes a peer | |
+| Restoring the matching key-string re-establishes the session | |
+| Rotating the key-string on the DUT re-keys the prefix MKT | |
+| Clearing the group tcp-ao retracts the prefix MKT | |
+| Restoring the group tcp-ao re-installs the prefix MKT | |
+| Teardown topology | |

--- a/bdd/docs/bgp_dynamic_nbr_md5.md
+++ b/bdd/docs/bgp_dynamic_nbr_md5.md
@@ -1,0 +1,46 @@
+# A dynamic (listen-range) peer authenticates with TCP MD5 (RFC 2385)
+
+## Overview
+
+As a network operator
+I want the password on a listen-range's neighbor-group to protect the range
+So unconfigured sources cannot open a session just by being in the prefix.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+```
+
+## Notes
+
+The DUT (z1) has no static neighbors: z2 arrives through the
+listen-range and inherits SENDERS, which carries the password.
+This needs a listener key scoped to the whole *prefix*, not to a peer
+address: a dynamic peer does not exist until its SYN is accepted, but
+the kernel validates the MD5 option during the handshake — so the
+per-address key used for static peers can never be installed in time.
+A mismatch is therefore invisible at the BGP layer: the kernel drops
+the SYN, no peer is ever materialized, and the DUT logs nothing.
+
+## Config Files
+
+- z1.yaml:        DUT — SENDERS carries `password`, listen-range 192.168.0.0/24
+- z1-nopass.yaml: same DUT with the group password removed
+- z2.yaml:        client, matching tcp-md5 password
+- z2-wrong.yaml:  client, mismatched tcp-md5 password
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Establish an MD5-authenticated dynamic session | |
+| A mismatched password never materializes a peer | |
+| Restoring the matching password re-establishes the session | |
+| Clearing the group password retracts the prefix key | |
+| Restoring the group password re-installs the prefix key | |
+| Teardown topology | |

--- a/bdd/docs/bgp_dynamic_nbr_policy.md
+++ b/bdd/docs/bgp_dynamic_nbr_policy.md
@@ -1,0 +1,40 @@
+# A dynamic (listen-range) peer inherits its neighbor-group's route policy
+
+## Overview
+
+As a network operator
+I want the `policy` bound on a listen-range's neighbor-group
+So every peer materialized from that range is filtered like a static member.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │
+   │ AS65002 │                  │ AS65001 │
+   │ .0.2    │                  │ .0.1    │
+   └─────────┘                  └─────────┘
+```
+
+## Notes
+
+z1 (the DUT) has no static neighbors; z2 arrives via the listen-range
+and inherits SENDERS. With SENDERS carrying `policy in DENY-ALL` the
+session must still establish, z1's own route must still flow out —
+but z2's route must be denied on ingress. Rebinding the group without
+the policy and re-materializing the peer readmits the route, proving
+the policy is resolved from the group at accept time, not baked in.
+
+## Config Files
+
+- z1-deny.yaml: DUT — SENDERS has `policy in DENY-ALL`, originates 10.0.1.1/32
+- z1-open.yaml: identical but the group carries no policy binding
+- z2.yaml:      client, static neighbor to .0.1, originates 10.0.2.2/32
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Establish with an inbound deny-all policy inherited from the group | |
+| Unbinding the group policy readmits the route on re-materialization | |
+| Teardown topology | |

--- a/bdd/docs/bgp_dynamic_neighbors.md
+++ b/bdd/docs/bgp_dynamic_neighbors.md
@@ -1,0 +1,50 @@
+# BGP dynamic neighbors materialize passive peers from a listen-range
+
+## Overview
+
+As a network operator
+I want `router bgp dynamic-neighbors listen-range <prefix> neighbor-group <G>`
+So sessions from an authorized source prefix establish without per-peer config.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z2    │ i1────────────i1 │   z1    │ i2────────────i1 │   z3    │
+   │ AS65002 │   (in range)     │ AS65001 │  (out of range)  │ AS65002 │
+   │ .0.2    │                  │.0.1 .1.1│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+```
+
+## Notes
+
+z1 has NO static neighbors. Its listen-range 192.168.0.0/24 binds
+neighbor-group SENDERS (remote-as 65002, ipv4 enabled), so z2's inbound
+connection materializes a passive peer that must reach Established and
+exchange routes in both directions (regression pin for PR #2044, where
+the materialized peer was left in Idle and every connection was
+dropped). z3 runs the same client config from 192.168.1.3 — outside
+the range — and must be refused at accept time with no peer state.
+`listen-limit` is 1 on the DUT, so every re-establishment below also
+proves the freed slot was actually returned — a leaked slot saturates
+the cap and the client can never reconnect.
+
+## Config Files
+
+- z1.yaml:         DUT — group SENDERS + listen-range 192.168.0.0/24, originates 10.0.1.1/32
+- z1-norange.yaml: same DUT with the listen-range deleted (group kept)
+- z2.yaml:         in-range client, static neighbor to .0.1, originates 10.0.2.2/32
+- z3.yaml:         out-of-range client, static neighbor to .1.1, originates 10.0.3.3/32
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the dynamic session | |
+| Routes flow in both directions over the dynamic session | |
+| A source outside every listen-range is refused without peer state | |
+| The client can hard-reset and re-establish the dynamic session | |
+| A DUT-side clear frees the peer and the next connect re-materializes it | |
+| Deleting the listen-range revokes the peers it materialized | |
+| Restoring the listen-range re-materializes the peer in the freed slot | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_es.md
+++ b/bdd/docs/bgp_evpn_es.md
@@ -1,0 +1,30 @@
+# BGP EVPN Ethernet Segment discovery (RFC 7432 Type-4)
+
+## Overview
+
+As a network operator
+I want each PE attached to a multihomed Ethernet Segment to advertise a
+Type-4 Ethernet Segment route (carrying the auto-derived ES-Import RT and a
+DF Election EC) and to discover the other PEs on the same ES, so the
+control-plane foundation for DF election and all-active multihoming is in
+place. (DF election itself and the data plane are later phases.)
+Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+bridge br0, both configured with the SAME Ethernet Segment es1 / ESI (the
+defining property of an ES — the shared CE looks identical to both PEs):
+```
+┌─────────────────────────────────┐
+│               br0               │
+└───────┬─────────────────┬───────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and EVPN iBGP with a shared Ethernet Segment | |
+| Each PE originates a Type-4 ES route the other imports | |
+| Each PE originates a per-ES Type-1 A-D route the other imports | |
+| ES membership shows both PEs on z1 | |
+| DF election carves the segment (default service-carving) | |
+| Removing the ES on z2 withdraws its Type-4 from z1 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_igmp_sync.md
+++ b/bdd/docs/bgp_evpn_igmp_sync.md
@@ -1,0 +1,44 @@
+# BGP EVPN IGMP/MLD Join/Leave Synch routes (RFC 9251 Type 7/8)
+
+## Overview
+
+As a network operator
+I want zebra-rs to originate, store, and route-reflect the RFC 9251
+multihoming synch routes — Type 7 (IGMP/MLD Join Synch) and Type 8
+(IGMP/MLD Leave Synch) — carrying their ES-Import RT and EVI-RT
+extended communities, so the control-plane foundation for all-active
+multihoming is exercised end to end. (DF election and the kernel-MDB
+synch dataplane are still deferred — there is no organic ES-snoop
+trigger yet, so origination is driven by the `clear bgp debug
+igmp-*-sync-*` test command.)
+Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+bridge br0:
+```
+┌─────────────────────────────────┐
+│               br0               │
+└───────┬─────────────────┬───────┘
+```
+z2 originates a Type-7/8 synch route via
+`clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <spec>`
+(spec = `vni,esi,group[,source]`); z1 imports it into its EVPN RIB and
+renders it under `show bgp evpn`, with the ES-Import RT and EVI-RT
+extended communities preserved.
+
+## Notes
+
+z2 originates a Type-7/8 synch route via
+`clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <spec>`
+(spec = `vni,esi,group[,source]`); z1 imports it into its EVPN RIB and
+renders it under `show bgp evpn`, with the ES-Import RT and EVI-RT
+extended communities preserved.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and EVPN iBGP | |
+| z2 originates a (*,G) Type-7 Join Synch route that z1 imports | |
+| Withdrawing the Type-7 route removes it from z1 | |
+| z2 originates a source-specific (S,G) Type-8 Leave Synch route | |
+| Withdrawing the Type-8 route removes it from z1 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_mpls.md
+++ b/bdd/docs/bgp_evpn_mpls.md
@@ -1,0 +1,58 @@
+# EVPN over MPLS advertises a per-EVI service label (RFC 7432)
+
+## Overview
+
+As a network operator running EVPN's L2 services over an MPLS core
+I want each PE to advertise its EVI with an MPLS service label and to
+program the matching decap, so a remote PE knows what to impose on frames
+toward this one — the control plane behind the eBPF data path that
+forwards it.
+Test topology (control plane only — no CEs, no bridges, no forwarding):
+```
+┌─────────────────────────────────────────┐
+│                   br0                   │
+└─────────────┬───────────────┬───────────┘
+```
+What distinguishes MPLS from the VXLAN and SRv6 encapsulations, and what
+this feature pins:
+- The EVI is *declared*, not inferred. VXLAN and SRv6 read a local VXLAN
+- The Type-3 IMET carries an MPLS **label** in its PMSI, not a VNI, and
+- The next hop and PMSI tunnel identifier are the router-id, not a VTEP.
+- No Encapsulation extended community is attached: RFC 8365 section 5.1.3
+- A decap ILM is programmed at the service label so a remote PE's frame
+Type-2 (MAC/IP) needs a datapath MAC learn and is covered by the
+cradle-rs `cradle_evpn_mpls_zebra` feature, which drives this same control
+plane with a real eBPF data plane and CE-to-CE traffic.
+
+## Notes
+
+What distinguishes MPLS from the VXLAN and SRv6 encapsulations, and what
+this feature pins:
+- The EVI is *declared*, not inferred. VXLAN and SRv6 read a local VXLAN
+  device's VNI; an MPLS EVI has no VNI, so `evi 100 bridge br100` is what
+  tells the PE this L2 service exists at all.
+- The Type-3 IMET carries an MPLS **label** in its PMSI, not a VNI, and
+  the label is a different number from the EVI id (it comes from the
+  dynamic block, so it is deliberately NOT asserted as a literal).
+- The next hop and PMSI tunnel identifier are the router-id, not a VTEP.
+- No Encapsulation extended community is attached: RFC 8365 section 5.1.3
+  makes MPLS the default and signals it by that EC's *absence*, so its
+  presence would be the bug.
+- A decap ILM is programmed at the service label so a remote PE's frame
+  pops into bridge domain 100. It is cradle-only — the kernel has no
+  action that pops a label into a bridge — so `show mpls ilm` is the only
+  place it is observable without a data plane.
+Type-2 (MAC/IP) needs a datapath MAC learn and is covered by the
+cradle-rs `cradle_evpn_mpls_zebra` feature, which drives this same control
+plane with a real eBPF data plane and CE-to-CE traffic.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN session | |
+| Each PE originates a Type-3 IMET for its declared EVI | |
+| The IMET reaches the far PE with an MPLS label, not a VNI | |
+| The route target carries the EVI and no encapsulation EC is set | |
+| Each PE programs a bridge-domain decap ILM for its EVI | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_rr_withdraw.md
+++ b/bdd/docs/bgp_evpn_rr_withdraw.md
@@ -1,0 +1,39 @@
+# EVPN route reflector propagates a client's withdraw
+
+## Overview
+
+As a network operator
+I want an EVPN route reflector to forward a client's withdraw to the
+other clients, so nobody keeps forwarding to a departed host's VTEP.
+
+## Test Topology
+
+```
+  ┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+  │     z1      │ EVPN │     z2      │ EVPN │     z3      │
+  │  AS 65001   │◀───▶│  AS 65001   │◀───▶│  AS 65001   │
+  │ vrf-blue    │ iBGP │   route     │ iBGP │  (client)   │
+  │ RD 65001:100│      │  reflector  │      │             │
+  │ Type-5 from │      │  (both are  │      │             │
+  │ 10.1.0.0/24 │      │   clients)  │      │             │
+  └─────────────┘      └─────────────┘      └─────────────┘
+   192.168.0.1          192.168.0.2          192.168.0.3
+```
+
+## Notes
+
+z1 originates an EVPN Type-5 for 10.1.0.0/24 (`evpn advertise-ipv4`);
+z2 reflects it to z3. Review finding #5: a received EVPN withdraw
+removed the route from the reflector's Loc-RIB but was never fanned
+to other peers — z3 kept the stale route (and its VTEP forwarding
+state) until its session bounced.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| The reflector reflects z1's Type-5 to z3 | |
+| z1's withdraw reaches z3 through the reflector | |
+| Re-advertising the network reaches z3 again | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_srv6_p2mp.md
+++ b/bdd/docs/bgp_evpn_srv6_p2mp.md
@@ -4,17 +4,21 @@
 
 As a network operator
 I want the BGP control plane to program EVPN BUM replication into the cradle
-eBPF engine: two SRv6 EVPN PEs exchange their End.DT2M SIDs over a Type-3 IMET,
-and each daemon (with `system ebpf enabled`) tees the datapath to cradle — its
-own End.DT2M leaf SID into the SRv6 table, and each remote PE's End.DT2M SID as
-a VNI-10 replication slot. This proves the control-plane -> cradle-tee
-integration end to end (session, SID exchange, engine programming). BUM
-forwarding is the cradle engine's job (the standalone tc-evpn-replicate offload
-is retired); its packet path is exercised by the veth scripts in cradle-rs
-(crates/tc-evpn-replicate/scripts/veth-*.sh). Requires /usr/bin/cradle.
-
+eBPF engine: two SRv6 EVPN PEs exchange their End.DT2M SIDs over a Type-3
+IMET, and each daemon (with `system ebpf enabled`) tees the datapath to
+cradle — its own End.DT2M leaf SID into the SRv6 table, and each remote PE's
+End.DT2M SID as a VNI-10 replication slot.
+This proves the control-plane -> cradle-tee integration end to end (session,
+SID exchange, engine programming). BUM forwarding is the cradle engine's job
+(the retired standalone tc-evpn-replicate offload is superseded); its packet
+path is exercised by the veth scripts in cradle-rs
+(crates/tc-evpn-replicate/scripts/veth-*.sh). Requires /usr/bin/cradle — see
+the cradle_spawn feature header for install instructions.
 Test Topology — z1 and z2 are SRv6 EVPN PEs on a direct underlay link, each a
-root + leaf for VNI 10, each running the cradle engine.
+root + leaf for VNI 10. Each runs the cradle engine, which encaps BUM toward
+the remote End.DT2M SID and decaps a replicated copy onto its bridge.
+```
+```
 
 ## Test Scenarios
 

--- a/bdd/docs/bgp_evpn_vpws.md
+++ b/bdd/docs/bgp_evpn_vpws.md
@@ -1,0 +1,32 @@
+# BGP EVPN VPWS E-Line signalling over SRv6 (RFC 8214)
+
+## Overview
+
+As a network operator
+I want each PE's `vpws` service to advertise a per-EVI Ethernet A-D route
+(Type-1) whose Ethernet Tag is its local service instance id, carrying an
+End.DX2 L2-Service Prefix-SID (RFC 9252 §6.3) carved from the BGP SRv6
+locator, and to bind the remote PE's Type-1 — matched by Ethernet Tag ==
+remote-service-id within the shared EVI — as the E-Line's remote end, so
+the point-to-point service signals with zero per-peer state.
+Control-plane only: no cradle dataplane is attached, so the `interface`
+leaf is just carried state and `show bgp evpn vpws` reaching `up` means
+the Type-1 exchange and the remote-SID bind both worked.
+Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+bridge br0, one E-Line service between them:
+```
+┌─────────────────────────────────┐
+│               br0               │
+└───────┬─────────────────┬───────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and EVPN iBGP with a VPWS service on each PE | |
+| Each PE originates a per-EVI Type-1 the other imports | |
+| The VPWS service binds the remote End.DX2 SID and reaches up | |
+| Re-pointing remote-service-id rebinds from the Loc-RIB without a route churn | |
+| Mismatched L2 MTUs block the bind until they agree (RFC 8214 §3.1) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_vpws_multihoming.md
+++ b/bdd/docs/bgp_evpn_vpws_multihoming.md
@@ -1,0 +1,50 @@
+# BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
+
+## Overview
+
+As a network operator
+I want a VPWS service whose attachment circuit sits on a multihomed
+Ethernet Segment to advertise its Type-1 under that segment's ESI, and to
+elect its primary/backup role per <ESI, VPWS service instance> across the
+PEs advertising the segment's Type-4, so the remote PE learns which of the
+two attached PEs to use — and learns it again, without any config change,
+when one of them leaves the segment.
+Control-plane only: no cradle dataplane is attached, so this asserts the
+Type-1 ESI, the Layer-2 Attributes P/B bits on the wire, and the role each
+PE reports. Which SID the remote *binds* from a multihomed pair is remote
+selection, a separate phase — z3 here still binds a single end.
+Test Topology — three iBGP (AS 65001) EVPN speakers on a shared transport
+bridge br0. z1 and z2 are dual-homed to one CE over Ethernet Segment es1
+and both advertise VPWS service instance 101; z3 is the single-homed
+remote end of the E-Line:
+```
+┌───────────────────────────────────────────────┐
+│                      br0                      │
+└────┬──────────────────┬──────────────────┬────┘
+```
+Instance 101 carves to ordinal 101 % 2 = 1 of the ascending VTEP list
+[.0.1, .0.2], so z2 is the DF (primary) and z1 its backup — the lower
+address deliberately is *not* the DF, which is what proves the carving
+keys on the service instance id rather than just picking the lowest PE.
+
+## Notes
+
+Instance 101 carves to ordinal 101 % 2 = 1 of the ascending VTEP list
+[.0.1, .0.2], so z2 is the DF (primary) and z1 its backup — the lower
+address deliberately is *not* the DF, which is what proves the carving
+keys on the service instance id rather than just picking the lowest PE.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology, two PEs on one Ethernet Segment plus a remote PE | |
+| Both attached PEs originate the Type-1 under the segment's ESI | |
+| Single-active carving elects one primary and one backup | |
+| All-active makes every attached PE primary | |
+| A PE leaving the segment re-elects the survivor with no config change on it | |
+| An AC claimed by two segments is reported, not guessed; the leaf resolves it | |
+| Preference-based DF election overrides the carving ordinal | |
+| The remote PE binds the primary of a multihomed pair | |
+| Losing the primary fails the service over to the backup | |
+| Teardown topology | |

--- a/bdd/docs/bgp_graceful_restart.md
+++ b/bdd/docs/bgp_graceful_restart.md
@@ -1,0 +1,29 @@
+# Graceful Restart advertises a usable Restart Time
+
+## Overview
+
+As a network operator
+I want a graceful-restart-enabled neighbor to advertise a sane RFC
+4724 Restart Time, so a helper retains routes across a real restart.
+
+## Test Topology
+
+```
+  z1 (AS65001) ──eBGP── z2 (AS65002)
+  192.168.0.1/24        192.168.0.2/24
+```
+
+## Notes
+
+Both enable `afi-safi ipv4 graceful-restart`. Review finding #15: the
+enable marker stored `1`, advertised verbatim as the Restart Time, so
+a helper flushed retained routes after ~1s — no forwarding continuity.
+The default is now 120s.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup and establish the session | |
+| The advertised/received Restart Time is the sane default, not 1 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_lua_gbp.md
+++ b/bdd/docs/bgp_lua_gbp.md
@@ -1,0 +1,48 @@
+# BGP EVPN Group-Based Policy via Lua scripting
+
+## Overview
+
+DISABLED for now: the embedded Lua scripting engine is off (the `lua`
+build feature defaults off and its BGP config schema is commented out),
+so this scenario's lua-script / lua-map / adj-rib-out-hook config no
+longer applies. The `@disabled` tag makes the harness skip this feature
+in every run (full suite and explicit --tags). To re-enable: remove
+`@disabled`, rebuild with `--features lua`, and uncomment the
+zebra-bgp-lua schema.
+As a network operator
+I want zebra-rs to carry a Group-Based Policy tag on EVPN Type-2 routes
+and enforce it in the dataplane, driven entirely by embedded Lua hooks,
+so the FRR-scripting "GBP over EVPN" demo runs end to end without any
+blocking I/O on the route path.
+Two iBGP (AS 65001) EVPN speakers on a shared transport bridge br0, each
+with a local VXLAN (VNI 10) enslaved to a per-node bridge br10:
+```
+┌───────────────────────────────────────────┐
+│                    br0                     │
+└───────────┬───────────────────┬───────────┘
+```
+Flow: z1 learns local MAC aa:bb:cc:dd:ee:01 and originates an EVPN
+Type-2 route. z1's egress Lua hook looks the MAC up in the `sgt` map
+(-> tag 100) and stamps a Group-Policy-ID extended community. z2's
+import Lua hook recovers the tag and runs `nft add element` to put the
+MAC in set `tag_100`; the withdraw hook removes it. The scripts are the
+shipped /usr/share/zebra-rs/lua/gbp-example.lua.
+
+## Notes
+
+Flow: z1 learns local MAC aa:bb:cc:dd:ee:01 and originates an EVPN
+Type-2 route. z1's egress Lua hook looks the MAC up in the `sgt` map
+(-> tag 100) and stamps a Group-Policy-ID extended community. z2's
+import Lua hook recovers the tag and runs `nft add element` to put the
+MAC in set `tag_100`; the withdraw hook removes it. The scripts are the
+shipped /usr/share/zebra-rs/lua/gbp-example.lua.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology, EVPN iBGP, GBP scripts, and the enforcement table | |
+| A local MAC makes z1 originate a Type-2 route z2 receives | |
+| z2's import hook programs the GBP tag set from the GPI community | |
+| Withdrawing the MAC tears the GBP set element down | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_capability.md
+++ b/bdd/docs/bgp_mup_capability.md
@@ -1,0 +1,52 @@
+# BGP Mobile User Plane (MUP) capability negotiation
+
+## Overview
+
+As a network operator
+I want two zebra-rs instances to negotiate the BGP MUP multiprotocol
+capability (SAFI 85, draft-ietf-bess-mup-safi) for BOTH IPv4-MUP (AFI 1) and IPv6-MUP
+(AFI 2) from a single `afi-safi mup enabled true` knob, and
+bring an iBGP session to Established, so the foundation for MUP route
+exchange (ISD / DSD / ST1 / ST2) is validated before origination is
+implemented.
+No MUP routes flow in this scenario — capability negotiation is the unit
+under test. zebra-rs cannot originate MUP routes yet (controller phase),
+so route exchange is exercised in a later feature once a peer can emit
+them.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Notes
+
+Both peers enable two AFI/SAFIs:
+  - ipv4 (so the session has a fallback AF and matches the
+    established BDD pattern)
+  - mup (the single knob this scenario validates; it
+    negotiates IPv4-MUP and IPv6-MUP)
+
+## Config Files
+
+- z1-1.yaml: AS 65001, peer to 192.168.0.2, mup enabled
+- z2-1.yaml: AS 65001, peer to 192.168.0.1, mup enabled
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with MUP capability | |
+| IPv4 and IPv6 MUP capabilities are advertised and received on both sides | |
+| show bgp mup renders the (empty) MUP RIB header | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_dynamic_rt.md
+++ b/bdd/docs/bgp_mup_dynamic_rt.md
@@ -1,0 +1,56 @@
+# BGP MUP export route-target applies dynamically to an originated ST route
+
+## Overview
+
+As a network operator
+I want a `set vrf <name> mup route-target export <rt>` change to take
+effect on an already-originated controller Session-Transformed route,
+re-stamping it with the new route-target and re-advertising it — without
+re-establishing the PFCP session. The export RTs are read from the VRF
+table at session-establish time, so a route originated before the RT is
+configured (or before a later export-RT commit) must be re-tagged in
+place. This regressed: the export-RT change refreshed only the DSD/ISD
+segment routes, never the controller's ST1/ST2 routes, so the new RT
+never reached the route or the peer.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+```
+
+## Notes
+
+z1 runs the controller (PFCP listener on 192.168.0.1:8805, VRF
+`mobile-up` binding Network Instance `core` to a Type-2 ST route with the
+Direct segment id `1:2`). The top-level `vrf mobile-up` starts with NO
+`mup route-target export`. z2 imports MUP route-target 100:10. The
+feature injects a session (z1 originates the ST2 with no RT), then applies
+`set vrf mobile-up mup route-target export 100:10` at runtime and checks
+the ST2 is re-stamped on z1 and the re-advertised route reaches z2's
+per-VRF view (which only imports 100:10).
+NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
+`cargo build --release -p pfcp-inject` and copy `target/release/pfcp-inject`
+to /usr/bin, the same way the zebra-rs / vtyctl binaries are staged.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with MUP capability | |
+| Originate an ST2 with no export RT, then apply the export RT dynamically | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_forwarding.md
+++ b/bdd/docs/bgp_mup_forwarding.md
@@ -1,0 +1,45 @@
+# BGP MUP End.DT46 datapath forwards real traffic (ST2 -> DSD)
+
+## Overview
+
+Two combined MUP UPF + interwork nodes (z1, z2) each terminate a PFCP
+session (NI `core`) and originate a Type-2 Session-Transformed (ST2) route
+whose endpoint is a host behind it (ceA behind z1, ceB behind z2), plus a
+Direct Segment Discovery (DSD) route carrying the per-VRF End.DT46 SID
+(draft-ietf-bess-mup-safi, SAFI 85). Each imports the other's DSD + ST2 and
+resolves them by Direct-segment id (MUP Extended Community), installing an
+SRv6 H.Encaps route for the remote ST2 endpoint toward the remote End.DT46
+SID, resolved through the IS-IS SRv6 underlay. So a bidirectional ceA<->ceB
+ping traverses the MUP End.DT46 datapath in BOTH directions using only
+MUP-installed routes — the forwarding counterpart of bgp_mup_st2_dsd_fib
+(which asserts the install; this drives real packets through it).
+zebra-rs uses End.DT46 as the mainline-kernel stand-in for the draft's
+GTP-U edge behaviours (GTP4.E / H.M.GTP4.D), which need a VPP/eBPF forwarder
+(see docs/design/bgp-mup-dataplane-plan.md, Plan A). Because a VRF binds a
+single MUP direction, one bidirectional subscriber path is realized by two
+collocated nodes (each an ST2 anchor for its own host), not one.
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+   ceA ─┤    z1    │══ IS-IS L2 ══│    z2    ├─ ceB
+ 10.10.1.2  UPF+MUP-C  SRv6+iBGP   UPF+MUP-C  10.20.2.2
+   /24  │ VRF N6   │   (mup)      │ VRF N6   │  /24
+        └──────────┘              └──────────┘
+   z1-z2 2001:db8:0:12::1/64  2001:db8:0:12::2/64
+```
+
+## Notes
+
+NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
+seg6 + IS-IS SRv6 underlay).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| Each node resolves the peer ST2 to its DSD and installs the encap | |
+| ceA <-> ceB traffic forwards over the MUP End.DT46 datapath | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_interwork.md
+++ b/bdd/docs/bgp_mup_interwork.md
@@ -1,0 +1,44 @@
+# BGP MUP interwork node resolves ST2 to the Direct segment
+
+## Overview
+
+As a network operator
+I want a zebra-rs BGP MUP interwork (SRGW) node — `afi-safi mup segment
+interwork` — to resolve each received Type-2 Session-Transformed (ST2)
+route to the matching Direct Segment Discovery (DSD) route by their BGP
+MUP Extended Community (Direct-segment id), so it knows the End.DT46
+segment a session's uplink GTP tunnel forwards into
+(draft-mpmz-bess-mup-safi §3.3.12, RFC 9433 End.DT46).
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ UPF +    │   iBGP (mup)    │ interwork│
+       │ MUP-C    │                 │  (SRGW)  │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+z1 is a combined UPF + controller: VRF N6 (`encapsulation srv6`, rd
+65501:10) with `afi-safi mup segment direct mup-ext-comm 1:2` plus
+`route st2 network-instance core mup-ext-comm 1:2` originates a DSD
+(End.DT46 SID + Direct-segment id 1:2) and — when `pfcp-inject` programs
+a session on Network Instance `core` — an ST2 (same id 1:2). z2 has
+`afi-safi mup segment interwork`,
+receives both, and resolves the ST2 to z1's End.DT46 Direct segment.
+NOTE: needs `pfcp-inject` on the BDD host PATH (cargo build --release -p
+pfcp-inject; copy to /usr/bin) and root netns (kernel VRF + seg6local).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z1 originates the DSD and (from PFCP) the ST2, both with id 1:2 | |
+| z2 (interwork) resolves the ST2 to z1's End.DT46 Direct segment | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_isd.md
+++ b/bdd/docs/bgp_mup_isd.md
@@ -1,0 +1,40 @@
+# BGP MUP PE originates an Interwork Segment Discovery (ISD) route over SRv6
+
+## Overview
+
+As a network operator
+I want a zebra-rs BGP MUP PE to originate an Interwork Segment Discovery
+(ISD, type 1, SAFI 85 / draft-ietf-bess-mup-safi) route for an `encapsulation srv6` VRF
+when `afi-safi mup segment interwork prefix <p>` is configured, so the
+per-VRF End.DT46 service SID is carved from the locator, installed into the
+kernel FIB, and advertised under the configured interwork prefix as the
+segment a receiving PE resolves for matching Session-Transformed routes.
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ vrf N6   │                 │          │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+z1 has VRF N6 (`encapsulation srv6`, rd 65501:10) and `afi-safi mup
+segment interwork prefix 10.60.0.0/16`, so it carves an End.DT46 SID from
+locator S, installs the seg6local decap into N6's table, and originates an
+ISD route (NLRI = rd + the interwork prefix 10.60.0.0/16) carrying that
+SID. z2 receives it.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z1 originates the ISD route and installs the End.DT46 SID | |
+| z2 receives the ISD route with the End.DT46 SID | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_mixed_afi.md
+++ b/bdd/docs/bgp_mup_mixed_afi.md
@@ -1,0 +1,40 @@
+# BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
+
+## Overview
+
+As a network operator running 5G backhaul where the UE address family and
+the N3 transport differ, I want the zebra-rs BGP MUP Controller to
+originate a Type-1 Session-Transformed route (SAFI 85,
+draft-ietf-bess-mup-safi) for an IPv6 UE whose GTP endpoint (gNB) is IPv4,
+and a peer zebra-rs to receive and show it. This validates two behaviours:
+
+## Test Topology
+
+```
+           ┌─────────┐     ┌─────────┐
+           │   z1    │ iBGP│   z2    │
+           │ MUP-C   │◄───►│ receiver│
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴───────┐
+           │ pfcp-inject │  (SMF simulator, run in z1)
+           └────────────┘
+```
+
+## Notes
+
+NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+binary (the test-only SMF simulator, `tools/pfcp-inject`) must be on the
+BDD host PATH — build with `cargo build --release -p pfcp-inject` and copy
+`target/release/pfcp-inject` to /usr/bin, the same way the zebra-rs /
+vtyctl binaries are staged for BDD.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with MUP capability | |
+| IPv6 UE with IPv4 endpoint originates an ST1 route the peer parses | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_peerdown.md
+++ b/bdd/docs/bgp_mup_peerdown.md
@@ -1,0 +1,42 @@
+# BGP MUP peer-down withdraws the RT-imported per-VRF copy
+
+## Overview
+
+As a network operator
+I want a BGP MUP route (SAFI 85 / draft-ietf-bess-mup-safi) learned from a
+peer to be withdrawn from EVERY table when that peer goes down — not just
+the main-instance MUP Loc-RIB but also every VRF that imported it by
+route-target — so a session loss cannot leak a stale route (and its derived
+SRv6 FIB entry) into a downlink VRF's RIB forever.
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ N6 (ISD) │                 │ N3 (imp) │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+z1's VRF N6 (rd 65501:20, `encapsulation srv6`, `afi-safi mup segment
+interwork prefix 10.60.0.0/16`) originates an ISD carrying export RT
+65501:10 and advertises it to z2. z2's VRF N3 (rd 65501:99) imports RT
+65501:10, so it pulls the peer-learned ISD in across the RD boundary and
+re-keys it under its own rd (65501:99). When z1 is stopped, z2's peer-down
+cleanup must drop the ISD from BOTH z2's main MUP Loc-RIB (`show bgp mup`)
+and N3's imported copy (`show bgp vrf N3 mup`). Before the fix the main copy
+was dropped but N3's RT-imported copy leaked.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z2 receives the ISD and imports it into VRF N3 by route-target | |
+| When the peer (z1) goes down z2 withdraws the ISD from BOTH tables | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_segment_dsd.md
+++ b/bdd/docs/bgp_mup_segment_dsd.md
@@ -1,0 +1,39 @@
+# BGP MUP PE originates a Direct Segment Discovery (DSD) route over SRv6
+
+## Overview
+
+As a network operator
+I want a zebra-rs BGP MUP PE to originate a Direct Segment Discovery
+(DSD, type 2, SAFI 85 / draft-ietf-bess-mup-safi) route for an `encapsulation srv6` VRF
+when `afi-safi mup segment direct` is configured, so the per-VRF End.DT46
+service SID is carved from the locator, installed into the kernel FIB, and
+advertised as the segment a receiving PE resolves for matching
+Session-Transformed routes (the draft-ietf-bess-mup-safi default).
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ vrf N6   │                 │          │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+z1 has VRF N6 (`encapsulation srv6`, rd 65501:10) and
+`afi-safi mup segment direct`, so it carves an End.DT46 SID from locator
+S, installs the seg6local decap into N6's table, and originates a DSD
+route (NLRI = rd + router-id 10.0.0.1) carrying that SID. z2 receives it.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z1 originates the DSD route and installs the End.DT46 SID | |
+| z2 receives the DSD route with the End.DT46 SID | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_single_vrf_dual_st.md
+++ b/bdd/docs/bgp_mup_single_vrf_dual_st.md
@@ -1,0 +1,54 @@
+# One MUP VRF binds both st1 and st2 and originates both ST routes
+
+## Overview
+
+As a network operator running a UPF with a single N6 interface (issue
+#1947), I want ONE `router bgp vrf` to bind BOTH `afi-safi mup route st1`
+(downlink) and `afi-safi mup route st2` (uplink) to the same Network
+Instance — so a single PFCP/N4 session originates the Type-1 ST (UE
+prefix + access tunnel) AND the Type-2 ST (core endpoint + GTP TEID)
+under ONE RD, instead of requiring two single-direction VRFs (and with
+them two N6-facing interfaces).
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+```
+
+## Notes
+
+z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1)
+with a SINGLE VRF `mobile` (rd 65000:1) whose `afi-safi mup` block binds
+both `route st1` and `route st2` (the st2 entry carrying Direct segment
+id `1:2`) to Network Instance `internet`. `pfcp-inject` plays the SMF: it
+sends an Association Setup + Session Establishment for UE 192.0.2.5 with
+an ACCESS-side F-TEID (gNB endpoint 10.0.0.1 / TEID 0x12345678) and a
+CORE-side F-TEID (endpoint 10.9.0.1 / TEID 0x87654321), Network Instance
+`internet`. z1 originates BOTH Session-Transformed routes from the one
+VRF — both under rd 65000:1 — and advertises them to z2.
+NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
+`cargo build --release -p pfcp-inject` and copy `target/release/pfcp-inject`
+to /usr/bin, the same way the zebra-rs / vtyctl binaries are staged.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with MUP capability | |
+| One PFCP session originates both STs from the single dual-direction VRF | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_st1_isd.md
+++ b/bdd/docs/bgp_mup_st1_isd.md
@@ -1,0 +1,44 @@
+# BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
+
+## Overview
+
+An interwork / UPF node imports a remote Interwork Segment Discovery (ISD,
+type 1, SAFI 85 / draft-ietf-bess-mup-safi) route — whose prefix is the gNB
+N3 network — and — via its MUP controller — originates a Type-1
+Session-Transformed (ST1) route whose GTP endpoint (gNB) address falls
+inside that prefix. Because the endpoint is covered by the (remote) ISD,
+the node resolves the ST1 to the ISD's End.DT46 segment and installs an
+SRv6 H.Encaps route for the ST1's **UE prefix** into the VRF table (the
+endpoint is the lookup key; the UE prefix is the forwarded destination),
+resolved through the IS-IS SRv6 underlay toward the ISD's next-hop.
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ access PE│   iBGP (mup)    │ UPF +    │
+       │  (ISD)   │                 │ MUP-C    │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+z1 (VRF N6, rd 65501:10, `segment interwork prefix 10.0.0.0/24`, export RT
+65501:10) originates the ISD (End.DT46 SID from locator S). z2 (VRF N6, rd
+65501:20, `encapsulation srv6`, import RT 65501:10) imports the ISD and,
+from a PFCP session on NI `access`, originates an ST1 (UE 10.60.1.5, gNB
+endpoint 10.0.0.1 inside 10.0.0.0/24). z2 resolves the ST1's endpoint to
+z1's segment and installs the UE-prefix encap.
+NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
+seg6 + IS-IS SRv6 underlay).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z2 resolves the ST1 to z1's ISD segment and installs the encap | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_st2_base.md
+++ b/bdd/docs/bgp_mup_st2_base.md
@@ -1,0 +1,53 @@
+# BGP MUP Controller originates a Type-2 ST route from a PFCP session
+
+## Overview
+
+As a network operator
+I want the zebra-rs BGP MUP Controller (MUP-C) to learn a mobile session
+over PFCP/N4 and originate a Type-2 Session-Transformed route (ST2, SAFI
+85, draft-mpmz-bess-mup-safi §3.1.4) for the uplink (N3) — the
+core endpoint + GTP TEID with the BGP MUP Extended Community of the Direct
+segment — so a peer zebra-rs receives it and the End.DT46 uplink/downlink
+forwarding model can be programmed from the Direct segment.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+```
+
+## Notes
+
+z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1,
+VRF `mobile-up` with `afi-safi mup segment direct` plus `route st2
+network-instance core` binding Network Instance `core` to its Type-2 ST /
+Direct segment, and carrying the Direct segment id `1:2` on both the
+segment and the st2 route). `pfcp-inject` plays the SMF: it
+sends an Association Setup + Session Establishment for endpoint 10.0.0.1 /
+TEID 0x12345678 (Network Instance `core`), so z1 originates the ST2 route
+and advertises it to z2.
+NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
+`cargo build --release -p pfcp-inject` and copy `target/release/pfcp-inject`
+to /usr/bin, the same way the zebra-rs / vtyctl binaries are staged.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with MUP capability | |
+| PFCP session establishment originates an ST2 route received by the peer | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_st2_dsd_fib.md
+++ b/bdd/docs/bgp_mup_st2_dsd_fib.md
@@ -1,0 +1,43 @@
+# BGP MUP interwork node installs the ST2->DSD SRv6 encap
+
+## Overview
+
+An interwork (SRGW) node imports a Type-2 Session-Transformed (ST2) route
+and a Direct Segment Discovery (DSD) route (SAFI 85 /
+draft-ietf-bess-mup-safi) into a *forwarding* VRF, resolves each ST2 to the
+matching DSD by their Direct-segment id (MUP Extended Community), and — the
+DSD being remote — installs an SRv6 H.Encaps route for the ST2 endpoint
+into the VRF table, resolved through the IS-IS SRv6 underlay toward the
+DSD's next-hop. This is the forwarding counterpart of the show-only
+interwork resolution.
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ UPF +    │   iBGP (mup)    │ interwork│
+       │ MUP-C    │                 │ (SRGW,   │
+       │ (DSD+ST2)│                 │  VRF N6) │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+z1 (VRF N6, rd 65501:10, `segment direct` + `route st2`, export RT
+65501:10) originates a DSD (End.DT46 SID from locator S + id 1:2) and, from
+a PFCP session on NI `core`, an ST2 (endpoint 10.0.0.1, id 1:2). z2 (VRF
+N6, rd 65501:20, `encapsulation srv6`, import RT 65501:10) imports both,
+resolves the ST2 to z1's Direct segment, and installs the endpoint encap.
+NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
+seg6 + IS-IS SRv6 underlay).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z2 resolves the ST2 to z1's Direct segment and installs the encap | |
+| Teardown topology | |

--- a/bdd/docs/bgp_mup_vrf_import.md
+++ b/bdd/docs/bgp_mup_vrf_import.md
@@ -1,0 +1,41 @@
+# BGP MUP cross-VRF import by route-target (RD-independent)
+
+## Overview
+
+As a network operator
+I want a locally-originated BGP MUP route (SAFI 85 / draft-ietf-bess-mup-safi) to be
+imported into every VRF whose `mup route-target import` overlaps the
+route's RTs — not just the VRF that owns the route's RD — so per-VRF MUP
+matches the VPNv4/v6 import model and a downlink VRF can pull in the
+upstream segment another VRF originated.
+
+## Test Topology
+
+```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ N6 + N3  │                 │          │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+```
+
+## Notes
+
+On z1, VRF N6 (rd 65501:20, `encapsulation srv6`, `afi-safi mup segment
+interwork prefix 10.60.0.0/16`) originates an ISD route carrying its export
+RT 65501:10. VRF N3 (rd 65501:10) imports RT 65501:10, so it pulls in N6's
+ISD even though the ISD's RD (65501:20) does not equal N3's own rd — the
+proof that per-VRF MUP import is route-target matched, not RD matched.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and establish iBGP with the MUP capability | |
+| z1 originates the ISD in N6 and installs the End.DT46 SID | |
+| N6 self-imports its own ISD (rd 65501:20 imports rt 65501:10) | |
+| N3 imports N6's ISD across the RD boundary by route-target | |
+| z2 receives the ISD route with the End.DT46 SID | |
+| Teardown topology | |

--- a/bdd/docs/bgp_out_policy_delete.md
+++ b/bdd/docs/bgp_out_policy_delete.md
@@ -1,0 +1,37 @@
+# Deleting an outbound route-policy re-advertises the suppressed routes
+
+## Overview
+
+As a network operator
+I want removing a neighbor's `afi-safi ipv4 policy out` binding to
+re-advertise the routes that policy was suppressing.
+
+## Test Topology
+
+```
+  z1 (AS65001) ──eBGP── z2 (AS65002)
+  192.168.0.1/24        192.168.0.2/24
+```
+
+## Notes
+
+z1 originates 10.0.0.1/32 and 10.0.0.2/32. With `policy out DENY-ALL`
+bound toward z2, neither reaches z2. Review finding #12: deleting that
+binding left z1's cached out-policy snapshot still denying everything
+and never re-advertised — z2 stayed route-less until a new policy name
+was bound.
+
+## Config Files
+
+- z1-deny.yaml: z1 with `afi-safi ipv4 policy out DENY-ALL`.
+- z1-nopolicy.yaml: same, minus the policy binding (the delete diff).
+- z2.yaml: plain AS65002 peer.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup; the out-policy denies both routes to z2 | |
+| Deleting the out-policy re-advertises both routes | |
+| Re-binding the out-policy denies them again | |
+| Teardown topology | |

--- a/bdd/docs/bgp_set_ext_large_community.md
+++ b/bdd/docs/bgp_set_ext_large_community.md
@@ -7,17 +7,17 @@ I want policy-list `set ext-community` and `set large-community`
 actions to stamp the EXT_COMMUNITIES and LARGE_COMMUNITIES attributes
 on routes, so that I can tag routes the same way `set community` tags
 the standard COMMUNITIES attribute.
-
 Both actions reference a named set (`ext-community-set` /
 `large-community-set`); only the set's exact members contribute
 concrete values (regex members are skipped). `replace` (default)
 overwrites the attribute, `additive` merges, `delete` removes — the
 same {replace|additive|delete} choice as `set community`.
-
 The set is applied as z2's INBOUND policy so the modified attribute
 lands in z2's own Loc-RIB and is directly observable via
 `show bgp -j`, which now surfaces `community`, `ext_community`, and
-`large_community` fields.
+`large_community` fields. Re-evaluation rides the policy-change
+trigger (PolicyRx -> soft-in): applying a config whose policy content
+changed re-runs the inbound policy over the Adj-RIB-In.
 
 ## Test Topology
 
@@ -33,6 +33,11 @@ lands in z2's own Loc-RIB and is directly observable via
            │  0.1/24 │     │  0.2/24 │
            └─────────┘     └─────────┘
 ```
+
+## Notes
+
+z1 originates 10.0.0.1/32 + 10.0.0.2/32 with no communities. z2
+swaps its inbound policy and we read back the stamped attributes.
 
 ## Config Files
 

--- a/bdd/docs/bgp_sr_policy_bsid_forwarding.md
+++ b/bdd/docs/bgp_sr_policy_bsid_forwarding.md
@@ -1,0 +1,27 @@
+# BGP SR Policy Binding-SID steering — end-to-end forwarding (RFC 9256 §8.5)
+
+## Overview
+
+A headend (crs1) receives a service route AND an SR Policy over SAFI 73
+from a controller (crs2), colours the route on ingress, and steers it
+onto the policy. With `steering-mode binding-sid` the installed route
+pushes only the policy's Binding SID (label 16100); with
+`steering-mode segment-list` it pushes the policy's whole SID list
+(label 16002). The two labels are distinct, so `show ip route` proves,
+at the FIB, both that steering fires on *received* SR-policy state and
+that the mode selects the Binding SID vs the inline segment list.
+This is the forwarding-plane companion to @bgp_sr_policy_bsid_steering
+(which covers the config/show surface). It exercises the real receive →
+consume → colour → steer path, not just config.
+Topology (single link, iBGP AS 65000):
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| crs1 consumes the received SR Policy and installs the service route | |
+| Colouring the route inbound steers it onto the Binding SID | |
+| Switching to segment-list mode pushes the inline SID list instead | |
+| Teardown topology | |

--- a/bdd/docs/bgp_sr_policy_bsid_steering.md
+++ b/bdd/docs/bgp_sr_policy_bsid_steering.md
@@ -1,0 +1,27 @@
+# BGP SR Policy Binding-SID steering mode (RFC 9256 §8.5)
+
+## Overview
+
+An operator selects how colour-matched service routes are steered onto
+an SR Policy: the whole SID list imposed inline (`segment-list`, the
+historical default) or just the policy's Binding SID (`binding-sid`,
+which the BSID's own forwarding entry — an SR-MPLS ILM or an SRv6
+End.B6.Encaps SID — expands). This feature validates the new
+`steering-mode` config surface end to end in a running daemon: the YANG
+parses, the callback stages the mode onto the Loc-RIB SR Policy DB, and
+`show bgp sr-policy` reflects it (both values). The steering *decision*
+logic — BSID selection, the RFC 9256 §8.8.1 CO-bit endpoint fallback,
+and the SR-MPLS ILM-installed gate — is covered by the unit tests in
+`zebra-rs/src/bgp/sr_policy.rs`.
+Topology:
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| The binding-sid steering mode is configured and shown | |
+| Flipping the mode back to segment-list takes effect live | |
+| Deleting the mode restores the segment-list default | |
+| Teardown topology | |

--- a/bdd/docs/bgp_srv6_nht.md
+++ b/bdd/docs/bgp_srv6_nht.md
@@ -1,0 +1,52 @@
+# BGP route inherits SRv6 segments from its covering route
+
+## Overview
+
+As a network operator
+I want a BGP route whose next-hop is reachable only through a
+BGP-over-SRv6 transport route to resolve recursively through it and
+inherit the H.Encap segment list — the BGP twin of the static-route
+inheritance in @static_srv6_nht, and the SRv6 analog of Inter-AS
+Option C (service routes riding a BGP-learned transport tunnel).
+
+## Test Topology
+
+```
+  ┌────────┐ i1 ── i2 ┌────────┐ i1 ──────── i1 ┌────────┐ i2 ─────── i1 ┌────────┐
+  │   z4   │──────────│   z1   │────────────────│   z2   │───────────────│   z3   │
+  │ service│ 2001:db8:│ egress │2001:db8:12::/64│  core  │2001:db8:23::/64 ingress│
+  │  node  │ cafe::/64│ LOC1   │                │        │               │        │
+  └────────┘          └────────┘                └────────┘               └────────┘
+   lo: 3001:db8:100::1     z2 knows ONLY the links and z1's locator
+   (service prefix          fcbb:bbbb:1::/48 — service prefixes cross
+    aggregate via BGP)      it exclusively inside SRv6 encapsulation
+```
+
+## Notes
+
+- Transport: z1<->z3 iBGP with `encapsulation-type srv6`; z1
+  redistributes connected, so 2001:db8:cafe::/64 (the z1-z4 subnet)
+  arrives at z3 as an SRv6 service route carrying z1's End.DT6 SID
+  fcbb:bbbb:1:40::.
+- Service: z4<->z3 iBGP. The TCP session itself crosses the core
+  inside the transport tunnel (encap at z3, decap at z1, plain
+  delivery to z4). z4 redistributes its blackhole aggregate
+  3001:db8:100::/64, which arrives at z3 with next-hop cafe::4 — an
+  address covered ONLY by the SRv6 transport route. NHT resolves the
+  next-hop through it and the installed route inherits the segment
+  list: `proto bgp ... encap seg6 segs [fcbb:bbbb:1:40::]`.
+- The ping to z4's loopback proves the end-to-end datapath: z2
+  cannot route the service prefix, so only the inherited
+  encapsulation can carry the traffic.
+
+## Config Files
+
+- z1.yaml, z2.yaml, z3.yaml, z4.yaml
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and converge the SRv6 transport | |
+| Service route resolves through the SRv6 transport and inherits its segments | |
+| Teardown topology | |

--- a/bdd/docs/bgp_unknown_attr_transitive.md
+++ b/bdd/docs/bgp_unknown_attr_transitive.md
@@ -1,0 +1,47 @@
+# BGP unrecognized path attribute handling (RFC 4271 §9)
+
+## Overview
+
+As a network operator
+I want zebra-rs to follow RFC 4271 §9 for unrecognized path attributes
+So an optional transitive unknown attribute survives and propagates with
+the Partial bit set, while an optional non-transitive one is dropped.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65003 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+```
+
+## Notes
+
+z1 originates 10.0.0.1/32. The debug knob `attach-unknown-attribute`
+on z1's session toward z2 stamps a synthetic unrecognized path
+attribute onto that route. Neither z2 nor z3 recognize the Type Code,
+so they exercise the receiver-side RFC 4271 §9 rules:
+  * Optional Transitive (flags 0xC0) → z2 accepts it, sets the Partial
+    bit, retains it, and re-advertises to z3 (which also keeps it,
+    Partial still set).
+  * Optional non-Transitive (flags 0x80) → z2 silently drops it; it
+    never reaches z3, and the 10.0.0.1/32 route itself is unaffected.
+
+## Config Files
+
+- z1-base.yaml:          z1 originates 10.0.0.1/32, no attach.
+- z1-transitive.yaml:    z1 attaches type 250, flags 0xC0, value deadbeef.
+- z1-nontransitive.yaml: z1 attaches type 251, flags 0x80, value 1234.
+- z2.yaml / z3.yaml:     plain transit / tail speakers.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup line topology and establish all sessions | |
+| Baseline - the route propagates with no unknown attributes | |
+| Optional transitive unknown attribute is retained, Partial set, and propagated | |
+| Optional non-transitive unknown attribute is dropped and not propagated | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_dual_home.md
+++ b/bdd/docs/bgp_vrf_dual_home.md
@@ -1,0 +1,40 @@
+# Dual-homed L3VPN prefix survives one PE's withdraw
+
+## Overview
+
+As a network operator
+I want a VRF that imports the same prefix from two PEs (two RDs) to
+keep forwarding via the surviving PE when the other withdraws.
+
+## Test Topology
+
+```
+  ┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+  │     z1      │VPNv4 │     z2      │VPNv4 │     z3      │
+  │  AS 65001   │◀───▶│  AS 65001   │◀───▶│  AS 65001   │
+  │ vrf-blue    │ iBGP │ vrf-blue    │ iBGP │ vrf-blue    │
+  │ RD 65001:1  │      │ RD 65001:2  │      │ RD 65001:3  │
+  │ net 10.9.   │      │ (import     │      │ net 10.9.   │
+  │  0.0/24     │      │  only)      │      │  0.0/24     │
+  └─────────────┘      └─────────────┘      └─────────────┘
+   192.168.0.1          192.168.0.2          192.168.0.3
+```
+
+## Notes
+
+All three share RT 65001:100. z1 and z3 both export 10.9.0.0/24 under
+their own RDs; z2 imports both into vrf-blue. Review finding #4: the
+two imports used to alias to one Loc-RIB row in z2's VRF, so either
+PE's withdraw removed the row that by then held the OTHER PE's
+still-valid route — a CE-side blackhole.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| z2 imports the prefix from both RDs | |
+| PE1's withdraw leaves the survivor in the VRF | |
+| The survivor's withdraw empties the VRF row | |
+| Re-adding the network on PE1 re-imports it | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_add_path.md
+++ b/bdd/docs/bgp_vrf_neighbor_add_path.md
@@ -1,0 +1,31 @@
+# Per-VRF BGP neighbor AddPath send (RFC 7911)
+
+## Overview
+
+As an operator of an L3VPN PE with redundant CE uplinks
+I want `router bgp vrf <name> neighbor <addr> afi-safi ipv4 add-path
+send-receive` to advertise every VRF path for a prefix
+So that a CE that negotiated AddPath receives BOTH paths for a
+multi-homed prefix, not just the single best one — the per-VRF exercise
+of AddPath send / path-id stamping.
+CE1 (65001) and CE2 (65002) both advertise 10.10.10.0/24 into vrf-cust,
+so PE1's VRF Loc-RIB holds two candidate paths. With AddPath negotiated
+toward CE3, PE1 advertises both, so CE3 sees two paths — one via AS 65001
+and one via AS 65002. Without AddPath send CE3 would hold only the single
+best path (one AS_PATH).
+
+## Test Topology
+
+```
+   ce1(65001) ─┐
+   ce2(65002) ─┼─ pe1 (65000, vrf-cust) ── ce3(65003, AddPath rx)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the AddPath VRF topology | |
+| PE1's VRF Loc-RIB holds both candidate paths | |
+| The AddPath receiver sees both paths for the prefix | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_afi_policy.md
+++ b/bdd/docs/bgp_vrf_neighbor_afi_policy.md
@@ -1,0 +1,38 @@
+# Per-VRF BGP neighbor per-AFI policy and prefix-set filters
+
+## Overview
+
+As an operator of an L3VPN PE
+I want `router bgp vrf <name> neighbor <addr> afi-safi ipv4
+{policy|prefix-set} {in|out}` to filter CE routes
+So that inbound and outbound route policy works on a per-VRF CE
+neighbor exactly as it does on a global neighbor — through the
+per-VRF policy-actor plumbing (`bgp-vrf:<name>` proto,
+`peer_policy_ident`), not just at the global scope.
+One scenario per binding. CE1 advertises 10.0.1.1..5/32 into vrf-cust.
+PE1's inbound filters on the CE1 neighbor drop .2 (prefix-set-in, a
+permit-list omitting it) and .3 (policy-in). PE1 re-advertises the VRF
+Loc-RIB to CE2, where the outbound filters on the CE2 neighbor drop .4
+(prefix-set-out) and .5 (policy-out). .1 survives every filter and is
+the control.
+
+## Test Topology
+
+```
+   ce1 ────────── pe1 ────────── ce2
+   AS 65001    AS 65000        AS 65002
+   nets .1..5   vrf-cust        receiver
+        .2 ── .1        .1 ── .2
+       10.1.0.0/30    10.2.0.0/30
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the per-AFI policy VRF topology | |
+| prefix-set in drops a CE prefix before the VRF Loc-RIB | |
+| policy in denies a CE prefix into the VRF Loc-RIB | |
+| prefix-set out withholds a VRF route from a CE neighbor | |
+| policy out withholds a VRF route from a CE neighbor | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_as_path.md
+++ b/bdd/docs/bgp_vrf_neighbor_as_path.md
@@ -1,0 +1,30 @@
+# Per-VRF BGP neighbor AS-path knobs (allowas-in, as-override, remove-private-as)
+
+## Overview
+
+As an operator of an L3VPN PE
+I want the AS-path manipulation knobs under `router bgp vrf <name>
+neighbor <addr>` to take effect on the per-VRF CE session
+So that allowas-in, as-override, and remove-private-as behave on a CE
+neighbor exactly as on a global neighbor — applied on the per-VRF
+receive / advertise path, not silently dropped.
+One scenario per knob, each on its own CE neighbor:
+
+## Test Topology
+
+```
+   ce2 (65001)
+        \
+   ce1 ── pe1 (65000, vrf-cust) ── ce3 (65003)
+  (65001)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the AS-path VRF topology | |
+| allowas-in accepts a CE route carrying the PE's own AS | |
+| as-override rewrites the shared AS so CE2 accepts the route | |
+| remove-private-as strips the private AS toward CE3 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_auth.md
+++ b/bdd/docs/bgp_vrf_neighbor_auth.md
@@ -1,0 +1,34 @@
+# Per-VRF BGP neighbor authentication (TCP-MD5 password, TCP-AO key-chain)
+
+## Overview
+
+As an operator of an L3VPN PE
+I want `router bgp vrf <name> neighbor <addr> {password | tcp-ao}` to
+authenticate the per-VRF CE session
+So that a matching key establishes and a wrong key is actually rejected
+— proving the per-VRF neighbor keys the connect socket AND the VRF's own
+listener, not that auth is silently ignored.
+One matching + one mismatching CE per knob:
+The matching cases exercise both auth directions (PE-initiated dial via
+the VRF-bound connect socket AND CE-initiated dial via the VRF listener);
+the mismatching cases are the regression guard that a bad key can't slip
+through.
+
+## Test Topology
+
+```
+   ce1  ce2   ce3  ce4
+     \   |     |   /
+        pe1 (65000, vrf-cust)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the auth VRF topology | |
+| A matching TCP-MD5 password establishes the CE session | |
+| A mismatched TCP-MD5 password is rejected | |
+| A matching TCP-AO key-chain establishes the CE session | |
+| A mismatched TCP-AO key-string is rejected | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_enforce_first_as.md
+++ b/bdd/docs/bgp_vrf_neighbor_enforce_first_as.md
@@ -1,0 +1,25 @@
+# Per-VRF BGP neighbor enforce-first-as
+
+## Overview
+
+As an operator of an L3VPN PE
+I want `router bgp vrf <name> neighbor <addr> enforce-first-as` to drop a
+CE UPDATE whose left-most AS is not the CE's own AS
+So that the RFC 4271 first-AS check runs on the per-VRF CE receive path,
+exactly as on a global eBGP neighbor — not silently skipped.
+CE1 advertises two routes over one eBGP session:
+
+## Test Topology
+
+```
+   ce1 (65001) ── pe1 (65000, vrf-cust)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the enforce-first-as VRF topology | |
+| A valid first-AS route is accepted | |
+| enforce-first-as drops the foreign-first-AS route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_next_hop.md
+++ b/bdd/docs/bgp_vrf_neighbor_next_hop.md
@@ -1,0 +1,32 @@
+# Per-VRF BGP neighbor per-AFI next-hop knobs (next-hop-self, next-hop-unchanged)
+
+## Overview
+
+As an operator of an L3VPN PE
+I want `router bgp vrf <name> neighbor <addr> afi-safi ipv4
+{next-hop-self | next-hop-unchanged}` to take effect on the plain
+IPv4-unicast advertise toward a CE
+So that the per-neighbor next-hop policy works on a PE-CE session — the
+knobs used to be honored only on the VPNv4 / labeled-unicast paths and
+were silently ignored for plain unicast.
+CE1 advertises 10.0.1.1/32 with its own address 10.1.0.2 as the next-hop.
+PE1 re-advertises it from the VRF Loc-RIB to the other CEs:
+
+## Test Topology
+
+```
+   ce1(65001) ─┐
+   ce2(65002) ─┼─ pe1 (65000, vrf-cust)
+   ce3(65003) ─┤
+   ce4(65000) ─┘   (ce4 is iBGP)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the next-hop VRF topology | |
+| next-hop-unchanged preserves the received next-hop toward an eBGP CE | |
+| default eBGP advertisement rewrites the next-hop to self | |
+| next-hop-self forces self toward an iBGP CE | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_rr_client.md
+++ b/bdd/docs/bgp_vrf_neighbor_rr_client.md
@@ -1,0 +1,30 @@
+# Per-VRF BGP neighbor route-reflector client
+
+## Overview
+
+As an operator running iBGP CE peers inside a VRF
+I want `router bgp vrf <name> neighbor <addr> route-reflector client` to
+reflect iBGP-learned routes to that CE
+So that route reflection works on a per-VRF CE session exactly as on a
+global neighbor — an iBGP-learned route reaches a client but not a
+plain iBGP peer.
+All three CEs are iBGP (AS 65000, same as PE1). CE1 originates
+10.0.1.1/32. iBGP-learned routes are not re-advertised to another iBGP
+peer unless that peer is a route-reflector client:
+
+## Test Topology
+
+```
+   ce1(65000) ─┐
+   ce2(65000) ─┼─ pe1 (65000, vrf-cust, route reflector)
+   ce3(65000) ─┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the route-reflector VRF topology | |
+| A route-reflector client receives the reflected iBGP route | |
+| A plain iBGP peer does not receive the reflected route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_neighbor_show.md
+++ b/bdd/docs/bgp_vrf_neighbor_show.md
@@ -1,0 +1,39 @@
+# Per-VRF BGP neighbor config-echo in the neighbor detail show
+
+## Overview
+
+As an operator of an L3VPN PE
+I want the per-VRF neighbor session and per-AFI knobs to be reflected in
+`show bgp vrf <name> neighbor`
+So that description, timers, update-source, ebgp-multihop, ttl-security,
+add-path, and graceful-restart / long-lived-GR are staged and rendered
+for a per-VRF CE neighbor exactly as for a global neighbor.
+One scenario per knob, each asserting the neighbor detail renders the
+configured value. CE1 carries the session + per-AFI knobs (established so
+the negotiated capabilities show); CE2 carries ttl-security, which is
+mutually exclusive with CE1's ebgp-multihop (echoed regardless of session
+state).
+
+## Test Topology
+
+```
+   ce1(65001) ─┐
+               ├─ pe1 (65000, vrf-cust)
+   ce2(65002) ─┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the config-echo VRF topology | |
+| description is rendered | |
+| hold-time is rendered | |
+| idle-hold-time is rendered | |
+| update-source is rendered as the local host | |
+| ebgp-multihop is rendered | |
+| add-path capability is rendered | |
+| graceful-restart is negotiated with a restart time | |
+| long-lived-graceful-restart is rendered | |
+| ttl-security (GTSM) is rendered | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_ospf_redist.md
+++ b/bdd/docs/bgp_vrf_ospf_redist.md
@@ -1,0 +1,36 @@
+# BGP per-VRF redistribute OSPF to VPNv4
+
+## Overview
+
+As a network operator
+I want `router bgp vrf X afi-safi ipv4 redistribute ospf` to pull a
+VRF's OSPF-learned routes (installed by a per-VRF OSPF instance into
+the VRF table) into the per-VRF BGP table and export them to VPNv4 —
+so a PE advertises CE-learned IGP routes into the L3VPN.
+
+## Test Topology
+
+```
+   ce(OSPF) ── oc1 ── z1[vrf-blue: ospf + bgp] ── VPNv4 iBGP ── z2[vrf-blue]
+   lo 10.9.9.9/32     10.0.0.1/30 (vrf-blue)                    RD 65001:200
+   area 0             router ospf vrf vrf-blue                  RT 65001:100 imp
+                      redistribute ospf, RD 65001:100
+   10.0.0.2/30 ───────────── (veth) ──────────
+   192.168.0.1 ───────────── br0 ───────────── 192.168.0.2
+```
+
+## Config Files
+
+- ce.yaml: OSPF only; lo 10.9.9.9/32 + eth0 10.0.0.2/30 in area 0.
+- z1-1.yaml: vrf-blue (RD 65001:100, RT 65001:100), oc1 in the VRF
+- z2-1.yaml: vrf-blue (RD 65001:200, RT 65001:100 import), VPNv4 iBGP
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| z1 learns the CE's OSPF route in the VRF table | |
+| z1 redistributes the VRF OSPF route as VPNv4, not the connected link | |
+| z2 receives the redistributed OSPF prefix as VPNv4 under z1's RD | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_redistribute.md
+++ b/bdd/docs/bgp_vrf_redistribute.md
@@ -1,0 +1,35 @@
+# BGP per-VRF redistribute connected/static to VPNv4
+
+## Overview
+
+As a network operator
+I want `router bgp vrf X afi-safi ipv4 redistribute {connected,static}`
+to pull a VRF's connected and static routes into the per-VRF BGP table
+and export them to VPNv4 toward a remote PE — the IOS-XR L3VPN model,
+without a CE-facing routing protocol.
+
+## Test Topology
+
+```
+   h1(10.1.0.2) ── z1[vrf-blue]  ── VPNv4 iBGP ──  z2[vrf-blue]
+                   vc1 10.1.0.1/24                  RD 65001:200
+                   static 10.2.0.0/24               RT 65001:100 import
+                   RD 65001:100, RT 65001:100
+                   redistribute connected + static
+   192.168.0.1 ───────────── br0 ───────────── 192.168.0.2
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, vrf-blue (RD 65001:100, RT 65001:100), vc1 in
+- z2-1.yaml: AS 65001, vrf-blue (RD 65001:200, RT 65001:100 import).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| The VRF connected route lands in the VRF table (Phase 0 prereq) | |
+| z1 redistributes the VRF connected + static routes as VPNv4 | |
+| z2 receives the redistributed VRF prefixes as VPNv4 under z1's RD | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_runtime_neighbor.md
+++ b/bdd/docs/bgp_vrf_runtime_neighbor.md
@@ -1,0 +1,49 @@
+# Per-VRF BGP neighbors applied to a running VRF at runtime
+
+## Overview
+
+As an operator of an L3VPN PE
+I want to add, reconfigure, and remove a `router bgp vrf <name>`
+neighbor on a VRF that is already running
+So that a customer-edge change takes effect on the live task without
+respawning it — CE1 keeps its session while CE2 is added, given BFD,
+and removed.
+Regression guard for the incremental per-VRF neighbor path (PR #2087)
+and its two follow-ups: TCP-AO re-subscribe on reconfigure (#2094) and
+live BFD for runtime-added neighbors (#2095). Before #2087 a neighbor
+edit either did nothing until the next respawn or reset every session
+in the VRF; these scenarios prove the edit is surgical.
+The whole point is that CE1's session must NOT flap while CE2 is
+churned: `runtime_structure_eq` keeps a neighbor-only edit off the
+respawn path, so CE1 is the "still Established" witness. CE2's BFD
+session appearing in `show bfd peers` after enable and disappearing
+after the neighbor delete guards the `AddPeer` BFD subscribe and the
+`remove_peer` / `UnsubscribeClient` teardown (a leaked session would
+linger).
+
+## Test Topology
+
+```
+   ce1 ────────── pe1 ────────── ce2
+   AS 65001    AS 65000        AS 65002
+   lo          vrf-cust        lo
+   10.0.1.1/32 RD 65000:1      10.0.2.1/32
+        .2 ── .1        .1 ── .2
+       10.1.0.0/30    10.2.0.0/30
+```
+
+## Notes
+
+Both PE-CE interfaces are enslaved to vrf-cust from the start; only
+the BGP neighbor for CE2 is deferred and driven in at runtime with
+`vtyctl apply -c`.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the runtime-neighbor VRF topology | |
+| Adding a neighbor at runtime brings it up without disturbing CE1 | |
+| Enabling BFD on a live neighbor subscribes a session | |
+| Removing a neighbor at runtime tears down its session, route, and BFD | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_self_network.md
+++ b/bdd/docs/bgp_vrf_self_network.md
@@ -1,0 +1,42 @@
+# Per-VRF self-originated `network` reaches CE neighbors
+
+## Overview
+
+As an operator of an L3VPN PE
+I want a `network` under `router bgp vrf X afi-safi {ipv4,ipv6}` to be
+advertised to the VRF's CE (unicast) neighbors
+So that a PE can originate a prefix into a customer VRF without a
+static route + redistribute workaround.
+Regression guard for two bugs:
+1. Split-horizon collision — the self-originated Loc-RIB row carried
+2. Runtime edits were never advertised — `originate_self_network_*` /
+
+## Test Topology
+
+```
+   ce1 ───────────────── pe1
+   AS 65001            AS 65000
+   global              vrf-cust (RD 65000:1)
+                        network 10.9.0.0/24
+                        network 2001:db8:9::/64
+        .2 ── .1   (10.1.0.0/30)
+        ::2 ── ::1 (2001:db8:1::/64)
+```
+
+## Config Files
+
+- pe1.yaml: AS 65000, vrf-cust with ipv4 (10.1.0.2) + ipv6 (2001:db8:1::2)
+- ce1.yaml: AS 65001, global neighbors to the PE (ipv4 + ipv6).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the PE-CE dual-stack topology and establish sessions | |
+| CE receives the PE's self-originated ipv4 network (ident-0 peer) | |
+| CE receives the PE's self-originated ipv6 network | |
+| An ipv4 network added at runtime is advertised to the CE | |
+| Removing the runtime ipv4 network withdraws it from the CE | |
+| An ipv6 network added at runtime is advertised to the CE | |
+| Removing the runtime ipv6 network withdraws it from the CE | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_show.md
+++ b/bdd/docs/bgp_vrf_show.md
@@ -31,5 +31,5 @@ redirect into the spawned per-VRF task.
 | Setup topology | |
 | Configure vrf-blue and observe via show | |
 | Inspect vrf-blue via the `show bgp vrf` AFI forms | |
-| Remove the BGP VRF block and observe the RD clear | |
+| Remove the BGP VRF block and observe the VRF despawn | |
 | Teardown topology | |

--- a/bdd/docs/bgp_vrf_vpnv4_export.md
+++ b/bdd/docs/bgp_vrf_vpnv4_export.md
@@ -39,4 +39,6 @@ inside vrf-blue and z2 peers with z1 over VPNv4 only.
 | z1 advertises the self-originated network as VPNv4 | |
 | z2 receives the VPNv4 NLRI under the same RD | |
 | VPNv4 route detail by address and by exact prefix | |
+| Deleting the VRF withdraws its VPNv4 exports from the remote PE | |
+| Re-adding the VRF re-exports the network | |
 | Teardown topology | |

--- a/bdd/docs/bgp_vrf_vpnv6_export.md
+++ b/bdd/docs/bgp_vrf_vpnv6_export.md
@@ -17,5 +17,6 @@ Topology: z1 (RD 65001:100) <-VPNv6 iBGP-> z2 (RD 65001:200), both AS
 |----------|--------|
 | Setup topology (z1 originates its vrf-blue v6 networks at spawn) | |
 | z1 originates the vrf-blue v6 networks; z2 receives them as VPNv6 | |
+| Deleting the VRF withdraws its VPNv6 exports from the remote PE | |
 | z1 dies; z2 withdraws the VPNv6 routes it learned from it | |
 | Teardown topology | |

--- a/bdd/docs/cradle_spawn.md
+++ b/bdd/docs/cradle_spawn.md
@@ -1,0 +1,27 @@
+# system ebpf spawns and supervises the cradle eBPF engine
+
+## Overview
+
+`system ebpf enabled true` makes zebra-rs run the cradle data-plane
+daemon as a managed child: spawn it, attach `interface <name> ebpf
+enabled` ports, respawn it with backoff when it dies (re-attaching the
+ports and replaying the mirrored FIB tee), and stop it when disabled.
+Prerequisite: /usr/bin/cradle (the cradle-rs engine binary). Install it
+from a cradle-rs checkout: `cargo build --release` then
+`install -m755 target/release/cradle /usr/bin/cradle`.
+Topology:
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Managed engine spawns with a data-plane port | |
+| The engine's tables and counters render through show ebpf | |
+| A crashed engine respawns, re-attaches the port, and replays the FIB | |
+| A VRF-enslaved port binds to the VRF's kernel table | |
+| A bridge-enslaved port becomes an L2 port in the bridge's flood domain | |
+| Disabling system ebpf stops the engine | |
+| Enabling ebpf after routes exist resyncs them into the engine | |
+| Teardown topology | |

--- a/bdd/docs/cradle_srv6_replicate_zebra.md
+++ b/bdd/docs/cradle_srv6_replicate_zebra.md
@@ -1,0 +1,25 @@
+# zebra-rs operator replication-segment programs the cradle End.Replicate datapath (RFC 9524)
+
+## Overview
+
+An operator `segment-routing replication-segment` declares a local SRv6
+End.Replicate SID and its downstream branches. zebra-rs registers the SID —
+which tees into the managed cradle engine's SRV6_LOCALSID, so the XDP stage
+hands matching frames to the TC replication path — and tees the branch set to
+cradle's REPL_SEG (SetReplSeg). This is the control-plane half of RFC 9524
+SR-P2MP replication; the datapath fan-out itself is proven by the cradle-rs
+`cradle_srv6_replicate` BDD.
+Prerequisite: /usr/bin/cradle (the cradle-rs engine binary) with the
+SetReplSeg RPC. Install from a cradle-rs checkout: `cargo build --release`
+then `install -m755 target/release/cradle /usr/bin/cradle`.
+Topology:
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| A replication-segment registers an End.Replicate SID and tees its branches | |
+| Deleting the replication-segment withdraws the End.Replicate SID | |
+| Teardown topology | |

--- a/bdd/docs/isis_bfd_ipv4_lan.md
+++ b/bdd/docs/isis_bfd_ipv4_lan.md
@@ -39,3 +39,4 @@ is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
 | BFD without Echo protects the LAN adjacency and tears it down on BFD failure | |
 | BFD with Echo in one direction (z1 transmit, z2 receive) | |
 | BFD with Echo in both directions | |
+| Teardown topology | |

--- a/bdd/docs/isis_bfd_ipv4_p2p.md
+++ b/bdd/docs/isis_bfd_ipv4_p2p.md
@@ -33,4 +33,6 @@ is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
 | BFD without Echo protects the adjacency and tears it down on BFD failure | |
 | BFD with Echo in one direction (z1 transmit, z2 receive) | |
 | Echo transmit is toggled at runtime on the live session | |
+| BFD Echo auto-attaches eBPF without an explicit interface ebpf line | |
 | BFD with Echo in both directions | |
+| Teardown topology | |

--- a/bdd/docs/isis_bfd_ipv6_lan.md
+++ b/bdd/docs/isis_bfd_ipv6_lan.md
@@ -39,3 +39,4 @@ is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
 | BFD without Echo protects the LAN adjacency and tears it down on BFD failure | |
 | BFD with Echo in one direction (z1 transmit, z2 receive) | |
 | BFD with Echo in both directions | |
+| Teardown topology | |

--- a/bdd/docs/isis_bfd_ipv6_p2p.md
+++ b/bdd/docs/isis_bfd_ipv6_p2p.md
@@ -33,3 +33,4 @@ is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
 | BFD without Echo protects the adjacency and tears it down on BFD failure | |
 | BFD with Echo in one direction (z1 transmit, z2 receive) | |
 | BFD with Echo in both directions | |
+| Teardown topology | |

--- a/bdd/docs/isis_csnp_large_lsdb.md
+++ b/bdd/docs/isis_csnp_large_lsdb.md
@@ -1,0 +1,49 @@
+# IS-IS CSNP/PSNP with a large LSDB (>15 LSP entries)
+
+## Overview
+
+Regression for a TLV 9 (LSP Entries) length-byte overflow. The
+LspEntries TLV's Length field is a single octet and each entry is 16
+bytes, so at most 255 / 16 = 15 entries fit in one TLV. The CSNP and
+PSNP builders, however, sized a single TLV by the MTU budget
+(available_len / 16 ≈ 90 entries at a 1500-byte MTU) rather than by
+that 15-entry ceiling. Once an LSDB held 16 or more LSPs the length
+byte wrapped modulo 256 (16 entries -> 256 -> length 0) while every
+entry was still emitted, so the receiver mis-framed the CSNP/PSNP and
+the DIS-driven database synchronisation was corrupt on the wire. The
+fix caps each LspEntries TLV at MAX_ENTRIES (15); larger LSDBs simply
+span more CSNP/PSNP PDUs.
+This is hard to trigger with a router-per-LSP topology (16+ daemons),
+so instead z1 is given a tight lsp-mtu-size and ~600 IPv4 networks: its
+self-LSP fragments into ~15-20 LSP fragments, each a distinct LSP in
+the LSDB. On the broadcast LAN the elected DIS must therefore list well
+over 15 LSPs in its periodic CSNP. z3 is then brought up *after* z1 and
+z2 have converged, so it must learn the established multi-fragment LSDB
+through the DIS's CSNP (and PSNP requests) rather than from the initial
+flood — making the CSNP path load-bearing.
+
+## Test Topology
+
+```
+    z1 (10.255.0.1/32, ~600 nets, lsp-mtu 400)
+    z2 (10.255.0.2/32)   -- come up together, converge --
+    z3 (10.255.0.3/32)   -- joins late, syncs via the DIS CSNP --
+```
+
+## Notes
+
+Note: the deterministic byte-level regression for the length-byte wrap
+is the `isis-packet` unit test `lsp_entries_over_max_wraps_length_byte`
+/ `lsp_entries_at_max_round_trips_with_exact_length`. This feature is
+the live-daemon counterpart: it drives csnp_generate / the PSNP builder
+with a >15-entry LSDB and proves a late joiner fully synchronises.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup — z1 (fragmented) and z2 converge on the LAN | |
+| z1's self-LSP fragments into a large (>15-LSP) LSDB | |
+| z2 synchronises the whole LSDB, including z1's highest fragment | |
+| A late joiner learns the established large LSDB via the DIS CSNP | |
+| Teardown topology | |

--- a/bdd/docs/isis_endx_ipv6.md
+++ b/bdd/docs/isis_endx_ipv6.md
@@ -24,7 +24,7 @@ IPv6 on an already-Up adjacency starts advertising an End.X without a flap.
 
 x1 runs SRv6 with a classic locator, so it owns an End SID and would carve
 an End.X for each IPv6-capable adjacency. The x1–x2 IS-IS circuit starts
-IPv4-only (IS-IS `ipv4 enable` only), so x2 advertises no IPv6 and x1 must
+IPv4-only (IS-IS `ipv4 enabled` only), so x2 advertises no IPv6 and x1 must
 NOT allocate an End.X for it. A later scenario enables IPv6 on the circuit;
 x2 then advertises IPv6 and x1 allocates the End.X by re-evaluation.
 This also pins the `show segment-routing srv6 sid` column rename: the owner

--- a/bdd/docs/isis_interface_metric.md
+++ b/bdd/docs/isis_interface_metric.md
@@ -1,0 +1,46 @@
+# IS-IS connected-prefix reachability reflects the interface metric
+
+## Overview
+
+As a network operator
+I want the IS-IS interface `metric` to apply not only to the IS
+reachability (adjacency cost) but also to the IPv4 (TLV 135) and
+IPv6 (TLV 236) reachability advertised for that interface's connected
+prefixes, so a non-default interface metric raises the advertised cost
+of the attached subnets the same way FRR / IOS-XR do — rather than a
+fixed metric 10 regardless of configuration.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+        10.0.1.1/24        10.0.1.2/24
+     2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+   lo: 10.0.0.1/32          lo: 10.0.0.2/32
+   2001:db8:0:ffff::1/128   2001:db8:0:ffff::2/128
+```
+
+## Notes
+
+Both configs set `metric 55` on the vzXns interface (a non-default
+value; the default is 10). The connected prefixes 10.0.1.0/24 and
+2001:db8:1::/64 must therefore appear in the LSPs with Metric 55.
+The loopbacks leave `metric` unset, so they stay at the default 10 —
+a built-in contrast that proves the metric is applied per interface.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup dual-stack IS-IS L2 with a non-default interface metric | |
+| IPv4 connected prefix (TLV 135) carries the interface metric | |
+| IPv6 connected prefix (TLV 236) carries the interface metric | |
+| The loopback prefixes keep the default metric 10 | |
+| Teardown topology | |

--- a/bdd/docs/isis_lan_dis_pseudonode_purge.md
+++ b/bdd/docs/isis_lan_dis_pseudonode_purge.md
@@ -1,0 +1,33 @@
+# A resigning DIS purges the pseudonode LSP it originated
+
+## Overview
+
+Regression for a pseudonode-LSP leak on DIS resignation.
+On a broadcast LAN the Designated IS originates a pseudonode LSP. When it
+ceases to be DIS it must purge that LSP (ISO 10589 §7.3.4.6) rather than
+leave it to age out over MaxAge (~20 min). `dis_selection` does this via
+`ifsm::dis_dropping`, but a circuit going down never reached that path —
+`Isis::link_state_down` reset `adj` and `dis_status` directly, and
+`dis_dropping` is the only caller that emits `Message::LspPurge` for a
+pseudonode. So a DIS that lost its circuit left a zombie pseudonode LSP
+behind, in its own LSDB and in every other LSDB in the area.
+Forwarding survived it — SPF's two-way check discards a pseudonode the
+ex-DIS's own LSP no longer references — which is exactly why a
+reachability test cannot catch this. The assertion has to look at the
+LSDB.
+Three L2 routers (a1, a2, a3) share one broadcast LAN (br0). a1 holds LAN
+priority 200 (a2/a3 default 64) so a1 is deterministically DIS and owns
+the pseudonode. Dropping a1's circuit must purge it.
+Note this scenario asserts on a1's *own* LSDB. With a single circuit a1
+has nowhere to flood the purge once that circuit is down, so its peers
+necessarily age the LSP out — unavoidable, and true of any
+implementation. A router that still holds another circuit does flood the
+purge to the rest of the area; the originator-side invariant asserted
+here is what makes that possible.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| a DIS that loses its circuit purges its pseudonode LSP | |
+| Teardown topology | |

--- a/bdd/docs/isis_lan_dis_reelection.md
+++ b/bdd/docs/isis_lan_dis_reelection.md
@@ -1,0 +1,25 @@
+# IS-IS LAN DIS re-election converges when priority changes
+
+## Overview
+
+Regression for a DIS-election convergence bug on a broadcast LAN.
+Three L2 routers (a1, a2, a3) share one LAN (br0), loopbacks
+10.0.0.{1,2,3}/32. a3 starts as DIS (LAN priority 100; a1/a2 at the
+default 64). Raising a1's LAN priority to 200 must move the DIS to a1 on
+*every* speaker while full loopback reachability is preserved.
+The bug: a non-DIS bystander (a2) that switched its elected DIS from a3
+to a1 while staying a non-DIS member (DisStatus Other -> Other) never
+re-registered its pseudonode adjacency — the adjacency update was gated
+on a DIS *status* change, and Other -> Other is not one. a2 kept
+pointing at a3's old pseudonode LSP, which the resigning DIS a3 had
+purged, so a2's SPF routed through a pseudonode that no longer existed
+and it lost the route to a1's loopback. The decisive assertions are
+that after the DIS moves, a2's interface adjacency points at a1's
+pseudonode (0000.0000.0001.*) and a2 still reaches 10.0.0.1/32.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| raising a non-DIS router's priority moves the DIS and the LAN stays reachable | |
+| Teardown topology | |

--- a/bdd/docs/isis_lan_pseudonode.md
+++ b/bdd/docs/isis_lan_pseudonode.md
@@ -1,0 +1,23 @@
+# IS-IS DIS pseudonode LSP lists every LAN member
+
+## Overview
+
+Regression for a DIS pseudonode-LSP bug. On a broadcast LAN the
+Designated IS originates a pseudonode LSP whose TLV 22 must list every
+Up IS adjacency on the circuit (ISO 10589 §7.3.16). We previously
+(re)originated it only on a DIS *status* change, so a router that came
+up after DIS election — while the DIS stayed DIS — was never folded
+into the pseudonode's IS-reach list and was unreachable in every
+speaker's SPF.
+Three L2 routers (a1, a2, a3) share one broadcast LAN (br0), with
+loopbacks 10.0.0.{1,2,3}/32. Whichever wins DIS must list all three in
+its pseudonode LSP; the decisive assertion is that every router has an
+IS-IS route to every other loopback — including the last member to
+converge, which the bug dropped.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| every router on the LAN reaches every loopback | |
+| Teardown topology | |

--- a/bdd/docs/isis_multi_topology.md
+++ b/bdd/docs/isis_multi_topology.md
@@ -31,6 +31,12 @@ topologies.
 Both configs add `multi-topology ipv6-unicast;` under `router/isis/`
 so the LSPs carry TLV 229 (capability), TLV 222 (MT IS Reach), and
 TLV 237 (MT IPv6 Reach).
+Both vzXns interfaces set a base `metric 55` and a per-MT override
+`multi-topology ipv6-unicast metric 77`. Because IPv6 rides MT 2, the
+connected prefix 2001:db8:1::/64 must be advertised in TLV 237 with the
+per-MT metric 77 — not the base 55 and not a fixed 10. The loopback
+leaves both unset, so it falls all the way back to the default 10: a
+built-in check of the per-MT → base → default fallback chain.
 
 ## Test Scenarios
 
@@ -39,4 +45,6 @@ TLV 237 (MT IPv6 Reach).
 | Setup IS-IS L2 with MT 2 over a shared bridge and confirm the link is up | |
 | MT 2 SPF installs reciprocal IPv6 routes to peer loopbacks | |
 | LSPs carry the multi-topology TLVs | |
+| MT IPv6 Reachability carries the per-MT interface metric | |
+| MT metric falls back to the default for an interface without an override | |
 | Teardown topology | |

--- a/bdd/docs/isis_sr_dataplane_choice.md
+++ b/bdd/docs/isis_sr_dataplane_choice.md
@@ -1,0 +1,41 @@
+# IS-IS segment-routing mpls/srv6 are mutually exclusive (YANG choice)
+
+## Overview
+
+As a network operator
+I want `router isis segment-routing mpls` and `router isis
+segment-routing srv6` to be a YANG choice, so committing one
+dataplane implicitly deletes the other (RFC 7950 §7.9.3) — a single
+`set router isis segment-routing srv6 locator LOC1` migrates a
+running SR-MPLS node to SRv6 without a separate `delete`, and the
+implicit delete tears the old dataplane's forwarding state down
+exactly as an explicit one would.
+z1 and z2 run dual-stack IS-IS L2 over one point-to-point link, both
+starting on SR-MPLS (Prefix-SID indexes 100/200 -> labels
+16100/16200 against the default SRGB base 16000). z1 additionally
+pre-provisions the global SRv6 locator LOC1 (fcbb:bbbb:1::/48)
+without binding it to IS-IS. The feature flips z1's dataplane to
+SRv6 and back with one `set` each way and checks three layers every
+time:
+- config: `show running-config formal` holds exactly one dataplane
+- local forwarding: the MPLS ILM empties and the locator's End SID
+- the peer: z2 stays on SR-MPLS throughout, and label 16100 leaves
+
+## Test Topology
+
+```
+   z1 ──────────────── z2
+   10.0.12.1/24        10.0.12.2/24
+   2001:db8:0:12::1/64 2001:db8:0:12::2/64
+   lo 10.0.0.1, 2001:db8::1, SID 100, LOC1 fcbb:bbbb:1::/48 (unbound)
+   lo 10.0.0.2, 2001:db8::2, SID 200 (SR-MPLS for the whole feature)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the dual-stack SR-MPLS topology | |
+| Setting srv6 implicitly deletes mpls and swaps the dataplane | |
+| Setting mpls implicitly deletes srv6 and restores the labels | |
+| Teardown topology | |

--- a/bdd/docs/isis_sr_switchover.md
+++ b/bdd/docs/isis_sr_switchover.md
@@ -1,0 +1,43 @@
+# Live switchover IS-IS SR-MPLS -> SRv6 (classic) -> SRv6 uSID -> SR-MPLS via vtyctl apply
+
+## Overview
+
+As a network operator
+I want to migrate a running IS-IS Segment Routing network between
+dataplanes by applying each node's ENTIRE configuration with
+`vtyctl apply -f` (the BDD `I apply config` step — a declarative
+whole-config replace: everything the new file omits is deleted), so
+an SR-MPLS domain can be moved to SRv6 classic SIDs, compressed to
+NEXT-C-SID micro-SIDs, and rolled back to SR-MPLS, with each
+transition tearing down the previous dataplane completely and
+bringing up the next one end to end.
+The per-node configurations are the playset trios (playset/
+isis-srmpls, isis-srv6-classic, isis-srv6-usid) on the RFC 9855
+topology: 8 core routers in IS-IS level-2-only. The three phases
+observably differ on node s:
+- SR-MPLS: v4 addressing; remote loopbacks carry Prefix-SID labels
+- SRv6 classic: v6 addressing; locators fcbb:bbbb:X::/48 are plain
+- SRv6 uSID: identical except `behavior: usid` on every locator —
+e1 (behind s) and e2 (behind d) are plain dual-stack host
+namespaces (no routing daemon) provisioned once with both edge
+addressings and default routes; whichever edge family the routers
+currently serve decides which of their pings forwards, so
+edge-to-edge reachability doubles as the phase's end-to-end proof
+and the retired family's ping must go dark.
+Test Topology (playset/isis-srmpls; metric shown where != 1;
+loopbacks 10.0.0.X / 2001:db8::X, Prefix-SID index X00, locators
+fcbb:bbbb:X::/48):
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology, dual-stack edge hosts, and the SR-MPLS baseline | |
+| SR-MPLS phase forwards labeled traffic end to end | |
+| Switch over to SRv6 classic — whole-config replace swaps the dataplane | |
+| The BGP SRv6 service layer carries the edge LANs after the switchover | |
+| Switch over to SRv6 uSID — locators recompress, the service layer never flaps | |
+| Roll back to SR-MPLS — labels return, SRv6 and BGP are torn down | |
+| Teardown topology | |

--- a/bdd/docs/isis_srmpls.md
+++ b/bdd/docs/isis_srmpls.md
@@ -1,0 +1,59 @@
+# IS-IS SR-MPLS static-route recursive nexthop tracking with TI-LFA
+
+## Overview
+
+As a network operator
+I want a static route whose nexthop is a remote loopback (s:
+172.168.1.0/24 via 10.0.0.8) to resolve recursively through the
+IS-IS SR-MPLS route to that loopback — inheriting its transport
+label stack — and to follow the underlay whenever IS-IS changes the
+installed path, including a TI-LFA `backup-as-primary` promotion
+that swaps the active nexthop of the covering `Protect` route.
+End hosts e1 (behind s) and e2 (behind d) carry only static default
+routes; an e1 -> e2 ping traverses the SR-MPLS core end-to-end and
+dies if any label hop fails to push/swap/pop, so it pins every
+static-resolution assertion to real forwarding.
+All links are point-to-point veth pairs; every core router is
+is-type level-2-only with `segment-routing mpls`. Prefix-SIDs index
+100..800 resolve against the RIB's default SRGB (base 16000): s's
+node SID is label 16100, n1's 16200, r1's 16500, d's 16800.
+`fast-reroute ti-lfa` is deliberately NOT in the startup configs —
+it is enabled at runtime mid-feature.
+The metrics are tuned so a plain loop-free alternate for the s-n1
+link is impossible: n2's shortest path to d (n2-r1-n1-d, cost 3)
+ties n2-s-n1-d, so protecting s-n1 needs an SR repair tunnel — P
+node r1 (node SID 16500) followed by adjacency SIDs r1->n1 and
+n1->d. Adjacency-SID values come from a first-fit SRLB pool (base
+15000) keyed on Hello arrival order, so scenarios assert only the
+deterministic node-SID labels, never adjacency-SID digits.
+
+## Test Topology
+
+```
+   e1 --- s (10.0.0.1)
+       1 / 1 \      \ 1000
+        n1    n2     n3
+    1 / |1 \1  \1     \1000
+ d ─┘ 1 |   \    \      \
+(10.0.0.8)   \1000\      \
+    1 \ |     r1───────── (r1-n3 1000)
+       r2    /  \1000
+    1000\   /1   \(r1-r2 1000)
+         r2 ──────┘
+           \1000
+            r3 (r3-d 1)   d --- e2
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SR-MPLS topology with e1/e2 hosts and confirm adjacencies | |
+| Static route resolves recursively through the SR-MPLS underlay | |
+| Runtime TI-LFA enable computes a repair without moving the static | |
+| backup-as-primary promotes the repair to the active route | |
+| Static nexthop tracking follows the promoted repair | |
+| Reverting backup-as-primary moves the static back | |
+| Teardown topology | |

--- a/bdd/docs/isis_srv6_endt.md
+++ b/bdd/docs/isis_srv6_endt.md
@@ -1,0 +1,28 @@
+# IS-IS advertises End.T / uT for VRF-bound SRv6 locators
+
+## Overview
+
+As a network operator
+I want a locator bound to a VRF (`vrf` leaf) to advertise its node
+SID as End.T — or uT for a uSID locator — so receivers know the End
+walk's egress lookup happens in the bound table (RFC 8986 §4.3).
+z1's classic locator carries `vrf: vrf-one` and `flavor: [psp]`: its
+End SID must advertise as `End.T (PSP)` (IANA codepoint 10). z2's
+uSID locator carries `vrf: vrf-two`: its node SID advertises as `uT`
+(End.T with NEXT-CSID, codepoint 85). The adjacency SIDs stay
+End.X/uA, and SPF/reachability must be unaffected.
+
+## Test Topology
+
+```
+   z1 ──2001:db8:0:12::/64── z2
+   LOC1 fcbb:bbbb:1::/48      LOC2 fcbb:bbbb:2::/48
+   classic + vrf-one + psp    usid + vrf-two
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| The table-scoped codepoints appear in the peer's database | |
+| Teardown topology | |

--- a/bdd/docs/isis_srv6_flavor.md
+++ b/bdd/docs/isis_srv6_flavor.md
@@ -1,0 +1,30 @@
+# IS-IS advertises PSP-flavored SRv6 endpoint behaviors
+
+## Overview
+
+As a network operator
+I want a locator's configured RFC 8986 §4.16 flavors folded into the
+advertised endpoint-behavior codepoints, so receivers know the SRH
+will be popped at this node and the data planes agree on the wire
+format.
+z1's uSID locator carries `flavor: [psp]`: its End SID must advertise
+as `uN (PSP)` (IANA codepoint 44, End with NEXT-CSID & PSP) and its
+End.X SID as `uA (PSP)` (53) — adjacency SIDs fold only the PSP bit.
+z2 is flavorless and must (a) keep advertising plain `uN`/`uA` and
+(b) still classify z1's flavored codepoints as NEXT-C-SID, so the
+adjacency and SPF are unaffected.
+
+## Test Topology
+
+```
+   z1 ──2001:db8:0:12::/64── z2
+   LOC1 fcbb:bbbb:1::/48      LOC2 fcbb:bbbb:2::/48
+   usid + flavor [psp]        usid (no flavor)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| The flavored codepoints appear in the peer's database | |
+| Teardown topology | |

--- a/bdd/docs/isis_srv6_replace.md
+++ b/bdd/docs/isis_srv6_replace.md
@@ -1,0 +1,33 @@
+# IS-IS advertises REPLACE-C-SID SRv6 endpoint behaviors
+
+## Overview
+
+As a network operator
+I want a locator's RFC 9800 REPLACE-C-SID format reflected in the
+advertised endpoint-behavior codepoints and SID structure, so SR
+source nodes can compress segment lists with 32-bit C-SIDs and the
+data planes agree on the wire format.
+z1's locator carries `behavior: replace` and `flavor: [psp, usd]`:
+its End SID must advertise as `End (REP, PSP, USD)` (IANA codepoint
+129, End with REPLACE-CSID, PSP & USD) and its End.X SID as
+`End.X (REP, PSP)` (106) — adjacency SIDs fold only the PSP bit.
+The advertised structure is LB 48 / LN 16 / Fun 16 / Arg 48 — the
+non-zero argument length is how receivers infer 32-bit compression
+(RFC 9800 §6.4). z2 is a plain uSID locator and must keep
+advertising `uN`/`uA`, and the adjacency and SPF must be unaffected
+by the REPLACE codepoints.
+
+## Test Topology
+
+```
+   z1 ──2001:db8:0:12::/64── z2
+   LOC1 fcbb:bbbb:1:1::/64    LOC2 fcbb:bbbb:2::/48
+   replace + psp,usd          usid (no flavor)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| The REPLACE-C-SID codepoints appear in the peer's database | |
+| Teardown topology | |

--- a/bdd/docs/isis_topology_output.md
+++ b/bdd/docs/isis_topology_output.md
@@ -1,0 +1,15 @@
+# show isis topology renders the FRR SPF-tree layout
+
+## Overview
+
+`show isis topology` lists the SPF tree as FRR does: every router,
+pseudonode, and prefix is a vertex, ordered by SPF metric. Three L2
+routers (a1, a2, a3) share one LAN (br0); a3 (LAN priority 100) is the
+DIS. The layout must show:
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| the SPF tree lists self-prefixes, the pseudonode, and remote prefixes | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_bgp_v4.md
+++ b/bdd/docs/l3vpn_bgp_v4.md
@@ -1,0 +1,42 @@
+# MPLS/VPN L3VPN (IPv4) with BGP PE-CE and a customer site
+
+## Overview
+
+As a service provider running RFC 4364 L3VPN over SR-MPLS
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the
+customer edge runs eBGP to the PE and the customer site originates a
+loopback, so that C1 and C2 can reach each other's loopback across the
+MPLS/VPN core (VPNv4 over an SR-MPLS LSP through the P transit).
+
+## Test Topology
+
+```
+   c1 --- ce1 --- pe1 --- p --- pe2 --- ce2 --- c2
+   lo      |       lo     lo     lo      |       lo
+  10.0.1.1 |    1.1.1.1 1.1.1.2 1.1.1.3  |    10.0.2.1
+           |    (sid 1) (sid 2) (sid 3)  |
+   AS65101 \_AS65001_/  vrf-cust  \_AS65002_/  AS65102
+```
+
+## Notes
+
+- Core (pe1-p-pe2): IS-IS L2 + segment-routing mpls; loopback
+  Prefix-SIDs build the PE-PE transport LSP (SRGB 16000), P is the
+  transit LSR. pe1<->pe2 iBGP carries VPNv4 over loopbacks.
+- PE-CE (ce<->pe, inside vrf-cust): eBGP; CE-learned routes export to
+  VPNv4 (RD 65000:1 / 65000:2, RT 65000:100).
+- C-CE (c<->ce): eBGP; C redistributes its loopback (connected) into
+  BGP and CE re-advertises it to the PE.
+- The C1<->C2 loopback ping exercises C-CE eBGP + PE-CE eBGP + VPNv4
+  over the SR-MPLS core.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L3VPN topology and bring up every session | |
+| SR-MPLS transport LSPs are installed on the core P router | |
+| PE-PE VPNv4 and C-CE eBGP sessions are Established | |
+| Customer loopbacks are exchanged as VPNv4 between the PEs | |
+| End-to-end customer loopback reachability across the MPLS/VPN core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_bgp_v6.md
+++ b/bdd/docs/l3vpn_bgp_v6.md
@@ -1,0 +1,45 @@
+# SRv6 L3VPN (IPv6) with BGP PE-CE and a customer site
+
+## Overview
+
+As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE, so
+IPv6 customer VPN traffic rides SRv6 End.DT46 rather than MPLS)
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the
+customer edge runs IPv6 eBGP to the PE and the customer site originates
+an IPv6 loopback, so that C1 and C2 can reach each other's loopback
+across the SRv6 VPNv6 core.
+
+## Test Topology
+
+```
+   c1 --- ce1 --- pe1 --- p --- pe2 --- ce2 --- c2
+   lo      |       lo     lo     lo      |       lo
+  c1::1    |    db8::1  db8::2 db8::3    |     c2::1
+           |   LOC1 fcbb:bbbb:1::/48     |
+           |        LOC2 fcbb:bbbb:2::/48|
+   AS65101 \_AS65001_/  vrf-cust  \_AS65002_/  AS65102
+```
+
+## Notes
+
+- Core (pe1-p-pe2): IS-IS L2 SRv6; PE loopbacks + locators are reached
+  natively over IPv6 through the P transit. pe1<->pe2 iBGP carries
+  VPNv6 over v6 loopbacks; the per-VRF End.DT46 SID (from each PE's
+  locator) is the service SID.
+- PE-CE (ce<->pe, inside vrf-cust, encapsulation srv6): IPv6 eBGP;
+  CE-learned routes export to VPNv6. Exercises the per-VRF neighbor
+  `afi-safi ipv6 enabled` knob.
+- C-CE (c<->ce): IPv6 eBGP; C redistributes its loopback (connected)
+  into BGP and CE re-advertises it to the PE.
+- The C1<->C2 IPv6 loopback ping exercises C-CE eBGP + PE-CE eBGP +
+  VPNv6 over the SRv6 core (z2 H.Encaps toward z1's End.DT46, z1 decaps).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 L3VPN topology and bring up every session | |
+| PE-PE VPNv6 and C-CE eBGP sessions are Established | |
+| Customer loopbacks are exchanged as VPNv6 between the PEs | |
+| End-to-end customer loopback reachability across the SRv6 core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_dual_ce.md
+++ b/bdd/docs/l3vpn_dual_ce.md
@@ -1,0 +1,53 @@
+# Two BGP CE neighbors under a single VRF
+
+## Overview
+
+As a service provider attaching more than one customer edge to the
+same VRF on a PE
+I want every neighbor under `router bgp vrf <name>` to establish and
+carry routes, not just the first one
+So that a multi-CE VRF converges instead of silently wedging one
+session in Idle.
+Regression guard for issue #2077 / PR #2071. `materialize_peers`
+used to call `Peer::start()` *before* `PeerMap::insert_with_key`
+assigned the peer's stable ident. `start_timer!` captures
+`peer.ident` by value when it arms the idle-hold timer, and the
+per-VRF loop dispatches `Message::Event(ident, …)` purely on that
+value, so every peer past the first armed its timer under ident 0
+and its `Event::Start` was delivered to the *first* peer instead.
+The wedged peer stays in Idle, which blocks the session from both
+directions: it never dials, and `handle_peer_connection` drops
+inbound streams for an Idle peer, so the CE's own dial is refused
+too. Before the fix CE2 below never leaves Idle.
+Every pre-existing BDD config puts at most one neighbor under a
+`router bgp vrf` block (106 such blocks, zero with two), which is
+why nothing caught this. The second neighbor is the entire point of
+this topology.
+
+## Test Topology
+
+```
+   ce1 ────────── pe1 ────────── ce2
+   AS 65001    AS 65000        AS 65002
+   lo          vrf-cust        lo
+   10.0.1.1/32 RD 65000:1      10.0.2.1/32
+        .2 ── .1        .1 ── .2
+       10.1.0.0/30    10.2.0.0/30
+```
+
+## Notes
+
+Both PE-CE sessions are eBGP and both live inside vrf-cust. There is
+no VPNv4 core: PE1 re-advertises each CE's prefixes to the other CE
+out of the same VRF Loc-RIB, so the CE-to-CE ping proves both
+sessions carry routes rather than merely reaching Established.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the dual-CE VRF topology | |
+| Both PE-CE sessions in the VRF reach Established | |
+| The VRF Loc-RIB holds both CE's prefixes | |
+| CE-to-CE reachability across the shared VRF | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_isis_bgppe_v4.md
+++ b/bdd/docs/l3vpn_isis_bgppe_v4.md
@@ -1,0 +1,18 @@
+# MPLS/VPN L3VPN (IPv4) with IS-IS C-CE and BGP PE-CE
+
+## Overview
+
+Second L3VPN PE-CE variant: the customer runs IS-IS to the CE, the
+CE-PE link is eBGP, and the CE bridges them with mutual redistribution
+(IS-IS<->BGP). The PE is a plain BGP PE-CE edge (like @l3vpn_bgp_v4).
+C1 and C2 reach each other's loopback across the MPLS/VPN core.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv4 (CE IS-IS->eBGP, up direction) | |
+| Remote customer loopbacks reach the customer site (CE eBGP->IS-IS, down direction) | |
+| End-to-end customer loopback reachability across the MPLS/VPN core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_isis_bgppe_v6.md
+++ b/bdd/docs/l3vpn_isis_bgppe_v6.md
@@ -1,0 +1,18 @@
+# SRv6 L3VPN (IPv6) with IS-IS C-CE and BGP PE-CE
+
+## Overview
+
+Second L3VPN PE-CE variant over SRv6: the customer runs IS-IS (IPv6) to
+the CE, the CE-PE link is IPv6 eBGP, and the CE bridges them with
+mutual redistribution (IS-IS<->BGP). The PE is a plain BGP PE-CE edge
+(like @l3vpn_bgp_v6). C1 and C2 reach each other's IPv6 loopback across
+the SRv6 core.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv6 (CE IS-IS->eBGP, up direction) | |
+| End-to-end customer loopback reachability across the SRv6 core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_isis_v4.md
+++ b/bdd/docs/l3vpn_isis_v4.md
@@ -1,0 +1,25 @@
+# MPLS/VPN L3VPN (IPv4) with IS-IS PE-CE both segments
+
+## Overview
+
+As a service provider running RFC 4364 L3VPN over SR-MPLS
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+C-CE and PE-CE segments run IS-IS and the PE does two-way
+redistribution (IS-IS<->VPNv4), so that C1 and C2 can reach each
+other's loopback across the MPLS/VPN core.
+The PE runs two IS-IS instances: the GLOBAL core (IS-IS L2 + SR-MPLS)
+and a per-VRF IS-IS (vrf-cust) toward the CE. Up: `router bgp vrf ...
+redistribute isis` -> VPNv4. Down: `router isis vrf ... redistribute
+bgp` -> the VPNv4 routes imported into the VRF are injected into the
+CE-facing IS-IS (IS-IS already supports redistribute bgp; only the
+per-VRF redist subscription proto needed fixing).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv4 (IS-IS -> BGP, up direction) | |
+| Remote customer loopbacks reach the customer site (BGP -> IS-IS, down direction) | |
+| End-to-end customer loopback reachability across the MPLS/VPN core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_isis_v6.md
+++ b/bdd/docs/l3vpn_isis_v6.md
@@ -1,0 +1,22 @@
+# SRv6 L3VPN (IPv6) with IS-IS PE-CE both segments
+
+## Overview
+
+As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE)
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+C-CE and PE-CE segments run IS-IS (IPv6) and the PE does two-way
+redistribution (IS-IS<->VPNv6 over SRv6 End.DT46), so that C1 and C2
+can reach each other's IPv6 loopback across the SRv6 core.
+The PE runs the global IS-IS SRv6 core plus a per-VRF IS-IS (IPv6) to
+the CE. Up: `router bgp vrf ... redistribute isis` -> VPNv6. Down:
+`router isis vrf ... afi-safi ipv6 redistribute bgp` -> the VPNv6
+routes imported into the VRF are injected into the CE-facing IS-IS.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv6 (IS-IS -> BGP, up direction) | |
+| End-to-end customer loopback reachability across the SRv6 core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_ospf_bgppe_v4.md
+++ b/bdd/docs/l3vpn_ospf_bgppe_v4.md
@@ -1,0 +1,22 @@
+# MPLS/VPN L3VPN (IPv4) with OSPFv2 C-CE and BGP PE-CE
+
+## Overview
+
+Second L3VPN PE-CE variant: the customer runs OSPFv2 to the CE, but the
+CE-PE link is eBGP (not OSPF). The CE bridges the two with mutual
+redistribution (OSPF<->BGP); the PE is a plain BGP PE-CE edge. So C1
+and C2 reach each other's loopback across the MPLS/VPN core.
+vs @l3vpn_ospf_v4 (OSPF on both segments): here the PE has no VRF OSPF
+— it runs an eBGP PE-CE session into vrf-cust like @l3vpn_bgp_v4, and
+the CE does `redistribute ospf`->BGP (up) and `redistribute bgp`->OSPF
+(down).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv4 (CE OSPF->eBGP, up direction) | |
+| Remote customer loopbacks reach the customer site (CE eBGP->OSPF, down direction) | |
+| End-to-end customer loopback reachability across the MPLS/VPN core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_ospf_bgppe_v6.md
+++ b/bdd/docs/l3vpn_ospf_bgppe_v6.md
@@ -1,0 +1,19 @@
+# SRv6 L3VPN (IPv6) with OSPFv3 C-CE and BGP PE-CE
+
+## Overview
+
+Second L3VPN PE-CE variant over SRv6: the customer runs OSPFv3 to the
+CE, the CE-PE link is IPv6 eBGP, and the CE bridges them with mutual
+redistribution (OSPFv3<->BGP). The PE is a plain BGP PE-CE edge like the
+l3vpn_bgp_v6 feature. C1 and C2 reach each other's IPv6 loopback across
+the SRv6 core. Exercises the relayed-SRv6-SID strip on the PE->CE eBGP
+advertisement (the CE is non-SRv6).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv6 (CE OSPFv3->eBGP, up direction) | |
+| End-to-end customer loopback reachability across the SRv6 core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_ospf_v4.md
+++ b/bdd/docs/l3vpn_ospf_v4.md
@@ -1,0 +1,23 @@
+# MPLS/VPN L3VPN (IPv4) with OSPFv2 PE-CE both segments
+
+## Overview
+
+As a service provider running RFC 4364 L3VPN over SR-MPLS
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+C-CE and PE-CE segments run OSPFv2 and the PE does two-way
+redistribution (OSPF<->VPNv4), so that C1 and C2 can reach each other's
+loopback across the MPLS/VPN core.
+Same core as @l3vpn_bgp_v4 (IS-IS L2 + SR-MPLS, iBGP VPNv4). The
+customer side runs OSPFv2 in area 0 (C-CE and CE-PE). The PE:
+- `router bgp vrf ... redistribute ospf` carries the customer routes
+- `router ospf vrf ... redistribute bgp` injects the VPNv4 routes
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv4 (OSPF -> BGP, up direction) | |
+| Remote customer loopbacks reach the customer site (BGP -> OSPF, down direction) | |
+| End-to-end customer loopback reachability across the MPLS/VPN core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_ospf_v6.md
+++ b/bdd/docs/l3vpn_ospf_v6.md
@@ -1,0 +1,25 @@
+# SRv6 L3VPN (IPv6) with OSPFv3 PE-CE both segments
+
+## Overview
+
+As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE)
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+C-CE and PE-CE segments run OSPFv3 and the PE does two-way
+redistribution (OSPFv3<->VPNv6 over SRv6 End.DT46), so that C1 and C2
+can reach each other's IPv6 loopback across the SRv6 core.
+The PE runs the global IS-IS SRv6 core plus a per-VRF OSPFv3 to the CE.
+Up: `router bgp vrf ... redistribute ospf` -> VPNv6. Down: `router
+ospfv3 vrf ... redistribute bgp` -> the VPNv6 routes imported into the
+VRF are injected into the CE-facing OSPFv3 as AS-External (Type-5)
+LSAs (the net-new OSPFv3 feature added for this). The customer
+loopbacks are advertised intra-area (OSPFv3 has no instance-level
+redistribute-connected).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 L3VPN topology and bring up the core | |
+| Customer routes are carried as VPNv6 (OSPFv3 -> BGP, up direction) | |
+| End-to-end customer loopback reachability across the SRv6 core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_static_v4.md
+++ b/bdd/docs/l3vpn_static_v4.md
@@ -1,0 +1,35 @@
+# MPLS/VPN L3VPN (IPv4) with static PE-CE and a customer site
+
+## Overview
+
+As a service provider running RFC 4364 L3VPN over SR-MPLS
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the PE-CE
+and C-CE segments are statically routed and the PE redistributes the
+customer static route into VPNv4, so that C1 and C2 can reach each
+other's loopback across the MPLS/VPN core.
+Test Topology (7 namespaces) — same core as @l3vpn_bgp_v4; the customer
+side is static instead of eBGP:
+```
+10.0.1.1 |    1.1.1.1 1.1.1.2 1.1.1.3  |    10.0.2.1
+```
+- Core (pe1-p-pe2): IS-IS L2 + segment-routing mpls; iBGP VPNv4.
+- PE-CE: PE holds a per-VRF static route to the customer loopback via
+
+## Notes
+
+- Core (pe1-p-pe2): IS-IS L2 + segment-routing mpls; iBGP VPNv4.
+- PE-CE: PE holds a per-VRF static route to the customer loopback via
+  the CE and `redistribute static` into VPNv4. The CE has a static
+  route to the customer loopback and a default toward the PE; the
+  customer has a default toward the CE. Down-direction traffic rides
+  the CE/customer default routes.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L3VPN topology and bring up the core | |
+| SR-MPLS transport LSPs are installed on the core P router | |
+| PE-PE VPNv4 session is Established and carries the customer loopbacks | |
+| End-to-end customer loopback reachability across the MPLS/VPN core | |
+| Teardown topology | |

--- a/bdd/docs/l3vpn_static_v6.md
+++ b/bdd/docs/l3vpn_static_v6.md
@@ -1,0 +1,22 @@
+# SRv6 L3VPN (IPv6) with static PE-CE and a customer site
+
+## Overview
+
+As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE)
+I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the PE-CE
+and C-CE segments are statically routed and the PE redistributes the
+customer static route into VPNv6 (End.DT46), so that C1 and C2 can
+reach each other's IPv6 loopback across the SRv6 core.
+Same core as @l3vpn_bgp_v6 (IS-IS L2 SRv6, iBGP VPNv6); the customer
+side is static instead of eBGP. The PE holds per-VRF static routes to
+the customer loopback + C-CE link via the CE and `redistribute static`;
+the CE/customer use default routes for the down direction.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 L3VPN topology and bring up the core | |
+| PE-PE VPNv6 session is Established and carries the customer loopbacks | |
+| End-to-end customer loopback reachability across the SRv6 core | |
+| Teardown topology | |

--- a/bdd/docs/mpls_ttl_propagate_local.md
+++ b/bdd/docs/mpls_ttl_propagate_local.md
@@ -1,0 +1,26 @@
+# MPLS TTL propagate-local — the RFC 3443 forwarded/local split (kernel half)
+
+## Overview
+
+As an operator running MPLS with the RFC 3443 TTL model
+I want to choose the label-TTL model for the router's OWN (locally
+originated) traffic independently of forwarded/transit traffic
+So that I can hide the LSP core from customer traceroutes (forwarded
+`pipe`) while still seeing every P router from the PE itself (local
+`uniform`) — the IOS `mpls ip propagate-ttl [forwarded | local]` split.
+Forwarded traffic is imposed by the cradle eBPF data plane (governed by
+`mpls ttl propagate`). Locally-originated traffic is imposed by the host
+kernel's own MPLS stack (the lwtunnel encap routes zebra installs), so the
+local half is the global `net.mpls.ip_ttl_propagate` sysctl. This feature
+validates that config surface end to end in a running daemon: the YANG
+parses, the callback drives the sysctl, and a live change / delete tracks
+it. `net.mpls.ip_ttl_propagate`: 1 = uniform (propagate), 0 = pipe (hide).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| propagate-local pipe seeds the kernel MPLS TTL sysctl to 0 | |
+| Flipping to uniform live restores propagation (sysctl 1) | |
+| Deleting the leaf restores the uniform default (sysctl 1) | |
+| Teardown topology | |

--- a/bdd/docs/ospf_clear_neighbor.md
+++ b/bdd/docs/ospf_clear_neighbor.md
@@ -27,3 +27,4 @@ been a no-op the up-time would keep climbing past the wait budget.
 | Scenario | Result |
 |----------|--------|
 | clear ospf neighbor destroys and re-forms the adjacency | |
+| Teardown topology | |

--- a/bdd/docs/ospf_router_id_change.md
+++ b/bdd/docs/ospf_router_id_change.md
@@ -1,0 +1,47 @@
+# OSPFv2 Router-ID set / change / delete on a live adjacency
+
+## Overview
+
+As a network operator
+I want zebra-rs to react correctly when an OSPFv2 instance's Router-ID is
+set, changed, or deleted while an adjacency is already up, so the peer
+re-learns the new identity, the database advertised under the old identity
+is withdrawn, and forwarding keeps working.
+Two routers on a point-to-point link, each advertising a loopback that is
+numerically distinct from any Router-ID, so a Router-ID only ever appears
+in the database as an *advertising router* (never as a stub prefix). That
+makes "the old Router-ID is gone" a clean, unambiguous assertion.
+
+## Test Topology
+
+```
+    r1 --- 10.0.12.0/30 (point-to-point, area 0.0.0.0) --- r2
+       eth1                                            eth2
+    loopbacks: 192.168.11.1/32 (r1)        192.168.22.1/32 (r2)
+    Router-IDs: r1 starts 1.1.1.1, r2 fixed 2.2.2.2
+```
+
+## Notes
+
+The bugs this guards against:
+* Every daemon boots with the constructor default Router-ID (10.0.0.1) and
+  only adopts the configured value once config is applied. The LSA
+  originated under the default was never withdrawn, so it lingered (and was
+  even kept refreshed) as a phantom node — two routers booting as 10.0.0.1
+  fought a sequence-number war and SPF failed to install transit routes,
+  so even a fresh bring-up could leave loopbacks unreachable.
+* OSPFv2 keys a neighbour by its source address and only recorded the
+  peer's Router-ID at neighbour creation. A peer that changed its Router-ID
+  kept its OLD Router-ID in our neighbour table forever — our Router-LSA
+  pointed at a node that no longer originated one, and the peer's new
+  identity never entered SPF.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup point-to-point topology, reach Full and exchange loopbacks | |
+| Changing r1's Router-ID re-forms the adjacency and withdraws the old identity | |
+| Deleting r1's Router-ID is handled gracefully and keeps forwarding | |
+| Setting an explicit Router-ID again re-converges the adjacency | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_area_range.md
+++ b/bdd/docs/ospfv2_area_range.md
@@ -1,0 +1,36 @@
+# OSPFv2 area ranges aggregate Type-3 summaries at the ABR
+
+## Overview
+
+As a network operator
+I want `area <id> range <prefix>` on an ABR to fold that area's
+intra-area routes into one aggregate Type-3 (RFC 2328 §12.4.3) —
+or hide the whole range with `not-advertise` — so that backbone
+routers carry one summary instead of every component prefix.
+
+## Test Topology
+
+```
+       area 0.0.0.1                          area 0.0.0.0
+    b (10.0.0.2) -- 10.0.12.0/30 -- a (ABR, 10.0.0.1) -- 10.0.13.0/30 -- c (10.0.0.3)
+    r1 10.1.1.0/24  <- inside the      area 0.0.0.1
+    r2 10.1.2.0/24  <- 10.1.0.0/16     range 10.1.0.0/16
+    lo 10.0.0.2/32  <- outside the range
+
+    on router X the interface toward router Y is named "ethY".
+```
+
+## Notes
+
+b's dummy interfaces r1/r2 are OSPF-enabled stub prefixes inside
+the range; its loopback /32 is outside. Metric check: components
+cost 20 at the ABR (link 10 + stub 10), so the aggregate rides at
+the largest component metric 20 and lands on c at [30].
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Components fold into one aggregate; prefixes outside the range still advertise | |
+| not-advertise hides the aggregate and the components | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_as_external.md
+++ b/bdd/docs/ospfv2_as_external.md
@@ -35,3 +35,4 @@ Loopbacks: 10.0.0.X/32.
 |----------|--------|
 | E2 metric — same external metric from all observers | |
 | E1 metric — external metric plus SPF cost to ASBR varies by location | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_auth.md
+++ b/bdd/docs/ospfv2_auth.md
@@ -1,0 +1,33 @@
+# OSPFv2 per-interface authentication gates adjacency formation
+
+## Overview
+
+As a network operator
+I want zebra-rs to authenticate OSPFv2 packets per interface — simple
+password (RFC 2328 §D.3), keyed-MD5 (§D.4), HMAC-SHA (RFC 5709) and
+RFC 8177 key-chains — so that adjacencies form only between routers
+sharing the key, and packets with mismatched keys are dropped.
+Two routers on a point-to-point link; each scenario brings the pair
+up under one authentication mode and proves the adjacency reaches
+Full and the loopbacks route. The final scenario proves the negative:
+same mode, different secrets, no neighbor ever appears.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  (10.0.0.X/32).
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Simple-password authentication forms a Full adjacency | |
+| Keyed-MD5 authentication forms a Full adjacency | |
+| HMAC-SHA-256 cryptographic authentication forms a Full adjacency | |
+| RFC 8177 key-chain authentication forms a Full adjacency | |
+| Mismatched MD5 secrets never form a neighbor | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_default_originate.md
+++ b/bdd/docs/ospfv2_default_originate.md
@@ -1,0 +1,25 @@
+# OSPFv2 default-information originate advertises a Type-5 default
+
+## Overview
+
+As a network operator
+I want `default-information originate [always]` to advertise a
+Type-5 default route (0.0.0.0/0) — unconditionally with `always`,
+or tracking the presence of a non-OSPF default route in the RIB
+without it — so downstream routers follow the ASBR for everything
+off-net.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (ASBR, 10.0.0.2)
+                                    default-information originate
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| always originates unconditionally at the configured metric | |
+| Without always, the default tracks a non-OSPF default route in the RIB | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_graceful_restart.md
+++ b/bdd/docs/ospfv2_graceful_restart.md
@@ -1,0 +1,42 @@
+# OSPFv2 graceful restart keeps forwarding through a daemon restart
+
+## Overview
+
+As a network operator
+I want zebra-rs to implement RFC 3623 graceful restart — the helper
+holding a restarting neighbor's adjacency past the dead interval, and
+the restarter checkpointing its LSDB, exiting, and resuming inside
+the grace window — so that a planned restart does not disturb
+forwarding.
+Two routers on a point-to-point link: a is the helper, b the
+restarter. The first scenario stages a restart and aborts it,
+proving the Grace-LSA drives helper entry on a. The second commits
+the restart: b's daemon exits, a holds the adjacency and the route
+well past the 40s dead interval, and b resumes from its checkpoint.
+
+## Test Topology
+
+```
+    a (helper, 10.0.0.1) -- 10.0.12.0/30 -- b (restarter, 10.0.0.2)
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  (10.0.0.X/32).
+```
+
+## Notes
+
+The restarter's checkpoint lands at the fixed path
+/var/lib/zebra-rs/checkpoint/ospf.cbor, which is shared by every
+namespace (netns does not isolate the filesystem). The restarted
+daemon deletes it after a successful load, but each scenario also
+removes it defensively so an aborted run can never poison a later
+zebra-rs start (any OSPF instance started within 1.5x the grace
+period would replay it).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Grace-LSA from a staged restart drives helper entry; abort recovers | |
+| Committed restart survives past the dead interval and resumes from the checkpoint | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_min_ls_arrival.md
+++ b/bdd/docs/ospfv2_min_ls_arrival.md
@@ -1,0 +1,25 @@
+# OSPFv2 MinLSArrival received-LSA rate limit is configurable
+
+## Overview
+
+As a network operator
+I want `router ospf min-ls-arrival` to set the receive-side rate
+limit (RFC 2328 §13 MinLSArrival, FRR `timers lsa min-arrival`) —
+a flooded LSA instance arriving less than that after the last
+accepted copy is discarded without acknowledgement — so I can tune
+it away from the fixed 1 s default while the topology still
+converges.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+    both routers set min-ls-arrival 2000 ms.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Configured MinLSArrival is applied and the topology still converges | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_min_ls_interval.md
+++ b/bdd/docs/ospfv2_min_ls_interval.md
@@ -1,0 +1,24 @@
+# OSPFv2 MinLSInterval self-LSA re-origination throttle
+
+## Overview
+
+As a network operator
+I want `router ospf min-ls-interval` to bound how often the router
+re-originates the same self-LSA (RFC 2328 §12.4 MinLSInterval, FRR
+`timers throttle lsa all`), so a burst of topology changes coalesces
+into one Router-LSA / Network-LSA update instead of a storm — while
+a stable topology still converges.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+    both routers set min-ls-interval 1500 ms.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Configured MinLSInterval is applied and the topology still converges | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_multi_area.md
+++ b/bdd/docs/ospfv2_multi_area.md
@@ -57,3 +57,4 @@ mirror image for f — so the ABR producer is exercised end to end.
 | Scenario | Result |
 |----------|--------|
 | Two ABRs glue three areas; inter-area routes form and resolve by cost | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_nssa_base.md
+++ b/bdd/docs/ospfv2_nssa_base.md
@@ -59,3 +59,4 @@ verbatim, independent of distance to the originator.
 | Totally-NSSA suppresses Type-3 summaries but keeps the default and translation | |
 | Translator-role never keeps the Type-7 in-area and out of the backbone | |
 | E1 metric grows with SPF distance to the originating ASBR and the translator | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_nssa_fa.md
+++ b/bdd/docs/ospfv2_nssa_fa.md
@@ -1,0 +1,30 @@
+# NSSA Type-7 forwarding address is originated, translated, and resolved
+
+## Overview
+
+As a network operator
+I want NSSA ASBRs to originate P-bit Type-7 LSAs with a non-zero
+forwarding address (RFC 3101 §2.3), the ABR to preserve it when
+translating to Type-5 (or zero it under `nssa-suppress-fa`), and
+backbone receivers to resolve the external route via the FA's
+intra/inter-area path (RFC 2328 §16.4 step 3) — previously such
+LSAs were skipped entirely.
+
+## Test Topology
+
+```
+     backbone            NSSA area 0.0.0.1
+    b -- 10.0.12.0/30 -- a (ABR/translator) -- 10.0.13.0/30 -- c (ASBR)
+                                          dummy on c: 10.9.9.0/24
+    Type-7 from c carries FA 10.0.13.2 (c's NSSA interface); b's
+    route to the external exists ONLY if it can resolve that FA via
+    its inter-area route to 10.0.13.0/30.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| FA-carrying external resolves on the backbone end to end | |
+| nssa-suppress-fa zeroes the FA and routing still works via the ABR | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_passive.md
+++ b/bdd/docs/ospfv2_passive.md
@@ -1,0 +1,31 @@
+# OSPFv2 passive interfaces advertise their prefix without forming adjacencies
+
+## Overview
+
+As a network operator
+I want `area <id> interface <n> passive true` to keep advertising
+the interface's prefix into the area while sending and accepting no
+Hellos — so stub networks are reachable without exposing an
+adjacency on them.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2) -- 10.0.23.0/30 -- c (10.0.0.3)
+                     active link       ethc PASSIVE on b   c runs OSPF actively
+
+    on router X the interface toward router Y is named "ethY".
+```
+
+## Notes
+
+b's ethc is passive. Its /30 must appear in a's routing table (the
+stub prefix rides b's Router-LSA), while c — actively speaking OSPF
+on that segment — must never become b's neighbor.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Passive interface prefix advertises; no adjacency forms across it | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_redist_route_map.md
+++ b/bdd/docs/ospfv2_redist_route_map.md
@@ -1,0 +1,32 @@
+# OSPFv2 redistribution route-map filters and re-applies dynamically
+
+## Overview
+
+As a network operator
+I want `redistribute <source> route-map <name>` to filter and
+modify routes entering OSPF as Type-5 AS-External LSAs — and I
+want edits to the route-map (or a prefix-set it references) to
+re-apply LIVE, originating newly-permitted prefixes and flushing
+newly-denied ones without touching the OSPF session.
+
+## Test Topology
+
+```
+    r1 -- 10.0.12.0/30 -- r2 (redistribute connected route-map RM)
+    r2 dummies (not OSPF-enabled): d1 10.1.1.0/24, d2 10.2.2.0/24
+    RM: permit prefix-set PS, set metric 555; implicit deny rest.
+```
+
+## Notes
+
+The scenarios share one topology: setup, two live edits, teardown
+(mirrors bgp_policy_dynamic_update).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup — route-map admits only the prefix-set, with set metric | |
+| Live edit — adding a prefix to the referenced prefix-set originates it | |
+| Live edit — removing a prefix flushes its Type-5 LSA | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_redist_table.md
+++ b/bdd/docs/ospfv2_redist_table.md
@@ -1,0 +1,25 @@
+# OSPFv2 redistributes routes from a kernel routing table
+
+## Overview
+
+As a network operator
+I want `redistribute table <id>` (FRR parity) to import routes the
+kernel holds in a non-main routing table — installed externally
+via `ip route ... table N` — as Type-5 AS-External LSAs, tracking
+the table live: routes added later originate, deleted ones flush.
+
+## Test Topology
+
+```
+    r1 -- 10.0.12.0/30 -- r2 (redistribute table 100, metric 30)
+    table 100 on r2 (unicast dev-lo routes): 10.55.1.0/24
+    (pre-start, covers the netlink dump path) and 10.55.2.0/24
+    (added live, covers the monitor delta path).
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Kernel-table routes originate as externals and track live changes | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_redistribute_static.md
+++ b/bdd/docs/ospfv2_redistribute_static.md
@@ -1,0 +1,37 @@
+# OSPFv2 instance-level redistribute static originates Type-5 AS-External LSAs
+
+## Overview
+
+As a network operator
+I want `router ospf redistribute static` to originate a Type-5
+AS-External LSA for every static route in the RIB — with the E-bit
+set in the Router-LSA so the domain computes paths to the ASBR — so
+that statically routed prefixes are reachable OSPF-wide without
+per-area configuration.
+Two routers on a point-to-point link. b carries a static route and
+redistributes it; a must install the prefix as an external route.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (ASBR, 10.0.0.2)
+                                    static 192.168.50.0/24 -> 10.0.12.1
+                                    redistribute static -> Type-5
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  (10.0.0.X/32).
+```
+
+## Notes
+
+The static route's nexthop deliberately points back across the OSPF
+link (it resolves via the connected /30), so the route is installed
+in b's RIB and delivered to OSPF through the RIB redistribution
+subscription — the same path any real static route takes.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Static route appears as an external route on the neighbor | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_spf_interval.md
+++ b/bdd/docs/ospfv2_spf_interval.md
@@ -1,0 +1,24 @@
+# OSPFv2 adaptive SPF throttle (spf-interval)
+
+## Overview
+
+As a network operator
+I want `router ospf spf-interval { initial-wait; secondary-wait;
+maximum-wait; }` to configure the IOS-XR-style exponential SPF
+hold-down (RFC-style backoff, mirroring zebra-rs IS-IS) instead of
+the old fixed 1-second coalescing timer, so a churning area backs
+off while a quiet topology still converges quickly.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+    both routers configure spf-interval 100 / 300 / 4000 ms.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Configured throttle is applied and the topology still converges | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_stub_base.md
+++ b/bdd/docs/ospfv2_stub_base.md
@@ -39,3 +39,4 @@ stub as a Type-3, so c reaches it across the area boundary.
 | Scenario | Result |
 |----------|--------|
 | Stub router learns inter-area Type-3 but never the Type-5 external | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_stub_router.md
+++ b/bdd/docs/ospfv2_stub_router.md
@@ -1,0 +1,25 @@
+# OSPFv2 stub-router advertisement (RFC 6987 max-metric router-lsa)
+
+## Overview
+
+As a network operator
+I want `max-metric router-lsa` to advertise my transit links at
+MaxLinkMetric (0xFFFF) — administratively for maintenance, or for a
+startup grace window — so neighbors route transit traffic around me
+while my own prefixes (stub links, normal cost) stay reachable.
+
+## Test Topology
+
+```
+    r1 ---10--- r2 ---10--- r3   (via r2: cost 20 — normally wins)
+     \---100--- r4 ---100---/    (via r4: cost 200 — the detour)
+    r3-lo 10.0.0.3/32; the stub router under test is r2.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Administrative max-metric pushes transit traffic onto the detour | |
+| on-startup max-metric expires and normal routing resumes | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_virtual_link.md
+++ b/bdd/docs/ospfv2_virtual_link.md
@@ -1,0 +1,29 @@
+# OSPFv2 virtual links connect a remote ABR to the backbone
+
+## Overview
+
+As a network operator
+I want `area <transit-id> virtual-link <router-id>` (RFC 2328 §15)
+to form a logical backbone adjacency between two ABRs across a
+non-backbone transit area — so an area with no physical backbone
+connection (area 2 below) still exchanges inter-area routes with
+area 0.
+
+## Test Topology
+
+```
+     area 0        area 0.0.0.1 (transit)      area 0.0.0.2
+    lo 10.0.0.1   r1 -- 10.0.12.0/30 -- r2 -- 10.0.23.0/30 -- r3
+                   \____ virtual-link ____/     lo 10.0.0.3
+    r2 has NO physical area-0 interface; without the VL, r2 is not
+    backbone-attached and area 2 never learns 10.0.0.1/32.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Virtual link forms and carries inter-area routes end to end | |
+| Multi-hop transit — the ABRs are two hops apart through the transit area | |
+| Virtual link with MD5 authentication forms and carries routes | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_adjacency.md
+++ b/bdd/docs/ospfv3_adjacency.md
@@ -32,3 +32,4 @@ hold.
 | Scenario | Result |
 |----------|--------|
 | Two OSPFv3 routers reach Full over a point-to-point link | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_area_range.md
+++ b/bdd/docs/ospfv3_area_range.md
@@ -1,0 +1,27 @@
+# OSPFv3 area ranges aggregate Inter-Area-Prefix-LSAs at the ABR
+
+## Overview
+
+As a network operator
+I want `area <id> range <prefix>` on an OSPFv3 ABR to fold that
+area's intra-area routes into one aggregate Inter-Area-Prefix-LSA
+(RFC 2328 §12.4.3 over the RFC 5340 LSA model) — or hide the whole
+range with `not-advertise` — mirroring ospfv2_area_range.
+
+## Test Topology
+
+```
+       area 0.0.0.1                            area 0.0.0.0
+    b -- 2001:db8:12::/64 -- a (ABR) -- 2001:db8:13::/64 -- c
+    r1 2001:db8:1:1::/64  <- inside the   area 0.0.0.1
+    r2 2001:db8:1:2::/64  <- 2001:db8:1::/48 range
+    lo 2001:db8::2/128    <- outside the range
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Components fold into one aggregate; prefixes outside the range still advertise | |
+| not-advertise hides the aggregate and the components | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_auth.md
+++ b/bdd/docs/ospfv3_auth.md
@@ -1,0 +1,28 @@
+# OSPFv3 native authentication config drives the RFC 7166 trailer
+
+## Overview
+
+As a network operator
+I want `router ospfv3 area <id> interface <n> authentication
+message-digest` with `crypto-key` / `key-chain` to configure the
+RFC 7166 Authentication Trailer natively — no `router ospf` block
+required in an IPv6-only deployment — so adjacencies form only
+between routers sharing the key.
+Two routers on a point-to-point link; each scenario brings the
+pair up under one keying mode. The final scenario proves the
+negative: same SA-ID, different secrets, no neighbor ever forms.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 2001:db8:12::/64 -- b (10.0.0.2)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| HMAC-SHA-256 trailer via native crypto-key forms a Full adjacency | |
+| RFC 8177 key-chain supplies the trailer key | |
+| Mismatched trailer secrets never form a neighbor | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_default_originate.md
+++ b/bdd/docs/ospfv3_default_originate.md
@@ -1,0 +1,24 @@
+# OSPFv3 default-information originate advertises an AS-External default
+
+## Overview
+
+As a network operator
+I want `default-information originate [always]` on OSPFv3 to
+advertise an AS-External default (::/0) — unconditionally with
+`always`, or tracking a non-OSPF default route in the RIB without
+it — mirroring ospfv2_default_originate.
+
+## Test Topology
+
+```
+    a -- 2001:db8:12::/64 -- b (ASBR)
+                             default-information originate
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| always originates unconditionally at the configured metric | |
+| Without always, the default tracks a non-OSPF default route in the RIB | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_graceful_restart.md
+++ b/bdd/docs/ospfv3_graceful_restart.md
@@ -1,0 +1,31 @@
+# OSPFv3 graceful restart keeps forwarding through a daemon restart
+
+## Overview
+
+As a network operator
+I want zebra-rs OSPFv3 to implement RFC 5187 graceful restart in
+both roles — the helper holding a restarting neighbor's adjacency
+past the dead interval, and the restarter checkpointing its LSDB,
+exiting, and resuming inside the grace window — mirroring
+ospfv2_graceful_restart over the v3 Grace-LSA (0x000B).
+
+## Test Topology
+
+```
+    a (helper, 10.0.0.1) -- 2001:db8:12::/64 -- b (restarter, 10.0.0.2)
+```
+
+## Notes
+
+The restarter's checkpoint lands at the fixed path
+/var/lib/zebra-rs/checkpoint/ospfv3.cbor, shared by every namespace
+(netns does not isolate the filesystem); each scenario removes it
+defensively so an aborted run can never poison a later start.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Grace-LSA from a staged restart drives helper entry; abort recovers | |
+| Committed restart survives past the dead interval and resumes from the checkpoint | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_instance_id.md
+++ b/bdd/docs/ospfv3_instance_id.md
@@ -1,0 +1,25 @@
+# OSPFv3 Instance ID separates instances on a link (RFC 5340)
+
+## Overview
+
+As a network operator
+I want the per-interface `instance-id` to be stamped into every
+OSPFv3 packet header (RFC 5340 §A.3.1) and enforced on receive
+(§8.2: drop on mismatch) — so multiple OSPFv3 instances can share
+one link without forming cross-instance adjacencies.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 2001:db8:12::/64 -- b (10.0.0.2)
+    matched scenario: both interfaces instance-id 5
+    mismatch scenario: a=5, b=7 — no adjacency may form
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Matching non-zero instance IDs form a normal adjacency | |
+| Mismatched instance IDs never form an adjacency | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_multi_area.md
+++ b/bdd/docs/ospfv3_multi_area.md
@@ -1,0 +1,44 @@
+# OSPFv3 ABR originates Inter-Area-Prefix-LSAs across three areas
+
+## Overview
+
+As a network operator
+I want a zebra-rs OSPFv3 Area Border Router to condense each area's
+routes into Inter-Area-Prefix-LSAs (0x2003) flooded into its other
+areas — with backbone split-horizon and per-area SPF — so that
+routers in different non-backbone areas reach each other through
+the backbone. Mirrors ospfv2_multi_area for the v3 LSA model.
+
+## Test Topology
+
+```
+                 area 0.0.0.1                 area 0.0.0.2
+                  e (2001:db8::5)              f (2001:db8::6)
+                     |                            |
+              2001:db8:15::/64             2001:db8:36::/64
+                     | ethe                  ethf |
+        ____________ a (ABR, 10.0.0.1) ........  c (ABR, 10.0.0.3) ____
+       |   area 0   /|                            |\   area 0          |
+   2001:db8:12::/64 /2001:db8:14::/64 (cost 20)   | 2001:db8:23::/64   |
+       |           /  | etha                 ethd | 2001:db8:34::/64   |
+       b (2001:db8::2) d (2001:db8::4) ___________/  (cost 20)         |
+       |  \________ 2001:db8:24::/64 (b - d) ______/                   |
+       \_______________________________________________________________|
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: 2001:db8::X/128, router-ids 10.0.0.X (a=1 .. f=6).
+```
+
+## Notes
+
+The cost-20 a-d and c-d links tie the two-hop alternative (a-b-d =
+c-b-d = 10+10), so d's loopback shows at metric 20 from a and c —
+with the default cost 10 the direct link would win at metric 10,
+making "metric 20" the deterministic proof the configured cost took.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Routers in two non-backbone areas reach each other through the backbone | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_nssa.md
+++ b/bdd/docs/ospfv3_nssa.md
@@ -48,3 +48,4 @@ link, so a translated Type-5 is the only way the prefix reaches it.
 |----------|--------|
 | Internal ASBR Type-7 is installed in-area and translated to Type-5 on the backbone | |
 | Translator-role never keeps the Type-7 in-area and out of the backbone | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_passive.md
+++ b/bdd/docs/ospfv3_passive.md
@@ -1,0 +1,22 @@
+# OSPFv3 passive interfaces advertise their prefix without forming adjacencies
+
+## Overview
+
+As a network operator
+I want `area <id> interface <n> passive true` on OSPFv3 to keep
+advertising the interface's prefix (Intra-Area-Prefix-LSA) while
+sending and accepting no Hellos — mirroring ospfv2_passive.
+
+## Test Topology
+
+```
+    a -- 2001:db8:12::/64 -- b -- 2001:db8:23::/64 -- c
+          active link           ethc PASSIVE on b     c active
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Passive interface prefix advertises; no adjacency forms across it | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_prefix_sid_flags.md
+++ b/bdd/docs/ospfv3_prefix_sid_flags.md
@@ -1,0 +1,36 @@
+# OSPFv3 Prefix-SID Sub-TLV flag bit positions (RFC 8666 §7.1)
+
+## Overview
+
+As a network operator
+I want zebra-rs to encode the OSPFv3 Prefix-SID Sub-TLV Flags octet at
+the bit positions RFC 8666 §7.1 assigns (shared with RFC 8665 §6 for
+OSPFv2 and matching FRR EXT_SUBTLV_PREFIX_SID_*FLG): NP = 0x40,
+M = 0x20, E = 0x10, V = 0x08, L = 0x04, with the MSB and the low two
+bits reserved — so a Prefix-SID advertised by one router is decoded
+with the correct flags by an interoperable peer.
+Regression coverage for the flag-placement bug where every flag sat
+one bit too high (NP = 0x80, ...): zebra-to-zebra flooding is
+symmetric, so the wire encoding is only observable by rendering the
+Prefix-SID sub-TLV a *peer* decoded from the flooded LSA. o1 and o2
+run OSPFv3 area 0 over one point-to-point link, both on SR-MPLS with a
+loopback Prefix-SID (index 100 / 200 -> labels 16100 / 16200 against
+the default SRGB base 16000). The index form carries NP (no-PHP), so
+each peer must render the other's Prefix-SID flags as exactly
+"0x40 : NP".
+
+## Test Topology
+
+```
+   o1 ──────────────── o2
+   2001:db8:12::1/64   2001:db8:12::2/64
+   lo 2001:db8::1 SID 100   lo 2001:db8::2 SID 200
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the OSPFv3 SR-MPLS topology | |
+| Prefix-SID flags decode at RFC 8666 bit positions on the peer | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_redistribute.md
+++ b/bdd/docs/ospfv3_redistribute.md
@@ -1,0 +1,32 @@
+# OSPFv3 instance-level redistribute originates AS-External LSAs
+
+## Overview
+
+As a network operator
+I want `router ospfv3 redistribute connected` and `redistribute
+static` to originate AS-External (Type-5, 0x4005) LSAs for the
+matching IPv6 routes — previously only `redistribute bgp` existed at
+the v3 instance level — so that non-OSPF prefixes are reachable
+OSPFv3-wide.
+Two routers on a point-to-point link. b redistributes both a
+connected prefix (a dummy interface outside OSPF) and a static
+route; a must install both as external routes.
+
+## Test Topology
+
+```
+    a (10.0.0.1) -- 2001:db8:12::/64 -- b (ASBR, 10.0.0.2)
+                                        dummy cafe0 2001:db8:cafe::1/64 (not in OSPF)
+                                        static 2001:db8:99::/64 -> 2001:db8:12::1
+                                        redistribute connected + static
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a 2001:db8::1/128  b 2001:db8::2/128.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Connected and static IPv6 routes appear as external routes on the neighbor | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_router_id_change.md
+++ b/bdd/docs/ospfv3_router_id_change.md
@@ -1,0 +1,32 @@
+# OSPFv3 Router-ID change on a live adjacency
+
+## Overview
+
+As a network operator
+I want zebra-rs to withdraw the LSAs advertised under an OSPFv3 instance's
+old Router-ID when that Router-ID changes on a running adjacency, so a
+stale identity does not linger in every router's database until MaxAge.
+Two OSPFv3 routers on a point-to-point link. OSPFv3 keys a neighbour by
+Router-ID (RFC 5340 §10), so when o1's Router-ID changes o2 naturally
+forms a fresh neighbour and the old one ages out on its dead timer. The
+part that needs a fix is the database: the LSAs o1 originated under the
+old Router-ID would otherwise survive as a phantom node. A Router-ID is
+numerically distinct from any IPv6 prefix here, so "the old Router-ID is
+gone from the database" is an unambiguous assertion.
+
+## Test Topology
+
+```
+    o1 --- 2001:db8:12::/64 (point-to-point, area 0.0.0.0) --- o2
+       eth1                                                eth2
+    loopbacks: 2001:db8::1/128 (o1)            2001:db8::2/128 (o2)
+    Router-IDs: o1 starts 1.1.1.1, o2 fixed 2.2.2.2
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup point-to-point topology and reach Full | |
+| Changing o1's Router-ID re-forms the adjacency and withdraws the old identity | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_sr_dataplane_choice.md
+++ b/bdd/docs/ospfv3_sr_dataplane_choice.md
@@ -1,0 +1,46 @@
+# OSPFv3 segment-routing mpls/srv6 are mutually exclusive (YANG choice)
+
+## Overview
+
+As a network operator
+I want `router ospfv3 segment-routing mpls` and `router ospfv3
+segment-routing srv6` to be a YANG choice, so committing one
+dataplane implicitly deletes the other (RFC 7950 §7.9.3) — a single
+`set router ospfv3 segment-routing srv6 locator LOC1` migrates a
+running RFC 8666 SR-MPLS node to RFC 9513 SRv6 without a separate
+`delete`, and the implicit delete tears the old dataplane's
+forwarding state down exactly as an explicit one would.
+This is the OSPFv3 sibling of @isis_sr_dataplane_choice — the choice
+enforcement is the same generic candidate-store purge, but the
+daemon-side effects it must drive are OSPFv3's own: the Prefix-SID
+sub-TLVs leave the E-LSAs and the ILM empties, while the SRv6
+Locator LSA is originated and the locator's End SID installs as a
+kernel seg6local route.
+z1 and z2 run OSPFv3 area 0 over one point-to-point link, both
+starting on SR-MPLS (Prefix-SID indexes 100/200 -> labels
+16100/16200 against the default SRGB base 16000). z1 additionally
+pre-provisions the global SRv6 locator LOC1 (fcbb:bbbb:1::/48,
+classic full-length SIDs) without binding it to OSPFv3. The feature
+flips z1's dataplane to SRv6 and back with one `set` each way and
+checks three layers every time:
+- config: `show running-config formal` holds exactly one dataplane
+- local forwarding: the MPLS ILM empties and the locator's End SID
+- the peer: z2 stays on SR-MPLS throughout; label 16100 leaves and
+
+## Test Topology
+
+```
+   z1 ──────────────── z2
+   2001:db8:12::1/64   2001:db8:12::2/64
+   lo 2001:db8::1, SID 100, LOC1 fcbb:bbbb:1::/48 (unbound)
+   lo 2001:db8::2, SID 200 (SR-MPLS for the whole feature)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the OSPFv3 SR-MPLS topology | |
+| Setting srv6 implicitly deletes mpls and swaps the dataplane | |
+| Setting mpls implicitly deletes srv6 and restores the labels | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_stub_router.md
+++ b/bdd/docs/ospfv3_stub_router.md
@@ -1,0 +1,26 @@
+# OSPFv3 stub-router advertisement (RFC 5340 R-bit clear)
+
+## Overview
+
+As a network operator
+I want `max-metric router-lsa` on OSPFv3 to clear the R and V6
+option bits in my Router-LSAs (ospf6d's `stub-router`) so
+neighbors exclude me from transit paths (RFC 5340 §4.8.1) while my
+own prefixes stay reachable — the v3 counterpart of v2's
+RFC 6987 MaxLinkMetric.
+
+## Test Topology
+
+```
+    r1 ---10--- r2 ---10--- r3   (via r2: cost 20 — normally wins)
+     \---100--- r4 ---100---/    (via r4: cost 200 — the detour)
+    r3-lo 2001:db8::3/128; the stub router under test is r2.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Administrative R-bit clear pushes transit traffic onto the detour | |
+| on-startup R-bit clear expires and the cheap path returns | |
+| Teardown topology | |

--- a/bdd/docs/pim6_adjacency.md
+++ b/bdd/docs/pim6_adjacency.md
@@ -1,0 +1,28 @@
+# PIMv6 two-router neighborship forms over link-local transport
+
+## Overview
+
+As a network operator
+I want two zebra-rs routers to run PIMv6 on an IPv6 link and discover
+each other through link-local-sourced Hellos, so the PIMv6 transport
+(raw protocol 103 over IPv6, ff02::d joins, in6_pktinfo source
+pinning and the pseudo-header checksum) and the address-family split
+(`router pim ipv6` spawning a default-table Pim<Ipv6>) are exercised
+router-to-router.
+PIMv6 Hellos are sourced from the interface link-local (fe80::/10,
+RFC 7761 §4.3.1), so each router learns the peer as a link-local
+neighbor.
+
+## Test Topology
+
+```
+    p1 (2001:db8:12::1/64, fe80 auto) --- veth --- p2 (2001:db8:12::2/64, fe80 auto)
+       eth1                                           eth2
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Two PIMv6 routers discover each other over link-local | |
+| Teardown topology | |

--- a/bdd/docs/pim6_asm.md
+++ b/bdd/docs/pim6_asm.md
@@ -1,0 +1,31 @@
+# PIMv6 ASM with a static RP — register, shared tree and SPT
+
+## Overview
+
+As a network operator
+I want an any-source MLD join at the last-hop router to build a shared
+tree to the static RP, a new IPv6 source's first-hop router to register
+it with the RP, the RP to join the source tree and stop the registers,
+and traffic to flow natively source→RP→receiver — the complete PIMv6-SM
+ASM control loop over three routers.
+r2 is the RP (2001:db8:12::2, its own interface address, configured
+statically on all three routers). h2 issues an any-source join for
+ff0e::1 (MLDv2 EXCLUDE{}); r3 (LHR) builds (*,G) toward the RP. h1 then
+sends: r1 (FHR/DR for the source subnet) registers with the RP, the RP
+joins (S,G) back toward r1 and answers Register-Stop — r1's register
+state must settle in RegPrune — and h1's datagrams must arrive at h2
+through the kernel MRT6 MFCs of all three routers.
+
+## Test Topology
+
+```
+    h1 (2001:db8:1::9, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (2001:db8:24::9, receiver)
+                                    2001:db8:1::1   2001:db8:12::1/.2       2001:db8:23::1/.2         2001:db8:24::1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Register, shared tree and SPT converge and traffic flows | |
+| Teardown topology | |

--- a/bdd/docs/pim6_assert.md
+++ b/bdd/docs/pim6_assert.md
@@ -1,0 +1,35 @@
+# PIMv6 assert election and LAN Join/Prune behaviors
+
+## Overview
+
+As a network operator
+I want duplicate forwarders on a shared IPv6 LAN to elect a single
+assert winner, routers sharing an upstream LAN to suppress each other's
+periodic Joins, and a Prune overheard on a LAN to be overridden by
+routers that still want the traffic — the RFC 7761 multi-access
+behaviors that keep exactly one copy of each packet on every LAN.
+r1 and r2 both connect the upstream LAN swA (toward r0 and the source)
+and the contested LAN swB. They must forward the same (S,G) onto swB by
+two independent mechanisms — so that DR gating cannot collapse the test
+to a single forwarder:
+Both forward onto swB and the duplicate data triggers the assert. The
+IPv6 assert tiebreak is the link-local source (non-deterministic on
+veths), so the winner is made deterministic by RPF cost instead: r2's
+static route to the source has a lower metric than r1's, so r2 wins and
+r1 steps down, prunes toward r0, and r2 overrides that Prune — the
+assert winner then carries swB for both receivers.
+
+## Test Topology
+
+```
+    h1(src) - r0 - [swA 2001:db8:61/64] - r1(::2) - [swB 2001:db8:62/64] - r2(::3, DR) - h2(::10 direct)
+                                             |             |
+                                          r0 also        r3(::1) - h3   (r3 RPFs to r1)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Assert election, join suppression and prune override on LANs | |
+| Teardown topology | |

--- a/bdd/docs/pim6_bsr.md
+++ b/bdd/docs/pim6_bsr.md
@@ -1,0 +1,28 @@
+# PIMv6 Bootstrap Router election and RP-set distribution
+
+## Overview
+
+As a network operator
+I want a candidate BSR to win the election, collect candidate-RP
+advertisements, and flood the RP-set in Bootstrap messages so every
+PIMv6 router learns the group-to-RP mapping without static config —
+then run the ASM control loop on the BSR-learned RP.
+r2 is candidate-BSR and candidate-RP (2001:db8:22::2). r1 and r3 must
+learn both the elected BSR and the RP purely from flooded BSMs. The
+Bootstrap messages are link-local-sourced multicast (like Hellos); the
+BSR / RP addresses they carry are the configured globals, so the
+election and RP mapping are deterministic.
+
+## Test Topology
+
+```
+    h1 (2001:db8:21::10, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(C-BSR,C-RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (2001:db8:24::10, receiver)
+                                       2001:db8:21::1   2001:db8:22::1/.2         2001:db8:23::1/.2         2001:db8:24::1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| BSR election, RP-set distribution and ASM traffic | |
+| Teardown topology | |

--- a/bdd/docs/pim6_embedded_rp.md
+++ b/bdd/docs/pim6_embedded_rp.md
@@ -1,0 +1,27 @@
+# PIMv6 Embedded-RP (RFC 3956) ASM with no RP configuration
+
+## Overview
+
+As a network operator
+I want an IPv6 multicast group that embeds its RP address in its own
+bits (RFC 3956, ff70::/12) to run the full ASM control loop with no
+static RP and no BSR — every router derives the same RP straight from
+the group address.
+The group ff7e:240:2001:db8:22::9 embeds RP 2001:db8:22::2 (flags R=P=T,
+RIID 2, prefix length 64, network prefix 2001:db8:22::). r2 owns that
+address and therefore acts as the RP purely by derivation. No router
+carries any `rp static` or `bsr` config.
+
+## Test Topology
+
+```
+    h1 (2001:db8:21::10, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(RP=2001:db8:22::2) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (2001:db8:24::10, receiver)
+                                       2001:db8:21::1   2001:db8:22::1/.2         2001:db8:23::1/.2         2001:db8:24::1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| The embedded RP is derived and the ASM loop runs | |
+| Teardown topology | |

--- a/bdd/docs/pim6_mld.md
+++ b/bdd/docs/pim6_mld.md
@@ -1,0 +1,26 @@
+# MLD membership tracking on a PIMv6 router
+
+## Overview
+
+As a network operator
+I want a zebra-rs router running MLD on an IPv6 interface to act as
+the querier and learn group memberships from MLDv2 reports, so the
+MLD codec (RFC 3810 over ICMPv6) driving the shared Gm<Ipv6> engine
+is exercised host-to-router.
+A host joins an IPv6 multicast group; its kernel emits an MLDv2
+report to ff02::16, which the router's querier (joined to ff02::16)
+receives and records as membership.
+
+## Test Topology
+
+```
+    r1 (2001:db8:1::1/64, MLD querier) --- veth --- h1 (2001:db8:1::9/64)
+       eth1                                            eth2
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| An MLDv2 report creates group membership on the querier | |
+| Teardown topology | |

--- a/bdd/docs/pim6_register.md
+++ b/bdd/docs/pim6_register.md
@@ -1,0 +1,31 @@
+# PIMv6 FHR Register to a static RP over unicast IPv6
+
+## Overview
+
+As a network operator
+I want a first-hop router to encapsulate a new IPv6 source's traffic
+in a PIM Register and unicast it to the statically configured RP, and
+the RP to answer Register-Stop so the FHR settles in suppression — the
+PIMv6 unicast Register control loop (transport slice of ASM), before
+the full shared-tree datapath.
+Unlike link-local PIM control (Hello / J/P / Assert to ff02::d), the
+Register and Register-Stop are unicast between the FHR and the RP: the
+FHR sources them from a routable (non-link-local) address so the RP can
+reply, and the RP accepts a non-link-local source on a unicast
+destination. There is no receiver, so the RP has no shared tree and
+answers Register-Stop immediately; the FHR's register state settles in
+RegPrune.
+
+## Test Topology
+
+```
+    h1 (2001:db8:1::9, source) --- eth0/eth1 --- r1 (FHR) --- eth2/eth3 --- r2 (RP, 2001:db8:12::2)
+                                       2001:db8:1::1        2001:db8:12::1/.2
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| FHR registers and the RP stops it | |
+| Teardown topology | |

--- a/bdd/docs/pim6_ssm.md
+++ b/bdd/docs/pim6_ssm.md
@@ -1,0 +1,33 @@
+# PIMv6 SSM (S,G) forwarding end to end across two routers
+
+## Overview
+
+As a network operator
+I want an MLDv2 source-specific join at the last-hop router to build
+an IPv6 (S,G) shortest-path tree back to the first-hop router and
+program the kernel MRT6 forwarding cache on both, so real IPv6 traffic
+from the source reaches the receiver — the first complete PIMv6
+control-plane-to-dataplane slice (MLD + PIMv6 J/P + the MRT6/MIF/MFC
+datapath).
+h1 sends UDPv6 to the SSM group ff3e::1. h2 issues a source-specific
+join for (2001:db8:14::2, ff3e::1). r2 (LHR) must translate the MLDv2
+membership into a PIMv6 (S,G) Join toward r1 — its RPF nexthop is r1's
+global on the transit link (a static route), which r1 advertises as a
+Hello secondary address so r2's neighbor_covers() matches it; the Join
+itself is sourced from r2's link-local. r1 (FHR, source directly
+connected) accepts the Join into its downstream state, and both
+install kernel MRT6 MFC entries that forward h1's datagrams to h2.
+
+## Test Topology
+
+```
+    h1 (2001:db8:14::2, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (2001:db8:15::2, receiver)
+                                       2001:db8:14::1   2001:db8:13::1/.2       2001:db8:15::1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| SSM join builds the IPv6 (S,G) tree and traffic flows | |
+| Teardown topology | |

--- a/bdd/docs/pim6_vrf.md
+++ b/bdd/docs/pim6_vrf.md
@@ -1,0 +1,28 @@
+# PIMv6 SSM forwarding inside a VRF
+
+## Overview
+
+As a network operator
+I want `router pim vrf <name> ipv6` to run a full per-VRF PIMv6
+instance — sockets bound into the VRF, the kernel MRT6 table selected
+with MRT6_TABLE, MLD and Join/Prune state scoped to the VRF — so IPv6
+multicast in one VRF neither sees nor disturbs the default table.
+Same shape as the pim6_ssm feature, but every router interface is
+enslaved to VRF mvrf and all PIMv6/MLD config lives under
+`router pim vrf mvrf ipv6`. The parent's per-VRF Pim<Ipv4> child spawns
+a per-VRF Pim<Ipv6> grandchild; the default IPv6 instance is never
+configured and must stay absent.
+
+## Test Topology
+
+```
+    h1 (2001:db8:14::10, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (2001:db8:15::10, receiver)
+                                       2001:db8:14::1   2001:db8:13::1/.2       2001:db8:15::1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| SSM join builds the (S,G) tree in the VRF and traffic flows | |
+| Teardown topology | |

--- a/bdd/docs/pim_adjacency.md
+++ b/bdd/docs/pim_adjacency.md
@@ -1,0 +1,27 @@
+# PIM-SM two-router neighborship forms on a point-to-point link
+
+## Overview
+
+As a network operator
+I want two zebra-rs PIM routers joined by a veth link to discover
+each other through Hellos and elect the Designated Router, so the
+PIM-SM neighbor plane (Hello options, holdtime, DR priority) is
+exercised router-to-router.
+p1 advertises DR priority 200, p2 the default-equivalent 1. With
+priority-based election the LOWER address 10.1.12.1 must win DR —
+proving the election used the DR-Priority option and not the
+highest-address fallback.
+
+## Test Topology
+
+```
+    p1 (10.1.12.1/24, DR prio 200) --- veth --- p2 (10.1.12.2/24, DR prio 1)
+       eth1                                        eth2
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Two PIM routers discover each other and elect the DR | |
+| Teardown topology | |

--- a/bdd/docs/pim_asm.md
+++ b/bdd/docs/pim_asm.md
@@ -1,0 +1,32 @@
+# PIM ASM with a static RP — register, shared tree and SPT
+
+## Overview
+
+As a network operator
+I want an any-source IGMP join at the last-hop router to build a
+shared tree to the static RP, a new source's first-hop router to
+register it with the RP, the RP to join the source tree and stop
+the registers, and traffic to flow natively source→RP→receiver —
+the complete PIM-SM ASM control loop over three routers.
+r2 is the RP (10.1.22.2, its own interface address, configured
+statically on all three routers). h2 issues an any-source join for
+239.2.2.2 (IGMPv3 EXCLUDE{}); r3 (LHR) builds (*,G) toward the RP.
+h1 then sends: r1 (FHR/DR for the source subnet) registers with the
+RP, the RP joins (S,G) back toward r1 and answers Register-Stop —
+r1's register state must settle in suppression (RegPrune) — and
+h1's datagrams must arrive at h2 through the kernel MFCs of all
+three routers.
+
+## Test Topology
+
+```
+    h1 (10.1.21.2, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (10.1.24.2, receiver)
+                                 10.1.21.1    10.1.22.1/.2       10.1.23.1/.2          10.1.24.1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Register, shared tree and SPT converge and traffic flows | |
+| Teardown topology | |

--- a/bdd/docs/pim_assert.md
+++ b/bdd/docs/pim_assert.md
@@ -1,0 +1,38 @@
+# PIM assert election and LAN Join/Prune behaviors
+
+## Overview
+
+As a network operator
+I want duplicate forwarders on a shared LAN to elect a single
+assert winner, a router's overheard Join on a shared upstream LAN
+to suppress the other joined router's periodic refresh (leaving
+one refresher per LAN), and a Prune overheard on a LAN to be
+overridden by routers that still want the traffic — the RFC 7761
+multi-access behaviors that keep exactly one copy of each packet
+on every LAN.
+r1 and r2 both connect the upstream LAN swA (toward r0 and the
+source) and the contested LAN swB. They must forward the same
+(S,G) onto swB by two independent mechanisms — so that DR gating
+(only the DR turns local membership into forwarding state) cannot
+collapse the test to a single forwarder:
+Both forward onto swB, the duplicate data triggers the assert, and
+the higher address (r2, 10.6.2.3) wins. r1 steps down; with its
+only outgoing interface assert-lost its JoinDesired collapses and
+it prunes toward r0. r2 overhears that Prune and overrides it,
+keeping r0 forwarding, and the assert winner then carries the LAN
+for both receivers.
+
+## Test Topology
+
+```
+    h1(src) - r0 - [swA 10.6.1/24] - r1(.2) - [swB 10.6.2/24] - r2(.3, DR) - h2(.10 direct)
+                                        |             |
+                                     r0 also        r3(.1) - h3   (r3 RPFs to r1)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Assert election, join suppression and prune override on LANs | |
+| Teardown topology | |

--- a/bdd/docs/pim_bsr.md
+++ b/bdd/docs/pim_bsr.md
@@ -1,0 +1,29 @@
+# PIM Bootstrap Router elects itself and distributes the RP-set
+
+## Overview
+
+As a network operator
+I want a candidate BSR to win the election, collect candidate-RP
+advertisements and flood the group-to-RP mapping in Bootstrap
+Messages, so every router in the domain learns the RP without any
+static configuration — and the full ASM control loop (shared tree,
+register, SPT) runs on the learned mapping.
+Same chain as the pim_asm feature, but NO router has a static RP:
+r2 is candidate-BSR and candidate-RP (10.9.22.2). r1 and r3 must
+learn both the elected BSR and the RP purely from flooded BSMs,
+after which an any-source join at h2 and a sender at h1 must
+converge exactly as the static-RP scenario did.
+
+## Test Topology
+
+```
+    h1 (10.9.21.10, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(C-BSR,C-RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (10.9.24.10, receiver)
+                                  10.9.21.1    10.9.22.1/.2          10.9.23.1/.2               10.9.24.1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| BSR election, RP-set distribution and ASM traffic | |
+| Teardown topology | |

--- a/bdd/docs/pim_igmp.md
+++ b/bdd/docs/pim_igmp.md
@@ -1,0 +1,28 @@
+# IGMP membership tracking and querier election
+
+## Overview
+
+As a network operator
+I want a zebra-rs router to learn IGMP group membership from
+attached hosts and to elect a single querier per LAN, so the
+receiver side of the multicast control plane works before PIM
+trees are built on top of it.
+r1 runs IGMP on two links: toward r2 (router-to-router, exercising
+querier election — the lower address 10.1.13.1 must win and r2 must
+step down to Non-Querier) and toward host h1, which joins group
+239.1.1.1 with a socat receiver (the kernel emits an IGMPv3 report);
+r1 must show the group in EXCLUDE mode.
+
+## Test Topology
+
+```
+    r2 (10.1.13.2) --- eth2/eth1 --- r1 (10.1.13.1)
+                                     r1 (10.1.14.1) --- eth3/eth4 --- h1 (10.1.14.2, receiver)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Querier election and receiver join | |
+| Teardown topology | |

--- a/bdd/docs/pim_ssm.md
+++ b/bdd/docs/pim_ssm.md
@@ -1,0 +1,30 @@
+# PIM SSM (S,G) forwarding end to end across two routers
+
+## Overview
+
+As a network operator
+I want an IGMPv3 source-specific join at the last-hop router to
+build an (S,G) shortest-path tree back to the first-hop router and
+program the kernel multicast forwarding cache on both, so real
+traffic from the source reaches the receiver — the first complete
+PIM-SM/SSM control-plane-to-dataplane slice.
+h1 sends UDP to the SSM group 232.1.1.1. h2 issues a source-specific
+join for (10.1.14.2, 232.1.1.1). r2 (LHR) must translate the IGMPv3
+membership into a PIM (S,G) Join toward r1 (RPF via a static route),
+r1 (FHR, source directly connected) must accept the Join into its
+downstream state, and both must install kernel MFC entries that
+forward h1's datagrams to h2.
+
+## Test Topology
+
+```
+    h1 (10.1.14.2, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (10.1.15.2, receiver)
+                                   10.1.14.1     10.1.13.1/.2       10.1.15.1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| SSM join builds the (S,G) tree and traffic flows | |
+| Teardown topology | |

--- a/bdd/docs/pim_vrf.md
+++ b/bdd/docs/pim_vrf.md
@@ -1,0 +1,27 @@
+# PIM SSM forwarding inside a VRF
+
+## Overview
+
+As a network operator
+I want `router pim vrf <name>` to run a full per-VRF PIM instance —
+sockets bound into the VRF, the kernel multicast table selected
+with MRT_TABLE, IGMP and Join/Prune state scoped to the VRF — so
+multicast in one VRF neither sees nor disturbs the default table.
+Same shape as the pim_ssm feature, but every router interface is
+enslaved to VRF mvrf and all PIM/IGMP config lives under
+`router pim vrf mvrf`. The default PIM instance runs with no
+interfaces and must stay empty while the mvrf child converges.
+
+## Test Topology
+
+```
+    h1 (10.8.14.10, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (10.8.15.10, receiver)
+                                    10.8.14.1     10.8.13.1/.2       10.8.15.1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| SSM join builds the (S,G) tree in the VRF and traffic flows | |
+| Teardown topology | |

--- a/bdd/docs/static_blackhole.md
+++ b/bdd/docs/static_blackhole.md
@@ -1,0 +1,18 @@
+# Static blackhole routes install RTN_BLACKHOLE discard entries
+
+## Overview
+
+As a network operator
+I want `router static <afi> route <prefix> nexthop blackhole` to
+install a discard route in the forwarding plane (kernel
+RTN_BLACKHOLE) with no gateway — so that traffic to the prefix is
+dropped at this router instead of forwarded or looped. This
+exercises the RIB `Nexthop::Blackhole` type end to end (config →
+RIB → netlink → kernel FIB).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| IPv4 and IPv6 blackhole static routes reach the kernel FIB | |
+| Teardown topology | |

--- a/bdd/docs/static_srv6_nht.md
+++ b/bdd/docs/static_srv6_nht.md
@@ -1,0 +1,52 @@
+# Static route inherits SRv6 segments from its covering route
+
+## Overview
+
+As a network operator
+I want a static route whose gateway is reachable only through a
+BGP-over-SRv6 service route to resolve recursively through it and
+inherit the H.Encap segment list — the SRv6 analog of the SR-MPLS
+label inheritance in @isis_srmpls.
+
+## Test Topology
+
+```
+  ┌────┐ eth0 ── i2 ┌────────┐ i1 ──────── i1 ┌────────┐ i2 ─────── i1 ┌────────┐
+  │ h1 │────────────│   z1   │────────────────│   z2   │───────────────│   z3   │
+  └────┘3001:db8::/64 egress │2001:db8:12::/64│  core  │2001:db8:23::/64 ingress│
+   3001:db8::1      │ LOC1   │                │        │               │        │
+                    └────────┘                └────────┘               └────────┘
+   cust0 on z1: 2001:db8:cafe::1/64      z2 knows ONLY the two links
+   (dummy — the gateway anchor)          and z1's locator fcbb:bbbb:1::/48
+```
+
+## Notes
+
+- z1 advertises locator LOC1 (fcbb:bbbb:1::/48) and redistributes
+  connected into BGP with `segment-routing srv6 ipv6-unicast`, so its
+  prefixes (h1's subnet, the cust0 anchor) carry the End.DT6 SID
+  fcbb:bbbb:1:40::.
+- z3 receives them over `encapsulation-type srv6` and installs
+  H.Encaps service routes.
+- The static under test on z3, `3001:db8::1/128 via 2001:db8:cafe::1`,
+  has a gateway covered ONLY by the 2001:db8:cafe::/64 SRv6 route:
+  NHT must resolve through it and inherit that route's segment list.
+  The transit core z2 knows nothing about the service prefixes, so
+  the end-to-end ping to the host h1 behind z1 proves the inherited
+  encapsulation carried the traffic (decap at z1's End.DT6, plain
+  IPv6 delivery to h1).
+- Deleting the static releases its seg6 nexthop group and forwarding
+  falls back to the BGP /64 covering h1's subnet.
+
+## Config Files
+
+- z1.yaml, z2.yaml, z3.yaml
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and converge BGP over SRv6 | |
+| Static route resolves through the SRv6 route and inherits its segments | |
+| Deleting the static falls back to the covering BGP route | |
+| Teardown topology | |

--- a/bdd/docs/system_hostname.md
+++ b/bdd/docs/system_hostname.md
@@ -1,0 +1,19 @@
+# system hostname configuration
+
+## Overview
+
+As a network operator
+I want `set system hostname <name>` to define the device's name so
+that `show hostname` (and the interactive vty prompt, which tracks
+the same running-config leaf via vtyhelper -H) reflects the
+configured identity instead of the OS hostname, and falls back to
+the OS hostname when the leaf is deleted.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build a single-node topology | |
+| Configured hostname wins over the OS hostname | |
+| Deleting the hostname falls back to the OS hostname | |
+| Teardown topology | |

--- a/bdd/docs/vrf_connected_route.md
+++ b/bdd/docs/vrf_connected_route.md
@@ -1,0 +1,21 @@
+# A VRF interface's connected route lands in the VRF table
+
+## Overview
+
+When an interface is enslaved to a VRF and carries an IPv4 address,
+the connected route derived from that address must be installed into
+the VRF's routing table — not the default table. The interface is
+enslaved asynchronously (the kernel acknowledges `master` via a later
+RTM_NEWLINK), so the connected route is often first filed in the
+default table and must be re-homed onto the VRF table once the enslave
+is observed. Regression test for: connected route shown in
+`show ip route` but missing from `show ip route vrf <name>`.
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Connected route of a VRF interface is in the VRF table only | |
+| Teardown topology | |


### PR DESCRIPTION
## Summary

`make -C bdd docs` had drifted a long way behind `bdd/tests/features/`. This is a pure regeneration — no hand edits, and `feature2md.sh` is unchanged.

- **121 new pages** for features that had no generated doc at all: the `bgp_mup_*`, `bgp_vrf_neighbor_*`, `bgp_dynamic_nbr_*`, `l3vpn_*`, `pim*`/`pim6_*`, `ospfv2_*`/`ospfv3_*` and `isis_srv6_*` families, plus `bgp_evpn_mpls` from #2128.
- **20 refreshed pages** that were missing scenarios added since their last regen — the `Teardown topology` rows across the OSPF and IS-IS BFD features, `isis_multi_topology`'s two new per-MT metric scenarios — or carrying prose that has since moved into a `Notes` section (`bgp_as_path_match`, `bgp_evpn_srv6_p2mp`, `bgp_set_ext_large_community`).

After this, all 268 feature files have a matching page.

## Notes for the reviewer

Two pre-existing quirks surfaced while regenerating. Neither is touched here:

1. `bdd/docs/interface_vrf_binding.md` is an orphan — added by hand in 4e75bdb7 with no `tests/features/interface_vrf_binding.feature` behind it, so `make docs` neither regenerates nor removes it. It is the only doc without a matching feature (269 docs vs 268 features).
2. `feature2md.sh`'s description extractor prints only non-blank lines, so a multi-paragraph `Feature:` description collapses into one paragraph (visible in `bgp_as_path_match.md`).

## Test plan

- `make -C bdd docs` run twice; the second run is byte-identical, so the output is stable against the current feature set.
- Docs-only change: nothing under `zebra-rs/`, `crates/` or `bdd/tests/` is modified, so no behavior is affected.

Generated with [Claude Code](https://claude.com/claude-code)