### PR TITLE
rib: restore an ECMP leg the BFD switchover evicted

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2895,6 +2895,16 @@ impl Isis {
     /// next received IIH promotes its adjacency back to Up. A no-op when the
     /// neighbour was not held (e.g. the normal first-Up after adjacency form).
     fn process_bfd_up(&mut self, key: &crate::bfd::session::SessionKey) {
+        // Undo the switchover's ECMP leg eviction FIRST, before any of the
+        // early returns below. Each of those is a legitimate "no adjacency
+        // bookkeeping to do" case — the neighbour re-formed from an IIH
+        // before this event landed, a flap already consumed the hold-down
+        // entry, the link went away — but the kernel groups still have this
+        // leg missing regardless, and the RIB has no other way to hear that
+        // it is back. Keying on `key.remote` is exactly what the eviction
+        // used, and the RIB no-ops when nothing was evicted.
+        let _ = self.ctx.rib.protect_restore(key.remote);
+
         // Primary path: resolve via the live neighbour entry in `nbrs`.
         let resolved = self.bfd_resolve_neighbor(key, false);
 
@@ -2940,6 +2950,24 @@ impl Isis {
                 ?level,
                 "isis: bfd recovered; lifting adjacency hold-down",
             );
+        }
+
+        // `key.remote` was already restored at entry; cover the rest of the
+        // keys the eviction used. process_bfd_down snapshots the whole
+        // address set (v4 interface addrs from TLV 132, v6 link-locals from
+        // TLV 232) because those are what SPF keyed the groups on, and a
+        // BFD session names only one of them. Collect before dropping the
+        // link borrow.
+        let mut recovered: Vec<std::net::IpAddr> = Vec::new();
+        if let Some(nbr) = link.state.nbrs.get(&level).get(&sys_id) {
+            recovered.extend(nbr.addr4.keys().copied().map(std::net::IpAddr::V4));
+            recovered.extend(nbr.addr6l.iter().copied().map(std::net::IpAddr::V6));
+        }
+        recovered.retain(|a| *a != key.remote);
+        recovered.sort();
+        recovered.dedup();
+        for addr in recovered {
+            let _ = self.ctx.rib.protect_restore(addr);
         }
     }
     pub fn top(&mut self) -> IsisTop<'_> {

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -140,6 +140,15 @@ impl RibClient {
         self.send(Message::ProtectSwitch { addr })
     }
 
