### PR TITLE
bgp: cancel the queued EVPN advertise a withdraw supersedes

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -823,6 +823,13 @@ impl PeerStat {
     }
 }
 
+/// Identity of one EVPN advertisement in [`Peer::cache_evpn_rev`]:
+/// `(RD, route key, AddPath path-id)` — the same triple the Adj-RIB-Out is
+/// keyed on, and everything a withdraw can reconstruct. Deliberately
+/// excludes the per-path forwarding properties (MPLS label / VNI, Type-5
+/// gateway IP) that the NLRI also carries.
+pub type EvpnCacheKey = (RouteDistinguisher, EvpnPrefix, u32);
+
 #[derive(Debug)]
 pub struct Peer {
     pub ident: usize,
@@ -1006,10 +1013,18 @@ pub struct Peer {
     pub cache_vpnv6_timer: Option<Timer>,
     /// EVPN advertise cache. Mirrors `cache_vpnv4` shape — NLRIs
     /// grouped by attribute so a single MP_REACH UPDATE on flush can
-    /// carry every route that shares one attr set. Withdraw path uses
-    /// the reverse map; not yet implemented in this PR.
+    /// carry every route that shares one attr set.
     pub cache_evpn: HashMap<Arc<BgpAttr>, HashSet<EvpnRoute>>,
-    pub cache_evpn_rev: HashMap<EvpnRoute, Arc<BgpAttr>>,
+    /// Reverse index into `cache_evpn`, keyed by **route identity**
+    /// ([`EvpnCacheKey`]) rather than by the `EvpnRoute` itself. The queued
+    /// NLRI carries per-path forwarding properties — the MPLS label / VNI,
+    /// the Type-5 gateway — that a withdraw does not know
+    /// (`evpn_route_from_prefix` zeroes them), so an `EvpnRoute`-keyed index
+    /// could not be looked up from the withdraw side. The value keeps the
+    /// NLRI exactly as queued so the eviction can remove it from the
+    /// attribute group. `Vpnv4Nlri` solves the same problem the other way
+    /// round, with a label-blind `PartialEq`/`Hash`.
+    pub cache_evpn_rev: HashMap<EvpnCacheKey, (Arc<BgpAttr>, EvpnRoute)>,
     pub cache_vpnv4_timer: Option<Timer>,
     pub cache_evpn_timer: Option<Timer>,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
@@ -4387,6 +4402,8 @@ mod as4_negotiation_tests {
 
 #[cfg(test)]
 mod adv_timer_phantom_tests {
+    use std::str::FromStr;
+
     use super::*;
 
     fn idle_peer() -> Peer {
@@ -4675,7 +4692,11 @@ mod adv_timer_phantom_tests {
                 .is_some_and(|set| set.contains(&route)),
             "the route must be queued under the attribute last advertised"
         );
-        assert_eq!(peer.cache_evpn_rev.get(&route), Some(&primary));
+        let (rd, prefix) = EvpnPrefix::from_route(&route);
+        assert_eq!(
+            peer.cache_evpn_rev.get(&(rd, prefix, 0)),
+            Some(&(primary.clone(), route.clone()))
+        );
 
         // Re-advertising with the *same* attribute is idempotent.
         peer.send_evpn(route.clone(), primary.clone(), true);
@@ -4685,6 +4706,46 @@ mod adv_timer_phantom_tests {
             Some(1),
             "a repeat advertise must not duplicate the NLRI"
         );
+    }
+
+    /// A withdraw must cancel the advertisement of the same route still
+    /// sitting in the debounce cache, even though the two carry different
+    /// label / gateway values: `evpn_route_from_prefix` rebuilds the NLRI
+    /// from the RIB key alone and zeroes both, while the queued copy holds
+    /// the real service label.
+    ///
+    /// Missing that eviction is what resurrected a withdrawn route: rebinding
+    /// a peer's EVPN out-policy to an undefined name ran two soft-outs (the
+    /// unbind of the old name, then the bind of the new one), the first
+    /// queued a re-advertise and the second sent the withdraw — and the
+    /// orphaned advertise reached the peer when the advertisement-interval
+    /// timer fired five seconds later.
+    #[tokio::test]
+    async fn cache_remove_evpn_cancels_a_queued_advertise_with_a_label() {
+        let (mut peer, _rx) = peer_with_channel();
+        let rd = RouteDistinguisher::from_str("65001:100").unwrap();
+        let advertised = EvpnRoute::Prefix(bgp_packet::EvpnIpPrefix {
+            id: 0,
+            rd,
+            esi: [0; 10],
+            ether_tag: 0,
+            prefix: "10.1.0.0/24".parse().unwrap(),
+            gw: IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+            label: 16,
+        });
+
+        peer.send_evpn(advertised.clone(), Arc::new(BgpAttr::new()), true);
+        assert_eq!(peer.cache_evpn.len(), 1);
+
+        // The withdraw side knows only (rd, prefix, path-id).
+        let (_, key) = EvpnPrefix::from_route(&advertised);
+        peer.cache_remove_evpn(rd, &key, 0);
+
+        assert!(
+            peer.cache_evpn.is_empty(),
+            "the queued advertise must be cancelled, not left to flush after the withdraw"
+        );
+        assert!(peer.cache_evpn_rev.is_empty());
     }
 
     /// EVPN twin of the VPNv4 zero-interval test above, using a

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5345,16 +5345,14 @@ fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
 /// Adj-RIB-Out clear); a non-zero `id` withdraws exactly that path.
 fn evpn_withdraw_one(peer: &mut Peer, rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32) {
     let route = evpn_route_from_prefix(rd, prefix, id);
-    // Drop a queued advertise for the same route from the peer's cache
-    // so flush_evpn doesn't ship a now-stale add after the withdraw.
-    if let Some(attr) = peer.cache_evpn_rev.remove(&route)
-        && let Some(set) = peer.cache_evpn.get_mut(&attr)
-    {
-        set.remove(&route);
-        if set.is_empty() {
-            peer.cache_evpn.remove(&attr);
-        }
-    }
+    // Drop a queued advertise for the same route from the peer's cache so
+    // flush_evpn doesn't ship a now-stale add after the withdraw. Keyed on
+    // `(rd, prefix, id)` — `route` above carries a zeroed label and gateway,
+    // so matching the queued NLRI itself would miss (and did: a rebind of an
+    // EVPN out-policy to an undefined name withdrew the route and then the
+    // advertisement-interval timer re-sent the copy queued moments earlier
+    // by the same soft-out, five seconds later).
+    peer.cache_remove_evpn(*rd, prefix, id);
     // Drop the Adj-RIB-Out entry so soft-out's baseline reflects
     // reality — without this a follow-up policy change would think the
     // route is still advertised and emit a redundant withdraw.
@@ -5417,6 +5415,31 @@ fn macip_service_field(rib: &BgpRib) -> u32 {
         .filter(|l| *l != 0)
         .or_else(|| extract_vni_from_attr(&rib.attr))
         .unwrap_or(0)
+}
+
+/// The RFC 7911 path-id carried on an EVPN NLRI — 0 for a non-AddPath
+/// advertisement, which is also the whole-prefix sentinel the Adj-RIB-Out
+/// and the advertise cache use.
+pub(super) fn evpn_path_id(route: &EvpnRoute) -> u32 {
+    match route {
+        EvpnRoute::EthernetAd(e) => e.id,
+        EvpnRoute::EthernetSeg(e) => e.id,
+        EvpnRoute::Mac(m) => m.id,
+        EvpnRoute::Multicast(m) => m.id,
+        EvpnRoute::Prefix(p) => p.id,
+        EvpnRoute::Smet(s) => s.id,
+        EvpnRoute::IgmpJoinSync(j) => j.id,
+        EvpnRoute::IgmpLeaveSync(l) => l.id,
+        EvpnRoute::PerRegionImet(r) => r.id,
+        EvpnRoute::SPmsi(r) => r.id,
+        EvpnRoute::LeafAd(r) => r.id,
+    }
+}
+
+/// The advertise-cache identity of `route` — see [`super::peer::EvpnCacheKey`].
+fn evpn_cache_key(route: &EvpnRoute) -> super::peer::EvpnCacheKey {
+    let (rd, prefix) = EvpnPrefix::from_route(route);
+    (rd, prefix, evpn_path_id(route))
 }
 
 fn evpn_route_from_prefix(rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32) -> EvpnRoute {
@@ -8024,19 +8047,7 @@ pub fn route_evpn_update(
     // reflect path as the other EVPN types; they carry no VXLAN dataplane
     // action (`route_evpn_export_selected` handles them as no-ops). Local
     // origination / segmentation re-origination lands in a later phase.
-    let id = match route {
-        EvpnRoute::EthernetAd(e) => e.id,
-        EvpnRoute::EthernetSeg(e) => e.id,
-        EvpnRoute::Mac(m) => m.id,
-        EvpnRoute::Multicast(m) => m.id,
-        EvpnRoute::Prefix(p) => p.id,
-        EvpnRoute::Smet(s) => s.id,
-        EvpnRoute::IgmpJoinSync(j) => j.id,
-        EvpnRoute::IgmpLeaveSync(l) => l.id,
-        EvpnRoute::PerRegionImet(r) => r.id,
-        EvpnRoute::SPmsi(r) => r.id,
-        EvpnRoute::LeafAd(r) => r.id,
-    };
+    let id = evpn_path_id(route);
 
     // Loop detection mirrors route_ipv4_update — drop the route silently
     // (no eprintln) on local-AS / ORIGINATOR_ID / CLUSTER_LIST hits.
@@ -8238,19 +8249,7 @@ pub fn route_evpn_update(
 /// and the Loc-RIB, then re-run best-path selection.
 pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, peers: &mut PeerMap) {
     let (rd, prefix) = EvpnPrefix::from_route(route);
-    let id = match route {
-        EvpnRoute::EthernetAd(e) => e.id,
-        EvpnRoute::EthernetSeg(e) => e.id,
-        EvpnRoute::Mac(m) => m.id,
-        EvpnRoute::Multicast(m) => m.id,
-        EvpnRoute::Prefix(p) => p.id,
-        EvpnRoute::Smet(s) => s.id,
-        EvpnRoute::IgmpJoinSync(j) => j.id,
-        EvpnRoute::IgmpLeaveSync(l) => l.id,
-        EvpnRoute::PerRegionImet(r) => r.id,
-        EvpnRoute::SPmsi(r) => r.id,
-        EvpnRoute::LeafAd(r) => r.id,
-    };
+    let id = evpn_path_id(route);
 
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
@@ -12587,28 +12586,46 @@ impl Peer {
     /// per-attribute batching so a single MP_REACH UPDATE can carry
     /// every route that shares an attribute set.
     pub fn send_evpn(&mut self, route: EvpnRoute, attr: Arc<BgpAttr>, timer: bool) {
-        // Re-advertising a route whose *attribute* changed must first evict
-        // it from the attr group it was queued under. `cache_evpn` groups
-        // pending NLRIs by attribute and `flush_evpn` emits one UPDATE per
-        // group, so leaving the stale entry ships the route twice — once
-        // with each attribute — and which one the peer ends up believing
-        // depends on `BTreeMap` iteration order over the attr keys. That is
-        // arbitrary, so the peer intermittently keeps the *old* attribute.
-        //
-        // `evpn_withdraw_one` already evicts this way for the withdraw case;
-        // this is the same eviction for the re-advertise case.
-        if let Some(old) = self.cache_evpn_rev.insert(route.clone(), attr.clone())
-            && old != attr
-            && let Some(set) = self.cache_evpn.get_mut(&old)
+        // Re-advertising a route must first evict whatever copy of it is
+        // already queued. `cache_evpn` groups pending NLRIs by attribute and
+        // `flush_evpn` emits one UPDATE per group, so leaving the stale entry
+        // ships the route twice — once with each attribute — and which one
+        // the peer ends up believing depends on `HashMap` iteration order
+        // over the attr keys. That is arbitrary, so the peer intermittently
+        // keeps the *old* attribute. Evicting on identity (not on the whole
+        // NLRI) also catches a re-advertise that changed only the label /
+        // gateway under an unchanged attribute set.
+        let key = evpn_cache_key(&route);
+        if let Some((old_attr, old_route)) = self
+            .cache_evpn_rev
+            .insert(key, (attr.clone(), route.clone()))
+            && let Some(set) = self.cache_evpn.get_mut(&old_attr)
         {
-            set.remove(&route);
+            set.remove(&old_route);
             if set.is_empty() {
-                self.cache_evpn.remove(&old);
+                self.cache_evpn.remove(&old_attr);
             }
         }
         self.cache_evpn.entry(attr).or_default().insert(route);
         if timer && self.cache_evpn_timer.is_none() {
             self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
+        }
+    }
+
+    /// Drop a not-yet-flushed EVPN advertisement of `(rd, prefix, id)` from
+    /// the advertise cache. The EVPN twin of [`Peer::cache_remove_vpnv4`],
+    /// and the reason `cache_evpn_rev` is keyed on identity: a withdraw
+    /// reconstructs the NLRI from the RIB key alone (`evpn_route_from_prefix`
+    /// zeroes the label and the Type-5 gateway), so it can never present the
+    /// queued NLRI byte-for-byte.
+    pub fn cache_remove_evpn(&mut self, rd: RouteDistinguisher, prefix: &EvpnPrefix, id: u32) {
+        if let Some((attr, route)) = self.cache_evpn_rev.remove(&(rd, prefix.clone(), id))
+            && let Some(set) = self.cache_evpn.get_mut(&attr)
+        {
+            set.remove(&route);
+            if set.is_empty() {
+                self.cache_evpn.remove(&attr);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the `@bgp_evpn_outpolicy_undef` BDD, which has been red since #2006.

## Symptom

Rebinding a neighbor's EVPN out-policy to a name that does not exist withdraws the route — and then re-advertises it five seconds later. The peer keeps a route the deny-all policy rejected.

## Mechanism

A whole-config replace of the bound name is a `Delete` of the old value followed by a `Set` of the new one. Since #2006 each half draws a `PolicyRx` reply, so **two** soft-outs run back to back:

| | slot name | decision | effect |
|---|---|---|---|
| Delete's reply | cleared | permit (unbound ⇒ permit-all) | re-advertise, parked in `cache_evpn` behind the 5 s iBGP advertisement-interval debounce |
| Set's reply | `NOPE` (undefined) | deny | withdraw sent immediately |

`evpn_withdraw_one` is meant to drain that pending advertise. It looked it up with the NLRI `evpn_route_from_prefix` rebuilds from the RIB key — **label 0, gateway unspecified** — while the queued copy carried the real service label (16 here). `EvpnRoute` equality covers those fields, so the lookup missed, the advertise survived, and the debounce timer shipped it *after* the withdraw had already landed.

Traced live on both daemons:

```
z1  soft_out_evpn ... was_adv=1 newly=1 withdraw=0    # Delete's reply: permit → queued
z1  soft_out_evpn ... was_adv=1 newly=0 withdraw=1    # Set's reply: deny → withdrawn
z2  route_evpn_withdraw ... removed=1 selected=0      # z2 correctly drops it
z2  rx evpn update ... label: 16                      # +5.005 s — the orphaned advertise
```

## Fix

Key `cache_evpn_rev` on route identity — `(RD, EvpnPrefix, path-id)`, the triple the Adj-RIB-Out already uses and all a withdraw can reconstruct — and store the NLRI as queued as the value so the eviction can still pull it out of its attribute group.

`Vpnv4Nlri` reaches the same place from the other side, with a hand-written label-blind `PartialEq`/`Hash`; that is why `cache_remove_vpnv4` never had this bug.

Evicting on identity also fixes a narrower case the old `old != attr` guard missed: a re-advertise that changes only the label or the Type-5 gateway under an unchanged attribute set left **both** NLRIs queued in the same group.

Also folds the three copies of the `EvpnRoute` → path-id match into one `evpn_path_id` helper.

## Verification

- **Red/green** on `@bgp_evpn_outpolicy_undef` — fix stashed → ✗, restored → ✓, same host and concurrency.
- Unit test for the label-mismatched eviction (`cache_remove_evpn_cancels_a_queued_advertise_with_a_label`).
- 1789 zebra-rs unit tests pass.
- All **23** EVPN BDD features pass.
- The seven policy / VPN features sharing the soft-out path pass: `bgp_out_policy_delete`, `bgp_policy_dynamic_update`, `bgp_route_map_match`, `bgp_table_map`, `bgp_v6_table_map`, `bgp_vrf_neighbor_afi_policy`, `l3vpn_dual_ce`.
- `cargo fmt` + workspace clippy `--all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)