### PR TITLE
isis: reserve circuit ids lazily, when a circuit stands for DIS

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2606,6 +2606,14 @@ impl Isis {
     }
 
     fn process_ifsm(&mut self, ev: IfsmEvent, ifindex: u32, level: Option<Level>) {
+        // A DIS election can leave this circuit as the DIS, which needs a
+        // circuit id to name the pseudonode LSP it then originates.
+        // Reserve one here rather than inside `dis_becoming`: the
+        // allocator must see every other link, which the mutable borrow
+        // `link_top` takes below rules out.
+        if ev == IfsmEvent::DisSelection {
+            self.ensure_circuit_id(ifindex);
+        }
         let Some(mut top) = self.link_top(ifindex) else {
             return;
         };

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -857,6 +857,45 @@ impl IsisLink {
 }
 
 impl Isis {
+    /// Reserve this circuit's IS-IS circuit id if it does not have one,
+    /// called as a LAN circuit stands for DIS election.
+    ///
+    /// Deliberately lazy. `RibRx::LinkAdd` fires for every interface the
+    /// daemon sees — VLAN subinterfaces, tunnels, veths, anything the
+    /// kernel reports — and links are never removed from `IsisLinks`, so
+    /// assigning at link-add would burn one of only 255 ids per interface
+    /// ever observed, however few of them run IS-IS. Reserving here scopes
+    /// the space to the circuits that can actually originate a pseudonode
+    /// LSP, which is the only thing a circuit id names.
+    ///
+    /// P2P circuits are skipped for the same reason: their `ExtIsReach`
+    /// carries `(peer-sys-id, 0)`, with no pseudonode and so no id to
+    /// spend.
+    ///
+    /// Runs before the caller takes the link's mutable borrow, because the
+    /// allocator has to see every *other* link to know what is free.
+    pub fn ensure_circuit_id(&mut self, ifindex: u32) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        if link.is_p2p() || link.state.circuit_id != 0 {
+            return;
+        }
+        let name = link.state.name.clone();
+        match self.links.alloc_circuit_id() {
+            Some(id) => {
+                if let Some(link) = self.links.get_mut(&ifindex) {
+                    link.state.circuit_id = id;
+                }
+            }
+            None => tracing::warn!(
+                "isis: circuit ids exhausted (255 in use); {name} (ifindex={ifindex}) falls \
+                 back to an ifindex-derived pseudonode id, which may collide with another \
+                 circuit's"
+            ),
+        }
+    }
+
     pub fn link_add(&mut self, link: Link) {
         // println!("ISIS: LinkAdd {} {}", link.name, link.index);
         if self.links.get(&link.index).is_some() {
@@ -865,17 +904,12 @@ impl Isis {
         let ifindex = link.index;
         let name = link.name.clone();
         match IsisLink::from(link, self.tx.clone()) {
-            Ok(mut is_link) => {
-                // Assign before insert, so the allocator never sees this
-                // link's own (still zero) id in the used set.
-                match self.links.alloc_circuit_id() {
-                    Some(id) => is_link.state.circuit_id = id,
-                    None => tracing::warn!(
-                        "isis: circuit ids exhausted (255 links); {name} (ifindex={ifindex}) \
-                         falls back to an ifindex-derived pseudonode id, which may collide \
-                         with another circuit's"
-                    ),
-                }
+            Ok(is_link) => {
+                // No circuit id yet. `RibRx::LinkAdd` fires for every
+                // interface the daemon sees, most of which never run IS-IS
+                // at all, and the id space is only 255 wide — see
+                // `Isis::ensure_circuit_id`, which reserves one when a
+                // circuit actually stands for DIS.
                 self.links.insert(is_link.ifindex, is_link);
             }
             Err(e) => {


### PR DESCRIPTION
> **Draft — do not merge yet.** Measurements below suggest this may destabilise `@isis_tilfa`, and the lazy arm has only 4 runs against the baseline's 20. See *Open question*.

## Summary

#2149 assigns a circuit id in `link_add`, which is too eager. That fires on every `RibRx::LinkAdd` — every interface the kernel reports, including VLAN subinterfaces, tunnels and veths that never run IS-IS — and links are never removed from `IsisLinks`. So the effective budget is 255 **interfaces ever observed** rather than 255 IS-IS circuits, which a box with interface churn could burn through while running IS-IS on a handful of links.

This reserves on demand instead. `Isis::ensure_circuit_id` runs at the top of `process_ifsm` for `IfsmEvent::DisSelection`, so an id is spent only by a circuit that actually stands for election. P2P circuits are skipped outright: their `ExtIsReach` is `(peer-sys-id, 0)` — no pseudonode, nothing to name.

It lives in `process_ifsm` rather than `dis_becoming` because the allocator must see every *other* link to know what is free, and `link_top`'s mutable borrow of this one rules that out. The placement is sufficient, not merely convenient: `dis_becoming` is reachable only from `dis_selection`, and both of its call sites are in this same `DisSelection` arm (per-level, and the level-agnostic re-election), so no path reaches it without the reservation having run. A missed path would not fail loudly — it would fall back to the ifindex fold and quietly give up the uniqueness guarantee.

Note it is less lazy than "only circuits that originate a pseudonode": it fires on every election, including ones the router **loses**. Visible in a test LSDB as `n1` allocating 2, 3, 4 with id 1 spent on a circuit that never became DIS. The goal still holds — consumption is bounded by IS-IS LAN circuits rather than all interfaces.

## Open question — why this is a draft

`@isis_tilfa` is a **pre-existing intermittent on `main`** (SPF settling on `via s-n1 metric 13` instead of the expected `via s-n2 metric 12`, all adjacencies `Up`). Measured solo at `--concurrency=1`:

| build | result |
|---|---|
| `main` (eager, #2149) | 19 passed / **1 failed** of 20 — ~5% |
| this branch (lazy) | 2 passed / **2 failed** of 4 — 50% |

Fisher's exact on that is p≈0.04, so it is suggestive rather than noise — but the lazy arm is only 4 runs. A matching 20-run lazy arm is needed before this can be judged.

A plausible mechanism, unverified: eager allocation derives ids from interface add order, so a given circuit gets the same id every run. Lazy allocation follows the order of DIS elections, so ids vary run to run. If SPF or TI-LFA tie-breaking is sensitive to pseudonode LSP identity, that converts a stable outcome into a variable one. If that holds, the fix is to keep laziness but make the id deterministic (e.g. ordered by ifindex at first election) so it does not buy nondeterminism.

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, 189 IS-IS unit tests — all clean.
- BDD: `isis_lan_dis_reelection`, `isis_lan_dis_pseudonode_purge`, `isis_l1l2`, `isis_lan_pseudonode`, `ecmp_bfd_evict` all pass. `isis_tilfa` per the table above.
- The `lowest_free_circuit_id` unit tests from #2149 still apply — the selection rule is unchanged, only when it is invoked.

## Also

`show isis interface` now reports `0x00` for a P2P circuit, and for a LAN circuit that has not yet elected, where #2149 showed a real id and before that the ifindex. Accurate — neither has a pseudonode — but it is a visible change. No BDD feature asserts on that column.

Ids are still never reclaimed; `LinkDel` handling is deliberately deferred, since recycling an id has to be safe against peers still holding the old pseudonode LSP in their LSDB.

Generated with [Claude Code](https://claude.com/claude-code)