### PR TITLE
bdd: EVPN Type-2 multihoming signal set over SRv6 (+ show ESI render fix)

### DIFF
--- a/bdd/docs/bgp_evpn_srv6_macip_multihoming.md
+++ b/bdd/docs/bgp_evpn_srv6_macip_multihoming.md
@@ -1,0 +1,49 @@
+# EVPN Type-2 multihoming signals over SRv6 — ESI on the MAC route
+
+## Overview
+
+As a network operator multihoming a CE to two EVPN-over-SRv6 PEs
+I want a MAC learned on an Ethernet Segment's access port to advertise
+its Type-2 under the segment ESI (RFC 7432 §7.1), alongside both PEs'
+per-ES Type-1 A-D and Type-4 routes, so a receiver holds the complete
+input set for §8.4 aliasing and §8.2 mass withdraw.
+
+Scope is the SIGNAL set, not its consumption: zebra-rs does not yet
+alias MAC traffic across the segment's PEs nor mass-withdraw MACs on
+a per-ES A-D loss (both exist for VPWS only — `vpws_gather_remotes`
+gates on per-ES A-D liveness; the MAC install path does not). What is
+proven here is that every route a consumer would need is originated,
+exchanged and revoked correctly under `encapsulation srv6`.
+
+The ES machinery itself (Type-4/ES-Import RT, membership, DF election)
+is covered by bgp_evpn_es under the default encapsulation with no MACs;
+single-PE runtime ESI bind/unbind by bgp_evpn_srv6_macip. This
+feature is the two-PE composition: a segment shared by both PEs, bound
+on z1 to an access port in the STARTUP config (the binding resolves via
+the RibRx::LinkAdd replay — host0 is created only after the config
+lands), and a CE MAC learned there. z2 configures the segment's ESI
+but binds no port: its Type-4 and per-ES A-D need none, and a bound
+port's own auto-generated MAC would originate an ESI-carrying Type-2
+from z2 that never transitions, defeating whole-output assertions on
+z1's bind/unbind. (Note z1's host0 own MAC is bridge-learned and
+advertised too — every z1 Type-2 sheds the ESI together on unbind.)
+
+```
+```
+
+## Config Files
+
+- z1.yaml, z2.yaml — `advertise-all-vni` + `encapsulation srv6`, a
+  locator each, the shared `ethernet-segment es1` (bound to `host0`
+  on z1 only), and the EVPN AFI/SAFI as the only negotiated family.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and the EVPN session over SRv6 | |
+| Both PEs discover each other on the segment under SRv6 encapsulation | |
+| A MAC on one attached PE advertises under the segment ESI | |
+| Unbinding the access port returns the MAC to single-homed | |
+| Deleting the segment revokes the mass-withdraw signal set | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_evpn_srv6_macip_multihoming/z1.yaml
+++ b/bdd/tests/configs/bgp_evpn_srv6_macip_multihoming/z1.yaml
@@ -1,0 +1,57 @@
+# z1 — one of two EVPN-over-SRv6 PEs attached to the SAME Ethernet Segment
+# es1 (RFC 7432 multihoming): both PEs configure the same ESI, and each
+# binds its own CE-facing access port (host0, created by the feature after
+# this config lands — the binding resolves on the RibRx::LinkAdd replay).
+# A MAC learned on that port originates a Type-2 carrying the segment ESI
+# (RFC 7432 §7.1) alongside its per-VNI End.DT2U SID — the input a receiver
+# needs for §8.4 aliasing and §8.2 mass withdraw.
+#
+# Control-plane only: the L2 datapath for End.DT2U/DT2M is the cradle eBPF
+# tee, so `system ebpf` is deliberately absent. The static route to z2's
+# locator lets received service SIDs resolve; there is no IGP here.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1z2
+  ipv6:
+    address: 2001:db8:12::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 2001:db8::1
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: all-active
+        interface: host0
+    neighbor:
+    - remote-address: 2001:db8:12::2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: evpn
+        enabled: true
+  static:
+    ipv6:
+      route:
+      - prefix: fcbb:bbbb:2::/48
+        nexthop:
+        - address: 2001:db8:12::2

