### PR TITLE
isis: never use pseudonode id 0 for a DIS circuit

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -447,10 +447,35 @@ pub fn stop(link: &mut LinkTop) {
     }
 }
 
+/// Circuit id for the pseudonode this router originates as DIS on
+/// `ifindex`, folded into `1..=255`.
+///
+/// Pseudonode id 0 is reserved for a router's own non-pseudonode LSP, so
+/// it can never name a circuit: a DIS that advertises `<sys-id>.00` as its
+/// LAN ID aliases its own node LSP. Both ends of the LAN then carry a
+/// self-referential `ExtIsReach` — the DIS lists itself as its own
+/// neighbour, and no pseudonode LSP enumerating the members is ever
+/// generated — so SPF sees a self-loop where the LAN should be and the
+/// whole segment drops out of the topology.
+///
+/// `ifindex as u8` did exactly that whenever the kernel index was a
+/// multiple of 256. That is a ~1-in-256 lottery per circuit, drawn afresh
+/// as ifindexes climb with each veth created and torn down, and it
+/// presented as an occasional "ECMP never forms" flake rather than
+/// anything that looked like an IS-IS bug.
+///
+/// Folding into `1..=255` leaves the collision profile unchanged — two
+/// circuits on one router still alias if their ifindexes are 255 apart,
+/// as they previously did at 256 — while removing the case that is
+/// guaranteed broken.
+fn dis_pseudo_id(ifindex: u32) -> u8 {
+    ((ifindex.max(1) - 1) % 255 + 1) as u8
+}
+
 pub fn dis_becoming(link: &mut LinkTop, level: Level) {
     use IfsmEvent::*;
 
-    let pseudo_id: u8 = link.ifindex as u8;
+    let pseudo_id: u8 = dis_pseudo_id(link.ifindex);
     let lsp_id = IsisLspId::new(link.up_config.net.sys_id(), pseudo_id, 0);
 
     // Register adjacency with LAN ID.
@@ -754,5 +779,42 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         && let Some((neighbor_id, _)) = link.state.adj.get(&level)
     {
         link.event(Message::DisOriginate(level, *neighbor_id, None));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dis_pseudo_id;
+
+    /// The defect this guards: `ifindex as u8` yields 0 on every
+    /// multiple of 256, and pseudonode id 0 aliases the router's own
+    /// node LSP. Observed live as `0000.0000.0003.00` in a neighbour's
+    /// LSDB, with the LAN's two members advertising themselves as their
+    /// own neighbour and the segment vanishing from SPF.
+    #[test]
+    fn dis_pseudo_id_is_never_zero() {
+        for ifindex in [1u32, 2, 254, 255, 256, 511, 512, 65_536, u32::MAX] {
+            let id = dis_pseudo_id(ifindex);
+            assert_ne!(
+                id, 0,
+                "ifindex {ifindex} produced pseudonode id 0, which aliases the node LSP"
+            );
+        }
+        // The truncation that used to break: 256 and 512 are exactly the
+        // indexes `as u8` mapped onto the reserved id.
+        assert_eq!(256u32 as u8, 0, "precondition: the old derivation gave 0");
+        assert_ne!(dis_pseudo_id(256), 0);
+        assert_ne!(dis_pseudo_id(512), 0);
+    }
+
+    /// Distinct circuits on one router must still get distinct ids
+    /// within any 255-index window, or two LANs would share a
+    /// pseudonode LSP.
+    #[test]
+    fn dis_pseudo_id_is_distinct_across_a_full_window() {
+        let ids: std::collections::BTreeSet<u8> = (1..=255u32).map(dis_pseudo_id).collect();
+        assert_eq!(ids.len(), 255, "255 consecutive ifindexes must not collide");
+        assert_eq!(*ids.iter().min().unwrap(), 1);
+        assert_eq!(*ids.iter().max().unwrap(), 255);
     }
 }


### PR DESCRIPTION
## Summary

`dis_becoming` derived the pseudonode id as `link.ifindex as u8`, so any circuit whose kernel ifindex is a multiple of 256 got id **0** — and 0 is reserved for a router's own non-pseudonode LSP.

The DIS then advertises `<sys-id>.00` as the LAN ID, which aliases its own node LSP. Both members of the LAN put that id in their Extended IS Reachability, so the DIS lists **itself** as its own neighbour, and no pseudonode LSP enumerating the members is ever generated. SPF sees a self-loop where the LAN should be, and the segment drops out of the topology: everything behind it reroutes the long way round, or goes unreachable if there is no other path.

## Evidence

Caught as an occasional "ECMP never forms" failure in `@ecmp_bfd_evict` — about 1 run in 30. It looked exactly like a convergence race and is not one. The LSDB at failure, with `b` = `0000.0000.0003`:

```
b.00-00
  Neighbor ID: 0000.0000.0001.fc, Metric: 1   <- s's pseudonode, correct
  Neighbor ID: 0000.0000.0003.00, Metric: 1   <- b, pointing at itself
d.00-00
  Neighbor ID: 0000.0000.0004.fd, Metric: 1   <- d's pseudonode, correct
  Neighbor ID: 0000.0000.0003.00, Metric: 1   <- same bogus id
```

No `b.XX-00` pseudonode LSP exists anywhere, while the healthy pseudonodes in the same database — `s.fc-00` and `d.fd-00` — carry ids **0xfc (252)** and **0xfd (253)**. The interfaces in that run were numbered 252..256 and b's landed on **256**. Both adjacencies were `Up` throughout; the route to `d` simply never became ECMP because SPF could not traverse `b -> d`.

A per-second capture of the failing run confirms adjacency timing was never involved:

```
T+ 6.2s  nbr[a=Up]        route[dev s-b]
T+10.4s  nbr[a=Up b=Up]   route[dev s-b]
T+11.4s  nbr[a=Up b=Up]   route[dev s-a]   <- flips, still single path, stays
```

For contrast, healthy runs converge to both legs in 11.3–12.5s with essentially no spread (6/6 measured), against a 40s assertion budget — so this was never marginal timing, and padding the timeout would have buried it.

## The fix

Fold the ifindex into `1..=255` via an extracted `dis_pseudo_id()`.

Two circuits on one router still alias if their ifindexes are 255 apart, exactly as they previously did at 256. That pre-existing weakness is deliberately unchanged — it wants a real per-instance circuit-id allocator — but the case that is *guaranteed* broken is gone.

## Test plan

- New unit tests: `dis_pseudo_id_is_never_zero` (covers the multiples of 256 that used to break, and pins `256 as u8 == 0` as the precondition) and `dis_pseudo_id_is_distinct_across_a_full_window` (255 consecutive ifindexes stay distinct).
- BDD, all pass: `isis_lan_pseudonode`, `isis_lan_dis_reelection`, `isis_lan_dis_pseudonode_purge`, `isis_l1l2`, `ecmp_bfd_evict`.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Note on what the BDD runs do and do not prove: re-running `ecmp_bfd_evict` cannot demonstrate the flake is gone, since 30 green runs is ~18% likely by chance at the observed 1-in-30 rate. The proof is the mechanism plus the unit tests. A deterministic end-to-end test would need a step that pads a namespace with dummy interfaces until the next veth lands on ifindex 256 — worth adding separately.

Generated with [Claude Code](https://claude.com/claude-code)