### PR TITLE
bdd: cover interface-to-VRF enslavement

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -283,6 +283,10 @@ vrf_phantom_instance:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_phantom_instance"
 
+interface_vrf_binding:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@interface_vrf_binding"
+
 vrf_connected_route:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_connected_route"

--- a/bdd/docs/interface_vrf_binding.md
+++ b/bdd/docs/interface_vrf_binding.md
@@ -1,0 +1,60 @@
+# Interface-to-VRF enslavement (`interface <name> vrf <vrf>`)
+
+## Overview
+
+As a network operator
+I want to enslave individual interfaces to a VRF master device
+So that traffic on those interfaces is routed in the VRF's table instead
+of the default routing instance.
+
+The binding is operator intent, not an immediate netlink call: either
+half can be missing when the config is committed. `link_vrf_bind` records
+the intent in `pending_vrf_bind` and replays it when the missing piece
+arrives — a kernel `NewLink` for the interface, or `VrfAdd` for the
+master — so config order is free. That deferral is what scenarios D and
+E pin; the rest pin the steady state and the show surfaces.
+
+Kernel state is asserted with `ip -d link show <if>` (`master <vrf>`)
+rather than through zebra-rs, so a show-layer bug cannot make a missing
+enslavement look present.
+
+## Test Topology
+
+```
+              ┌─────────────────────────────┐
+              │              z1             │
+              │   ┌─────────────────────┐   │
+              │   │      vrf vrf1       │   │  table-id allocated
+              │   └──────────┬──────────┘   │
+              │              │ master       │
+              │   ┌──────────┴──────────┐   │
+              │   │         vi1         │   │  192.168.10.1/24
+              │   └─────────────────────┘   │
+              │                             │
+              │             vi2             │  10.0.0.1/24, default VRF
+              └─────────────────────────────┘
+```
+
+## Notes
+
+vi1 and vi2 are dummy interfaces created before the daemon starts; vi3 is
+created mid-run by scenario D to prove a binding survives the netdev not
+existing yet. vi2 never joins a VRF and is the control for the `default`
+rendering in `show interface brief`.
+
+## Config Files
+
+- z1.yaml: vrf1, vi1 enslaved to it with 192.168.10.1/24, unbound vi2.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup — a VRF master with one member, bound in a single commit | |
+| A - an address committed with the binding lands in the VRF table | |
+| B - show vrf lists the member and show interface brief names the VRF | |
+| C - unbinding returns the interface to the default VRF | |
+| D - a binding set before the netdev exists fires on create | |
+| E - re-binding moves the interface to a second VRF | |
+| F - deleting the VRF detaches its members, re-creating re-enslaves | |
+| Teardown topology | |

--- a/bdd/tests/configs/interface_vrf_binding/z1.yaml
+++ b/bdd/tests/configs/interface_vrf_binding/z1.yaml
@@ -1,0 +1,16 @@
+# z1 — one router, one VRF, two dummy interfaces.
+#
+# vi1 is enslaved to vrf1 AND given an address in the same commit, so the
+# ordering inside a single apply is exercised: the address must end up in
+# the VRF's table, not the default one. vi2 stays unbound as the control
+# for `show interface brief`'s VRF column.
+vrf:
+- name: vrf1
+interface:
+- if-name: vi1
+  vrf: vrf1
+  ipv4:
+    address: 192.168.10.1/24
+- if-name: vi2
+  ipv4:
+    address: 10.0.0.1/24

