### PR TITLE
bdd: run the suite against a staged toolchain, not the /usr install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ allure-report/
 allure-results/
 .allure/
 typescript
+# Per-worktree staged toolchain (make -C bdd stage)
+/bdd/.stage/
+/bdd/.stage.tmp/

--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -338,7 +338,7 @@ vrf_phantom_instance:
 
 interface_vrf_binding:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@interface_vrf_binding"
+	$(CUCUMBER) -- --concurrency=1 --tags "@interface_vrf_binding"
 
 vrf_connected_route:
 	mkdir -p allure-results
@@ -549,7 +549,7 @@ bgp_evpn_vpws_multihoming:
 # this target runs longer than most.
 bgp_evpn_vpws_startup_delay:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_vpws_startup_delay"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_vpws_startup_delay"
 
 # EVPN Type-5 over SRv6 (End.DT46) with CE-to-CE forwarding. Kernel
 # dataplane only — no cradle engine needed.

--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -1,60 +1,113 @@
+# ── Per-worktree toolchain staging ───────────────────────────────────────
+#
+# A BDD run must exercise THIS worktree's binaries and YANG schemas. Left to
+# themselves the daemon and CLIs resolve host-global paths (/usr/bin/zebra-rs,
+# /usr/bin/vtyctl, /usr/bin/pfcp-inject, /usr/share/zebra-rs/yang), which
+# `make install` overwrites — so two worktrees clobber each other and a run
+# silently tests whichever one installed last.
+#
+# `stage` builds this worktree and copies the result into `.stage/`, mirroring
+# the /usr layout. The harness picks it up automatically (see
+# bdd/src/toolchain.rs) and reads nothing under /usr. Every test target below
+# runs `stage` first, so it is impossible to test a stale binary through make.
+#
+# Copies, not symlinks into target/: cargo rewrites target/<profile>/zebra-rs
+# in place, so a rebuild during a run would otherwise swap the binary out from
+# under it.
+#
+# PROFILE=debug builds faster and is fine for control-plane features; the
+# default matches `make install` (release), which the timing-sensitive
+# convergence scenarios expect.
+PROFILE ?= release
+CARGO_PROFILE_FLAG := $(if $(filter release,$(PROFILE)),--release,)
+TARGET_DIR ?= $(if $(CARGO_TARGET_DIR),$(CARGO_TARGET_DIR),../target)
+STAGE := .stage
+# Package name == binary name for all four; each crate has a single bin.
+STAGE_BINS := zebra-rs vtyctl vtyhelper pfcp-inject
+
+# Every cucumber invocation goes through this, so staging can never be
+# skipped by running a target directly.
+CUCUMBER = $(MAKE) --no-print-directory stage && cargo test --test cucumber
+
+.DEFAULT_GOAL := all
+
+# Populates a scratch directory and renames it into place, so an interrupted
+# stage never leaves a half-filled .stage behind — the harness refuses to run
+# against one rather than silently falling back to /usr.
+.PHONY: stage
+stage:
+	cargo build $(CARGO_PROFILE_FLAG) $(addprefix -p ,$(STAGE_BINS))
+	@rm -rf $(STAGE).tmp
+	@mkdir -p $(STAGE).tmp/bin $(STAGE).tmp/share/zebra-rs/yang
+	@install -m 0755 $(addprefix $(TARGET_DIR)/$(PROFILE)/,$(STAGE_BINS)) $(STAGE).tmp/bin/
+	@install -m 0644 ../zebra-rs/yang/*.yang $(STAGE).tmp/share/zebra-rs/yang/
+	@rm -rf $(STAGE)
+	@mv $(STAGE).tmp $(STAGE)
+	@echo "[staged $(PROFILE) toolchain in $(CURDIR)/$(STAGE)]"
+
+# Drop the staged toolchain; subsequent runs fall back to the host-global
+# /usr layout (i.e. pre-staging behavior).
+.PHONY: unstage
+unstage:
+	rm -rf $(STAGE) $(STAGE).tmp
+
 all:
 	rm -rf allure-results
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=16
+	$(CUCUMBER) -- --concurrency=16
 
 ibgp:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_basic_ibgp"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_basic_ibgp"
 
 ebgp:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_basic_ebgp"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_basic_ebgp"
 
 rr:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_basic_rr"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_basic_rr"
 
 bgp_adv_interval_zero:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_adv_interval_zero"
 
 bgp_adv_interval_zero_v6:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero_v6"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_adv_interval_zero_v6"
 
 bgp_adv_interval_zero_vrf:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_adv_interval_zero_vrf"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_adv_interval_zero_vrf"
 
 bgp_vrf_self_network:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_self_network"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_self_network"
 
 # IPv4 unicast announced inside MP_REACH_NLRI (RFC 4760 §3) by a scripted
 # speaker (tests/scripts/bgp_mp_reach_send.py) — zebra-rs/FRR/GoBGP all
 # emit traditional NLRI, so only the script can produce this encoding.
 bgp_mp_reach_ipv4:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mp_reach_ipv4"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mp_reach_ipv4"
 
 bgp_srv6_redistribute:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_srv6_redistribute"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_srv6_redistribute"
 
 # MUP controller end-to-end: PFCP session -> ST route origination ->
 # peer receive. Needs the `pfcp-inject` binary on the host PATH
 # (cargo build --release -p pfcp-inject; copy to /usr/bin).
 bgp_mup_e2e:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_e2e"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_e2e"
 
 # MUP mixed-AFI: IPv6 UE with an IPv4 GTP endpoint, originated by the MUP-C
 # with no SRv6 locator and parsed by the peer. Needs `pfcp-inject` on the
 # host PATH (cargo build --release -p pfcp-inject; copy to /usr/bin).
 bgp_mup_mixed_afi:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_mixed_afi"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_mixed_afi"
 
 # MUP segment DSD: a PE with `encapsulation srv6` VRF + `afi-safi mup
 # segment direct` carves a per-VRF End.DT46 SID, installs the seg6local
@@ -62,7 +115,7 @@ bgp_mup_mixed_afi:
 # receives. Needs root netns (kernel VRF + seg6local).
 bgp_mup_segment_dsd:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_segment_dsd"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_segment_dsd"
 
 # MUP segment ISD: a PE with `encapsulation srv6` VRF + `afi-safi mup
 # segment interwork prefix <p>` carves a per-VRF End.DT46 SID, installs the
@@ -71,7 +124,7 @@ bgp_mup_segment_dsd:
 # (kernel VRF + seg6local).
 bgp_mup_isd:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_isd"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_isd"
 
 # MUP ST1->ISD encap: one interwork node originates a local ISD (`segment
 # interwork prefix <p>`) and, via its MUP-C, an ST1 whose UE is inside <p>.
@@ -80,7 +133,7 @@ bgp_mup_isd:
 # `pfcp-inject` on the host PATH + root netns (kernel VRF + seg6).
 bgp_mup_st1_isd:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st1_isd"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_st1_isd"
 
 # MUP ST2->DSD encap: an interwork node imports an ST2 + a *remote* DSD into
 # a forwarding VRF, resolves them by Direct-segment id, and installs the ST2
@@ -88,7 +141,7 @@ bgp_mup_st1_isd:
 # SRv6 underlay. Needs `pfcp-inject` on the host PATH + root netns.
 bgp_mup_st2_dsd_fib:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st2_dsd_fib"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_st2_dsd_fib"
 
 # MUP End.DT46 dataplane forwarding: two collocated UPF+interwork nodes each
 # originate an ST2 (endpoint = a host behind it) + a DSD from a PFCP session,
@@ -98,7 +151,7 @@ bgp_mup_st2_dsd_fib:
 # host PATH + root netns (kernel VRF + seg6 + IS-IS SRv6 underlay).
 bgp_mup_forwarding:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_forwarding"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_forwarding"
 
 # MUP ST2: the MUP-C learns a PFCP decapsulation session (Network Instance
 # `core`) and originates a Type-2 Session-Transformed route carrying the
@@ -107,7 +160,7 @@ bgp_mup_forwarding:
 # (cargo build --release -p pfcp-inject; copy to /usr/bin).
 bgp_mup_st2_base:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st2_base"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_st2_base"
 
 # MUP interwork: a combined UPF+controller (z1) originates a DSD (End.DT46
 # + Direct-segment id) and an ST2 (same id) from a PFCP session; the
@@ -116,7 +169,7 @@ bgp_mup_st2_base:
 # `pfcp-inject` on the host PATH and root netns (kernel VRF + seg6local).
 bgp_mup_interwork:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_interwork"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_interwork"
 
 # MUP dual-ST: two VRFs (st1 downlink + st2 uplink) bind the same Network
 # Instance, so one PFCP session originates BOTH Session-Transformed routes
@@ -124,7 +177,7 @@ bgp_mup_interwork:
 # PATH (cargo build --release -p pfcp-inject; copy to /usr/bin).
 bgp_mup_dual_st:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dual_st"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_dual_st"
 
 # MUP cross-VRF import: a PE originates an ISD route in one VRF (rd 65501:20)
 # and imports it into a DIFFERENT VRF (rd 65501:10) purely by route-target,
@@ -132,7 +185,7 @@ bgp_mup_dual_st:
 # Needs root netns (kernel VRF + seg6local for the End.DT46 install).
 bgp_mup_vrf_import:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_vrf_import"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_vrf_import"
 
 # MUP dynamic export RT: a controller ST2 is originated with no export
 # route-target, then `set vrf mobile-up mup route-target export 100:10` is
@@ -142,7 +195,7 @@ bgp_mup_vrf_import:
 # for the export-RT to flow through the RIB Vrf row).
 bgp_mup_dynamic_rt:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dynamic_rt"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_dynamic_rt"
 
 # MUP peer-down withdraw: z1 originates an ISD carrying rt 65501:10 that z2
 # imports into VRF N3 (rd 65501:99) by route-target. When z1 is stopped, z2's
@@ -150,82 +203,82 @@ bgp_mup_dynamic_rt:
 # N3's RT-imported copy — the regression test for the leaked per-VRF copy.
 bgp_mup_peerdown:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_peerdown"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_peerdown"
 
 rib_static_ipv6:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"
+	$(CUCUMBER) -- --concurrency=1 --tags "@rib_static_ipv6"
 
 static_srv6_nht:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@static_srv6_nht"
+	$(CUCUMBER) -- --concurrency=1 --tags "@static_srv6_nht"
 
 bgp_srv6_nht:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_srv6_nht"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_srv6_nht"
 
 # Run all IS-IS tests.
 isis:
 	rm -rf allure-results
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=20 --tags "@isis"
+	$(CUCUMBER) -- --concurrency=20 --tags "@isis"
 
 isis_lan_dis_reelection:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_lan_dis_reelection"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_lan_dis_reelection"
 
 # A DIS that loses its circuit must purge the pseudonode LSP it originated
 # rather than leave it to age out over MaxAge (~20 min). Slow by nature:
 # the purged copy has to outlive ZeroAgeLifetime (60s) before eviction.
 isis_lan_dis_pseudonode_purge:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_lan_dis_pseudonode_purge"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_lan_dis_pseudonode_purge"
 
 isis_topology_output:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_topology_output"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_topology_output"
 
 # Run all BFD tests.
 bfd:
 	rm -rf allure-results
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=20 --tags "@bfd"
+	$(CUCUMBER) -- --concurrency=20 --tags "@bfd"
 
 isis_ipv6:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_ipv6"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_ipv6"
 
 isis_interface_metric:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_interface_metric"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_interface_metric"
 
 isis_multi_topology:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_multi_topology"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_multi_topology"
 
 isis_srv6_base:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srv6_base"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_srv6_base"
 
 isis_fragmentation_ipv6:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_fragmentation_ipv6"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_fragmentation_ipv6"
 
 isis_fragmentation_ipv4:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_fragmentation_ipv4"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_fragmentation_ipv4"
 
 isis_l1p2p:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1p2p"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_l1p2p"
 
 isis_tilfa:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_tilfa"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_tilfa"
 
 isis_srmpls:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srmpls"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_srmpls"
 
 # Live dataplane switchover: SR-MPLS -> SRv6 classic -> SRv6 uSID ->
 # SR-MPLS on the RFC 9855 playset topology, each phase applied as a
@@ -233,55 +286,55 @@ isis_srmpls:
 # convergence waits — give it a few minutes.
 isis_sr_switchover:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_sr_switchover"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_sr_switchover"
 
 isis_sr_dataplane_choice:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_sr_dataplane_choice"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_sr_dataplane_choice"
 
 ospfv3_sr_dataplane_choice:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_sr_dataplane_choice"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv3_sr_dataplane_choice"
 
 system_hostname:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@system_hostname"
+	$(CUCUMBER) -- --concurrency=1 --tags "@system_hostname"
 
 isis_l1l2:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1l2"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_l1l2"
 
 tilfa_bfd:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@tilfa_bfd"
+	$(CUCUMBER) -- --concurrency=1 --tags "@tilfa_bfd"
 
 ospfv2_bfd_frr:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_bfd_frr"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv2_bfd_frr"
 
 ospfv3_bfd_frr:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_bfd_frr"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv3_bfd_frr"
 
 ecmp_bfd_evict:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ecmp_bfd_evict"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ecmp_bfd_evict"
 
 isis_redist:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_redist"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_redist"
 
 isis_hello_auth_keychain:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_hello_auth_keychain"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_hello_auth_keychain"
 
 isis_passive:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_passive"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_passive"
 
 vrf_phantom_instance:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_phantom_instance"
+	$(CUCUMBER) -- --concurrency=1 --tags "@vrf_phantom_instance"
 
 interface_vrf_binding:
 	mkdir -p allure-results
@@ -289,63 +342,63 @@ interface_vrf_binding:
 
 vrf_connected_route:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_connected_route"
+	$(CUCUMBER) -- --concurrency=1 --tags "@vrf_connected_route"
 
 l3vpn_dual_ce:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@l3vpn_dual_ce"
+	$(CUCUMBER) -- --concurrency=1 --tags "@l3vpn_dual_ce"
 
 bgp_vrf_runtime_neighbor:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_runtime_neighbor"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_runtime_neighbor"
 
 bgp_vrf_neighbor_afi_policy:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_afi_policy"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_afi_policy"
 
 bgp_vrf_neighbor_as_path:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_as_path"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_as_path"
 
 bgp_vrf_neighbor_auth:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_auth"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_auth"
 
 bgp_vrf_neighbor_next_hop:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_next_hop"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_next_hop"
 
 bgp_vrf_neighbor_enforce_first_as:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_enforce_first_as"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_enforce_first_as"
 
 bgp_vrf_neighbor_rr_client:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_rr_client"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_rr_client"
 
 bgp_vrf_neighbor_show:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_show"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_show"
 
 bgp_vrf_neighbor_add_path:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_neighbor_add_path"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_neighbor_add_path"
 
 bgp_vrf_redistribute:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_redistribute"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_redistribute"
 
 bgp_vrf_ospf_redist:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_ospf_redist"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_ospf_redist"
 
 isis_afi_enable:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_afi_enable"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_afi_enable"
 
 isis_endx_ipv6:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_endx_ipv6"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_endx_ipv6"
 
 # IS-IS BFD over IPv6. The `_echo` targets exercise the Echo scenarios, which
 # require the cradle engine (`/usr/bin/cradle`, from the cradle-rs package) for
@@ -353,19 +406,19 @@ isis_endx_ipv6:
 # the no-echo scenario.
 isis_bfd_ipv6_p2p:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and not @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and not @bfd_echo"
 
 isis_bfd_ipv6_p2p_echo:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and @bfd_echo"
 
 isis_bfd_ipv6_lan:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and not @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and not @bfd_echo"
 
 isis_bfd_ipv6_lan_echo:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and @bfd_echo"
 
 # IS-IS BFD over IPv4. The `_echo` targets exercise the Echo scenarios, which
 # require the cradle engine (`/usr/bin/cradle`, from the cradle-rs package) for
@@ -373,123 +426,123 @@ isis_bfd_ipv6_lan_echo:
 # no-echo scenario.
 isis_bfd_ipv4_p2p:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and not @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and not @bfd_echo"
 
 isis_bfd_ipv4_p2p_echo:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_echo"
 
 isis_bfd_ipv4_p2p_autoattach:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_autoattach"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_autoattach"
 
 isis_bfd_ipv4_lan:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and not @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and not @bfd_echo"
 
 isis_bfd_ipv4_lan_echo:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and @bfd_echo"
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and @bfd_echo"
 
 ospf_clear_neighbor:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospf_clear_neighbor"
 
 ospfv2_nssa_base:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_nssa_base"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv2_nssa_base"
 
 ospfv2_stub_base:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_stub_base"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv2_stub_base"
 
 ospfv3_nssa:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_nssa"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv3_nssa"
 
 bgp_peer_down_cleanup:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_peer_down_cleanup"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_peer_down_cleanup"
 
 bgp_ipv6_over_v4_session:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_ipv6_over_v4_session"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_ipv6_over_v4_session"
 
 ospfv2_tilfa:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_tilfa"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv2_tilfa"
 
 ospfv3_tilfa:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_tilfa"
+	$(CUCUMBER) -- --concurrency=1 --tags "@ospfv3_tilfa"
 
 stamp_te_metric:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@stamp_te_metric"
+	$(CUCUMBER) -- --concurrency=1 --tags "@stamp_te_metric"
 
 stamp_v6_te_metric:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@stamp_v6_te_metric"
+	$(CUCUMBER) -- --concurrency=1 --tags "@stamp_v6_te_metric"
 
 bgp_evpn_capability:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_capability"
 
 bgp_vrf_evpn_type5:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_evpn_type5"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_evpn_type5"
 
 bgp_evpn_outpolicy_undef:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_outpolicy_undef"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_outpolicy_undef"
 
 bgp_route_map_match:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_route_map_match"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_route_map_match"
 
 bgp_policy_dynamic_update:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_policy_dynamic_update"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_policy_dynamic_update"
 
 bgp_table_map:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_table_map"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_table_map"
 
 bgp_v6_table_map:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_v6_table_map"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_v6_table_map"
 
 bgp_community:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_community"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_community"
 
 bgp_neighbor_group:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_neighbor_group"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_neighbor_group"
 
 bgp_unnumbered_neighbor:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unnumbered_neighbor"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_unnumbered_neighbor"
 
 nd_show:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@nd_show"
+	$(CUCUMBER) -- --concurrency=1 --tags "@nd_show"
 
 # Requires /usr/bin/cradle (the cradle-rs engine binary) — see the
 # feature header for the install one-liner.
 cradle_spawn:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@cradle_spawn"
+	$(CUCUMBER) -- --concurrency=1 --tags "@cradle_spawn"
 
 # EVPN BUM over SRv6 P2MP, cradle-engine mode. Requires /usr/bin/cradle.
 bgp_evpn_srv6_p2mp:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_p2mp"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_srv6_p2mp"
 
 # EVPN VPWS multihoming: Type-1 under the segment ESI, DF-elected P/B.
 bgp_evpn_vpws_multihoming:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_vpws_multihoming"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_vpws_multihoming"
 
 # EVPN df-election startup-delay: a booting PE withholds its ES routes and
 # stays out of the election until the timer fires. Waits out a 50s hold, so
@@ -502,64 +555,64 @@ bgp_evpn_vpws_startup_delay:
 # dataplane only — no cradle engine needed.
 bgp_evpn_srv6_type5:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_type5"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_srv6_type5"
 
 # EVPN Type-2 / Type-3 over SRv6 (End.DT2U / End.DT2M) signalling — the
 # `afi-safi evpn encapsulation srv6` leaf. Control-plane only, so no
 # cradle engine needed (the L2 datapath for those SIDs is the tee).
 bgp_evpn_srv6_macip:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_macip"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_srv6_macip"
 
 # EVPN-over-SRv6 L2 service SIDs follow the locator lifecycle: routes
 # originated before the locator resolves, a prefix move, and withdrawal.
 bgp_evpn_srv6_sid_lifecycle:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_sid_lifecycle"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_srv6_sid_lifecycle"
 
 # EVPN-over-SRv6 through a route reflector: the L2 Service TLV must
 # survive reflection (the RR and the far PE carve no SID of their own).
 bgp_evpn_srv6_rr:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_rr"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_srv6_rr"
 
 # L2 (End.DT2U/DT2M) and L3 (End.DT46) EVPN-over-SRv6 on one PE, both
 # carving from the same locator's SID pool.
 bgp_evpn_srv6_irb:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_irb"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_srv6_irb"
 
 bgp_interas_option_c:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_c"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_interas_option_c"
 
 bgp_interas_option_a:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_a"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_interas_option_a"
 
 bgp_interas_option_b:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_b"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_interas_option_b"
 
 bgp_interas_option_ab:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_ab"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_interas_option_ab"
 
 bgp_port:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_port"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_port"
 
 bgp_ip_transparent:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_ip_transparent"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_ip_transparent"
 
 bgp_local_as:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_local_as"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_local_as"
 
 bgp_unknown_attr_transitive:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unknown_attr_transitive"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_unknown_attr_transitive"
 
 # Fast external failover: a direct single-hop eBGP session must be reset
 # the moment its veth link goes down (both ends — carrier drops on both),
@@ -567,7 +620,7 @@ bgp_unknown_attr_transitive:
 # same link cut when `fast-external-failover false` is set.
 bgp_fast_external_failover:
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_fast_external_failover"
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_fast_external_failover"
 
 generate:
 	rm -rf allure-report

--- a/bdd/src/lib.rs
+++ b/bdd/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod netns;
+pub mod toolchain;
 
 mod tag_guard;

--- a/bdd/src/main.rs
+++ b/bdd/src/main.rs
@@ -1,4 +1,8 @@
 pub mod netns;
+// `netns` is compiled into this scratch binary as its own module tree (not
+// pulled from the lib), so its `crate::toolchain` dependency has to be
+// declared here as well.
+pub mod toolchain;
 
 #[tokio::main]
 async fn main() {

--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::fs;
 use tokio::process::Command;
 
+use crate::toolchain;
+
 /// Per-process counter for generating unique temporary veth names in
 /// `connect_netns_pair` and `connect_netns_to_bridge`. Names get renamed
 /// and moved into namespaces immediately after creation, so they only need
@@ -29,13 +31,39 @@ async fn run_cmd(args: &[&str], error_msg: &str) -> Result<()> {
     }
 }
 
+/// Build the `sudo ip netns exec <netns> [env KEY=VAL …]` prelude shared by
+/// every in-namespace command.
+///
+/// `assignments` are pre-rendered `KEY=VAL` strings. When this worktree has
+/// a staged toolchain (see [`crate::toolchain`]), a `PATH=` assignment
+/// leading with the stage's `bin/` is prepended, so commands built from this
+/// repo — `zebra-rs`, `vtyctl`, `pfcp-inject`, and anything a feature file
+/// names — resolve to this worktree's copies instead of whatever another
+/// worktree last installed under `/usr/bin`. System tools (`ip`, `bridge`,
+/// `timeout`, `python3`) resolve exactly as before.
+///
+/// `sudo` resets the environment, which is why the assignments ride on an
+/// `env` prefix rather than on the harness process. GNU `env` applies them
+/// to its own environment before `execvp`, so the command name is looked up
+/// against the PATH set here.
+fn netns_prelude(c: &mut Command, netns: &str, assignments: &[String]) {
+    c.arg("ip").arg("netns").arg("exec").arg(netns);
+
+    let path = toolchain::prefix().map(|p| p.path_env());
+    if path.is_some() || !assignments.is_empty() {
+        c.arg("env");
+        if let Some(path) = path {
+            c.arg(path);
+        }
+        c.args(assignments);
+    }
+}
+
 /// Execute a command in a network namespace
 pub async fn exec_in_netns(netns: &str, cmd: &str, args: &[&str]) -> Result<String> {
-    let output = Command::new("sudo")
-        .arg("ip")
-        .arg("netns")
-        .arg("exec")
-        .arg(netns)
+    let mut c = Command::new("sudo");
+    netns_prelude(&mut c, netns, &[]);
+    let output = c
         .arg(cmd)
         .args(args)
         .stdout(Stdio::piped())
@@ -353,8 +381,8 @@ pub async fn spawn_in_netns_env(
     cmd: &str,
     args: &[&str],
 ) -> Result<tokio::process::Child> {
-    let mut c = Command::new("sudo");
-    c.arg("ip").arg("netns").arg("exec").arg(netns);
+    let is_zebra = cmd == "zebra-rs";
+    let mut assignments: Vec<String> = Vec::new();
 
     // Give each zebra-rs daemon a per-namespace OSPF graceful-restart
     // checkpoint dir. The daemon otherwise reads/writes the fixed
@@ -369,17 +397,15 @@ pub async fn spawn_in_netns_env(
     // checkpoint private while staying STABLE across a same-namespace
     // restart, so graceful-restart resume still works; the daemon
     // create_dir_all's it on write.
-    let ckpt = format!("ZEBRA_OSPF_CHECKPOINT_DIR=/tmp/zebra-rs-ckpt/{netns}");
-    let is_zebra = cmd == "zebra-rs";
-    if is_zebra || !env.is_empty() {
-        c.arg("env");
-        if is_zebra {
-            c.arg(&ckpt);
-        }
-        for (k, v) in env {
-            c.arg(format!("{k}={v}"));
-        }
+    if is_zebra {
+        assignments.push(format!(
+            "ZEBRA_OSPF_CHECKPOINT_DIR=/tmp/zebra-rs-ckpt/{netns}"
+        ));
     }
+    assignments.extend(env.iter().map(|(k, v)| format!("{k}={v}")));
+
+    let mut c = Command::new("sudo");
+    netns_prelude(&mut c, netns, &assignments);
     c.arg(cmd);
     // Force every BDD daemon to cold-start from an empty config. Without an
     // explicit `--config-file`, zebra-rs loads its default config file; under
@@ -395,6 +421,17 @@ pub async fn spawn_in_netns_env(
     // untouched, so we neither depend on nor delete it.
     if is_zebra {
         c.arg("-c").arg("/dev/null");
+
+        // Pin the schemas to this worktree's staged copy. Without it the
+        // daemon walks its own search order — `~/.zebra-rs/yang` then
+        // `/usr/share/zebra-rs/yang` (see `yang_path()` in zebra-rs's
+        // main.rs) — and both are host-global. Under `sudo` HOME is /root,
+        // so a stray `/root/.zebra-rs/yang` shadows even the installed set;
+        // whichever wins, a schema from a different worktree rejects config
+        // this binary supports, surfacing as "unknown key" at apply time.
+        if let Some(prefix) = toolchain::prefix() {
+            c.arg("--yang-path").arg(prefix.yang_dir());
+        }
     }
     c.args(args);
     c.stdout(Stdio::null()).stderr(Stdio::null());

--- a/bdd/src/tag_guard.rs
+++ b/bdd/src/tag_guard.rs
@@ -3,20 +3,51 @@
 //! Every feature scopes its host resources (netns, pid files, bridge,
 //! veths) by its first non-special tag, and both the pre-run sweep and
 //! `the test environment should be clean` match them by the raw string
-//! prefix `<tag>_`. If one feature's tag is a prefix of another's, the
-//! shorter feature's sweep/clean check matches the longer feature's live
-//! resources whenever the two run concurrently — a scheduling-dependent
-//! flake (bit `isis_fragmentation` in PR #1193, then `mirror_sid_node`,
-//! `ospfv2_nssa`, and `ospfv2_stub` in the 2026-07-04 full-suite run).
+//! prefix `<tag>_`. A feature whose tag *extends* another's therefore
+//! shares that feature's prefix: `bgp_evpn_vpws_multihoming`'s namespaces
+//! and pid files look exactly like `bgp_evpn_vpws` resources.
 //!
-//! This unit test fails the build-time `cargo test -p bdd --lib` (and any
-//! full BDD run, which compiles the crate) as soon as a new feature tag
-//! prefixes an existing one, instead of leaving it to bite as a flake.
+//! That used to be banned outright, and this module failed the build for
+//! any prefix pair. Since `d154dfc` the harness tolerates the pairs
+//! instead: `World::sibling_prefixes` lists the features whose tags extend
+//! this one's, and all four scans skip names owned by one of them. Banning
+//! the pairs on top of that would forbid what the harness now handles —
+//! and it did, leaving `cargo test -p bdd --lib` red for the three pairs
+//! that legitimately exist.
+//!
+//! What still needs guarding is that mitigation's precondition. The lookup
+//! enumerates the **file stems** under `tests/features`, while the
+//! resources it protects are named from each feature's **tag**. Those
+//! coincide for most features and deliberately do not for seven — the tag
+//! in `isis_tilfa_srv6.feature` is `tilfa_srv6`, and `isis-redist.feature`
+//! spells its tag `isis_redist`. So a sibling is only covered when its own
+//! file name lines up with its tag; for any other, `sibling_prefixes`
+//! yields a prefix that matches none of the sibling's real resource names
+//! and leaves it exposed to exactly the clobbering `d154dfc` removed —
+//! silently, and only under concurrency.
+//!
+//! So the invariant enforced here is no longer "no tag prefixes another"
+//! but "every tag that prefixes another names a sibling the harness can
+//! actually see".
 
 #[cfg(test)]
 mod tests {
     use std::fs;
     use std::path::PathBuf;
+
+    struct Feature {
+        /// File name without the `.feature` extension — what
+        /// `World::sibling_prefixes` matches on.
+        stem: String,
+        /// First non-special tag — what every resource name is built from.
+        tag: String,
+    }
+
+    impl Feature {
+        fn file(&self) -> String {
+            format!("{}.feature", self.stem)
+        }
+    }
 
     /// First non-special tag of a `.feature` file — the same selection the
     /// cucumber `before` hook uses for `World::feature_tag`.
@@ -29,62 +60,131 @@ mod tests {
             .map(str::to_string)
     }
 
-    #[test]
-    fn no_feature_tag_is_a_prefix_of_another() {
+    fn load_features() -> Vec<Feature> {
         let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/features");
-        let mut tags = Vec::new();
+        let mut features = Vec::new();
         for entry in fs::read_dir(&dir).expect("read tests/features") {
             let path = entry.expect("dir entry").path();
             if path.extension().is_some_and(|e| e == "feature") {
                 let text = fs::read_to_string(&path).expect("read feature file");
                 let tag = feature_tag(&text)
                     .unwrap_or_else(|| panic!("{} has no scoping tag", path.display()));
-                tags.push((
+                features.push(Feature {
+                    stem: path.file_stem().unwrap().to_string_lossy().into_owned(),
                     tag,
-                    path.file_name().unwrap().to_string_lossy().into_owned(),
-                ));
+                });
             }
         }
         assert!(
-            !tags.is_empty(),
+            !features.is_empty(),
             "no feature files found in {}",
             dir.display()
         );
+        features
+    }
 
-        let mut collisions = Vec::new();
-        for (a, fa) in &tags {
-            for (b, fb) in &tags {
-                if a != b && b.starts_with(&format!("{a}_")) {
-                    collisions.push(format!(
-                        "tag `{a}` ({fa}) is a prefix of `{b}` ({fb}) — \
-                         the `{a}_` resource sweep/clean check matches `{b}`'s \
-                         namespaces and pid files when both run concurrently"
+    /// The prefixes `World::sibling_prefixes` produces for `tag`, mirrored
+    /// exactly — filename-based semantics included, since that is the
+    /// property under test.
+    fn harness_sibling_prefixes(tag: &str, stems: &[&str]) -> Vec<String> {
+        let own = format!("{tag}_");
+        stems
+            .iter()
+            .filter(|stem| stem.len() > tag.len() && stem.starts_with(&own))
+            .map(|stem| format!("{stem}_"))
+            .collect()
+    }
+
+    #[test]
+    fn every_prefix_sibling_is_visible_to_the_harness() {
+        let features = load_features();
+        let stems: Vec<&str> = features.iter().map(|f| f.stem.as_str()).collect();
+
+        let mut unprotected = Vec::new();
+        for parent in &features {
+            let siblings = harness_sibling_prefixes(&parent.tag, &stems);
+            for child in &features {
+                if child.tag == parent.tag || !child.tag.starts_with(&format!("{}_", parent.tag)) {
+                    continue;
+                }
+                // The child's resources are named `<child.tag>_<logical>`,
+                // and the harness skips a name only when it starts with one
+                // of `siblings`. Testing `<child.tag>_` covers every such
+                // name at once.
+                let owned = format!("{}_", child.tag);
+                if !siblings.iter().any(|p| owned.starts_with(p.as_str())) {
+                    unprotected.push(format!(
+                        "tag `{}` ({}) is a prefix of `{}` ({}), but the sweep/clean scans in \
+                         `{}` cannot tell them apart: `World::sibling_prefixes` finds siblings \
+                         by file name, and `{}` does not match the tag `{}` its resources are \
+                         named from. Rename the file to `{}.feature` (or change the tag to \
+                         `{}`) so the two agree.",
+                        parent.tag,
+                        parent.file(),
+                        child.tag,
+                        child.file(),
+                        parent.file(),
+                        child.file(),
+                        child.tag,
+                        child.tag,
+                        child.stem,
                     ));
                 }
             }
         }
         assert!(
-            collisions.is_empty(),
-            "feature-tag prefix collisions:\n{}",
-            collisions.join("\n")
+            unprotected.is_empty(),
+            "feature-tag prefix collisions the harness cannot defend against:\n{}",
+            unprotected.join("\n")
         );
+    }
+
+    /// The three pairs that exist today are the reason the blanket ban had
+    /// to go; pin that they stay covered, so a future rename of one of
+    /// these files fails here rather than as a concurrency flake.
+    #[test]
+    fn known_prefix_pairs_are_covered() {
+        let features = load_features();
+        let stems: Vec<&str> = features.iter().map(|f| f.stem.as_str()).collect();
+        for (parent, child) in [
+            ("bgp_evpn_vpws", "bgp_evpn_vpws_multihoming"),
+            ("bgp_adv_interval_zero", "bgp_adv_interval_zero_v6"),
+            ("bgp_adv_interval_zero", "bgp_adv_interval_zero_vrf"),
+        ] {
+            assert!(
+                features.iter().any(|f| f.tag == child),
+                "expected a feature tagged `{child}`"
+            );
+            let siblings = harness_sibling_prefixes(parent, &stems);
+            assert!(
+                siblings.iter().any(|p| format!("{child}_").starts_with(p)),
+                "`{parent}` no longer skips `{child}`'s resources; \
+                 sibling prefixes were {siblings:?}"
+            );
+        }
     }
 
     #[test]
     fn feature_tags_are_unique() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/features");
         let mut seen: std::collections::HashMap<String, String> = Default::default();
-        for entry in fs::read_dir(&dir).expect("read tests/features") {
-            let path = entry.expect("dir entry").path();
-            if path.extension().is_some_and(|e| e == "feature") {
-                let text = fs::read_to_string(&path).expect("read feature file");
-                if let Some(tag) = feature_tag(&text) {
-                    let name = path.file_name().unwrap().to_string_lossy().into_owned();
-                    if let Some(prev) = seen.insert(tag.clone(), name.clone()) {
-                        panic!("tag `{tag}` used by both {prev} and {name}");
-                    }
-                }
+        for f in load_features() {
+            if let Some(prev) = seen.insert(f.tag.clone(), f.file()) {
+                panic!("tag `{}` used by both {prev} and {}", f.tag, f.file());
             }
         }
+    }
+
+    #[test]
+    fn sibling_prefixes_only_match_a_name_that_matches_the_tag() {
+        // A sibling whose file name equals its tag is found...
+        let stems = ["a_b", "a_b_c"];
+        assert_eq!(harness_sibling_prefixes("a_b", &stems), vec!["a_b_c_"]);
+        // ...and the parent itself is never its own sibling.
+        assert!(harness_sibling_prefixes("a_b_c", &stems).is_empty());
+        // A sibling filed under an unrelated name is invisible — this is
+        // the hole `every_prefix_sibling_is_visible_to_the_harness` exists
+        // to keep out of the features directory.
+        let renamed = ["a_b", "isis_a_b_c"];
+        assert!(harness_sibling_prefixes("a_b", &renamed).is_empty());
     }
 }

--- a/bdd/src/toolchain.rs
+++ b/bdd/src/toolchain.rs
@@ -1,0 +1,173 @@
+//! Which zebra-rs toolchain a BDD run executes.
+//!
+//! Every daemon and CLI the harness launches inside a namespace used to be
+//! resolved by bare name through root's PATH — `/usr/bin/zebra-rs`,
+//! `/usr/bin/vtyctl`, `/usr/bin/pfcp-inject` — and the daemon then loaded
+//! its schemas from `/usr/share/zebra-rs/yang`. All four are host-global,
+//! and `make install` overwrites them. Two git worktrees that each install
+//! therefore clobber one another: a run in worktree A silently exercises
+//! whichever binary and schema set worktree B installed last, which reads
+//! as an inexplicable product regression.
+//!
+//! A *staged prefix* removes the host from the picture. `make -C bdd stage`
+//! builds this worktree's binaries and copies them, together with this
+//! worktree's YANG schemas, into a private tree:
+//!
+//! ```text
+//! <worktree>/bdd/.stage/
+//!   bin/{zebra-rs,vtyctl,vtyhelper,pfcp-inject}
+//!   share/zebra-rs/yang/*.yang
+//! ```
+//!
+//! The harness then prepends `bin/` to PATH for every in-namespace command
+//! and points the daemon at `share/zebra-rs/yang` with `--yang-path`, so a
+//! run reads nothing under `/usr` at all.
+//!
+//! Staged binaries are *copies*, not symlinks into `target/`: cargo rewrites
+//! `target/release/zebra-rs` in place, so a rebuild in the same worktree
+//! would otherwise swap the binary out from under a run already in flight.
+//! Copying pins the whole toolchain for the duration.
+//!
+//! Resolution order:
+//!   1. `$ZEBRA_BDD_PREFIX`, if set and non-empty
+//!   2. `<bdd crate>/.stage`, if it exists
+//!   3. nothing — fall back to the host-global layout, i.e. exactly the
+//!      behavior before staging existed, so a bare
+//!      `cargo test --test cucumber` still runs.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Staging root for this worktree. Baked at compile time from the `bdd`
+/// crate's own directory, so a test binary built in worktree A can never
+/// pick up worktree B's stage no matter where it is invoked from.
+const STAGE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/.stage");
+
+/// PATH tail appended after the staged `bin/`. Deliberately a fixed list
+/// rather than the harness process's own PATH: the commands run as root
+/// under `sudo`, which would normally confine them to `secure_path`, and
+/// splicing the invoking user's PATH into a root command would both widen
+/// that and make resolution differ from machine to machine.
+const SYSTEM_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// A resolved staging prefix: binaries under `bin/`, schemas under
+/// `share/zebra-rs/yang/`, mirroring the `/usr` layout `make install`
+/// writes.
+#[derive(Debug, Clone)]
+pub struct Prefix {
+    root: PathBuf,
+}
+
+impl Prefix {
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Directory holding the staged binaries.
+    pub fn bin_dir(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+
+    /// Directory holding the staged YANG schemas, for `--yang-path`.
+    pub fn yang_dir(&self) -> PathBuf {
+        self.root.join("share/zebra-rs/yang")
+    }
+
+    /// `PATH=…` assignment to hand to `env` ahead of an in-namespace
+    /// command, so `zebra-rs` / `vtyctl` / `pfcp-inject` resolve to this
+    /// worktree's copies while system tools (`ip`, `bridge`, `timeout`)
+    /// keep resolving as before.
+    pub fn path_env(&self) -> String {
+        format!("PATH={}:{}", self.bin_dir().display(), SYSTEM_PATH)
+    }
+}
+
+/// The staging prefix for this run, or `None` when the harness should use
+/// the host-global toolchain.
+///
+/// Resolved once per process. Panics if a prefix is present but incomplete —
+/// a half-populated stage would otherwise silently fall through to `/usr`,
+/// which is the failure mode staging exists to prevent.
+pub fn prefix() -> Option<&'static Prefix> {
+    static PREFIX: OnceLock<Option<Prefix>> = OnceLock::new();
+    PREFIX.get_or_init(resolve).as_ref()
+}
+
+fn resolve() -> Option<Prefix> {
+    if let Ok(raw) = std::env::var("ZEBRA_BDD_PREFIX")
+        && !raw.trim().is_empty()
+    {
+        return Some(check(PathBuf::from(raw.trim()), "$ZEBRA_BDD_PREFIX"));
+    }
+
+    let stage = PathBuf::from(STAGE_DIR);
+    if !stage.exists() {
+        return None;
+    }
+    Some(check(stage, "the staged toolchain"))
+}
+
+/// Reject a prefix that is missing either half. `make stage` builds into a
+/// scratch directory and renames it into place, so an incomplete `.stage`
+/// means an interrupted or hand-edited stage rather than a race — and the
+/// only safe response is to say so instead of quietly testing `/usr`.
+fn check(root: PathBuf, what: &str) -> Prefix {
+    let prefix = Prefix { root };
+    let zebra = prefix.bin_dir().join("zebra-rs");
+    let yang = prefix.yang_dir();
+    assert!(
+        zebra.is_file() && yang.is_dir(),
+        "{what} at {} is incomplete (expected {} and {}); re-run `make -C bdd stage`",
+        prefix.root.display(),
+        zebra.display(),
+        yang.display(),
+    );
+    prefix
+}
+
+/// One-line description of the resolved toolchain, printed in the run
+/// header. A run that fails for a stale-binary reason should be able to
+/// prove it from its own log.
+pub fn describe() -> String {
+    match prefix() {
+        Some(p) => {
+            let zebra = p.bin_dir().join("zebra-rs");
+            let size = std::fs::metadata(&zebra).map(|m| m.len()).unwrap_or(0);
+            format!(
+                "toolchain: staged at {} (zebra-rs {size} bytes)",
+                p.root().display()
+            )
+        }
+        None => "toolchain: host-global (/usr/bin, /usr/share/zebra-rs/yang) \
+                 — run `make -C bdd stage` to isolate this worktree"
+            .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_mirrors_the_usr_layout() {
+        let p = Prefix {
+            root: PathBuf::from("/w/bdd/.stage"),
+        };
+        assert_eq!(p.bin_dir(), PathBuf::from("/w/bdd/.stage/bin"));
+        assert_eq!(
+            p.yang_dir(),
+            PathBuf::from("/w/bdd/.stage/share/zebra-rs/yang")
+        );
+    }
+
+    #[test]
+    fn path_env_puts_the_stage_first() {
+        let p = Prefix {
+            root: PathBuf::from("/w/bdd/.stage"),
+        };
+        assert_eq!(
+            p.path_env(),
+            format!("PATH=/w/bdd/.stage/bin:{}", SYSTEM_PATH)
+        );
+    }
+}

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -2884,6 +2884,12 @@ async fn main() {
     let _ = fs::create_dir_all("logs");
     let _ = fs::create_dir_all("allure-results");
 
+    // Say which binaries and schemas this run executes. A failure caused by
+    // a stale or foreign toolchain (another worktree's `make install`) is
+    // otherwise indistinguishable from a product bug, so the run log has to
+    // carry the evidence. See `bdd::toolchain`.
+    println!("{}", bdd::toolchain::describe());
+
     // Parse the standard cucumber CLI ourselves. Each feature is run in its
     // own cucumber instance with scenarios forced serial (and in declaration
     // order) via `max_concurrent_scenarios(1)`, while *different* features run

--- a/book/src/ch-11-00-bdd-tests.md
+++ b/book/src/ch-11-00-bdd-tests.md
@@ -58,6 +58,53 @@ namespaces). The `--tags` expression supports `not`, `and`, and `or`, so
 you can select or exclude scenarios — e.g. `--tags "@isis_l1_p2p or
 @isis_tilfa"`.
 
+## Which binaries the suite tests — the staged toolchain
+
+The daemons and CLIs a scenario runs are resolved by name, so left alone
+they come from the host-global install: `/usr/bin/zebra-rs`,
+`/usr/bin/vtyctl`, `/usr/bin/pfcp-inject`, and the schemas under
+`/usr/share/zebra-rs/yang`. `make install` overwrites all of those, so
+two checkouts — most commonly two **git worktrees** — clobber one
+another and a run silently exercises whichever one installed last. A
+foreign binary or schema set then reads as an inexplicable product
+failure; "unknown key" at apply time is the classic symptom.
+
+`make stage` takes the host out of the picture. It builds *this*
+worktree and copies the result into `bdd/.stage/`, mirroring the `/usr`
+layout:
+
+```text
+bdd/.stage/
+  bin/{zebra-rs,vtyctl,vtyhelper,pfcp-inject}
+  share/zebra-rs/yang/*.yang
+```
+
+The harness picks that up on its own: it prepends `bin/` to `PATH` for
+every in-namespace command and points the daemon at the staged schemas
+with `--yang-path`, so a run reads nothing under `/usr`. Every test
+target in `bdd/Makefile` depends on `stage`, which makes it impossible
+to test a stale binary through make. Each run prints what it resolved:
+
+```text
+toolchain: staged at /path/to/worktree/bdd/.stage (zebra-rs 38487872 bytes)
+```
+
+The staged binaries are copies rather than symlinks into `target/`,
+because cargo rewrites `target/release/zebra-rs` in place — a rebuild
+would otherwise swap the binary out from under a run already in flight.
+
+Useful knobs:
+
+```sh
+make stage PROFILE=debug   # faster to build; fine for control-plane features
+make unstage               # drop .stage and fall back to the /usr install
+ZEBRA_BDD_PREFIX=/some/prefix cargo test --test cucumber -- …
+```
+
+Running `cargo test --test cucumber` directly without a staged prefix
+still works and falls back to the host-global install — the run header
+tells you which one you got.
+
 ## Keeping the topology for inspection — `BDD_KEEP`
 
 By default a scenario tears its topology down at the end, even on

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -92,7 +92,37 @@ fn set_git_info() {
     println!("cargo:rustc-env=GIT_DIRTY={git_dirty}");
     println!("cargo:rustc-env=BUILD_DATE={build_date}");
 
-    // Rerun build script if git HEAD changes
-    println!("cargo:rerun-if-changed=../.git/HEAD");
-    println!("cargo:rerun-if-changed=../.git/refs");
+    // Rerun the build script when HEAD or a ref moves. The paths are
+    // resolved through git rather than assumed to be `../.git/<name>`,
+    // because `../.git` is only a directory in a primary checkout: in a
+    // linked git worktree it is a FILE holding `gitdir: …`, so
+    // `../.git/HEAD` does not exist. `rerun-if-changed` on a MISSING path
+    // makes cargo treat the build script as permanently dirty, which fully
+    // rebuilt zebra-rs — the largest crate in the workspace — on every
+    // cargo invocation in every worktree (and in any source-tarball build,
+    // which has no git metadata at all). A path that still doesn't resolve
+    // is therefore skipped rather than emitted.
+    for name in ["HEAD", "refs"] {
+        if let Some(path) = git_path(name) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+/// Absolute path to `name` inside the repository's git directory, or `None`
+/// when this is not a git checkout.
+///
+/// `git rev-parse --git-path` knows the linked-worktree split that a plain
+/// `../.git/<name>` join cannot express: HEAD lives in the worktree's
+/// private directory while `refs` lives in the shared common directory.
+fn git_path(name: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-path", name])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    std::path::Path::new(&path).exists().then_some(path)
 }


### PR DESCRIPTION
## Summary

The BDD suite resolved every daemon and CLI by bare name through root's PATH — `/usr/bin/zebra-rs`, `/usr/bin/vtyctl`, `/usr/bin/pfcp-inject` — and the daemon loaded its schemas from `/usr/share/zebra-rs/yang`. All four are host-global and `make install` overwrites them, so two checkouts (most often two git worktrees) clobber one another and a run silently exercises whichever binary and schema set the other installed last. That reads as an inexplicable product regression; "unknown key" at apply time is the classic symptom.

`make -C bdd stage` now builds *this* worktree and copies the result into `bdd/.stage/`, mirroring the layout `make install` writes:

```
bdd/.stage/bin/{zebra-rs,vtyctl,vtyhelper,pfcp-inject}
bdd/.stage/share/zebra-rs/yang/*.yang
```

The harness picks it up on its own: `netns_prelude` prepends the staged `bin/` to PATH for every in-namespace command, and the daemon additionally gets `--yang-path` at the staged schemas. A run then reads nothing under `/usr`, and `make install` is no longer a prerequisite. Every test target goes through `$(CUCUMBER)`, which stages first, so no make target can test a stale binary. Each run prints what it resolved:

```
toolchain: staged at /path/to/worktree/bdd/.stage (zebra-rs 38649104 bytes)
```

`ZEBRA_BDD_PREFIX` overrides the location, `make unstage` falls back to the host-global install, and a bare `cargo test --test cucumber` with no stage works exactly as before.

### Also in this PR

- **`zebra-rs/build.rs`** (independent, first commit): `cargo:rerun-if-changed` on a path that does not exist makes cargo treat the build script as permanently dirty. `../.git/HEAD` is exactly that in a linked worktree, where `.git` is a *file*. zebra-rs — the largest crate in the workspace — was fully rebuilding on **every** cargo invocation in every worktree: 44s for what should be a 0.15s no-op. Resolved through `git rev-parse --git-path`, which knows the worktree split.
- **`tag_guard`**: the blanket ban on prefix-extending feature tags predated d154dfc, which taught the harness to tolerate them — so it failed the build for the pairs the harness now handles. Replaced with a guard on that mitigation's actual precondition: `sibling_prefixes` matches on *file stems* while resources are named from *tags*, and those deliberately differ for seven features, so a mis-filed sibling would be left exposed silently and only under concurrency.

## Test plan

- Full suite at `--concurrency=16`: **270 ran, 268 passed**. No leaked netns or daemons.
- Isolation verified under load: all 41 live daemons resolved to `.stage/bin/zebra-rs` with `--yang-path` into the stage, **none** to `/usr/bin`, across 1166 config applies with zero schema errors.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p bdd --lib` (6/6) all clean.
- The two suite failures are pre-existing and unrelated: `bgp_neighbor_adj_rib_v6` passes solo (c=16 load margin), and `ecmp_bfd_evict` is a ~50% intermittent even solo (fail/pass/fail/pass over four c=1 runs) — the BFD-eviction recovery path does not reliably re-expand the ECMP set. Being investigated separately.

Generated with [Claude Code](https://claude.com/claude-code)