### PR TITLE
config: replace the VTY_TRACING const with system tracing config vty

### DIFF
--- a/book/src/ch-03-06-rib-fib-tracing.md
+++ b/book/src/ch-03-06-rib-fib-tracing.md
@@ -113,6 +113,7 @@ from the configuration subsystem itself:
 | Category | What it traces | Modifiers |
 |---|---|---|
 | `startup` | The startup-config apply summary — resolved path, detected format, and `applied N of M commands` — emitted once the startup commit completes. | — |
+| `vty` | VTY session lifecycle and per-RPC events: session creation on first RPC, per-RPC accept, logout / disable, `enable` promotion, session removal when the client shell exits, and GC sweeps that removed sessions. Denied RPCs and authentication failures are warnings and always logged. | — |
 
 ```
 system {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4250,7 +4250,7 @@ mod yang_load_tests {
 
         let (code, _comps, _state) = parse(
             "set system tracing config startup",
-            entry,
+            entry.clone(),
             None,
             State::new(),
         );
@@ -4258,6 +4258,14 @@ mod yang_load_tests {
             code,
             ExecCode::Success,
             "`set system tracing config startup` must be a valid settable path",
+        );
+
+        let (code, _comps, _state) =
+            parse("set system tracing config vty", entry, None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set system tracing config vty` must be a valid settable path",
         );
     }
 

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -29,8 +29,6 @@ use super::vty::{
     LogoutRequest, ShowReply, ShowRequest, YangMatch,
 };
 