--- a/bdd/tests/features/interface_vrf_binding.feature
+++ b/bdd/tests/features/interface_vrf_binding.feature
@@ -1,0 +1,126 @@
+@serial
+@interface_vrf_binding
+Feature: Interface-to-VRF enslavement (`interface <name> vrf <vrf>`)
+  As a network operator
+  I want to enslave individual interfaces to a VRF master device
+  So that traffic on those interfaces is routed in the VRF's table instead
+  of the default routing instance.
+
+  The binding is operator intent, not an immediate netlink call: either
+  half can be missing when the config is committed. `link_vrf_bind` records
+  the intent in `pending_vrf_bind` and replays it when the missing piece
+  arrives — a kernel `NewLink` for the interface, or `VrfAdd` for the
+  master — so config order is free. That deferral is what scenarios D and
+  E pin; the rest pin the steady state and the show surfaces.
+
+  Kernel state is asserted with `ip -d link show <if>` (`master <vrf>`)
+  rather than through zebra-rs, so a show-layer bug cannot make a missing
+  enslavement look present.
+
+  Test Topology:
+  ```
+              ┌─────────────────────────────┐
+              │              z1             │
+              │   ┌─────────────────────┐   │
+              │   │      vrf vrf1       │   │  table-id allocated
+              │   └──────────┬──────────┘   │
+              │              │ master       │
+              │   ┌──────────┴──────────┐   │
+              │   │         vi1         │   │  192.168.10.1/24
+              │   └─────────────────────┘   │
+              │                             │
+              │             vi2             │  10.0.0.1/24, default VRF
+              └─────────────────────────────┘
+  ```
+
+  vi1 and vi2 are dummy interfaces created before the daemon starts; vi3 is
+  created mid-run by scenario D to prove a binding survives the netdev not
+  existing yet. vi2 never joins a VRF and is the control for the `default`
+  rendering in `show interface brief`.
+
+  Config files (in configs/interface_vrf_binding/):
+  - z1.yaml: vrf1, vi1 enslaved to it with 192.168.10.1/24, unbound vi2.
+
+  Scenario: Setup — a VRF master with one member, bound in a single commit
+    Given a clean test environment
+    When I create namespace "z1"
+    And I execute "ip link add vi1 type dummy" in namespace "z1"
+    And I execute "ip link set vi1 up" in namespace "z1"
+    And I execute "ip link add vi2 type dummy" in namespace "z1"
+    And I execute "ip link set vi2 up" in namespace "z1"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+    # The VRF master device is created with a table id of its own.
+    Then command "ip -d link show vrf1" in namespace "z1" should eventually contain "vrf table"
+    # …and vi1 is enslaved to it.
+    And command "ip -d link show vi1" in namespace "z1" should eventually contain "master vrf1"
+
+  # The address and the binding arrived in one commit, so whichever the RIB
+  # processes first, the connected prefix must end up in the VRF's table —
+  # never left behind in the default one.
+  Scenario: A - an address committed with the binding lands in the VRF table
+    Given the test topology exists
+    Then command "ip route show vrf vrf1" in namespace "z1" should eventually contain "192.168.10.0/24"
+    And show command "show ip route vrf vrf1" in namespace "z1" should eventually contain "192.168.10.0/24"
+    And show command "show ip route" in namespace "z1" should not contain "192.168.10.0/24"
+
+  Scenario: B - show vrf lists the member and show interface brief names the VRF
+    Given the test topology exists
+    Then show command "show vrf" in namespace "z1" should eventually contain "vrf1"
+    And show command "show vrf" in namespace "z1" should eventually contain "vi1"
+    And show command "show interface brief" in namespace "z1" should eventually contain "vrf1"
+    # vi2 was never bound, so it renders as the default routing instance.
+    And show command "show interface brief" in namespace "z1" should eventually contain "default"
+
+  # `delete` carries the leaf's value, like every other leaf in the grammar;
+  # the bare `delete interface vi1 vrf` is rejected with an error reply.
+  Scenario: C - unbinding returns the interface to the default VRF
+    Given the test topology exists
+    When I apply command "delete interface vi1 vrf vrf1" in namespace "z1"
+    Then command "ip -d link show vi1" in namespace "z1" should eventually not contain "master vrf1"
+    # The member column empties out with it.
+    And show command "show vrf" in namespace "z1" should eventually not contain "vi1"
+    # reset for the scenarios below
+    When I apply command "set interface vi1 vrf vrf1" in namespace "z1"
+    Then command "ip -d link show vi1" in namespace "z1" should eventually contain "master vrf1"
+
+  # pending_vrf_bind replayed on NewLink: the binding is committed while the
+  # netdev does not exist, and fires by itself the moment it is created.
+  Scenario: D - a binding set before the netdev exists fires on create
+    Given the test topology exists
+    When I apply command "set interface vi3 vrf vrf1" in namespace "z1"
+    And I wait 2 seconds
+    # Nothing to enslave yet — the intent is parked, not lost.
+    Then command "ip link show" in namespace "z1" should not contain "vi3"
+    When I execute "ip link add vi3 type dummy" in namespace "z1"
+    And I execute "ip link set vi3 up" in namespace "z1"
+    Then command "ip -d link show vi3" in namespace "z1" should eventually contain "master vrf1"
+    And show command "show vrf" in namespace "z1" should eventually contain "vi3"
+
+  Scenario: E - re-binding moves the interface to a second VRF
+    Given the test topology exists
+    When I apply command "set vrf vrf2" in namespace "z1"
+    And I apply command "set interface vi1 vrf vrf2" in namespace "z1"
+    Then command "ip -d link show vi1" in namespace "z1" should eventually contain "master vrf2"
+    And command "ip -d link show vi1" in namespace "z1" should eventually not contain "master vrf1"
+
+  # Deleting the master is allowed with members still bound: the kernel
+  # detaches them when the device goes. The operator never withdrew the
+  # binding, though, so the intent outlives the VRF and re-creating it
+  # re-enslaves vi3 with no second `set interface` — the VrfAdd half of
+  # the deferred bind, the mirror of scenario D's NewLink half.
+  Scenario: F - deleting the VRF detaches its members, re-creating re-enslaves
+    Given the test topology exists
+    When I apply command "delete vrf vrf1" in namespace "z1"
+    Then command "ip -d link show vi3" in namespace "z1" should eventually not contain "master vrf1"
+    And show command "show vrf" in namespace "z1" should eventually not contain "vrf1"
+    # The binding was never withdrawn, so the master coming back is enough.
+    When I apply command "set vrf vrf1" in namespace "z1"
+    Then command "ip -d link show vi3" in namespace "z1" should eventually contain "master vrf1"
+    And show command "show vrf" in namespace "z1" should eventually contain "vi3"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

