### PR TITLE
bgp: carry the Ethernet Segment's ESI on locally-originated Type-2 routes

### DIFF
--- a/bdd/docs/bgp_evpn_srv6_macip.md
+++ b/bdd/docs/bgp_evpn_srv6_macip.md
@@ -37,5 +37,7 @@ toggle, and the withdraw — everything up to the datapath handoff.
 | A local MAC originates a Type-2 carrying a per-VNI End.DT2U SID | |
 | The importing PE binds the remote End.DT2U SID to the MAC | |
 | Toggling the encapsulation re-originates the routes in place | |
+| Binding the learning port to an Ethernet Segment stamps its ESI | |
+| Deleting the segment returns the MAC to single-homed | |
 | Withdrawing the local MAC withdraws the Type-2 and its MAC entry | |
 | Teardown topology | |

--- a/bdd/tests/features/bgp_evpn_srv6_macip.feature
+++ b/bdd/tests/features/bgp_evpn_srv6_macip.feature
@@ -95,6 +95,31 @@ Feature: EVPN Type-2 / Type-3 over SRv6 — End.DT2U and End.DT2M signalling
     And show command "show bgp evpn" in namespace "z2" should contain "Remote SID: fcbb:bbbb:1:"
     And show command "show l2 mac table" in namespace "z2" should eventually contain "srv6"
 
+  Scenario: Binding the learning port to an Ethernet Segment stamps its ESI
+    Given the test topology exists
+    # An `ESI:` line renders only for a Type-2 — a Type-1 or Type-4 carries
+    # its ESI in the NLRI key rather than on the path — so this assertion is
+    # unambiguous even once the ES routes below start flowing. Until a segment
+    # claims the port the MAC sits on, the MAC is advertised single-homed.
+    Then show command "show bgp evpn" in namespace "z2" should not contain "ESI:"
+    # Declare the segment, then bind it to host0 — the port this MAC was
+    # learned on. Neither edit touches the FDB, so re-originating the
+    # already-advertised Type-2 under the new ESI is the config handler's job.
+    When I apply command "set router bgp afi-safi evpn ethernet-segment es1 esi 00:11:22:33:44:55:66:77:88:99" in namespace "z1"
+    And I apply command "set router bgp afi-safi evpn ethernet-segment es1 interface host0" in namespace "z1"
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    # A refresh, not a re-learn: the MAC and its End.DT2U SID are unchanged.
+    And show command "show bgp evpn" in namespace "z2" should contain "aa:bb:cc:dd:ee:01"
+    And show command "show bgp evpn" in namespace "z2" should contain "(End.DT2U)"
+
+  Scenario: Deleting the segment returns the MAC to single-homed
+    Given the test topology exists
+    When I apply command "delete router bgp afi-safi evpn ethernet-segment es1" in namespace "z1"
+    Then show command "show bgp evpn" in namespace "z2" should eventually not contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    # The MAC route itself survives losing its segment.
+    And show command "show bgp evpn" in namespace "z2" should contain "aa:bb:cc:dd:ee:01"
+
   Scenario: Withdrawing the local MAC withdraws the Type-2 and its MAC entry
     Given the test topology exists
     When I execute "bridge fdb del aa:bb:cc:dd:ee:01 dev host0 master" in namespace "z1"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1830,6 +1830,9 @@ fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     // A VPWS service naming this segment resolves through it for its ESI and
     // redundancy mode; deleting it makes those services single-homed again.
     bgp.vpws_resync_es();
+    // MACs already learned on the segment's access port carry its ESI on their
+    // Type-2s, so adding or removing the segment changes what we advertise.
+    bgp.evpn_resync_macip_esi();
     Some(())
 }
 
@@ -1873,6 +1876,9 @@ fn config_ethernet_segment_esi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
     // The ESI is part of a VPWS Type-1's NLRI key, so services on this
     // segment must be re-originated under the new one.
     bgp.vpws_resync_es();