-pub(super) const VTY_TRACING: bool = false;
-
 #[derive(Debug)]
 struct ExecService {
     pub tx: mpsc::Sender<Message>,
@@ -220,7 +218,7 @@ impl Exec for ExecService {
     ) -> Result<Response<LogoutReply>, tonic::Status> {
         if let Some(ctx) = request.extensions().get::<SessionContext>() {
             let removed = self.sessions.remove(&ctx.key);
-            if VTY_TRACING {
+            if super::tracing::vty() {
                 tracing::info!(uid = ctx.key.0, bash_pid = ctx.key.1, removed, "vty logout",);
             }
         }
@@ -240,7 +238,7 @@ impl Exec for ExecService {
 
         // Root (D20) is already Admin from session creation.
         if uid == 0 {
-            if VTY_TRACING {
+            if super::tracing::vty() {
                 tracing::info!(uid, "enable noop (root permanent admin)");
             }
             return Ok(Response::new(EnableReply {
@@ -258,7 +256,7 @@ impl Exec for ExecService {
             if !promoted {
                 return Err(tonic::Status::unauthenticated("session vanished"));
             }
-            if VTY_TRACING {
+            if super::tracing::vty() {
                 tracing::info!(uid, "enable success (config group)");
             }
             return Ok(Response::new(EnableReply {
@@ -302,7 +300,7 @@ impl Exec for ExecService {
                 if !promoted {
                     return Err(tonic::Status::unauthenticated("session vanished"));
                 }
-                if VTY_TRACING {
+                if super::tracing::vty() {
                     tracing::info!(uid, auth_user = %target_user, "enable success");
                 }
                 Ok(Response::new(EnableReply {
@@ -338,7 +336,7 @@ impl Exec for ExecService {
     ) -> Result<Response<DisableReply>, tonic::Status> {
         if let Some(ctx) = request.extensions().get::<SessionContext>() {
             let cleared = self.sessions.disable(&ctx.key);
-            if VTY_TRACING {
+            if super::tracing::vty() {
                 tracing::info!(
                     uid = ctx.key.0,
                     bash_pid = ctx.key.1,
@@ -673,7 +671,7 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
                         key: (skey_uid, bash_pid),
                     });
                     if is_new {
-                        if VTY_TRACING {
+                        if super::tracing::vty() {
                             tracing::info!(
                                 uid = skey_uid,
                                 gid,
@@ -686,7 +684,7 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
                         tokio::spawn(async move {
                             watch_bash_death(table, (skey_uid, bash_pid), bash_pid).await;
                         });
-                    } else if VTY_TRACING {
+                    } else if super::tracing::vty() {
                         tracing::info!(uid = skey_uid, gid, pid, bash_pid, "vty rpc");
                     }
                 }
@@ -722,8 +720,12 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
 
 pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     let config_group_gid = SessionTable::resolve_config_group_gid();
-    if VTY_TRACING && let Some(gid) = config_group_gid {
-        tracing::info!(gid, "VTY configure-authorization group active");
+    // The one-shot setup notices in this function run before the startup
+    // config is loaded (`serve()` precedes `event_loop`), so no runtime
+    // toggle could be live yet — they log at debug level instead of
+    // consulting `system tracing config vty` like the per-session sites.
+    if let Some(gid) = config_group_gid {
+        tracing::debug!(gid, "VTY configure-authorization group active");
     } else {
         tracing::debug!("VTY configure-authorization group not found; PAM-only fallback");
     }
@@ -746,8 +748,8 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     };
 
     let interceptor = VtyPeerInterceptor::from_env(sessions.clone());
-    if VTY_TRACING && let Some(set) = &interceptor.allow_uids {
-        tracing::info!(uids = ?set, "VTY peer UID allow-list active (log-only)");
+    if let Some(set) = &interceptor.allow_uids {
+        tracing::debug!(uids = ?set, "VTY peer UID allow-list active (log-only)");
     }
 
     {
@@ -761,13 +763,11 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
             )
             .await
         });
-        if VTY_TRACING {
-            tracing::info!(
-                interval_secs = DEFAULT_GC_INTERVAL.as_secs(),
-                idle_ttl_secs = DEFAULT_IDLE_TTL.as_secs(),
-                "VTY session GC sweep started",
-            );
-        }
+        tracing::debug!(
+            interval_secs = DEFAULT_GC_INTERVAL.as_secs(),
+            idle_ttl_secs = DEFAULT_IDLE_TTL.as_secs(),
+            "VTY session GC sweep started",
+        );
     }
 
     let builder = Server::builder()
@@ -787,16 +787,12 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
 
     match addr {
         VtyAddr::Tcp(addr) => {
-            if VTY_TRACING {
-                tracing::info!("VTY gRPC listening on tcp://{addr}");
-            }
+            tracing::debug!("VTY gRPC listening on tcp://{addr}");
             tokio::spawn(async move { builder.serve(addr).await });
         }
         VtyAddr::AbstractUds(name) => {
             let incoming = bind_abstract_uds(&name)?;
-            if VTY_TRACING {
-                tracing::info!("VTY gRPC listening on abstract UDS @{name}");
-            }
+            tracing::debug!("VTY gRPC listening on abstract UDS @{name}");
             tokio::spawn(async move { builder.serve_with_incoming(incoming).await });
         }
     }

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -13,8 +13,6 @@ use std::time::{Duration, Instant};
 #[cfg(target_os = "linux")]
 use dashmap::DashMap;
 
-use super::serve::VTY_TRACING;
-
 /// Default idle TTL for VTY sessions. Mirrors the typical Cisco IOS
 /// `exec-timeout 10 0` default.
 #[cfg(target_os = "linux")]
@@ -517,7 +515,7 @@ pub async fn watch_bash_death(table: Arc<SessionTable>, key: SessionKey, bash_pi
     match async_fd.readable().await {
         Ok(_guard) => {
             if table.remove(&key) {
-                if VTY_TRACING {
+                if super::tracing::vty() {
                     tracing::info!(uid = key.0, bash_pid, "vty session removed (bash exited)");
                 }
             } else {
@@ -550,7 +548,7 @@ where
         ticker.tick().await;
         let stats = table.gc_once(&reader, idle_ttl);
         if stats.removed_idle > 0 || stats.removed_gone > 0 {
-            if VTY_TRACING {
+            if super::tracing::vty() {
                 tracing::info!(
                     removed_idle = stats.removed_idle,
                     removed_gone = stats.removed_gone,

--- a/zebra-rs/src/config/tracing.rs
+++ b/zebra-rs/src/config/tracing.rs
@@ -31,6 +31,16 @@ struct State {
     /// `system tracing config startup` — the startup-config apply
     /// summary (`applied N of M commands`).
     startup: AtomicBool,
+
+    /// `system tracing config vty` — VTY session lifecycle and RPC
+    /// events (session create / remove, enable / disable, per-RPC
+    /// accept, GC sweeps). These are recurring runtime events, so the
+    /// ordinary commit path is early enough — no bootstrap subtlety
+    /// like `startup`'s. The one-shot `serve()` setup notices are NOT
+    /// here: they fire before the startup config is loaded, so they
+    /// log at debug level instead of consulting a toggle no config
+    /// could have set yet.
+    vty: AtomicBool,
 }
 
 impl State {
@@ -38,6 +48,7 @@ impl State {
         State {
             all: AtomicBool::new(false),
             startup: AtomicBool::new(false),
+            vty: AtomicBool::new(false),
         }
     }
 
@@ -56,6 +67,7 @@ impl State {
         match line {
             "system tracing all" => self.all.store(set, Relaxed),
             "system tracing config startup" => self.startup.store(set, Relaxed),
+            "system tracing config vty" => self.vty.store(set, Relaxed),
             _ => {}
         }
     }
@@ -77,6 +89,12 @@ pub(super) fn startup() -> bool {
     STATE.on(&STATE.startup)
 }
 
+/// `system tracing config vty` — gate for VTY session lifecycle and
+/// RPC traces.
+pub(super) fn vty() -> bool {
+    STATE.on(&STATE.vty)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,12 +109,24 @@ mod tests {
     }
 
     #[test]
-    fn all_master_switch_covers_startup() {
+    fn vty_toggle_set_delete() {
+        let s = State::new();
+        s.apply("system tracing config vty", ConfigOp::Set);
+        assert!(s.on(&s.vty));
+        assert!(!s.on(&s.startup));
+        s.apply("system tracing config vty", ConfigOp::Delete);
+        assert!(!s.on(&s.vty));
+    }
+
+    #[test]
+    fn all_master_switch_covers_every_category() {
         let s = State::new();
         s.apply("system tracing all", ConfigOp::Set);
         assert!(s.on(&s.startup));
+        assert!(s.on(&s.vty));
         s.apply("system tracing all", ConfigOp::Delete);
         assert!(!s.on(&s.startup));
+        assert!(!s.on(&s.vty));
     }
 
     #[test]

--- a/zebra-rs/yang/zebra-rib-tracing.yang
+++ b/zebra-rs/yang/zebra-rib-tracing.yang
@@ -100,8 +100,11 @@ module zebra-rib-tracing {
        Failure outcomes (missing / empty / unreadable / rejected
        startup config) stay unconditional: they fire only when the
        config file carries no commands, so a config-borne toggle could
-       never have enabled them. The `all` master switch covers the new
-       block.";
+       never have enabled them. `config vty` gates the VTY session
+       lifecycle / RPC traces (formerly behind the compile-time
+       VTY_TRACING const); the one-shot serve() setup notices fire
+       before the startup config is loaded and log at debug level
+       instead. The `all` master switch covers the new block.";
   }
 
   revision 2026-07-07 {
@@ -208,6 +211,23 @@ module zebra-rib-tracing {
              toggle; the empty-file and missing-file notes are also
              unconditional, since a boot that hits them had no config
              that could have carried the toggle.";
+        }
+
+        leaf vty {
+          ext:help "Trace VTY session lifecycle and RPC events";
+          type empty;
+          description
+            "Log VTY session lifecycle and per-RPC events: session
+             creation on first RPC, per-RPC accept, logout / disable,
+             enable promotion (root noop, config-group, PAM success),
+             session removal when the client shell exits, and GC
+             sweeps that removed sessions. Denied RPCs and
+             authentication failures are warnings and always logged
+             regardless of this toggle. The one-shot serve() setup
+             notices (listening socket, configure-authorization group,
+             peer allow-list, GC start) fire before the startup config
+             is loaded, so they are debug-level rather than gated
+             here.";
         }
       }
 


### PR DESCRIPTION
Follow-up to #2158, covering the remaining compile-time-gated info! sites under `src/config/` with the runtime tracing config.

## What changed

- **New `system tracing config vty` category** (`zebra-rib-tracing.yang`, covered by `all`): gates the recurring VTY session/RPC traces formerly behind `const VTY_TRACING: bool = false` — session creation on first RPC, per-RPC accept, logout / disable, `enable` promotion (root noop, config-group, PAM success), session removal when the client shell exits, and GC sweeps that removed sessions. Denied RPCs and auth failures stay warn-level and unconditional. The const is deleted.
- **One-shot `serve()` setup notices become `debug!`** (listening socket, configure-authorization group, peer allow-list, GC start): `serve()` runs before `event_loop` loads the startup config, so no runtime toggle could be live when they fire — gating them would make them permanently dead. `debug!` preserves today's default silence while keeping them reachable via `RUST_LOG`. This also fixes a quirk: with the const off, a *present* config group logged the misleading "not found; PAM-only fallback" debug line.
- Settability test extended to `set system tracing config vty`; unit tests for the new toggle; book chapter updated with the `vty` row.

## Verification

- `cargo clippy --workspace` clean; full `cargo test --workspace --exclude bdd` green (39/39 binaries); `make book` builds.
- Live (debug daemon + `vtyctl show`): toggle absent → no vty lines; `system tracing config vty` in the startup config → `vty rpc (new session)` / `vty rpc` logged with uid/gid/pid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)