### PR TITLE
config: gate the startup-config apply summary behind tracing config

### DIFF
--- a/book/src/ch-03-06-rib-fib-tracing.md
+++ b/book/src/ch-03-06-rib-fib-tracing.md
@@ -18,6 +18,7 @@ rather than a routing protocol, the block lives under the top-level
 ```
 system {
   tracing {
+    config { ... }
     rib { ... }
     fib { ... }
   }
@@ -52,7 +53,8 @@ system {
 }
 ```
 
-`all` turns on **every** category under both planes at summary level. It
+`all` turns on **every** category — both planes plus the
+[`config` block](#config-subsystem-categories) — at summary level. It
 does not imply `detail` — that stays opt-in.
 
 ## RIB categories
@@ -102,6 +104,37 @@ system tracing fib l2 mdb       # multicast forwarding database
 > `static`, `vrf`, `kernel`, `neighbor`, `l2 bridge`) are accepted,
 > stored, and covered by `all` — they light up once their sites are
 > instrumented.
+
+## Config subsystem categories
+
+Alongside the two forwarding planes, a small `config` block gates traces
+from the configuration subsystem itself:
+
+| Category | What it traces | Modifiers |
+|---|---|---|
+| `startup` | The startup-config apply summary — resolved path, detected format, and `applied N of M commands` — emitted once the startup commit completes. | — |
+
+```
+system {
+  tracing {
+    config { startup; }
+  }
+}
+```
+
+Two properties are worth knowing:
+
+- **The toggle works from the very file it traces.** Unlike the RIB /
+  FIB categories (dispatched to the RIB task over a channel), `config`
+  toggles are applied by the config manager synchronously at commit
+  time, and the startup summary is emitted after that commit. Putting
+  `system tracing config startup` in the startup config therefore
+  enables the summary for that same boot — no save-and-restart dance.
+- **Failures stay loud.** Only the *success* summary is gated. An
+  unreadable file, per-command rejections, and a schema-rejected
+  commit are always logged at error level; the empty-file and
+  missing-file notes are also unconditional, since a boot that hits
+  them had no config that could have carried the toggle.
 
 ## Modifiers
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -712,6 +712,15 @@ impl ConfigManager {
             if op == ConfigOp::Set && line.starts_with("logging output") {
                 self.handle_logging_config(&line);
             }
+            // The config subsystem's own trace toggles are applied here,
+            // synchronously, not in a subscriber task: `load_config`
+            // consults them the moment this commit returns, so a channel
+            // dispatch would race the very startup summary they gate.
+            // The RIB / FIB categories still travel the normal subscriber
+            // path; this dispatch ignores their lines.
+            if line.starts_with("system tracing") {
+                super::tracing::config_dispatch(&line, op);
+            }
         }
         for line in diff.lines() {
             if !line.is_empty() {
@@ -849,8 +858,12 @@ impl ConfigManager {
         // file, a shadowed path (`~/.zebra-rs/zebra-rs.conf` wins over
         // /etc when both exist), and per-command rejections were all
         // swallowed, so a daemon that came up unconfigured gave the
-        // operator nothing to go on. Log every outcome — including
-        // success — with the resolved path.
+        // operator nothing to go on. Log every failure outcome, with the
+        // resolved path. The success summary is deferred to the bottom of
+        // the function and gated on `system tracing config startup`: the
+        // commit below is what applies that toggle, so logging any earlier
+        // would miss a toggle carried in this very file.
+        let mut summary = None;
         match std::fs::read_to_string(&self.config_path) {
             // An empty (or comment/whitespace-only) config file carries no
             // commands. Skip the format parsers entirely so the YAML
@@ -859,6 +872,10 @@ impl ConfigManager {
             // path keeps its existing empty-document behavior — an empty
             // apply must not clear+commit the running config.)
             Ok(output) if output.trim().is_empty() => {
+                // Unconditional, unlike the applied summary: the trace
+                // toggle rides in the config file, so a boot that lands
+                // here (or in the missing-file arm below) had nothing
+                // that could have enabled it.
                 tracing::info!(
                     "startup config {} is empty; starting unconfigured",
                     self.config_path.display()
@@ -890,13 +907,7 @@ impl ConfigManager {
                             render_rejected_commands(&self.config_path, &rejected)
                         );
                     }
-                    tracing::info!(
-                        "startup config {} ({:?} format): applied {} of {} commands",
-                        self.config_path.display(),
-                        format,
-                        cmds.len() - rejected.len(),
-                        cmds.len()
-                    );
+                    summary = Some((format, cmds.len() - rejected.len(), cmds.len()));
                 }
                 Err(doc_errors) => {
                     tracing::error!("{}", render_config_errors(&self.config_path, &doc_errors));
@@ -929,6 +940,19 @@ impl ConfigManager {
                 "startup config {} rejected by schema validation: {}",
                 self.config_path.display(),
                 e
+            );
+        }
+        // Gated after the commit so `system tracing config startup` set in
+        // this very startup file counts (commit_config applied it above).
+        if let Some((format, applied, total)) = summary
+            && super::tracing::startup()
+        {
+            tracing::info!(
+                "startup config {} ({:?} format): applied {} of {} commands",
+                self.config_path.display(),
+                format,
+                applied,
+                total
             );
         }
     }
@@ -1384,8 +1408,9 @@ impl ConfigManager {
             };
 
             // Note: Due to tracing-subscriber limitations, we can't reinitialize at runtime
-            // This would require a restart to take effect
-            tracing::info!(
+            // This would require a restart to take effect — warn, so the
+            // operator learns their committed change is not yet live.
+            tracing::warn!(
                 "Logging output configuration change detected: {} (restart required)",
                 output_type
             );
@@ -4200,6 +4225,39 @@ mod yang_load_tests {
             code,
             ExecCode::Success,
             "`set bfd tracing true` must be a valid settable path",
+        );
+    }
+
+    /// `system tracing config startup` gates the startup-config apply
+    /// summary. The toggle is dispatched line-based from
+    /// `commit_config` (not via a subscriber), so a YANG misplacement
+    /// would silently strand the dispatch — assert the path parses.
+    #[test]
+    fn system_tracing_config_startup_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set system tracing config startup",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set system tracing config startup` must be a valid settable path",
         );
     }
 

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -52,5 +52,6 @@ mod parse;
 mod pim;
 mod stamp;
 mod token;
+mod tracing;
 mod util;
 mod yaml;

--- a/zebra-rs/src/config/tracing.rs
+++ b/zebra-rs/src/config/tracing.rs
@@ -1,0 +1,111 @@
+//! Runtime tracing configuration for the config subsystem itself.
+//!
+//! Backs the `system tracing { config {...} }` block defined in
+//! `zebra-rib-tracing.yang` (the module that owns the whole
+//! `system tracing` tree). The RIB / FIB categories in that tree are
+//! applied by the RIB task when the committed paths reach it over its
+//! subscriber channel; the config manager's own categories cannot take
+//! that route — the startup summary this block gates is emitted right
+//! after `commit_config` returns, so a channel dispatch would race it.
+//! Instead [`ConfigManager::commit_config`] applies `system tracing`
+//! lines here synchronously, while walking the commit diff. That is
+//! what makes the bootstrap case work: a toggle carried in the startup
+//! config file is live before the summary describing that very file's
+//! application is (or is not) logged.
+//!
+//! Same storage model as `rib::tracing`: one process-global block of
+//! atomics, lock-free `Relaxed` reads, written only at commit.
+//!
+//! [`ConfigManager::commit_config`]: super::ConfigManager::commit_config
+
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+
+use super::ConfigOp;
+
+struct State {
+    /// The `system tracing all` master switch — the same leaf the RIB /
+    /// FIB block honors; mirrored here so `all` covers the config
+    /// categories too.
+    all: AtomicBool,
+
+    /// `system tracing config startup` — the startup-config apply
+    /// summary (`applied N of M commands`).
+    startup: AtomicBool,
+}
+
+impl State {
+    const fn new() -> Self {
+        State {
+            all: AtomicBool::new(false),
+            startup: AtomicBool::new(false),
+        }
+    }
+
+    /// A category is on when its own toggle is set, or the `all` master
+    /// switch is.
+    fn on(&self, flag: &AtomicBool) -> bool {
+        self.all.load(Relaxed) || flag.load(Relaxed)
+    }
+
+    /// Apply one committed config line. The manager hands over every
+    /// `system tracing …` diff line; the RIB / FIB category lines fall
+    /// through the match untouched (the RIB task owns those), so a miss
+    /// here is expected, not an error.
+    fn apply(&self, line: &str, op: ConfigOp) {
+        let set = op.is_set();
+        match line {
+            "system tracing all" => self.all.store(set, Relaxed),
+            "system tracing config startup" => self.startup.store(set, Relaxed),
+            _ => {}
+        }
+    }
+}
+
+static STATE: State = State::new();
+
+/// Apply a committed `system tracing …` Set/Delete line, in CLI-line
+/// form (the same flat rendering `commit_config` diffs). Called from
+/// the manager's commit loop; lines outside this block's categories are
+/// ignored.
+pub(super) fn config_dispatch(line: &str, op: ConfigOp) {
+    STATE.apply(line, op);
+}
+
+/// `system tracing config startup` — gate for the startup-config apply
+/// summary.
+pub(super) fn startup() -> bool {
+    STATE.on(&STATE.startup)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_toggle_set_delete() {
+        let s = State::new();
+        s.apply("system tracing config startup", ConfigOp::Set);
+        assert!(s.on(&s.startup));
+        s.apply("system tracing config startup", ConfigOp::Delete);
+        assert!(!s.on(&s.startup));
+    }
+
+    #[test]
+    fn all_master_switch_covers_startup() {
+        let s = State::new();
+        s.apply("system tracing all", ConfigOp::Set);
+        assert!(s.on(&s.startup));
+        s.apply("system tracing all", ConfigOp::Delete);
+        assert!(!s.on(&s.startup));
+    }
+
+    #[test]
+    fn foreign_tracing_lines_ignored() {
+        let s = State::new();
+        // RIB / FIB category lines flow through the same dispatch and
+        // must not disturb the config-side toggles.
+        s.apply("system tracing rib route", ConfigOp::Set);
+        s.apply("system tracing fib kernel direction receive", ConfigOp::Set);
+        assert!(!s.on(&s.startup));
+    }
+}

--- a/zebra-rs/yang/zebra-rib-tracing.yang
+++ b/zebra-rs/yang/zebra-rib-tracing.yang
@@ -88,6 +88,22 @@ module zebra-rib-tracing {
      BGP `tracing` blocks: the config callbacks key off set vs delete
      and never read a value, so `type empty` is the honest type.";
 
+  revision 2026-07-29 {
+    description
+      "Add the `config` block — categories for the configuration
+       subsystem itself, applied by the config manager synchronously
+       at commit time rather than via a subscriber task. `config
+       startup` gates the startup-config apply summary (`applied N of
+       M commands`), which previously logged unconditionally; because
+       the toggle is applied before the summary is emitted, it can be
+       carried in the very startup file whose application it traces.
+       Failure outcomes (missing / empty / unreadable / rejected
+       startup config) stay unconditional: they fire only when the
+       config file carries no commands, so a config-borne toggle could
+       never have enabled them. The `all` master switch covers the new
+       block.";
+  }
+
   revision 2026-07-07 {
     description
       "Add the top-level `task` category — gates daemon task
@@ -155,7 +171,7 @@ module zebra-rib-tracing {
         description
           "Master switch — when present, every tracing category is
            traced regardless of its individual leaf: `task` and
-           everything under `rib` and `fib`.";
+           everything under `config`, `rib` and `fib`.";
       }
 
       leaf task {
@@ -169,6 +185,30 @@ module zebra-rib-tracing {
            before its earlier subscribe delivered its dump. Unlike `rib`
            and `fib`, this is a cross-cutting category, not tied to a
            single forwarding plane.";
+      }
+
+      container config {
+        ext:help "Trace configuration subsystem processing";
+        description
+          "Categories for the configuration subsystem itself. Unlike
+           `rib` / `fib`, these toggles are applied by the config
+           manager synchronously at commit time (not via a subscriber
+           task), so a toggle carried in the startup config file is
+           live before the startup summary it gates is emitted.";
+
+        leaf startup {
+          ext:help "Trace the startup config apply summary";
+          type empty;
+          description
+            "Log the startup-config success summary — resolved path,
+             detected format, and `applied N of M commands` — after
+             the startup commit. Failure outcomes (unreadable file,
+             per-command rejections, schema-rejected commit) are
+             logged unconditionally at error level regardless of this
+             toggle; the empty-file and missing-file notes are also
+             unconditional, since a boot that hits them had no config
+             that could have carried the toggle.";
+        }
       }
 
       container rib {


### PR DESCRIPTION
The startup summary (`applied N of M commands`, `manager.rs` `load_config`) logged unconditionally at info level on every boot. This PR covers it with the runtime tracing config.

## What changed

- **New `system tracing config { startup }` block** in `zebra-rib-tracing.yang` (new revision; the `all` master switch covers it). CLI: `set system tracing config startup`.
- **New `src/config/tracing.rs`** — process-global atomics following the `rib::tracing` pattern, with unit tests.
- **Synchronous dispatch in `commit_config`**: the manager applies `system tracing` diff lines itself while walking the commit (same precedent as `handle_logging_config`) instead of a subscriber channel, and `load_config` emits the summary *after* `commit_config` — so a toggle carried in the very startup file whose application it traces is live on that same boot. RIB/FIB category lines still travel the normal subscriber path.
- **yang_load test** asserting `set system tracing config startup` parses.

## Other unconditional info! sites under src/config

- The **empty-file / missing-file** startup notes stay unconditional: they fire only when the config file carries no commands, so a config-borne toggle could never have enabled them (rationale in code comments + YANG description).
- The **logging output "restart required"** notice becomes `warn!` — it tells the operator their committed change is not yet live, so hiding it behind a toggle would be wrong.
- The VTY session/auth info! sites are already gated by the compile-time `VTY_TRACING` const (a candidate for a future `config vty` runtime category, left out of scope here).

## Verification

- `cargo clippy --workspace` clean; full `cargo test --workspace --exclude bdd` green (39/39 binaries).
- Live boots (debug daemon, `--config-file`): toggle absent → no summary line; `system tracing config startup` in the startup file → summary logged; `system tracing all` → summary logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)