### PR TITLE
yang: name the knob that actually enables the cradle tee

### DIFF
--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -94,8 +94,10 @@ module zebra-bgp-evpn {
              (IMET) routes, carved from the BGP SRv6 locator, and
              install received MACs against the peer's L2 service SIDs.
              Requires `segment-routing srv6 locator`; the L2 data
-             plane is the cradle eBPF tee (`system cradle grpc-endpoint`) —
-             the kernel has no End.DT2U/DT2M seg6local actions.";
+             plane is the cradle eBPF tee (`system cradle enabled`,
+             with an engine from `system ebpf enabled` or run
+             externally) — the kernel has no End.DT2U/DT2M seg6local
+             actions.";
         }
         enum mpls {
           description
@@ -105,7 +107,8 @@ module zebra-bgp-evpn {
              pops it into the EVI's bridge domain. Bridge domains are
              declared explicitly with the `evi` list (there is no VXLAN
              device to read a VNI from). The L2 data plane is the
-             cradle eBPF tee (`system cradle grpc-endpoint`) — the
+             cradle eBPF tee (`system cradle enabled`, with an engine
+             from `system ebpf enabled` or run externally) — the
              kernel has no action that pops a label into a bridge.";
         }
       }

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -715,8 +715,10 @@ module zebra-bgp-vrf {
               description
                 "Real GTP-U: install the tunnel from the ST route's endpoint
                  and TEID via the cradle eBPF forwarder (GTP4.E downlink /
-                 H.M.GTP4.D uplink). Requires `system cradle grpc-endpoint` to point at
-                 the forwarder; the mainline kernel has no GTP action.";
+                 H.M.GTP4.D uplink). Requires `system cradle enabled` to tee
+                 into the forwarder (`system cradle grpc-endpoint` only
+                 overrides where it is); the mainline kernel has no GTP
+                 action.";
             }
           }
           default end-dt46;


### PR DESCRIPTION
Follow-up to #2131, which found this while auditing the EVPN-over-MPLS chapter.

Three YANG descriptions told operators the eBPF data plane is reached via **`system cradle grpc-endpoint`**. That leaf is an endpoint override — it enables nothing on its own (`config.yang:536`: *"it only takes effect while the tee is enabled — on its own it does not enable it"*). The switch is **`system cradle enabled`**, and there has to be an engine to tee into, either managed by `system ebpf enabled` or run externally.

| File | Feature described |
|---|---|
| `zebra-bgp-evpn.yang:97` | `encapsulation srv6` — EVPN-over-SRv6 L2 |
| `zebra-bgp-evpn.yang:108` | `encapsulation mpls` — EVPN-over-MPLS L2 |
| `zebra-bgp-vrf.yang:718` | MUP `dataplane gtp` |

The wording matters more here than in most descriptions: all three are features the mainline kernel cannot forward at all (no End.DT2U/DT2M seg6local action, no MPLS-to-bridge action, no GTP action). Setting only the endpoint leaf leaves the control plane advertising and receiving perfectly correctly with nothing programmed anywhere — the hardest kind of failure to spot, and the one #2129 chased down end to end.

These strings surface in `?` / CLI help, so they are the first thing an operator reads when configuring any of the three.

Descriptions only — no grammar changes, no leaf changes. `cargo test -p zebra-rs` passes (1788), which covers the YANG load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)