+    // Type-2s carry the ESI on the path rather than in the key, so they only
+    // need refreshing under the new value — not withdrawing first.
+    bgp.evpn_resync_macip_esi();
     Some(())
 }
 
@@ -2023,6 +2029,9 @@ fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp
     };
     bgp.ethernet_segments.entry(name).or_default().interface = interface;
     bgp.vpws_resync_es();
+    // This leaf is what decides whether a learned MAC's port is on a segment
+    // at all, so it moves Type-2s between single- and multi-homed.
+    bgp.evpn_resync_macip_esi();
     Some(())
 }
 

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -6,10 +6,55 @@
 //! those are later phases. The config handlers live in `config.rs` alongside
 //! the other EVPN afi-safi knobs; this module owns the state types.
 
+use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
 use bgp_packet::{DfElectionEc, ExtCommunityValue};
+
+use super::vpws::{EsBinding, bind_es};
+
+/// The interface name for `ifindex`, from the `if-name` → `ifindex` mirror
+/// BGP keeps off `RibRx::LinkAdd`.
+///
+/// `ifindex == 0` is "no port", not a lookup miss, and never matches: an FDB
+/// learn that carries no interface (every MAC from the cradle datapath, whose
+/// `FdbEvent` reports only `(mac, bd)`) must not be attributed to whichever
+/// link happens to sit at index 0.
+pub fn ac_name_for_ifindex(ifindex: u32, links: &BTreeMap<String, u32>) -> Option<String> {
+    if ifindex == 0 {
+        return None;
+    }
+    links
+        .iter()
+        .find_map(|(name, &idx)| (idx == ifindex).then(|| name.clone()))
+}
+
+/// The ESI a route learned on access port `ac` should carry, or `None` for
+/// single-homed.
+///
+/// The learning port *is* the attachment circuit, so this reuses the same
+/// [`bind_es`] inference VPWS does — with no explicit leaf to honour, because
+/// a MAC learn carries no operator intent to override. Two segments claiming
+/// one port resolves to single-homed rather than a tie-break: the wrong ESI
+/// is a silent blackhole once a remote PE starts aliasing (RFC 7432 §8.4)
+/// toward the segment we misnamed. `Err` returns the competing names so the
+/// caller can say so.
+pub fn esi_for_ac(
+    ac: &str,
+    segments: &BTreeMap<String, EthernetSegment>,
+) -> Result<Option<[u8; 10]>, Vec<String>> {
+    // `bind_es` keys on the same `Option<&String>` the VPWS `interface` leaf
+    // hands it; the temporary is one allocation per MAC learn.
+    let ac = ac.to_string();
+    match bind_es(None, Some(&ac), segments) {
+        EsBinding::Derived(name) | EsBinding::Explicit(name) => {
+            Ok(segments.get(&name).and_then(|es| es.esi))
+        }
+        EsBinding::Ambiguous(claims) => Err(claims),
+        EsBinding::None | EsBinding::Unresolved(_) => Ok(None),
+    }
+}
 
 /// All-active vs single-active multihoming redundancy mode (RFC 7432 §14.1).
 /// Carried in the ESI Label EC's flag on the per-ES A-D route.
