### PR TITLE
isis: allocate circuit ids per instance instead of deriving them

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -447,8 +447,13 @@ pub fn stop(link: &mut LinkTop) {
     }
 }
 
-/// Circuit id for the pseudonode this router originates as DIS on
-/// `ifindex`, folded into `1..=255`.
+/// Fallback circuit id derived from `ifindex`, folded into `1..=255`.
+///
+/// Only reached when the per-instance allocator
+/// ([`crate::isis::link::IsisLinks::alloc_circuit_id`]) had nothing left
+/// to hand out, i.e. this router already runs IS-IS on 255 circuits. The
+/// pseudonode id is 8 bits, so beyond that some pair must collide however
+/// it is chosen; this at least keeps the value out of the reserved 0.
 ///
 /// Pseudonode id 0 is reserved for a router's own non-pseudonode LSP, so
 /// it can never name a circuit: a DIS that advertises `<sys-id>.00` as its
@@ -475,7 +480,13 @@ fn dis_pseudo_id(ifindex: u32) -> u8 {
 pub fn dis_becoming(link: &mut LinkTop, level: Level) {
     use IfsmEvent::*;
 
-    let pseudo_id: u8 = dis_pseudo_id(link.ifindex);
+    // The circuit's allocated id, unique across this instance's links.
+    // Zero means the allocator was exhausted (or this link predates
+    // assignment), so fall back to the ifindex fold — still never 0.
+    let pseudo_id: u8 = match link.state.circuit_id {
+        0 => dis_pseudo_id(link.ifindex),
+        id => id,
+    };
     let lsp_id = IsisLspId::new(link.up_config.net.sys_id(), pseudo_id, 0);
 
     // Register adjacency with LAN ID.

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -81,6 +81,14 @@ pub struct IsisLinks {
     pub map: BTreeMap<u32, IsisLink>,
 }
 
+/// Lowest id in `1..=255` absent from `used`, or `None` when the space is
+/// full. Split out from [`IsisLinks::alloc_circuit_id`] so the selection
+/// rule is testable without standing up real links (an `IsisLink` owns a
+/// raw `AF_PACKET` socket).
+fn lowest_free_circuit_id(used: &BTreeSet<u8>) -> Option<u8> {
+    (1u8..=255).find(|id| !used.contains(id))
+}
+
 impl IsisLinks {
     pub fn get(&self, key: &u32) -> Option<&IsisLink> {
         self.map.get(key)
@@ -96,6 +104,30 @@ impl IsisLinks {
 
     pub fn insert(&mut self, key: u32, value: IsisLink) -> Option<IsisLink> {
         self.map.insert(key, value)
+    }
+
+    /// Lowest circuit id in `1..=255` not already taken by a link this
+    /// instance holds, or `None` when all 255 are in use.
+    ///
+    /// The used set is read straight off the map rather than tracked in a
+    /// side table: the map is the only source of truth for which circuits
+    /// exist, so uniqueness cannot drift out of sync with it. Links are
+    /// never removed from `IsisLinks`, so ids are never recycled and an
+    /// assignment stays valid for the link's lifetime — which matters,
+    /// because the id names a pseudonode LSP that peers hold in their
+    /// LSDB.
+    ///
+    /// `0` is excluded by construction: it is the router's own
+    /// non-pseudonode LSP id, and a DIS that claimed it would advertise a
+    /// LAN ID aliasing that LSP.
+    pub fn alloc_circuit_id(&self) -> Option<u8> {
+        let used: BTreeSet<u8> = self
+            .map
+            .values()
+            .map(|link| link.state.circuit_id)
+            .filter(|id| *id != 0)
+            .collect();
+        lowest_free_circuit_id(&used)
     }
 
     pub fn iter(&self) -> Iter<'_, u32, IsisLink> {
@@ -642,6 +674,18 @@ impl DisStatistics {
 pub struct LinkState {
     // pub ifindex: u32,
     pub name: String,
+
+    /// This circuit's IS-IS circuit id, `1..=255`, assigned once when the
+    /// link is admitted and stable for its lifetime. It names the
+    /// pseudonode this router originates while DIS here: the pseudonode
+    /// LSP id is `(sys-id, circuit_id)`, so the value must be unique
+    /// across this instance's circuits and must never be 0 — 0 is the
+    /// router's own non-pseudonode LSP, and a LAN claiming it aliases
+    /// that LSP (see `ifsm::dis_becoming`).
+    ///
+    /// 0 means "unassigned": either the link predates assignment, or the
+    /// instance already holds 255 circuits and the space is exhausted.
+    pub circuit_id: u8,
     pub mtu: u32,
     pub mac: Option<MacAddr>,
 
@@ -821,7 +865,17 @@ impl Isis {
         let ifindex = link.index;
         let name = link.name.clone();
         match IsisLink::from(link, self.tx.clone()) {
-            Ok(is_link) => {
+            Ok(mut is_link) => {
+                // Assign before insert, so the allocator never sees this
+                // link's own (still zero) id in the used set.
+                match self.links.alloc_circuit_id() {
+                    Some(id) => is_link.state.circuit_id = id,
+                    None => tracing::warn!(
+                        "isis: circuit ids exhausted (255 links); {name} (ifindex={ifindex}) \
+                         falls back to an ifindex-derived pseudonode id, which may collide \
+                         with another circuit's"
+                    ),
+                }
                 self.links.insert(is_link.ifindex, is_link);
             }
             Err(e) => {
@@ -2050,7 +2104,12 @@ pub fn show_detail(
                         "Down".to_string()
                     },
                     active: true,
-                    circuit_id: format!("0x{:02X}", link.ifindex),
+                    // The circuit's real IS-IS id — what a pseudonode LSP
+                    // this router originates here is named with. Showing
+                    // the ifindex instead made the two disagree, so an
+                    // operator matching `show isis database` against this
+                    // column saw ids that did not exist.
+                    circuit_id: format!("0x{:02X}", link.state.circuit_id),
                     network_type: format!("{}", link.config.network_type()),
                     level: format!("{}", link.state.level()),
                     snpa: link.state.mac.map(|mac| mac.to_string()),
@@ -2647,5 +2706,55 @@ mod te_metric_tests {
                 ..Default::default()
             }
         );
+    }
+}
+
+#[cfg(test)]
+mod circuit_id_tests {
+    use super::lowest_free_circuit_id;
+    use std::collections::BTreeSet;
+
+    fn used(ids: &[u8]) -> BTreeSet<u8> {
+        ids.iter().copied().collect()
+    }
+
+    /// 0 is the router's own non-pseudonode LSP id. A circuit that took
+    /// it would make the DIS advertise a LAN ID aliasing that LSP, which
+    /// is the bug this allocator exists to make unrepresentable.
+    #[test]
+    fn never_allocates_zero() {
+        assert_eq!(lowest_free_circuit_id(&used(&[])), Some(1));
+        // Even if a stale 0 somehow sits in the used set, it is not a
+        // candidate to hand back.
+        assert_eq!(lowest_free_circuit_id(&used(&[0])), Some(1));
+    }
+
+    /// Ids must be distinct across circuits: two LANs sharing one would
+    /// share a pseudonode LSP id and collide in every peer's LSDB.
+    #[test]
+    fn hands_out_distinct_ids_until_exhausted() {
+        let mut used = BTreeSet::new();
+        for expected in 1..=255u8 {
+            let id = lowest_free_circuit_id(&used).expect("space remains");
+            assert_eq!(id, expected, "allocation must be dense and in order");
+            assert!(used.insert(id), "id {id} handed out twice");
+        }
+        assert_eq!(used.len(), 255);
+        assert_eq!(
+            lowest_free_circuit_id(&used),
+            None,
+            "256th circuit must report exhaustion, not wrap to 0"
+        );
+    }
+
+    /// Gaps are reused. Links are never removed today, so this is
+    /// forward cover for the day they are.
+    #[test]
+    fn fills_the_lowest_gap() {
+        assert_eq!(lowest_free_circuit_id(&used(&[1, 2, 4])), Some(3));
+        assert_eq!(lowest_free_circuit_id(&used(&[2, 3])), Some(1));
+        let mut full: BTreeSet<u8> = (1..=255u8).collect();
+        full.remove(&200);
+        assert_eq!(lowest_free_circuit_id(&full), Some(200));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2146, which stopped `ifindex as u8` producing the reserved pseudonode id 0 by folding into `1..=255`. That removed the guaranteed-broken case but left the underlying weakness: the id was still an accident of interface numbering, so two circuits collided whenever their ifindexes were congruent mod 256 (mod 255 after the fold).

The pseudonode LSP a router originates while DIS is named `(sys-id, circuit-id)`, so the circuit id has to be unique across that router's circuits. Now it is, by allocation rather than by luck:

- `LinkState` carries `circuit_id`.
- `IsisLinks::alloc_circuit_id()` hands out the lowest free id in `1..=255`.
- `Isis::link_add` assigns one **before** inserting the link — before, so the allocator never sees the new link's own zero in the used set.

### Design notes

**The used set is read straight off the links map, not tracked beside it.** The map is the only record of which circuits exist, so uniqueness cannot drift out of sync with it; a parallel bitmap is exactly where a leak would develop. Links are never removed from `IsisLinks`, so ids are never recycled and an assignment stays valid for the link's lifetime — which matters, because peers hold the resulting pseudonode LSP in their LSDB.

**Exhaustion keeps the fold.** Past 255 circuits the 8-bit field forces some pair to collide however the value is chosen, so `dis_becoming` falls back to #2146's ifindex fold and logs which interface hit it. That path is no longer reachable in any normal configuration.

**`show isis interface` printed the ifindex in its Circuit Id column.** Harmless while the two were the same number, actively misleading now — an operator matching the column against `show isis database` would look for pseudonode ids that do not exist. Fixed to show the real id.

## Test plan

- New unit tests: `never_allocates_zero`, `hands_out_distinct_ids_until_exhausted` (walks all 255, asserting dense in-order allocation, no duplicates, and that the 256th reports exhaustion rather than wrapping to 0), and `fills_the_lowest_gap` (forward cover for if links ever become removable). The selection rule is split into a pure `lowest_free_circuit_id` so it is testable without standing up real links — an `IsisLink` owns a raw `AF_PACKET` socket.
- 189 IS-IS unit tests pass.
- BDD, all pass: `isis_lan_pseudonode`, `isis_lan_dis_reelection`, `isis_lan_dis_pseudonode_purge`, `isis_l1l2`, `isis_tilfa`, `isis_fragmentation_ipv4`, `ecmp_bfd_evict`. The first three are the LAN/DIS pseudonode paths this touches directly; the last is the feature whose intermittent failure exposed the original id-0 bug.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean, re-run after rebasing onto current main.

Generated with [Claude Code](https://claude.com/claude-code)