--- a/bdd/tests/configs/bgp_evpn_srv6_macip_multihoming/z2.yaml
+++ b/bdd/tests/configs/bgp_evpn_srv6_macip_multihoming/z2.yaml
@@ -1,0 +1,52 @@
+# z2 — the second PE on Ethernet Segment es1; mirror of z1.yaml (same ESI,
+# own locator/router-id). z2 never learns the CE MAC itself — it is the PE
+# a receiver could alias through (RFC 7432 §8.4), advertising only the
+# segment's Type-4 and per-ES Type-1 A-D. Deliberately NO `interface`
+# binding: the ES routes need none, and a bound port's own (auto-generated)
+# MAC would otherwise originate an ESI-carrying Type-2 from z2 that never
+# goes away, masking z1's transitions in whole-output show assertions.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2z1
+  ipv6:
+    address: 2001:db8:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 2001:db8::2
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: all-active
+    neighbor:
+    - remote-address: 2001:db8:12::1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: evpn
+        enabled: true
+  static:
+    ipv6:
+      route:
+      - prefix: fcbb:bbbb:1::/48
+        nexthop:
+        - address: 2001:db8:12::1

--- a/bdd/tests/features/bgp_evpn_srv6_macip_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_srv6_macip_multihoming.feature
@@ -1,0 +1,130 @@
+@serial
+@bgp_evpn_srv6_macip_multihoming
+Feature: EVPN Type-2 multihoming signals over SRv6 — ESI on the MAC route
+  As a network operator multihoming a CE to two EVPN-over-SRv6 PEs
+  I want a MAC learned on an Ethernet Segment's access port to advertise
+  its Type-2 under the segment ESI (RFC 7432 §7.1), alongside both PEs'
+  per-ES Type-1 A-D and Type-4 routes, so a receiver holds the complete
+  input set for §8.4 aliasing and §8.2 mass withdraw.
+
+  Scope is the SIGNAL set, not its consumption: zebra-rs does not yet
+  alias MAC traffic across the segment's PEs nor mass-withdraw MACs on
+  a per-ES A-D loss (both exist for VPWS only — `vpws_gather_remotes`
+  gates on per-ES A-D liveness; the MAC install path does not). What is
+  proven here is that every route a consumer would need is originated,
+  exchanged and revoked correctly under `encapsulation srv6`.
+
+  The ES machinery itself (Type-4/ES-Import RT, membership, DF election)
+  is covered by bgp_evpn_es under the default encapsulation with no MACs;
+  single-PE runtime ESI bind/unbind by bgp_evpn_srv6_macip. This
+  feature is the two-PE composition: a segment shared by both PEs, bound
+  on z1 to an access port in the STARTUP config (the binding resolves via
+  the RibRx::LinkAdd replay — host0 is created only after the config
+  lands), and a CE MAC learned there. z2 configures the segment's ESI
+  but binds no port: its Type-4 and per-ES A-D need none, and a bound
+  port's own auto-generated MAC would originate an ESI-carrying Type-2
+  from z2 that never transitions, defeating whole-output assertions on
+  z1's bind/unbind. (Note z1's host0 own MAC is bridge-learned and
+  advertised too — every z1 Type-2 sheds the ESI together on unbind.)
+
+  ```
+   z1 [br10: vxlan10 + host0]  ══════  z2 [br10: vxlan10]
+      LOC1 fcbb:bbbb:1::/48   2001:db8:12::/64   LOC2 fcbb:bbbb:2::/48
+      router-id 192.168.0.1                      router-id 192.168.0.2
+      both: ethernet-segment es1, esi 00:11:..:99 (z1: interface host0)
+      CE MAC aa:bb:cc:dd:ee:01 parked on z1's host0
+  ```
+
+  Config files (in `bdd/tests/configs/bgp_evpn_srv6_macip_multihoming/`):
+  - z1.yaml, z2.yaml — `advertise-all-vni` + `encapsulation srv6`, a
+    locator each, the shared `ethernet-segment es1` (bound to `host0`
+    on z1 only), and the EVPN AFI/SAFI as the only negotiated family.
+
+  Scenario: Setup topology and the EVPN session over SRv6
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1z2" to namespace "z2" interface "z2z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    # Each PE gets a learning bridge for VNI 10; z1 also gets the host0
+    # access port. host0 is created AFTER the config named it as es1's
+    # interface, so the ES binding starts unresolvable and must catch up
+    # on the LinkAdd event.
+    And I execute "ip link add br10 type bridge" in namespace "z1"
+    And I execute "ip link set vxlan10 master br10" in namespace "z1"
+    And I execute "ip link set br10 up" in namespace "z1"
+    And I execute "ip link add host0 type dummy" in namespace "z1"
+    And I execute "ip link set host0 master br10" in namespace "z1"
+    And I execute "ip link set host0 up" in namespace "z1"
+    And I execute "ip link add br10 type bridge" in namespace "z2"
+    And I execute "ip link set vxlan10 master br10" in namespace "z2"
+    And I execute "ip link set br10 up" in namespace "z2"
+    And I wait 12 seconds for BGP to operate
+    Then BGP session in "z1" to "2001:db8:12::2" should be "Established"
+    And BGP session in "z2" to "2001:db8:12::1" should be "Established"
+
+  Scenario: Both PEs discover each other on the segment under SRv6 encapsulation
+    Given the test topology exists
+    # z1 imports z2's Type-4 — the ES routes are encapsulation-independent
+    # and must flow unchanged with `encapsulation srv6` configured.
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.1]"
+    # The per-ES A-D (mass-withdraw carrier) with the all-active ESI Label EC.
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "[1]:[00:11:22:33:44:55:66:77:88:99]:[4294967295]"
+    And show command "show bgp evpn" in namespace "z2" should contain "esi-label:all-active:0"
+    # Membership agrees on both nodes; the usual 2-PE service carving elects
+    # the lower VTEP (z1) as DF for tag 0.
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Member VTEPs (2)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Designated Forwarder (tag 0): 192.168.0.1"
+
+  Scenario: A MAC on one attached PE advertises under the segment ESI
+    Given the test topology exists
+    # The CE MAC appears on z1's access port only. Its Type-2 must carry
+    # es1's ESI — the startup-config binding resolved via LinkAdd, since
+    # host0 postdates the config — and the per-VNI End.DT2U SID as usual.
+    When I execute "bridge fdb add aa:bb:cc:dd:ee:01 dev host0 master static" in namespace "z1"
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "aa:bb:cc:dd:ee:01"
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    And show command "show bgp evpn" in namespace "z2" should contain "(End.DT2U)"
+    # z2 now holds the complete RFC 7432 §8.4 aliasing input set: the MAC
+    # under a non-zero ESI, plus a live per-ES A-D for that ESI from z1 —
+    # and z2 is itself attached to the segment.
+    And show command "show bgp evpn" in namespace "z2" should contain "[1]:[00:11:22:33:44:55:66:77:88:99]:[4294967295]"
+
+  Scenario: Unbinding the access port returns the MAC to single-homed
+    Given the test topology exists
+    # Only the port binding goes; the segment stays configured, so the ES
+    # routes (Type-4, per-ES A-D) must survive while the Type-2 sheds its
+    # ESI — this isolates the §7.1 MAC binding from the ES lifecycle.
+    When I apply command "delete router bgp afi-safi evpn ethernet-segment es1 interface host0" in namespace "z1"
+    Then show command "show bgp evpn" in namespace "z2" should eventually not contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    And show command "show bgp evpn" in namespace "z2" should contain "aa:bb:cc:dd:ee:01"
+    And show command "show bgp evpn" in namespace "z2" should contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.1]"
+    # Re-binding restores the multihomed advertisement in place.
+    When I apply command "set router bgp afi-safi evpn ethernet-segment es1 interface host0" in namespace "z1"
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+
+  Scenario: Deleting the segment revokes the mass-withdraw signal set
+    Given the test topology exists
+    # Removing es1 on z1 is the §8.2 trigger a consumer would react to:
+    # z1's Type-4 and per-ES A-D are withdrawn, membership shrinks to z2
+    # alone, and the MAC re-originates single-homed — but the Type-2
+    # itself survives, because the MAC is still a local host on z1.
+    When I apply command "delete router bgp afi-safi evpn ethernet-segment es1" in namespace "z1"
+    Then show command "show bgp evpn" in namespace "z2" should eventually not contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.1]"
+    And show command "show bgp evpn" in namespace "z2" should eventually not contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Member VTEPs (1)"
+    And show command "show bgp evpn" in namespace "z2" should contain "aa:bb:cc:dd:ee:01"
+    And show command "show bgp evpn" in namespace "z2" should contain "(End.DT2U)"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1514,7 +1514,12 @@ fn show_adj_rib_routes_evpn<D: RibDirection>(
                     nexthop, med, local_pref, weight, aspath, origin
                 )?;
 