+    /// Undo the switchover's ECMP leg eviction for the adjacency at
+    /// `addr`. Protocols call this on BFD-up-with-link-up, the mirror
+    /// of `protect_switch`: the eviction shrank kernel nexthop groups
+    /// in place, and a recovery that produces no route change would
+    /// otherwise leave them shrunk forever.
+    pub fn protect_restore(&self, addr: std::net::IpAddr) -> Result<(), SendError<RibInbound>> {
+        self.send(Message::ProtectRestore { addr })
+    }
+
     /// Toggle FIB-install suppression for this client and every clone
     /// that shares its `Arc`. Idempotent.
     pub fn set_suppress_install(&self, suppress: bool) {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -194,6 +194,18 @@ pub enum Message {
     ProtectSwitch {
         addr: IpAddr,
     },
+    /// The inverse of [`Message::ProtectSwitch`]: the adjacency at
+    /// `addr` is back (BFD Up while the link never went down). The
+    /// switchover's ECMP leg eviction shrank kernel nexthop groups in
+    /// place, and nothing else tells the RIB the leg returned — the
+    /// eviction only drains via refcnt if reconvergence happens to
+    /// rewrite the affected prefixes, which it does not when SPF's
+    /// post-recovery result equals what the RIB already holds. Without
+    /// this the group stays shrunk indefinitely: the RIB shows every
+    /// leg while the kernel forwards over a subset.
+    ProtectRestore {
+        addr: IpAddr,
+    },
     /// Drop `proto`'s interest in `nh`; the tracking entry is removed
     /// once its last watcher unregisters.
     NexthopUnregister {
@@ -2696,6 +2708,39 @@ impl Rib {
                 }
                 if rewired == 0 && evicted == 0 {
                     tracing::debug!("ProtectSwitch {addr} table {table_id}: no eligible groups");
+                }
+            }
+            Message::ProtectRestore { addr } => {
+                // Re-derive membership through the ordinary nexthop sync
+                // rather than re-installing here: that pass already
+                // recomputes each member's validity from link and route
+                // state and issues one atomic replace per group whose
+                // kernel membership diverged. Duplicating it would risk
+                // resurrecting a leg the sync would reject.
+                let stale = self.nmap.protect_restore_candidates(table_id, addr);
+                if stale.is_empty() {
+                    tracing::debug!("ProtectRestore {addr} table {table_id}: nothing evicted");
+                } else {
+                    tracing::info!(
+                        "ProtectRestore {addr} table {table_id}: {} ECMP group(s) missing this leg, re-syncing",
+                        stale.len()
+                    );
+                    ipv4_nexthop_sync(
+                        &mut self.nmap,
+                        &self.table,
+                        &self.vrf_tables,
+                        &self.links,
+                        &self.fib_handle,
+                    )
+                    .await;
+                    ipv6_nexthop_sync(
+                        &mut self.nmap,
+                        &self.table_v6,
+                        &self.vrf_tables,
+                        &self.links,
+                        &self.fib_handle,
+                    )
+                    .await;
                 }
             }
             Message::NexthopUnregister { proto, nh, vrf_id } => {

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -305,6 +305,41 @@ impl NexthopMap {
             .collect()
     }
 
+    /// Multi groups whose kernel membership is missing a member that
+    /// rides `(table_id, addr)` — the inverse of
+    /// [`Self::protect_evict_candidates`], which is why it scans `set`
+    /// (the group's full membership, and its identity) rather than
+    /// `valid` (what the kernel currently holds): eviction removed the
+    /// leg from `valid` precisely so it would stop matching there.
+    ///
+    /// A leg that is legitimately still down also shows up here; that
+    /// is harmless, because the nexthop sync re-derives each member's
+    /// validity from link and route state before deciding what to
+    /// install, and leaves such a group alone.
+    pub fn protect_restore_candidates(&self, table_id: u32, addr: IpAddr) -> Vec<(usize, usize)> {
+        self.groups
+            .iter()
+            .flatten()
+            .filter_map(|grp| {
+                let Group::Multi(multi) = grp else {
+                    return None;
+                };
+                for (m, w) in multi.set.iter() {
+                    if multi.valid.contains(&(*m, *w)) {
+                        continue;
+                    }
+                    if let Some(uni) = self.get_uni(*m)
+                        && uni.table_id == table_id
+                        && uni.addr == addr
+                    {
+                        return Some((multi.gid(), *m));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
     pub fn fetch_multi(&mut self, set: &BTreeSet<(usize, u8)>) -> Option<&mut Group> {
         let gid = if let Some(&gid) = self.set.get(set) {
             let update = self.groups.get_mut(gid)?;

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -3196,6 +3196,81 @@ mod tests {
         assert!(nmap.protect_switch_candidates(0, addr).is_empty());
     }
 
+    /// The eviction/restore pair must be exact inverses: whatever
+    /// `protect_evict_candidates` drops from a group's kernel
+    /// membership, `protect_restore_candidates` has to find again once
+    /// the adjacency returns. Eviction removes the leg from `valid`,
+    /// so a restore query that also scanned `valid` would match
+    /// nothing and the group would stay shrunk forever — the
+    /// ecmp_bfd_evict failure.
+    #[test]
+    fn protect_restore_candidates_find_what_eviction_dropped() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{NexthopMulti, NexthopUni};
+        use super::super::{Group, Nexthop, NexthopMap};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        // Two-leg ECMP, both legs pinned to live links so they resolve.
+        let mut leg_a = NexthopUni::new("10.1.0.2".parse().unwrap(), 20, vec![]);
+        leg_a.ifindex_origin = Some(10);
+        let mut leg_b = NexthopUni::new("10.2.0.2".parse().unwrap(), 20, vec![]);
+        leg_b.ifindex_origin = Some(20);
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::Multi(NexthopMulti {
+            metric: 20,
+            nexthops: vec![leg_a, leg_b],
+            gid: 0,
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
+        let Nexthop::Multi(multi) = &entry.nexthop else {
+            panic!("still Multi");
+        };
+        let (gid, a_gid) = (multi.gid, multi.nexthops[0].gid);
+
+        let failed: std::net::IpAddr = "10.1.0.2".parse().unwrap();
+        // Healthy: the kernel holds every leg, so there is nothing to
+        // restore — the message must be a no-op in steady state.
+        assert!(
+            nmap.protect_restore_candidates(0, failed).is_empty(),
+            "a group with full membership is not a restore candidate"
+        );
+
+        // BFD down: eviction drops the failed leg from kernel membership.
+        let evicted = nmap.protect_evict_candidates(0, failed);
+        assert_eq!(evicted, vec![(gid, a_gid)]);
+        if let Some(Group::Multi(m)) = nmap.get_mut(gid) {
+            m.valid.retain(|(m, _)| *m != a_gid);
+        }
+
+        // BFD up: the same (table, addr) now names a shrunken group.
+        assert_eq!(
+            nmap.protect_restore_candidates(0, failed),
+            vec![(gid, a_gid)]
+        );
+        assert!(
+            nmap.protect_restore_candidates(0, "10.9.9.9".parse().unwrap())
+                .is_empty(),
+            "other gateways unaffected"
+        );
+        assert!(
+            nmap.protect_restore_candidates(254, failed).is_empty(),
+            "other tables unaffected"
+        );
+
+        // The surviving leg was never evicted, so it never needs restoring.
+        assert!(
+            nmap.protect_restore_candidates(0, "10.2.0.2".parse().unwrap())
+                .is_empty(),
+            "the leg that stayed up is not a restore candidate"
+        );
+    }
+
     /// A seg6 repair is switchover-eligible like any other live Uni
     /// backup: seg6 members forward correctly through groups (the
     /// black-hole theory was refuted — design doc correction), so


### PR DESCRIPTION
## Summary

`protect_switch` handles a BFD-down-with-link-up by dropping the dead leg from each kernel ECMP group — `multi.valid.retain(...)` plus one atomic `RTM_NEWNEXTHOP` per group — so traffic stops hashing onto it before SPF reconverges. **Nothing performs the inverse.** `process_bfd_up` only lifts the adjacency hold-down; the RIB is never told the leg came back.

The eviction assumed the group would "drain via refcnt and be recreated fresh on recovery", which only holds if reconvergence rewrites the affected prefixes. It does not when SPF's post-recovery result equals what the RIB already holds — the adjacency returning before SPF ran leaves the entry untouched, so `resolve_nexthop_multi` never re-runs, the nexthop sync never re-evaluates the group, and the kernel keeps the shrunken membership indefinitely.

The failure is silent and asymmetric: `show ip route` lists every leg while the kernel forwards over a subset, at reduced capacity and with no protection on the legs that remain. Proof from a failing run — RIB correct, kernel not:

```
L2 *> 10.0.0.4/32 [115/12] via 10.1.0.2, s-a, weight 1, 00:00:54
                           via 10.2.0.2, s-b, weight 1, 00:00:54
$ ip route show 10.0.0.4
10.0.0.4 nhid 3 via 10.2.0.2 dev s-b proto isis metric 12 onlink
```

(The `00:00:54` uptime is the tell: the entry was never recomputed across the whole down/up cycle.)

## The fix

`Message::ProtectRestore` asks the RIB to re-derive membership for groups that lost a member riding `addr`. `protect_restore_candidates` finds them by scanning `multi.set` rather than `multi.valid` — eviction removed the leg from `valid` precisely so it would stop matching there, so the inverse query has to look at full membership.

The handler deliberately installs nothing itself; it runs the ordinary v4+v6 nexthop sync, which already recomputes each member's validity from link and route state and issues one replace per diverged group. A leg that is genuinely still down therefore stays out, instead of the restore resurrecting it.

**Placement matters.** ISIS sends it as the *first statement* of `process_bfd_up`, ahead of the early returns for "neighbour already re-formed from an IIH" / "hold-down entry consumed by a flap" / "link gone". Those are legitimate no-ops for adjacency bookkeeping, but the kernel group is missing the leg regardless. A first version of this fix sat behind those returns and still lost 1 run in 10, with the daemon log showing **10 evictions against 9 restores**.

## Test plan

- `@ecmp_bfd_evict` failed **~50% of solo runs** before this (fail/pass/fail/fail). After: **18 solo runs, 0 failures at the recovery assert (feature line 83)**, with evictions and restores at **17:17**. That 1:1 ratio is the invariant to check, not just the pass count.
- Full suite `make -C bdd all` (c=16): **270 ran, 266 passed**, no leaked namespaces or daemons. `ecmp_bfd_evict` passes; it was a failure in the pre-fix run on the same base.
- The 4 suite failures are unrelated: `bgp_as_path_match`, `bgp_enforce_first_as`, `bgp_neighbor_adj_rib_v6` all pass solo (c=16 load margin). `ospfv3_tilfa` fails solo — but **also fails solo on the parent commit** (fail/pass over 2 runs there), so it is a pre-existing intermittent, not a regression from this change.
- New unit test `protect_restore_candidates_find_what_eviction_dropped` pins the evict/restore inverse, including that a full-membership group is not a candidate and that other gateways/tables are unaffected.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Not covered

**OSPF has the same asymmetry.** `ospf/inst.rs` also calls `protect_switch`, but `process_bfd_event` early-returns on anything that is not a transition to `Down`, and that path unsubscribes the session — so there is no Up event to hook, and the restore would have to hang off adjacency re-formation in `bfd_reconcile_nbr`. No BDD feature reproduces ECMP eviction under OSPF, so it could not be validated; left deliberately rather than changed blind.

Separately, `ecmp_bfd_evict` carries a second unrelated flake at feature line 57, where the b-plane sometimes never joins the ECMP set during *initial* convergence. Distinct mechanism, still open.

Generated with [Claude Code](https://claude.com/claude-code)