### PR TITLE
bgp: place cradle-learned MACs on their Ethernet Segment

### DIFF
--- a/bdd/tests/features/bgp_evpn_srv6_macip.feature
+++ b/bdd/tests/features/bgp_evpn_srv6_macip.feature
@@ -107,8 +107,13 @@ Feature: EVPN Type-2 / Type-3 over SRv6 — End.DT2U and End.DT2M signalling
     # already-advertised Type-2 under the new ESI is the config handler's job.
     When I apply command "set router bgp afi-safi evpn ethernet-segment es1 esi 00:11:22:33:44:55:66:77:88:99" in namespace "z1"
     And I apply command "set router bgp afi-safi evpn ethernet-segment es1 interface host0" in namespace "z1"
-    Then show command "show bgp evpn" in namespace "z1" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
-    And show command "show bgp evpn" in namespace "z2" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    # Assert on z2, the PE that has to act on the ESI: aliasing (RFC 7432
+    # §8.4) is something the REMOTE PE does, so z2 seeing it is the property
+    # worth pinning. z1 is also the weaker vantage point — it originates the
+    # segment's own ES routes, and before those were gated out of the
+    # path-level `ESI:` line their value satisfied this substring on z1
+    # whether or not the Type-2 ever carried it.
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
     # A refresh, not a re-learn: the MAC and its End.DT2U SID are unchanged.
     And show command "show bgp evpn" in namespace "z2" should contain "aa:bb:cc:dd:ee:01"
     And show command "show bgp evpn" in namespace "z2" should contain "(End.DT2U)"

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -270,6 +270,13 @@ message FdbEvent {
   // 0 = learned; 1 = aged out (the entry was removed after `fdb_age_secs`
   // idle — the control plane should withdraw its Type-2).
   uint32 event = 3;
+  // Ifindex of the port the MAC was learned on, so the MAC can be placed on
+  // an Ethernet Segment (RFC 7432 §7.1) instead of being advertised
+  // single-homed. Set on learn events only; 0 means "unknown" and must be
+  // treated as single-homed rather than as a port — that is also what an
+  // older cradle, which never sets this, leaves behind. Field number must
+  // match cradle-rs's proto/cradle.proto.
+  uint32 port = 4;
 }
 
 // --- BFD Echo / detection offload ---

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -18,9 +18,10 @@ use super::vpws::{EsBinding, bind_es};
 /// BGP keeps off `RibRx::LinkAdd`.
 ///
 /// `ifindex == 0` is "no port", not a lookup miss, and never matches: an FDB