-                write_evpn_path_attrs(&mut buf, &rib.attr, rib.is_originated(), rib.esi)?;
+                write_evpn_path_attrs(
+                    &mut buf,
+                    &rib.attr,
+                    rib.is_originated(),
+                    path_level_esi(prefix, rib.esi),
+                )?;
             }
         }
     }
@@ -4184,6 +4189,20 @@ fn format_pmsi_tunnel(p: &PmsiTunnel, mpls: bool) -> String {
 ///   rendered together on one line as in the unicast detail view.
 /// - Aggregation (RFC 4271): Atomic-Aggregate flag and Aggregator AS/IP.
 /// - Accumulated IGP metric (RFC 7311).
+/// The path-level ESI to render for a route on `prefix`: only a Type-2
+/// (MAC/IP) or Type-5 (IP Prefix) carries its ESI on the path — every other
+/// route type keys on the ESI, which the prefix column already shows. Without
+/// this gate a locally-originated Type-1/Type-4 (whose `rib.esi` is set)
+/// would grow an `ESI:` line that the same route received from a peer never
+/// has, and "the ESI is gone from `show bgp evpn`" would be unobservable on
+/// any node that has a segment of its own configured.
+fn path_level_esi(prefix: &EvpnPrefix, esi: Option<[u8; 10]>) -> Option<[u8; 10]> {
+    match prefix {
+        EvpnPrefix::MacIp { .. } | EvpnPrefix::IpPrefix { .. } => esi,
+        _ => None,
+    }
+}
+
 fn write_evpn_path_attrs(
     buf: &mut String,
     attr: &BgpAttr,
@@ -4213,7 +4232,9 @@ fn write_evpn_path_attrs(
     // behind. An NLRI field rather than a path attribute, but it belongs with
     // the forwarding story: it is what lets a remote PE alias traffic across
     // every PE attached to the same segment (RFC 7432 §8.4). Suppressed when
-    // zero — that is the single-homed case, which is most routes.
+    // zero — that is the single-homed case, which is most routes. Callers
+    // gate on the route type via `path_level_esi`, so a Type-1/4 (ESI in the
+    // prefix column) never doubles it here.
     if let Some(esi) = esi.filter(|esi| esi != &[0u8; 10]) {
         writeln!(buf, "{PAD}ESI: {}", bgp_packet::esi_display(&esi))?;
     }
@@ -4408,7 +4429,12 @@ fn show_bgp_evpn(
             // route-reflection attrs (RFC 4456: Originator / Cluster list),
             // aggregation (RFC 4271), and AIGP (RFC 7311). Lines are emitted
             // only when the attribute is present.
-            write_evpn_path_attrs(&mut buf, &rib.attr, rib.is_originated(), rib.esi)?;
+            write_evpn_path_attrs(
+                &mut buf,
+                &rib.attr,
+                rib.is_originated(),
+                path_level_esi(prefix, rib.esi),
+            )?;
 
             // Line 4 (Type-9 only): RFC 9572 §5.3.1 inter-AS DF election among
             // the ASBRs advertising this region's Per-Region I-PMSI.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4172,6 +4172,20 @@ fn format_pmsi_tunnel(p: &PmsiTunnel, mpls: bool) -> String {
     s
 }
 
+/// The path-level ESI to render for a route on `prefix`: only a Type-2
+/// (MAC/IP) or Type-5 (IP Prefix) carries its ESI on the path — every other
+/// route type keys on the ESI, which the prefix column already shows. Without
+/// this gate a locally-originated Type-1/Type-4 (whose `rib.esi` is set)
+/// would grow an `ESI:` line that the same route received from a peer never
+/// has, and "the ESI is gone from `show bgp evpn`" would be unobservable on
+/// any node that has a segment of its own configured.
+fn path_level_esi(prefix: &EvpnPrefix, esi: Option<[u8; 10]>) -> Option<[u8; 10]> {
+    match prefix {
+        EvpnPrefix::MacIp { .. } | EvpnPrefix::IpPrefix { .. } => esi,
+        _ => None,
+    }
+}
+
 /// Append the per-route attribute lines shared by the EVPN table renderers
 /// (`show_bgp_evpn` and `show_adj_rib_routes_evpn`). Each attribute prints on
 /// its own 20-space-indented line (aligned under the "Next Hop" column),
@@ -4189,20 +4203,6 @@ fn format_pmsi_tunnel(p: &PmsiTunnel, mpls: bool) -> String {
 ///   rendered together on one line as in the unicast detail view.
 /// - Aggregation (RFC 4271): Atomic-Aggregate flag and Aggregator AS/IP.
 /// - Accumulated IGP metric (RFC 7311).
-/// The path-level ESI to render for a route on `prefix`: only a Type-2
-/// (MAC/IP) or Type-5 (IP Prefix) carries its ESI on the path — every other
-/// route type keys on the ESI, which the prefix column already shows. Without
-/// this gate a locally-originated Type-1/Type-4 (whose `rib.esi` is set)
-/// would grow an `ESI:` line that the same route received from a peer never
-/// has, and "the ESI is gone from `show bgp evpn`" would be unobservable on
-/// any node that has a segment of its own configured.
-fn path_level_esi(prefix: &EvpnPrefix, esi: Option<[u8; 10]>) -> Option<[u8; 10]> {
-    match prefix {
-        EvpnPrefix::MacIp { .. } | EvpnPrefix::IpPrefix { .. } => esi,
-        _ => None,
-    }
-}
-
 fn write_evpn_path_attrs(
     buf: &mut String,
     attr: &BgpAttr,


### PR DESCRIPTION
## Summary

Phase 3b of the EVPN-over-SRv6 BDD coverage plan: the two-PE composition that #2148/#2150 (Type-2 ESI origination) enable. Two PEs share Ethernet Segment `es1`; a CE MAC learned on z1's bound access port advertises its Type-2 under the segment ESI alongside both PEs' Type-4 and per-ES Type-1 A-D routes — the complete input set a receiver needs for RFC 7432 §8.4 aliasing and §8.2 mass withdraw. Scope is the **signal set, not its consumption** (aliasing/mass-withdraw consumers exist for VPWS only today); the feature header states this explicitly.

## Scenarios (6)

1. Setup — SRv6 underlay, EVPN-only session, VNI 10 bridges; z1's `host0` access port is created **after** the startup config named it as `es1`'s interface, so the binding resolves via the `RibRx::LinkAdd` replay (#2150) in a live daemon.
2. ES discovery under `encapsulation srv6` — Type-4 both ways, per-ES A-D with the all-active ESI Label EC, membership (2), DF election.
3. The CE MAC advertises under the segment ESI with its End.DT2U SID; z2 holds the full §8.4 aliasing input set.
4. Interface unbind → the Type-2 sheds the ESI while the ES routes survive; re-bind restores it in place.
5. Segment delete → Type-4 withdrawn, membership shrinks to 1, the MAC re-originates single-homed but survives.
6. Teardown.

## Show fix the feature surfaced

`write_evpn_path_attrs` printed an `ESI:` line for **any** path with non-zero `rib.esi` — but locally-originated Type-4 / per-ES A-D / IGMP-synch routes all set `rib.esi`, while the receive path sets it only for Type-2. Originated Type-1/4 therefore rendered an `ESI:` line their received twins never have (duplicating the prefix column), and on any node with its own segment, "the ESI is gone" was unobservable in `show bgp evpn`. Now gated at the callers to Type-2/Type-5, the route types that carry the ESI on the path rather than in the NLRI key.

## Testing

- New feature: 6/6 scenarios green (staged worktree toolchain, concurrency 1).
- Neighbors re-run green against the gated show: `bgp_evpn_es` (7), `bgp_evpn_srv6_macip` (9).
- `cargo test -p zebra-rs`: 1812 passed; workspace clippy `-D warnings` clean; `make docs` page included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)