The `vrf` leaf on `list interface` shipped in 4e75bdb7 with no BDD feature behind it — only a hand-written plan under `bdd/docs/`, which #2134 removed as an orphan once the docs target started rejecting pages with no feature. This turns that plan into a running test.

Eight scenarios on a single namespace:

- **Setup** — a VRF master and a member bound in one commit; the master gets a table id and `vi1` gets `master vrf1`.
- **A** — the address committed alongside the binding lands in the VRF table and is absent from the default one.
- **B** — the `show vrf` Members column and the `show interface brief` VRF column, against an unbound control interface that must render as `default`.
- **C** — unbind returns the interface to the default VRF and empties the members column.
- **D** — deferred bind, `NewLink` half: the binding is committed while the netdev does not exist, is parked rather than lost, and fires by itself when the interface is created.
- **E** — re-binding moves the interface to a second VRF.
- **F** — deferred bind, `VrfAdd` half: deleting the master detaches its members, but the operator's intent outlives it, so re-creating the VRF re-enslaves with no second `set interface`.
- **Teardown topology** — stops the daemon, deletes the namespace, asserts the environment is clean.

Kernel state is read with `ip -d link show`, not through zebra-rs, so a show-layer bug cannot make a missing enslavement look present.

Two things the original plan asserted turned out to be wrong, corrected against a live daemon:

- `delete interface X vrf` is rejected with an error reply — the leaf's value is part of the delete, so it is `delete interface X vrf vrf1`.
- Detaching leaves no `nomaster` in `ip link` output; it simply drops `master <vrf>`.

## Test plan

- `make -C bdd interface_vrf_binding` — **8 scenarios, 49 steps, all passing**, run twice against a freshly built `zebra-rs`.
- Teardown verified: `the test environment should be clean` passes, and no namespaces or `zebra-rs` processes are left behind afterwards.
- `make -C bdd docs` regenerates cleanly and the orphan guard from #2134 passes: 270 features, 270 pages, no drift in any other doc.
- Test-only change: nothing under `zebra-rs/` or `crates/` is touched.

Generated with [Claude Code](https://claude.com/claude-code)