@@ -300,6 +345,87 @@ pub fn vpws_role(
         VpwsRole::Backup
     } else {
         VpwsRole::NonDesignated
+    }
+}
+
+#[cfg(test)]
+mod ac_esi_tests {
+    use super::*;
+
+    const ESI_A: [u8; 10] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99];
+    const ESI_B: [u8; 10] = [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03];
+
+    fn links(entries: &[(&str, u32)]) -> BTreeMap<String, u32> {
+        entries
+            .iter()
+            .map(|(name, idx)| (name.to_string(), *idx))
+            .collect()
+    }
+
+    fn segments(
+        entries: &[(&str, Option<&str>, Option<[u8; 10]>)],
+    ) -> BTreeMap<String, EthernetSegment> {
+        entries
+            .iter()
+            .map(|(name, iface, esi)| {
+                (
+                    name.to_string(),
+                    EthernetSegment {
+                        esi: *esi,
+                        interface: iface.map(str::to_string),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn ifindex_resolves_to_its_link_name() {
+        let links = links(&[("eth0", 2), ("eth1", 3)]);
+        assert_eq!(ac_name_for_ifindex(3, &links).as_deref(), Some("eth1"));
+        // An index no link claims is a miss, not a wrong answer.
+        assert_eq!(ac_name_for_ifindex(9, &links), None);
+    }
+
+    /// The cradle datapath's `FdbEvent` carries no port, so its learns arrive
+    /// with `ifindex: 0`. That must never be attributed to a link — including
+    /// one that somehow sits at index 0 — or every cradle-learned MAC would
+    /// inherit that link's segment.
+    #[test]
+    fn ifindex_zero_never_resolves() {
+        assert_eq!(ac_name_for_ifindex(0, &links(&[("eth0", 0)])), None);
+        assert_eq!(ac_name_for_ifindex(0, &links(&[("eth0", 2)])), None);
+    }
+
+    #[test]
+    fn port_on_one_segment_takes_its_esi() {
+        let segs = segments(&[("es1", Some("eth0"), Some(ESI_A))]);
+        assert_eq!(esi_for_ac("eth0", &segs), Ok(Some(ESI_A)));
+    }
+
+    #[test]
+    fn port_on_no_segment_is_single_homed() {
+        let segs = segments(&[("es1", Some("eth0"), Some(ESI_A))]);
+        assert_eq!(esi_for_ac("eth1", &segs), Ok(None));
+        // A segment that claims the port but has no ESI configured yet is
+        // still single-homed — there is nothing to advertise.
+        let pending = segments(&[("es1", Some("eth0"), None)]);
+        assert_eq!(esi_for_ac("eth0", &pending), Ok(None));
+    }
+
+    /// Two segments claiming one port must not tie-break: picking the wrong
+    /// ESI blackholes traffic a remote PE aliases toward that segment.
+    #[test]
+    fn port_claimed_twice_is_ambiguous_not_arbitrary() {
+        let segs = segments(&[
+            ("es1", Some("eth0"), Some(ESI_A)),
+            ("es2", Some("eth0"), Some(ESI_B)),
+        ]);
+        assert_eq!(
+            esi_for_ac("eth0", &segs),
+            Err(vec!["es1".to_string(), "es2".to_string()])
+        );
     }
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15455,13 +15455,15 @@ impl Bgp {
     ///     remote VTEP MAC); re-advertising them would loop.
     ///
     /// Hardcodes (per RFC 8365 single-homed VLAN-Based service):
-    ///   - ESI = 0 (no multi-homing)
     ///   - Ethernet Tag = 0 (one bridge per VNI)
     ///   - IP component absent (MAC-only Type-2; MAC+IP needs ARP/NDP
     ///     correlation, follow-up).
     ///   - RD = `<router-id>:<VNI>` (Type-1, IPv4 + 2-byte). VNIs
     ///     above 65535 are skipped — Type-0 ASN-format RD support
     ///     for big VNIs is a follow-up.
+    ///
+    /// The ESI comes from [`Self::macip_esi`] — non-zero when the port that
+    /// learned the MAC is an Ethernet Segment's access port, zero otherwise.
     pub fn evpn_originate_macip(&mut self, entry: &FdbEntry) {
         if !self.advertise_all_vni {
             return;
@@ -15600,6 +15602,11 @@ impl Bgp {
             None,
             false,
         );
+        // RFC 7432 §7.2: the ESI of the Ethernet Segment this MAC was learned
+        // on. Set before `update_evpn` — the clone that lands in the Loc-RIB is
+        // what the advertise path re-encodes into the NLRI.
+        rib.esi = self.macip_esi(entry);
+
         let (_replaced, selected, next_id) =
             self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
         rib.local_id = next_id;
@@ -15664,7 +15671,69 @@ impl Bgp {
         // re-evaluation here — for a locally-originated route there
         // is no other path that would replace it; the peers can
         // figure it out when they see the MP_UNREACH.
+        //
+        // The withdrawal reconstructs the NLRI with a zero ESI even when the
+        // advertisement carried one. That is deliberate and interoperable: the
+        // MAC/IP route key is (RD, Ethernet Tag, MAC, IP) — the ESI rides in
+        // the NLRI but is not part of the key — so a receiver matches this
+        // against the advertised route regardless. It is also what our own
+        // receive path does, keying `EvpnPrefix::MacIp` on the same four
+        // fields and carrying the ESI on the path.
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// The ESI to stamp on a Type-2 originated from `entry`: that of the
+    /// Ethernet Segment whose access port learned the MAC, or `None`
+    /// (encoded as the all-zero ESI) when the port is not on a segment.
+    ///
+    /// The learning port *is* the attachment circuit, so this is the same
+    /// inference [`bind_es`] does for VPWS — with no explicit leaf to honour,
+    /// because a MAC learn carries no operator intent to override. Two
+    /// segments claiming one port stays ambiguous rather than tie-breaking:
+    /// the wrong ESI here is a silent blackhole once a remote PE starts
+    /// aliasing (RFC 7432 §8.4) toward the segment we misnamed.
+    ///
+    /// `ifindex == 0` means the learn carries no port. That is every MAC from
+    /// the cradle datapath — `FdbEvent` (proto/cradle.proto) reports only
+    /// `(mac, bd)`, so cradle-learned MACs stay single-homed here until that
+    /// stream carries the learning port. Kernel bridge learns do carry it.
+    pub fn macip_esi(&self, entry: &FdbEntry) -> Option<[u8; 10]> {
+        let ac =
+            super::ethernet_segment::ac_name_for_ifindex(entry.ifindex, &self.link_index_by_name)?;
+        match super::ethernet_segment::esi_for_ac(&ac, &self.ethernet_segments) {
+            Ok(esi) => esi,
+            Err(claims) => {
+                tracing::warn!(
+                    "evpn_originate_macip: interface {} is claimed by {} ethernet segments ({}); \
+                     originating {} as single-homed",
+                    ac,
+                    claims.len(),
+                    claims.join(", "),
+                    entry.mac,
+                );
+                None
+            }
+        }
+    }
+
+    /// Re-originate every locally-learned Type-2 so its ESI matches the
+    /// current `ethernet_segments`. The ESI is carried on the path rather
+    /// than in the route key, so this is a plain refresh — no withdraw first,
+    /// and MAC mobility sequence numbers are untouched (a local
+    /// re-advertisement does not bump them).
+    ///
+    /// The Type-2 twin of [`Self::vpws_resync_es`], called from the same
+    /// config sites: anything that changes which port belongs to which
+    /// segment, or what that segment's ESI is, changes what we should be
+    /// advertising for MACs already learned on it.
+    pub fn evpn_resync_macip_esi(&mut self) {
+        if !self.advertise_all_vni {
+            return;
+        }
+        let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+        for entry in entries {
+            self.evpn_originate_macip(&entry);
+        }
     }
 
     /// Originate (or refresh) an EVPN Type-5 (IP Prefix) route for a

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1514,7 +1514,7 @@ fn show_adj_rib_routes_evpn<D: RibDirection>(
                     nexthop, med, local_pref, weight, aspath, origin
                 )?;
 
-                write_evpn_path_attrs(&mut buf, &rib.attr, rib.is_originated())?;
+                write_evpn_path_attrs(&mut buf, &rib.attr, rib.is_originated(), rib.esi)?;
             }
         }
     }
@@ -4184,7 +4184,12 @@ fn format_pmsi_tunnel(p: &PmsiTunnel, mpls: bool) -> String {
 ///   rendered together on one line as in the unicast detail view.
 /// - Aggregation (RFC 4271): Atomic-Aggregate flag and Aggregator AS/IP.
 /// - Accumulated IGP metric (RFC 7311).
-fn write_evpn_path_attrs(buf: &mut String, attr: &BgpAttr, originated: bool) -> std::fmt::Result {
+fn write_evpn_path_attrs(
+    buf: &mut String,
+    attr: &BgpAttr,
+    originated: bool,
+    esi: Option<[u8; 10]>,
+) -> std::fmt::Result {
     const PAD: &str = "                    ";
 
     // SRv6 service SIDs (RFC 9252), printed first so they sit directly
@@ -4202,6 +4207,15 @@ fn write_evpn_path_attrs(buf: &mut String, attr: &BgpAttr, originated: bool) -> 
     };
     for (sid, behavior) in attr.srv6_l2_sids().chain(attr.srv6_l3_sids()) {
         writeln!(buf, "{PAD}{kind}: {sid} ({})", srv6_behavior_name(behavior))?;
+    }
+
+    // The Ethernet Segment this route's MAC (Type-2) or prefix (Type-5) sits
+    // behind. An NLRI field rather than a path attribute, but it belongs with
+    // the forwarding story: it is what lets a remote PE alias traffic across
+    // every PE attached to the same segment (RFC 7432 §8.4). Suppressed when
+    // zero — that is the single-homed case, which is most routes.
+    if let Some(esi) = esi.filter(|esi| esi != &[0u8; 10]) {
+        writeln!(buf, "{PAD}ESI: {}", bgp_packet::esi_display(&esi))?;
     }
 
     let ecom = show_evpn_ecom(attr);
@@ -4394,7 +4408,7 @@ fn show_bgp_evpn(
             // route-reflection attrs (RFC 4456: Originator / Cluster list),
             // aggregation (RFC 4271), and AIGP (RFC 7311). Lines are emitted
             // only when the attribute is present.
-            write_evpn_path_attrs(&mut buf, &rib.attr, rib.is_originated())?;
+            write_evpn_path_attrs(&mut buf, &rib.attr, rib.is_originated(), rib.esi)?;
 
             // Line 4 (Type-9 only): RFC 9572 §5.3.1 inter-AS DF election among
             // the ASBRs advertising this region's Per-Region I-PMSI.
@@ -5440,7 +5454,7 @@ mod evpn_show_tests {
         };
 
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &attr, false).unwrap();
+        write_evpn_path_attrs(&mut buf, &attr, false, None).unwrap();
 
         let pad = " ".repeat(20);
         let expected = format!(
@@ -5465,7 +5479,7 @@ mod evpn_show_tests {
         };
 
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &attr, false).unwrap();
+        write_evpn_path_attrs(&mut buf, &attr, false, None).unwrap();
 
         let pad = " ".repeat(20);
         assert_eq!(
@@ -5487,7 +5501,7 @@ mod evpn_show_tests {
         };
 
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &attr, false).unwrap();
+        write_evpn_path_attrs(&mut buf, &attr, false, None).unwrap();
 
         let pad = " ".repeat(20);
         assert_eq!(buf, format!("{pad}Cluster list: 10.0.0.2\n"));
@@ -5507,7 +5521,7 @@ mod evpn_show_tests {
         };
 
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &attr, false).unwrap();
+        write_evpn_path_attrs(&mut buf, &attr, false, None).unwrap();
 
         let pad = " ".repeat(20);
         let expected = format!(
@@ -5525,7 +5539,7 @@ mod evpn_show_tests {
     #[test]
     fn write_path_attrs_empty_attr_writes_nothing() {
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &BgpAttr::default(), false).unwrap();
+        write_evpn_path_attrs(&mut buf, &BgpAttr::default(), false, None).unwrap();
         assert!(buf.is_empty());
     }
 
@@ -5549,7 +5563,7 @@ mod evpn_show_tests {
         };
 
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &attr, false).unwrap();
+        write_evpn_path_attrs(&mut buf, &attr, false, None).unwrap();
 
         let pad = " ".repeat(20);
         assert_eq!(
@@ -5582,7 +5596,7 @@ mod evpn_show_tests {
             };
 
             let mut buf = String::new();
-            write_evpn_path_attrs(&mut buf, &attr, true).unwrap();
+            write_evpn_path_attrs(&mut buf, &attr, true, None).unwrap();
 
             let pad = " ".repeat(20);
             assert_eq!(
@@ -5624,7 +5638,7 @@ mod evpn_show_tests {
         };
 
         let mut buf = String::new();
-        write_evpn_path_attrs(&mut buf, &attr, false).unwrap();
+        write_evpn_path_attrs(&mut buf, &attr, false, None).unwrap();
 
         let pad = " ".repeat(20);
         assert_eq!(


### PR DESCRIPTION
`evpn_originate_macip` never assigned `rib.esi`, so every Type-2 this PE
originated went out with the all-zero ESI — on every encapsulation, not just
SRv6. A remote PE could not tell that two PEs advertising the same MAC were
attached to the same Ethernet Segment, which is what RFC 7432 §8.4 aliasing and
§8.2 mass withdraw are keyed on. ES-aware origination existed only for Type-4
and the per-ES Type-1, which is why VPWS multihoming works and MAC multihoming
does not.

### How the ESI is inferred

The learning port is the attachment circuit, so this reuses the path VPWS
already uses: `FdbEntry.ifindex` resolves through BGP's name/ifindex mirror to a
port name, and `bind_es` matches that against each segment's `interface`.

Two segments claiming one port stays **single-homed** rather than tie-breaking,
and logs which segments collided — a wrong ESI is a silent blackhole once a
remote starts aliasing toward the segment we misnamed.

The decision lives in two pure functions in `ethernet_segment.rs`
(`ac_name_for_ifindex`, `esi_for_ac`) so it is unit-testable without
constructing a `Bgp`.

### Known scope limit

`ifindex == 0` is treated as "no port", not a lookup miss — index 0 must never
be attributed to whatever link happens to sit there (there is a test pinning
this). That is every MAC from the cradle datapath: `FdbEvent` in
`proto/cradle.proto` reports only `(mac, bd)`, so `rib/inst.rs` synthesizes
those entries with `ifindex: 0`.

**MAC multihoming therefore works on kernel-bridge learns but not on the
SRv6/cradle datapath** until `FdbEvent` carries the learning port — a cradle-rs
proto + datapath change. Cradle's XDP stage already knows the ingress ifindex,
so it is feasible as a follow-up in that repo.

### Re-origination on config change

Edits that move a port between segments, or change a segment's ESI,
re-originate the affected Type-2s via `evpn_resync_macip_esi` — the Type-2 twin
of `vpws_resync_es`, called from the same three handlers. The ESI rides on the
path rather than in the route key, so this is a plain refresh: no withdraw
first, and MAC mobility sequence numbers are untouched.

### Observability

`show bgp evpn` renders a non-zero ESI on the path. Only a Type-2 sets
`rib.esi` on receive, so the line is unambiguous — a Type-1/Type-4 carries its
ESI in the NLRI key and prints it in the prefix instead.

### Testing

- 1808 unit tests pass (5 new), workspace clippy `-D warnings` and fmt clean
- `bgp_evpn_srv6_macip` passes with 9 scenarios against the staged toolchain

The two new BDD scenarios prove the ESI reaches the far PE on an ES bind and
disappears again on delete, with the MAC route and its End.DT2U SID surviving
both. That was worth asserting rather than assuming: an ESI-only change leaves
the path *attributes* identical, so it was genuinely unclear whether the
re-advertisement would be suppressed. It is not — `evpn_advertise_one` has no
attribute-equality dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
