### PR TITLE
book: cover IS-IS conditional tracing; refresh BGP/OSPF tracing chapters

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -73,6 +73,7 @@
   - [Route Redistribution](ch-07-06-isis-redistribution.md)
   - [Passive Interfaces](ch-07-07-isis-passive.md)
   - [Egress Protection (Mirror SID)](ch-07-08-isis-egress-protection.md)
+  - [Conditional Tracing](ch-07-09-isis-tracing.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Minimum Working Example](ch-08-04-ospf-minimum-working-example.md)
   - [Area Configuration](ch-08-05-ospf-area-configuration.md)

--- a/book/src/ch-02-10-bgp-tracing.md
+++ b/book/src/ch-02-10-bgp-tracing.md
@@ -8,8 +8,9 @@ typed config block of per-**category** switches that turn detailed
 `info`-level traces on at runtime, with no rebuild and no global log-level
 change.
 
-This mirrors the IS-IS / OSPF `tracing` model — gated log macros consult a
-config struct — but with the BGP-specific category set.
+This mirrors the [IS-IS](ch-07-09-isis-tracing.md) /
+[OSPF](ch-08-10-ospf-tracing.md) `tracing` model — gated log macros
+consult a config struct — but with the BGP-specific category set.
 
 Every traced line is stamped `proto="bgp"` and `category="<name>"`, so the
 filtering recipes in [Protocol-Specific Logging](ch-03-03-protocol-logging.md)
@@ -26,9 +27,11 @@ The same `tracing { ... }` block attaches at two points:
 
 Per-neighbour config is **additive** to the instance config: a category is
 traced for a peer if either the instance block *or* that peer's block