-/// learn that carries no interface (every MAC from the cradle datapath, whose
-/// `FdbEvent` reports only `(mac, bd)`) must not be attributed to whichever
-/// link happens to sit at index 0.
+/// learn that carries no interface must not be attributed to whichever link
+/// happens to sit at index 0. Both learn sources normally carry a port — the
+/// kernel bridge always, cradle via `FdbEvent.port` — so 0 now means only
+/// that the source could not attribute the learn.
 pub fn ac_name_for_ifindex(ifindex: u32, links: &BTreeMap<String, u32>) -> Option<String> {
     if ifindex == 0 {
         return None;
@@ -388,10 +389,10 @@ mod ac_esi_tests {
         assert_eq!(ac_name_for_ifindex(9, &links), None);
     }
 
-    /// The cradle datapath's `FdbEvent` carries no port, so its learns arrive
-    /// with `ifindex: 0`. That must never be attributed to a link — including
-    /// one that somehow sits at index 0 — or every cradle-learned MAC would
-    /// inherit that link's segment.
+    /// A learn whose source could not attribute a port arrives with
+    /// `ifindex: 0`. That must never be attributed to a link — including one
+    /// that somehow sits at index 0 — or every such MAC would inherit that
+    /// link's segment.
     #[test]
     fn ifindex_zero_never_resolves() {
         assert_eq!(ac_name_for_ifindex(0, &links(&[("eth0", 0)])), None);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15693,10 +15693,10 @@ impl Bgp {
     /// the wrong ESI here is a silent blackhole once a remote PE starts
     /// aliasing (RFC 7432 §8.4) toward the segment we misnamed.
     ///
-    /// `ifindex == 0` means the learn carries no port. That is every MAC from
-    /// the cradle datapath — `FdbEvent` (proto/cradle.proto) reports only
-    /// `(mac, bd)`, so cradle-learned MACs stay single-homed here until that
-    /// stream carries the learning port. Kernel bridge learns do carry it.
+    /// `ifindex == 0` means the learn carries no port and the MAC is
+    /// advertised single-homed. Kernel bridge learns always carry one; a
+    /// cradle-datapath learn carries `FdbEvent.port` (proto/cradle.proto),
+    /// which is 0 only against a cradle predating that field.
     pub fn macip_esi(&self, entry: &FdbEntry) -> Option<[u8; 10]> {
         let ac =
             super::ethernet_segment::ac_name_for_ifindex(entry.ifindex, &self.link_index_by_name)?;

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -441,6 +441,10 @@ pub enum Message {
     CradleFdbLearn {
         vni: u32,
         mac: MacAddr,
+        /// The port the datapath learned it on, or 0 when cradle did not
+        /// report one (an older cradle, or a learn it could not attribute).
+        /// Zero flows through as "no port", which BGP reads as single-homed.
+        ifindex: u32,
     },
     /// A cradle-learned MAC aged out (idle past `fdb_age_secs`) — withdraw
     /// its Type-2 by re-emitting the same synthesized entry as a
@@ -3522,8 +3526,8 @@ impl Rib {
             Message::MacDel { vni, mac } => {
                 self.mac_del(vni, mac).await;
             }
-            Message::CradleFdbLearn { vni, mac } => {
-                self.cradle_fdb_learn(vni, mac);
+            Message::CradleFdbLearn { vni, mac, ifindex } => {
+                self.cradle_fdb_learn(vni, mac, ifindex);
             }
             Message::CradleFdbAge { vni, mac } => {
                 self.cradle_fdb_age(vni, mac);
@@ -4255,7 +4259,11 @@ impl Rib {
                             let msg = if ev.event == 1 {
                                 Message::CradleFdbAge { vni: ev.bd, mac }
                             } else {
-                                Message::CradleFdbLearn { vni: ev.bd, mac }
+                                Message::CradleFdbLearn {
+                                    vni: ev.bd,
+                                    mac,
+                                    ifindex: ev.port,
+                                }
                             };
                             let _ = tx.send(msg);
                         }
@@ -4275,7 +4283,14 @@ impl Rib {
     /// would for a kernel-learned MAC. The VXLAN local address (the BGP
     /// nexthop source) resolves from the VNI's vxlan device when one is
     /// configured; router-id is the callers' fallback.
-    fn cradle_fdb_learn(&mut self, vni: u32, mac: MacAddr) {
+    ///
+    /// `ifindex` is the port cradle learned the MAC on, which is what lets
+    /// BGP place it on an Ethernet Segment. It shares the RIB's namespace,
+    /// so it indexes the same links: cradle is a sidecar in this daemon's
+    /// netns. 0 means cradle reported no port and the MAC stays
+    /// single-homed. `bridge_ifindex` stays 0 — a cradle bridge domain is a
+    /// datapath map, not a kernel bridge device.
+    fn cradle_fdb_learn(&mut self, vni: u32, mac: MacAddr, ifindex: u32) {
         if mac.is_multicast() {
             return;
         }
@@ -4287,7 +4302,7 @@ impl Rib {
         let entry = FdbEntry {
             vni,
             mac,
-            ifindex: 0,
+            ifindex,
             bridge_ifindex: 0,
             flags: 0,
             vxlan_local,


### PR DESCRIPTION
## Summary

#2148 inferred a locally-originated Type-2's ESI from the port the MAC was
learned on, but the cradle datapath could not supply one: `FdbEvent` reported
`(mac, bd)` and nothing else, so `cradle_fdb_learn` synthesized every entry
with `ifindex: 0` and `macip_esi` correctly read that as "no port".

**MAC multihoming therefore worked over a kernel bridge and not over the
datapath EVPN-over-SRv6 actually runs on** — the encapsulation the feature
exists for.

cradle now reports the learning port as `FdbEvent.port`; this consumes it.
Paired with cradle-rs `fdb: report the learning port on every WatchFdb learn
event`, which needs **no eBPF change** — both learn sites already stored the
ingress ifindex in `FdbEntry.oif`, and `fdb_local_entries` read it and dropped
it one line later.

## Details

- The ifindex needs no translation: cradle is a sidecar in this daemon's netns,
  so it indexes the same links `link_index_by_name` mirrors.
- `port` is 0 on an age event and from any cradle predating the field, and 0
  still flows through as "no port" — an older cradle degrades to exactly
  today's behaviour rather than misattributing the MAC to whatever link sits
  at index 0.
- `bridge_ifindex` stays 0: a cradle bridge domain is a datapath map, not a
  kernel bridge device.

## Test plan

- 1812 unit tests, workspace clippy `-D warnings` and fmt clean
- `bgp_evpn_srv6_macip` green at 9/9 scenarios
- End-to-end proof is in cradle-rs: `@cradle_evpn_srv6_zebra` binds an Ethernet
  Segment to pe1's cradle-owned CE port and asserts the ESI reaches pe2 —
  **red** against a zebra pinned to `ifindex: 0`, green with this change.

The BDD's ESI assertion also moves off the originating PE onto z2, the PE that
has to act on the ESI (aliasing is the remote PE's job). z1 was the weaker
vantage point: before a4783dc9 gated ES routes out of the path-level `ESI:`
line, their value satisfied the substring on z1 whether or not the Type-2
carried it — the z1 form passed against the deliberately-broken daemon, so it
was never testing the thing it named.

Generated with [Claude Code](https://claude.com/claude-code)