-enables it. Instance-only categories (`vpn`, `srv6`, `vrf`, `bfd`,
+enables it. The instance-scoped categories (`vpn`, `srv6`, `vrf`, `bfd`,
 `label`) are most useful at the instance scope, since they are not tied to
-a single session.
+a single session; `sharding` exists **only** at the instance scope — the
+values it reports are chosen once for the whole BGP instance, before any
+neighbour exists.
 
 ## The `all` master switch
 
@@ -59,6 +62,7 @@ Absence means the category is silent.
 | `srv6` | instance | SRv6 locator resolution and per-VRF End.DT46 service-SID reconciliation (L3VPN over SRv6). |
 | `vrf` | instance | Per-VRF task lifecycle — spawn / respawn / despawn / shutdown, inbound-connection routing, and the staged per-VRF config observed at commit. |
 | `bfd` | instance | BGP's interaction with the BFD client — session state changes and client-readiness that drive RFC 5882 peer teardown. |
+| `sharding` | instance only | The instance-lifetime concurrency knobs frozen at spawn — the RIB shard count and the per-peer egress-task model, each with the source it came from (config, environment, or default) — plus update-group egress task spawn/exit. |
 
 > **Warnings stay on.** Tracing categories gate *diagnostic* `info`/`debug`
 > detail only. Operator-facing **warnings and errors** — missing RD,

--- a/book/src/ch-03-00-logging-overview.md
+++ b/book/src/ch-03-00-logging-overview.md
@@ -8,6 +8,7 @@ Zebra-rs provides flexible logging capabilities with multiple output destination
 - **Multiple Formats**: terminal (human-readable), JSON, Elasticsearch-compatible
 - **Protocol-Aware Logging**: Automatic protocol field inclusion (ISIS, BGP, OSPF)
 - **Config-Driven RIB/FIB Tracing**: Runtime-toggleable trace categories under `system tracing` (see [RIB/FIB Tracing](ch-03-06-rib-fib-tracing.md))
+- **Per-Protocol Conditional Tracing**: The same runtime model per routing protocol — [BGP](ch-02-10-bgp-tracing.md), [IS-IS](ch-07-09-isis-tracing.md), [OSPFv2](ch-08-10-ospf-tracing.md), [OSPFv3](ch-15-13-ospfv3-tracing.md)
 - **Structured Logging**: Rich metadata for filtering and analysis
 - **Fallback Mechanisms**: Automatic fallback when preferred output is unavailable
 

--- a/book/src/ch-07-09-isis-tracing.md
+++ b/book/src/ch-07-09-isis-tracing.md
@@ -1,0 +1,96 @@
+# Conditional Tracing
+
+IS-IS shares the conditional-tracing model of BGP and OSPF: a typed
+config block of per-category switches that turn detailed `info`-level
+traces on at runtime, with no rebuild and no global log-level change.
+Each toggle is a *presence* flag — name it in the config to enable,
+delete it to disable — and the gated log sites consult the live config
+on every PDU, transition and event. Absence means the category is
+silent.
+
+The block attaches at the `router isis` instance and applies to every
+interface and neighbor:
+
+```
+router isis {
+  tracing {
+    packet {
+      hello { direction receive; }   # received IIHs only
+      lsp { level level-2; }         # Level-2 LSPs only
+    }
+    fsm { nfsm; }                    # adjacency state machine
+    lsp-originate;                   # self-LSP (re)origination
+  }
+}
+```
+
+| Category | Toggles |
+|---|---|
+| `all` | master switch — traces every category below |
+| `packet` | `hello`, `lsp`, `csnp`, `psnp`, `all` |
+| `fsm` | `nfsm` (adjacency state machine) |
+| `lsp-originate` | self-LSP origination |
+| `lsp-purge` | LSP purge events |
+| `lsdb` | link-state database install / flooding decisions |
+| `bfd` | IS-IS↔BFD interaction (RFC 5882) — session state changes, subscribe, adjacency teardown, hold-down recovery |
+
+## The `level` filter
+
+The IS-IS-specific addition over the OSPF/BGP model is a functional
+**level** refinement: every `packet` type and the `lsp-originate` /
+`lsp-purge` / `lsdb` event toggles accept an optional
+`level level-1` or `level level-2`. Omit it to trace both levels —
+there is no explicit `both` value; absence means both.
+
+```
+router isis {
+  tracing {
+    lsdb { level level-1; }          # L1 database activity only
+  }
+}
+```
+
+## Packet tracing
+
+Each PDU type (`hello` — the IIHs, `lsp`, `csnp`, `psnp`) is a presence
+container; naming it enables tracing for that type in both directions
+and levels. Two optional children narrow it: `direction`
+(`send` / `receive`; omit for both) and the `level` filter above.
+`all` covers every PDU type at once. Unlike OSPF and BGP, the IS-IS
+packet toggles have no `detail` refinement — each trace is a one-line
+summary of the PDU.
+
+## Notes
+
+- `fsm nfsm` traces the neighbor (adjacency) state machine. There is
+  no `ifsm` toggle — the interface FSM has no trace sites yet.
+- `bfd` is a bare presence flag with no `level` refinement: a BFD
+  session is keyed per interface and neighbor address, not per IS-IS
+  level.
+- **Warnings stay on.** Tracing categories gate diagnostic detail
+  only; operator-facing warnings and errors are always emitted
+  (tagged `proto="isis"`) regardless of the tracing config.
+
+## Structured fields
+
+Every gated line is stamped `proto="isis"` plus a `category` and the
+per-category fields, so the filtering recipes in
+[Protocol-Specific Logging](ch-03-03-protocol-logging.md) apply
+directly:
+
+- `packet` lines carry `category="packet"`, `packet_type`,
+  `direction`, and `level`.
+- `lsp-originate` / `lsp-purge` lines carry `category="event"`,
+  `event_type`, and `level`.
+- `lsdb` lines carry `category="database"`, `db_type`, and `level`.
+
+## Interaction with `RUST_LOG`
+
+Tracing categories are a *content* filter — they decide which sites
+emit — and the lines they emit are at `info` level. They are
+independent of the
+[`RUST_LOG`](ch-03-03-protocol-logging.md#protocol-specific-debug-levels)
+*level* filter: a category produces nothing unless the IS-IS module's
+level admits `info` (the default does). Use tracing categories to pick
+*what* to see at runtime; use `RUST_LOG` only when you need a coarser
+module-level sweep.

--- a/book/src/ch-08-10-ospf-tracing.md
+++ b/book/src/ch-08-10-ospf-tracing.md
@@ -2,7 +2,8 @@
 
 Conditional tracing is a runtime debug switch: a category is silent
 until you name it in the config, at which point the matching log
-sites start emitting. It mirrors the BGP and IS-IS `tracing` model —
+sites start emitting. It mirrors the [BGP](ch-02-10-bgp-tracing.md)
+and [IS-IS](ch-07-09-isis-tracing.md) `tracing` model —
 each toggle is a *presence* flag (name it to enable, delete it to
 disable), and the gated log macros consult the live config on every
 packet, transition, and event, so categories turn on and off without

--- a/book/src/ch-15-13-ospfv3-tracing.md
+++ b/book/src/ch-15-13-ospfv3-tracing.md
@@ -1,7 +1,9 @@
 # Conditional Tracing
 
-OSPFv3 shares the conditional-tracing model of OSPFv2, BGP and
-IS-IS: each category is a *presence* toggle — name it in the config
+OSPFv3 shares the conditional-tracing model of
+[OSPFv2](ch-08-10-ospf-tracing.md), [BGP](ch-02-10-bgp-tracing.md) and
+[IS-IS](ch-07-09-isis-tracing.md): each category is a *presence*
+toggle — name it in the config
 to enable, delete it to disable — and the gated log sites consult
 the live config on every packet, transition and event, so
 categories flip without a restart. The block is identical to the v2


### PR DESCRIPTION
The book documents conditional tracing for BGP, OSPFv2, and OSPFv3 — but not IS-IS, even though the other chapters reference "the IS-IS tracing model". This fills the gap and fixes the drift found while checking the existing chapters against their YANG modules.

## What changed

- **New chapter `ch-07-09-isis-tracing.md`** (added to SUMMARY under IS-IS), written from `zebra-isis-tracing.yang`:
  - Category table: `packet {hello, lsp, csnp, psnp, all}`, `fsm nfsm`, `lsp-originate`, `lsp-purge`, `lsdb`, `bfd`, and the `all` master switch
  - The IS-IS-specific `level level-1|level-2` functional filter on packet and event categories
  - Differences called out: packet toggles have no `detail` refinement (unlike OSPF/BGP); no `ifsm` (no trace sites yet); `bfd` takes no level (sessions are keyed per interface/neighbor, not per level)
  - Structured log fields (`category="packet"/"event"/"database"`, `packet_type`/`event_type`/`db_type`, `level`) verified against `src/isis/tracing.rs`
- **BGP chapter**: add the instance-only `sharding` category (present in `zebra-bgp-tracing.yang` since the RIB-sharding work, missing from the book) and clarify that it is the one category absent from the per-neighbour block.
- **Cross-links**: the four protocol tracing chapters now link to each other, and the logging overview lists per-protocol conditional tracing alongside RIB/FIB tracing.

OSPFv2/OSPFv3 chapters were checked against `zebra-ospf-tracing.yang` and match — only the cross-links were added there.

`make book` builds cleanly. Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)