### PR TITLE
ospf: gate the unconditional info! sites behind conditional tracing

### DIFF
--- a/book/src/ch-08-10-ospf-tracing.md
+++ b/book/src/ch-08-10-ospf-tracing.md
@@ -38,6 +38,7 @@ router ospfv3 {
 | `fsm` | `ifsm`, `nfsm`, `all` |
 | `spf` | SPF (shortest-path-first) calculation |
 | `lsdb` | LSA origination / installation / flooding |
+| `bfd` | OSPF↔BFD interaction (RFC 5882 session state changes) |
 
 Each `packet` toggle is a presence container carrying two optional
 refinements: `direction` (`send` or `receive`; omit for both) and

--- a/book/src/ch-15-13-ospfv3-tracing.md
+++ b/book/src/ch-15-13-ospfv3-tracing.md
@@ -31,6 +31,7 @@ router ospfv3 {
 | `fsm` | `ifsm`, `nfsm`, `all` |
 | `spf` | SPF (shortest-path-first) calculation |
 | `lsdb` | LSA origination / installation / flooding |
+| `bfd` | OSPF↔BFD interaction (RFC 5882 session state changes) |
 
 Each `packet` toggle accepts the optional `direction`
 (`send` / `receive`) and `detail` refinements; each `fsm` toggle an

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4269,6 +4269,34 @@ mod yang_load_tests {
         );
     }
 
+    /// The OSPF `bfd` tracing category is dispatched path-based from
+    /// `config_tracing_dispatch` — assert the YANG leaf parses on both
+    /// versions so a misplacement can't silently strand the dispatch.
+    #[test]
+    fn ospf_tracing_bfd_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router ospf tracing bfd",
+            "set router ospfv3 tracing bfd",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be settable");
+        }
+    }
+
     /// The BGP SRv6 service-SID locator lives at `router bgp
     /// segment-routing srv6 locator <name>` (mirroring `router isis
     /// segment-routing srv6 locator`; BGP has no SR-MPLS sibling). It is a

--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -45,7 +45,7 @@ pub fn ospf_ls_request_lookup(nbr: &Neighbor, h: &OspfLsaHeader) -> Option<usize
 
 // OSPF LSA flooding -- RFC2328 Section 13.3.
 // Following the ref/ospfd/ospf_flood.c ospf_flood_through_interface() pattern.
-pub fn ospf_flood_through_interface(_oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
+pub fn ospf_flood_through_interface(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
     // For neighbors in Exchange or Loading state, check ls_req list.
     if nbr.state >= NfsmState::Exchange
         && nbr.state < NfsmState::Full
@@ -54,7 +54,9 @@ pub fn ospf_flood_through_interface(_oi: &mut OspfInterface, nbr: &mut Neighbor,
         // The received LSA is the same or newer than what we requested.
         // Remove it from ls_req list.
         nbr.ls_req.remove(idx);
-        tracing::info!(
+        crate::ospf_event_trace!(
+            oi.tracing,
+            Lsdb,
             "[Flood] Removed LSA {} from ls_req (remaining: {})",
             lsa.h.ls_id,
             nbr.ls_req.len()
@@ -111,7 +113,7 @@ pub fn ospf_flood(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
         FloodScope::As => None,
         _ => Some(oi.area_id),
     };
-    lsdb.insert_received(lsa.clone(), oi.tx, area_id);
+    lsdb.insert_received(lsa.clone(), oi.tx, area_id, oi.tracing);
     if matches!(
         lsa.h.ls_type,
         OspfLsType::Router
@@ -141,7 +143,9 @@ pub fn ospf_flood(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
     {
         let _ = oi.tx.send(Message::NssaTranslateResync(area_id));
     }
-    tracing::info!(
+    crate::ospf_event_trace!(
+        oi.tracing,
+        Lsdb,
         "[Flood] Installed LSA type={:?} id={} adv={}",
         lsa.h.ls_type,
         lsa.h.ls_id,

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -30,7 +30,7 @@ use crate::{
         path_from_command, vrf_config_split,
     },
     context::Task,
-    ospf_event_trace, ospf_fsm_trace,
+    ospf_event_trace, ospf_fsm_trace, ospf_packet_trace,
 };
 
 use super::area::{OspfArea, OspfAreaMap};
@@ -869,7 +869,7 @@ impl<V: OspfVersion> Ospf<V> {
             },
             None => super::link::LinkTeMetric::default(),
         };
-        tracing::info!(
+        tracing::debug!(
             ifindex = key.ifindex,
             ?snapshot,
             "{}: stamp metric update applied",
@@ -885,13 +885,14 @@ impl<V: OspfVersion> Ospf<V> {
     /// subscribe) and non-Down transitions are ignored.
     pub(crate) fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
         let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
-        tracing::info!(
+        ospf_event_trace!(
+            self.tracing,
+            Bfd,
             ?key,
             from = %change.from,
             to = %change.to,
             diag = %change.diag,
-            "{}: bfd session state change",
-            V::PROTO,
+            "bfd session state change",
         );
         if change.from == change.to || change.to != bfd_packet::State::Down {
             return;
@@ -2092,7 +2093,7 @@ impl Ospf<Ospfv2> {
                 lsa.update();
                 let flood_lsa = lsa.clone();
                 area.lsdb
-                    .insert_self_originated(lsa, &self.tx, Some(area_id));
+                    .insert_self_originated(lsa, &self.tx, Some(area_id), &self.tracing);
                 Self::ospf_spf_schedule(&self.tx, area, self.spf_interval);
                 Some(flood_lsa)
             } else {
@@ -2106,7 +2107,7 @@ impl Ospf<Ospfv2> {
     }
 
     pub fn router_lsa_originate(&mut self) {
-        tracing::info!("Router LSA Originate");
+        ospf_event_trace!(self.tracing, Lsdb, "Router LSA Originate");
         self.router_lsa_originate_with_min_seq(None);
     }
 
@@ -2381,7 +2382,10 @@ impl Ospf<Ospfv2> {
                     link.addr = vec![super::addr::OspfAddr { prefix }];
                     link.ident.prefix = prefix;
                     changed = true;
-                    tracing::info!(
+                    ospf_fsm_trace!(
+                        self.tracing,
+                        Ifsm,
+                        false,
                         "[VL] area {} peer {} refreshed: cost={} local={} remote={}",
                         transit,
                         peer,
@@ -2420,7 +2424,10 @@ impl Ospf<Ospfv2> {
                 keep.insert(idx);
                 let _ = self.tx.send(Message::Ifsm(idx, IfsmEvent::InterfaceUp));
                 changed = true;
-                tracing::info!(
+                ospf_fsm_trace!(
+                    self.tracing,
+                    Ifsm,
+                    false,
                     "[VL] area {} peer {} up: cost={} local={} remote={} ifindex={:#x}",
                     transit,
                     peer,
@@ -2441,7 +2448,13 @@ impl Ospf<Ospfv2> {
             .collect();
         for idx in stale {
             if let Some(link) = self.links.get_mut(&idx) {
-                tracing::info!("[VL] {} down (unreachable or deconfigured)", link.name);
+                ospf_fsm_trace!(
+                    self.tracing,
+                    Ifsm,
+                    false,
+                    "[VL] {} down (unreachable or deconfigured)",
+                    link.name
+                );
                 ospf_ifsm(link, IfsmEvent::InterfaceDown);
             }
             if let Some(area0) = self.areas.get_mut(AREA0) {
@@ -2713,7 +2726,7 @@ impl Ospf<Ospfv2> {
             lsa.update();
             let flood_lsa = lsa.clone();
             area.lsdb
-                .insert_self_originated(lsa, &self.tx, Some(area_id));
+                .insert_self_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Some(flood_lsa)
         } else {
             None
@@ -2894,7 +2907,7 @@ impl Ospf<Ospfv2> {
             lsa.update();
             let flood_lsa = lsa.clone();
             area.lsdb
-                .insert_self_originated(lsa, &self.tx, Some(area_id));
+                .insert_self_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Some(flood_lsa)
         } else {
             None
@@ -2951,7 +2964,8 @@ impl Ospf<Ospfv2> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(AREA0) {
-                area.lsdb.insert_self_originated(lsa, &self.tx, Some(AREA0));
+                area.lsdb
+                    .insert_self_originated(lsa, &self.tx, Some(AREA0), &self.tracing);
             }
             self.flood_self_originated_lsa(AREA0, &flood_lsa);
         } else {
@@ -3107,7 +3121,8 @@ impl Ospf<Ospfv2> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(AREA0) {
-                area.lsdb.insert_self_originated(lsa, &self.tx, Some(AREA0));
+                area.lsdb
+                    .insert_self_originated(lsa, &self.tx, Some(AREA0), &self.tracing);
             }
             self.flood_self_originated_lsa(AREA0, &flood_lsa);
         } else {
@@ -3172,7 +3187,8 @@ impl Ospf<Ospfv2> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(AREA0) {
-                area.lsdb.insert_self_originated(lsa, &self.tx, Some(AREA0));
+                area.lsdb
+                    .insert_self_originated(lsa, &self.tx, Some(AREA0), &self.tracing);
             }
             self.flood_self_originated_lsa(AREA0, &flood_lsa);
         } else {
@@ -3262,7 +3278,7 @@ impl Ospf<Ospfv2> {
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb
-                .insert_self_originated(lsa, &self.tx, Some(area_id));
+                .insert_self_originated(lsa, &self.tx, Some(area_id), &self.tracing);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
@@ -3329,7 +3345,8 @@ impl Ospf<Ospfv2> {
         lsa.update();
 
         let flood_lsa = lsa.clone();
-        self.lsdb_as.insert_self_originated(lsa, &self.tx, None);
+        self.lsdb_as
+            .insert_self_originated(lsa, &self.tx, None, &self.tracing);
         self.flood_lsa_through_as(&flood_lsa, None);
     }
 
@@ -3765,7 +3782,8 @@ impl Ospf<Ospfv2> {
         new_lsa.update();
 
         let flood_lsa = new_lsa.clone();
-        self.lsdb_as.insert_self_originated(new_lsa, &self.tx, None);
+        self.lsdb_as
+            .insert_self_originated(new_lsa, &self.tx, None, &self.tracing);
         self.flood_lsa_through_as(&flood_lsa, None);
         true
     }
@@ -4089,7 +4107,9 @@ impl Ospf<Ospfv2> {
         // a dedicated originator exists (Router / Network LSA). Otherwise
         // fall back to cloning the old body and bumping the sequence number.
         if ev == LsdbEvent::RefreshTimerExpire {
-            tracing::info!(
+            ospf_event_trace!(
+                self.tracing,
+                Lsdb,
                 "LSDB refresh timer expired: type={} id={} adv={}",
                 ls_type,
                 ls_id,
@@ -4157,7 +4177,9 @@ impl Ospf<Ospfv2> {
             };
             match ev {
                 LsdbEvent::HoldTimerExpire => {
-                    tracing::info!(
+                    ospf_event_trace!(
+                        self.tracing,
+                        Lsdb,
                         "LSDB hold timer expired: type={} id={} adv={}",
                         ls_type,
                         ls_id,
@@ -4215,7 +4237,9 @@ impl Ospf<Ospfv2> {
 
         match ls_type {
             OspfLsType::Router => {
-                tracing::info!(
+                ospf_event_trace!(
+                    self.tracing,
+                    Lsdb,
                     "[Self-Originated] Re-originating Router LSA id={} seq={:#x}",
                     ls_id,
                     received_seq
@@ -4224,7 +4248,9 @@ impl Ospf<Ospfv2> {
             }
             OspfLsType::Network => {
                 if self.is_dr_for_network_lsa(ls_id) {
-                    tracing::info!(
+                    ospf_event_trace!(
+                        self.tracing,
+                        Lsdb,
                         "[Self-Originated] Re-originating Network LSA id={} seq={:#x}",
                         ls_id,
                         received_seq
@@ -4250,7 +4276,9 @@ impl Ospf<Ospfv2> {
                         }
                     }
                 } else {
-                    tracing::info!(
+                    ospf_event_trace!(
+                        self.tracing,
+                        Lsdb,
                         "[Self-Originated] Flushing Network LSA id={} (no longer DR)",
                         ls_id
                     );
@@ -4278,7 +4306,9 @@ impl Ospf<Ospfv2> {
                     return;
                 };
                 if ls_id.is_unspecified() {
-                    tracing::info!(
+                    ospf_event_trace!(
+                        self.tracing,
+                        Lsdb,
                         "[Self-Originated] Re-originating NSSA default Type-7 id={} seq={:#x}",
                         ls_id,
                         received_seq
@@ -4296,7 +4326,9 @@ impl Ospf<Ospfv2> {
                     })
                     .unwrap_or(false);
                 if owned_redist {
-                    tracing::info!(
+                    ospf_event_trace!(
+                        self.tracing,
+                        Lsdb,
                         "[Self-Originated] Re-originating NSSA redistribute Type-7 id={} seq={:#x}",
                         ls_id,
                         received_seq
@@ -4304,7 +4336,9 @@ impl Ospf<Ospfv2> {
                     self.nssa_redist_connected_resync(area_id);
                     return;
                 }
-                tracing::info!(
+                ospf_event_trace!(
+                    self.tracing,
+                    Lsdb,
                     "[Self-Originated] Flushing Type-7 LSA id={} (no owner)",
                     ls_id
                 );
@@ -4339,7 +4373,9 @@ impl Ospf<Ospfv2> {
                 if network
                     .is_some_and(|p| self.redist_originated.values().any(|set| set.contains(&p)))
                 {
-                    tracing::info!(
+                    ospf_event_trace!(
+                        self.tracing,
+                        Lsdb,
                         "[Self-Originated] Re-originating redistribute Type-5 id={} seq={:#x}",
                         ls_id,
                         received_seq
@@ -4353,7 +4389,9 @@ impl Ospf<Ospfv2> {
                         .find(|(_, area)| area.nssa_translated.contains(&ls_id))
                         .map(|(&id, _)| id);
                     if let Some(area_id) = owning_area {
-                        tracing::info!(
+                        ospf_event_trace!(
+                            self.tracing,
+                            Lsdb,
                             "[Self-Originated] Re-translating Type-5 from NSSA area {} id={} seq={:#x}",
                             area_id,
                             ls_id,
@@ -4361,7 +4399,9 @@ impl Ospf<Ospfv2> {
                         );
                         self.nssa_translate_resync(area_id);
                     } else {
-                        tracing::info!(
+                        ospf_event_trace!(
+                            self.tracing,
+                            Lsdb,
                             "[Self-Originated] Flushing AS-External LSA id={} (no owner)",
                             ls_id
                         );
@@ -4389,7 +4429,9 @@ impl Ospf<Ospfv2> {
                 let opaque_id = u32::from(ls_id) & 0x00FF_FFFF;
                 match opaque_type {
                     OpaqueLsaType::ROUTER_INFO => {
-                        tracing::info!(
+                        ospf_event_trace!(
+                            self.tracing,
+                            Lsdb,
                             "[Self-Originated] Re-originating Router-Info Opaque LSA id={} seq={:#x}",
                             ls_id,
                             received_seq
@@ -4397,7 +4439,9 @@ impl Ospf<Ospfv2> {
                         self.router_info_lsa_originate();
                     }
                     OpaqueLsaType::EXT_PREFIX => {
-                        tracing::info!(
+                        ospf_event_trace!(
+                            self.tracing,
+                            Lsdb,
                             "[Self-Originated] Re-originating Ext-Prefix Opaque LSA id={} ifindex={} seq={:#x}",
                             ls_id,
                             opaque_id,
@@ -4406,7 +4450,9 @@ impl Ospf<Ospfv2> {
                         self.ext_prefix_lsa_originate(opaque_id);
                     }
                     OpaqueLsaType::EXT_LINK => {
-                        tracing::info!(
+                        ospf_event_trace!(
+                            self.tracing,
+                            Lsdb,
                             "[Self-Originated] Re-originating Ext-Link Opaque LSA id={} ifindex={} seq={:#x}",
                             ls_id,
                             opaque_id,
@@ -4415,7 +4461,9 @@ impl Ospf<Ospfv2> {
                         self.ext_link_lsa_originate(opaque_id);
                     }
                     _ => {
-                        tracing::info!(
+                        ospf_event_trace!(
+                            self.tracing,
+                            Lsdb,
                             "[Self-Originated] Flushing Opaque LSA id={} opaque-type={} (unknown owner)",
                             ls_id,
                             opaque_type
@@ -4441,7 +4489,9 @@ impl Ospf<Ospfv2> {
                 // with the body intact (content changes are handled by
                 // `abr_summary_originate`); a stale summary we no longer
                 // want is dropped on the next SPF-driven sync instead.
-                tracing::info!(
+                ospf_event_trace!(
+                    self.tracing,
+                    Lsdb,
                     "[Self-Originated] Re-asserting Summary LSA type={:?} id={} seq={:#x}",
                     ls_type,
                     ls_id,
@@ -4470,7 +4520,9 @@ impl Ospf<Ospfv2> {
             _ => {
                 // Other self-originated types we don't re-originate yet;
                 // flush with MaxAge.
-                tracing::info!(
+                ospf_event_trace!(
+                    self.tracing,
+                    Lsdb,
                     "[Self-Originated] Flushing LSA type={:?} id={} (not re-originable)",
                     ls_type,
                     ls_id
@@ -4497,7 +4549,12 @@ impl Ospf<Ospfv2> {
 
     /// Re-originate Router LSA with seq# >= min_seq + 1.
     fn router_lsa_reoriginate(&mut self, min_seq: u32) {
-        tracing::info!("Router LSA Re-originate (min_seq={:#x})", min_seq);
+        ospf_event_trace!(
+            self.tracing,
+            Lsdb,
+            "Router LSA Re-originate (min_seq={:#x})",
+            min_seq
+        );
         self.router_lsa_originate_with_min_seq(Some(min_seq));
     }
 
@@ -4600,7 +4657,7 @@ impl Ospf<Ospfv2> {
                 lsa.update();
                 let flood_lsa = lsa.clone();
                 area.lsdb
-                    .insert_self_originated(lsa, &self.tx, Some(area_id));
+                    .insert_self_originated(lsa, &self.tx, Some(area_id), &self.tracing);
                 Some(flood_lsa)
             }
         } else {
@@ -4686,7 +4743,10 @@ impl Ospf<Ospfv2> {
             link.state
         };
 
-        tracing::info!(
+        ospf_fsm_trace!(
+            self.tracing,
+            Nfsm,
+            false,
             "[NFSM:FullTransition] ifindex={} nbr={} {} -> {}",
             ifindex,
             nbr_addr,
@@ -5124,11 +5184,15 @@ impl Ospf<Ospfv2> {
                     continue;
                 };
                 if snap.self_originated {
-                    area.lsdb
-                        .insert_self_originated(lsa, &self.tx, Some(area_cp.area_id));
+                    area.lsdb.insert_self_originated(
+                        lsa,
+                        &self.tx,
+                        Some(area_cp.area_id),
+                        &self.tracing,
+                    );
                 } else {
                     area.lsdb
-                        .insert_received(lsa, &self.tx, Some(area_cp.area_id));
+                        .insert_received(lsa, &self.tx, Some(area_cp.area_id), &self.tracing);
                 }
                 total_lsas += 1;
             }
@@ -5378,7 +5442,7 @@ impl Ospf<Ospfv2> {
         let flood_copy = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb
-                .insert_self_originated(lsa, &self.tx, Some(area_id));
+                .insert_self_originated(lsa, &self.tx, Some(area_id), &self.tracing);
         }
         self.flood_link_scope_lsa_v2(ifindex, &flood_copy);
         true
@@ -5533,7 +5597,10 @@ impl Ospf<Ospfv2> {
                     &mut packet,
                     &build_auth_ctx(auth_mode, auth_key, crypto_key.clone(), md5_seq_cell),
                 );
-                tracing::info!(
+                ospf_packet_trace!(
+                    self.tracing,
+                    LsUpdate,
+                    Send,
                     "[Flood] Sending LSA type={:?} id={} adv={} to nbr={}",
                     lsa.h.ls_type,
                     lsa.h.ls_id,
@@ -5591,7 +5658,14 @@ impl Ospf<Ospfv2> {
             return;
         }
         let lsas: Vec<OspfLsa> = nbr.ls_rxmt.values().cloned().collect();
-        tracing::info!("[Retransmit] Sending {} LSAs to {}", lsas.len(), addr);
+        ospf_packet_trace!(
+            self.tracing,
+            LsUpdate,
+            Send,
+            "[Retransmit] Sending {} LSAs to {}",
+            lsas.len(),
+            addr
+        );
         let ls_upd = OspfLsUpdate { lsas };
         let mut packet =
             Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
@@ -5635,7 +5709,14 @@ impl Ospf<Ospfv2> {
             Ospfv2Payload::DbDesc(sent.clone()),
         );
         apply_link_auth(&mut packet, &link.auth_send_ctx());
-        tracing::info!("[DB Desc:Retransmit] to {} seq={:#x}", addr, sent.seqnum);
+        ospf_packet_trace!(
+            link.tracing,
+            DbDesc,
+            Send,
+            "[DB Desc:Retransmit] to {} seq={:#x}",
+            addr,
+            sent.seqnum
+        );
         let _ = nbr.ptx.send(Message::Send(
             packet,
             nbr.ifindex,
@@ -5673,7 +5754,10 @@ impl Ospf<Ospfv2> {
             return;
         }
         let ack_headers: Vec<OspfLsaHeader> = link.ls_ack_delayed.drain(..).collect();
-        tracing::info!(
+        ospf_packet_trace!(
+            self.tracing,
+            LsAck,
+            Send,
             "[DelayedAck] Sending {} acks on ifindex={}",
             ack_headers.len(),
             ifindex
@@ -6264,7 +6348,12 @@ impl Ospf<Ospfv2> {
                     let output = compute_spf(input);
                     let _ = tx.send(Message::SpfDone(Box::new(output)));
                 });
-                tracing::info!("[SPF] Calculation dispatched for area {}", area_id);
+                ospf_event_trace!(
+                    self.tracing,
+                    Spf,
+                    "[SPF] Calculation dispatched for area {}",
+                    area_id
+                );
             }
             Message::SpfDone(output) => {
                 let area_id = output.area_id;
@@ -7570,7 +7659,8 @@ impl Ospf<Ospfv3> {
 
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
 
@@ -7678,7 +7768,8 @@ impl Ospf<Ospfv3> {
 
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
@@ -7769,7 +7860,8 @@ impl Ospf<Ospfv3> {
         lsa.update();
 
         let flood_lsa = lsa.clone();
-        self.lsdb_as.install_originated(lsa, &self.tx, None);
+        self.lsdb_as
+            .install_originated(lsa, &self.tx, None, &self.tracing);
         self.flood_lsa_through_as_v3(&flood_lsa, None);
     }
 
@@ -8382,7 +8474,8 @@ impl Ospf<Ospfv3> {
             }
             lsa.update();
             let flood_lsa = lsa.clone();
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Some(flood_lsa)
         } else {
             None
@@ -8587,7 +8680,8 @@ impl Ospf<Ospfv3> {
             }
             lsa.update();
             let flood_lsa = lsa.clone();
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Some(flood_lsa)
         } else {
             None
@@ -8681,7 +8775,8 @@ impl Ospf<Ospfv3> {
             }
             lsa.update();
             let flood_lsa = lsa.clone();
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Some(flood_lsa)
         } else {
             None
@@ -8964,11 +9059,19 @@ impl Ospf<Ospfv3> {
                     // The decoded LSA carries its exact wire bytes in
                     // `raw`, so the re-flood matches helpers' snapshot
                     // verbatim; install_originated arms hold/refresh.
-                    area.lsdb
-                        .install_originated(lsa, &self.tx, Some(area_cp.area_id));
+                    area.lsdb.install_originated(
+                        lsa,
+                        &self.tx,
+                        Some(area_cp.area_id),
+                        &self.tracing,
+                    );
                 } else {
-                    area.lsdb
-                        .insert_received_v3(lsa, &self.tx, Some(area_cp.area_id));
+                    area.lsdb.insert_received_v3(
+                        lsa,
+                        &self.tx,
+                        Some(area_cp.area_id),
+                        &self.tracing,
+                    );
                 }
                 total_lsas += 1;
             }
@@ -9135,7 +9238,8 @@ impl Ospf<Ospfv3> {
         new_lsa.update();
 
         let flood_lsa = new_lsa.clone();
-        self.lsdb_as.install_originated(new_lsa, &self.tx, None);
+        self.lsdb_as
+            .install_originated(new_lsa, &self.tx, None, &self.tracing);
         self.flood_lsa_through_as_v3(&flood_lsa, None);
         true
     }
@@ -9549,7 +9653,10 @@ impl Ospf<Ospfv3> {
         }
 
         let lsas: Vec<ospf_packet::Ospfv3Lsa> = nbr.ls_rxmt.values().cloned().collect();
-        tracing::info!(
+        ospf_packet_trace!(
+            self.tracing,
+            LsUpdate,
+            Send,
             "[v3 Retransmit] Sending {} LSAs to {}",
             lsas.len(),
             router_id
@@ -9606,7 +9713,10 @@ impl Ospf<Ospfv3> {
             nbr.timer.db_desc = None;
             return;
         }
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            DbDesc,
+            Send,
             "[v3 DBD:Retransmit] to {} seq={:#x}",
             router_id,
             nbr.dd.seqnum
@@ -9629,7 +9739,10 @@ impl Ospf<Ospfv3> {
             return;
         }
         let ident = *oi.ident;
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsRequest,
+            Send,
             "[v3 LSReq:Retransmit] to {} entries={}",
             router_id,
             nbr.ls_req.len()
@@ -9856,7 +9969,12 @@ impl Ospf<Ospfv3> {
                     let output = compute_spf(input);
                     let _ = tx.send(Message::SpfDone(Box::new(output)));
                 });
-                tracing::info!("[v3 SPF] Calculation dispatched for area {}", area_id);
+                ospf_event_trace!(
+                    self.tracing,
+                    Spf,
+                    "[v3 SPF] Calculation dispatched for area {}",
+                    area_id
+                );
             }
             Message::SpfDone(output) => {
                 let area_id = output.area_id;
@@ -10116,7 +10234,8 @@ impl Ospf<Ospfv3> {
             // Link-LSA lives in the per-link LSDB; no area_id is
             // associated with link-scope LSAs in the hold-timer
             // protocol, so pass `None`.
-            link.lsdb.install_originated(lsa, &self.tx, None);
+            link.lsdb
+                .install_originated(lsa, &self.tx, None, &self.tracing);
         }
         self.flood_link_scope_lsa(ifindex, &flood_lsa);
     }
@@ -10284,7 +10403,8 @@ impl Ospf<Ospfv3> {
 
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
@@ -10379,7 +10499,8 @@ impl Ospf<Ospfv3> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(area_id) {
-                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+                area.lsdb
+                    .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             }
             self.flood_self_originated_lsa(area_id, &flood_lsa);
         } else {
@@ -10604,7 +10725,8 @@ impl Ospf<Ospfv3> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(area_id) {
-                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+                area.lsdb
+                    .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             }
             self.flood_self_originated_lsa(area_id, &flood_lsa);
         } else {
@@ -10667,7 +10789,8 @@ impl Ospf<Ospfv3> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(area_id) {
-                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+                area.lsdb
+                    .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             }
             self.flood_self_originated_lsa(area_id, &flood_lsa);
         } else {
@@ -10832,7 +10955,8 @@ impl Ospf<Ospfv3> {
 
             let flood_lsa = lsa.clone();
             if let Some(area) = self.areas.get_mut(area_id) {
-                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+                area.lsdb
+                    .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             }
             self.flood_self_originated_lsa(area_id, &flood_lsa);
         } else {
@@ -11160,7 +11284,10 @@ impl Ospf<Ospfv3> {
             (link.state, link.area)
         };
 
-        tracing::info!(
+        ospf_fsm_trace!(
+            self.tracing,
+            Nfsm,
+            false,
             "[v3 NFSM:FullTransition] ifindex={} nbr={} {} -> {}",
             ifindex,
             nbr_addr,
@@ -11326,7 +11453,8 @@ impl Ospf<Ospfv3> {
 
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
@@ -11498,7 +11626,8 @@ impl Ospf<Ospfv3> {
 
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
-            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            area.lsdb
+                .install_originated(lsa, &self.tx, Some(area_id), &self.tracing);
             Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -7,6 +7,7 @@ use crate::spf::label_block::{LabelBlock, LabelConfig, LabelMap};
 
 use super::ReachMap;
 use super::inst::Message;
+use super::tracing::OspfTracing;
 use super::version::{OspfVersion, Ospfv2};
 use crate::context::{Timer, TimerType};
 
@@ -393,6 +394,7 @@ impl<V: OspfVersion> Lsdb<V> {
         lsa_data: V::Lsa,
         tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
+        tracing: &OspfTracing,
     ) {
         let lsa_key: OspfLsaKey = {
             let h = V::lsa_header(&lsa_data);
@@ -401,7 +403,9 @@ impl<V: OspfVersion> Lsdb<V> {
         let ls_age = V::ls_age(V::lsa_header(&lsa_data));
         let hold_secs = (OSPF_MAX_AGE - ls_age).max(1);
         let (ls_type_raw, ls_id_raw, adv_router) = lsa_key;
-        tracing::info!(
+        crate::ospf_event_trace!(
+            tracing,
+            Lsdb,
             "[LSDB install_lsa] type=0x{:04x} id=0x{:08x} adv={} ls_age={} hold={}s",
             ls_type_raw,
             ls_id_raw,
@@ -425,6 +429,7 @@ impl<V: OspfVersion> Lsdb<V> {
         lsa_data: V::Lsa,
         tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
+        tracing: &OspfTracing,
     ) {
         let lsa_key: OspfLsaKey = {
             let h = V::lsa_header(&lsa_data);
@@ -433,7 +438,9 @@ impl<V: OspfVersion> Lsdb<V> {
         let ls_age = V::ls_age(V::lsa_header(&lsa_data));
         let hold_secs = (OSPF_MAX_AGE - ls_age).max(1);
         let (ls_type_raw, ls_id_raw, adv_router) = lsa_key;
-        tracing::info!(
+        crate::ospf_event_trace!(
+            tracing,
+            Lsdb,
             "[LSDB install_originated] type=0x{:04x} id=0x{:08x} adv={} ls_age={} hold={}s refresh={}s",
             ls_type_raw,
             ls_id_raw,
@@ -529,6 +536,7 @@ impl Lsdb<Ospfv2> {
         mut ospf_lsa: OspfLsa,
         tx: &UnboundedSender<Message<Ospfv2>>,
         area_id: Option<Ipv4Addr>,
+        tracing: &OspfTracing,
     ) {
         use OspfLsType::*;
         match ospf_lsa.h.ls_type {
@@ -537,7 +545,7 @@ impl Lsdb<Ospfv2> {
                 // v2-specific Fletcher checksum + length recompute,
                 // then dispatch through the generic install path.
                 ospf_lsa.update();
-                self.install_originated(ospf_lsa, tx, area_id);
+                self.install_originated(ospf_lsa, tx, area_id, tracing);
             }
             _ => {}
         }
@@ -548,13 +556,14 @@ impl Lsdb<Ospfv2> {
         ospf_lsa: OspfLsa,
         tx: &UnboundedSender<Message<Ospfv2>>,
         area_id: Option<Ipv4Addr>,
+        tracing: &OspfTracing,
     ) {
         // v2-specific SR-MPLS / Opaque ExtPrefix ingestion (label
         // map + reach map). Stays v2-only because OspfLsp variants
         // are v2 codec types with no v3 analogue.
         self.update_lsa(&ospf_lsa);
         // Generic key construction + hold timer + insertion.
-        self.install_lsa(ospf_lsa, tx, area_id);
+        self.install_lsa(ospf_lsa, tx, area_id, tracing);
     }
 
     pub fn update_lsa(&mut self, lsa: &OspfLsa) {
@@ -603,9 +612,10 @@ impl Lsdb<super::version::Ospfv3> {
         ospf_lsa: Ospfv3Lsa,
         tx: &UnboundedSender<Message<super::version::Ospfv3>>,
         area_id: Option<Ipv4Addr>,
+        tracing: &OspfTracing,
     ) {
         self.update_lsa_v3(&ospf_lsa);
-        self.install_lsa(ospf_lsa, tx, area_id);
+        self.install_lsa(ospf_lsa, tx, area_id, tracing);
     }
 
     /// Scan an inbound v3 LSA for RFC 8666 §3 SR capability TLVs

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -5,10 +5,7 @@ use rand::RngExt;
 use tokio::time::Instant;
 
 use super::version::{OspfVersion, Ospfv2, Ospfv3};
-use super::{
-    Identity, IfsmEvent, Message, Neighbor, inst::OspfInterface, ospf_ls_request_isempty,
-    tracing::FsmType,
-};
+use super::{Identity, IfsmEvent, Message, Neighbor, inst::OspfInterface, ospf_ls_request_isempty};
 use crate::context::{Timer, TimerType};
 
 /// Neighbor state machine state — RFC 2328 §10.1.
@@ -476,7 +473,13 @@ pub fn ospf_nfsm_negotiation_done<V: OspfVersion>(
     // v3 inherits the no-op default until its NFSM path lands.
     V::populate_initial_db_summary(oi, nbr);
 
-    tracing::info!("[NFSM:NegotiationDone] DB Summary len {}", nbr.db_sum.len());
+    crate::ospf_fsm_trace!(
+        oi.tracing,
+        Nfsm,
+        true,
+        "[NFSM:NegotiationDone] DB Summary len {}",
+        nbr.db_sum.len()
+    );
     None
 }
 
@@ -635,7 +638,7 @@ fn ospf_nfsm_change_state<V: OspfVersion>(
         nbr.dd.flags.set_more(true);
         nbr.dd.flags.set_init(true);
 
-        tracing::info!("DB_DESC send from NFSM");
+        crate::ospf_fsm_trace!(oi.tracing, Nfsm, true, "DB_DESC send from NFSM");
         V::send_db_desc(oi, nbr, oident);
     }
 }
@@ -662,14 +665,15 @@ pub fn ospf_nfsm<V: OspfVersion>(
 
     // If a state transition occurs, update the state.
     if let Some(new_state) = next_state {
-        if link.tracing.should_trace_fsm(FsmType::Nfsm, false) {
-            tracing::info!(
-                "[NFSM:State] {}: {:?} -> {:?}",
-                nbr.ident.router_id,
-                nbr.state,
-                new_state
-            );
-        }
+        crate::ospf_fsm_trace!(
+            link.tracing,
+            Nfsm,
+            false,
+            "[NFSM:State] {}: {:?} -> {:?}",
+            nbr.ident.router_id,
+            nbr.state,
+            new_state
+        );
         if new_state != nbr.state {
             ospf_nfsm_change_state(link, nbr, new_state, oident, event);
         }

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -10,7 +10,7 @@ use crate::{
         nfsm::{ospf_db_summary_isempty, ospf_nfsm, ospf_nfsm_ls_req_timer_on},
         ospf_ls_rquest_new,
     },
-    ospf_pdu_trace,
+    ospf_fsm_trace, ospf_packet_trace, ospf_pdu_trace,
 };
 
 use super::{
@@ -371,7 +371,8 @@ pub fn ospf_hello_recv(
     let prefix = Ipv4Net::new(*src, prefixlen).unwrap();
 
     if addr.prefix.prefix_len() != prefixlen {
-        tracing::info!(
+        ospf_pdu_trace!(
+            tracing,
             "prefixlen mismatch hello {} ifaddr {}",
             prefixlen,
             addr.prefix.prefix_len()
@@ -386,7 +387,8 @@ pub fn ospf_hello_recv(
     if hello.options.external() != oi.area_type.e_bit()
         || hello.options.nssa() != oi.area_type.n_bit()
     {
-        tracing::info!(
+        ospf_pdu_trace!(
+            tracing,
             "[Hello:Recv] dropping {}: option mismatch (peer E={} N={}, area {:?})",
             src,
             hello.options.external(),
@@ -456,11 +458,11 @@ pub fn ospf_hello_recv(
         if oi.state == IfsmState::Waiting {
             use IfsmEvent::*;
             if nbr.ident.prefix.addr() == hello.bd_router {
-                tracing::info!("[IFSM:Event] BackupSeen");
+                ospf_fsm_trace!(tracing, Ifsm, false, "[IFSM:Event] BackupSeen");
                 oi.tx.send(Message::Ifsm(oi.index, BackupSeen)).unwrap();
             }
             if nbr.ident.prefix.addr() == hello.d_router && hello.bd_router.is_unspecified() {
-                tracing::info!("[IFSM:Event] BackupSeen");
+                ospf_fsm_trace!(tracing, Ifsm, false, "[IFSM:Event] BackupSeen");
                 oi.tx.send(Message::Ifsm(oi.index, BackupSeen)).unwrap();
             }
         };
@@ -642,7 +644,10 @@ fn ospf_db_desc_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, dd: &OspfDbDesc
         }
     } else {
         // Slave.
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            DbDesc,
+            Recv,
             "[DB Desc] packet as Slave: dd.flags.more() {}",
             dd.flags.more()
         );
@@ -651,7 +656,7 @@ fn ospf_db_desc_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, dd: &OspfDbDesc
         // When master's more flags is not set and local system does not have
         // information to be sent.
         if !dd.flags.more() && ospf_db_summary_isempty(nbr) {
-            tracing::info!("[NFSM:Event] ExchangeDone");
+            ospf_fsm_trace!(oi.tracing, Nfsm, false, "[NFSM:Event] ExchangeDone");
             nbr.dd.flags.set_more(false);
             nbr_sched_event(nbr, NfsmEvent::ExchangeDone);
         }
@@ -731,7 +736,8 @@ pub fn ospf_db_desc_recv(
         // 10.6.  Receiving Database Description Packets
         // ExStart
         ExStart => {
-            tracing::info!(
+            ospf_pdu_trace!(
+                oi.tracing,
                 "DB_DESC: Under ExStart {} <-> {}",
                 nbr.ident.router_id,
                 oi.router_id
@@ -748,7 +754,7 @@ pub fn ospf_db_desc_recv(
                 nbr.dd.flags.set_init(false);
                 nbr.dd.seqnum = dd.seqnum;
                 nbr.options = (nbr.options.into_bits() | dd.options.into_bits()).into();
-                tracing::info!("[DB Desc] Becoming Slave {:?}", nbr.dd.flags);
+                ospf_pdu_trace!(oi.tracing, "[DB Desc] Becoming Slave {:?}", nbr.dd.flags);
             }
             // o   The initialize(I) and master(MS) bits are off, the
             //     packet's DD sequence number equals the neighbor data
@@ -763,7 +769,7 @@ pub fn ospf_db_desc_recv(
             {
                 nbr.dd.flags.set_init(false);
                 nbr.options = (nbr.options.into_bits() | dd.options.into_bits()).into();
-                tracing::info!("[DB Desc] Becoming Master {:?}", nbr.dd.flags);
+                ospf_pdu_trace!(oi.tracing, "[DB Desc] Becoming Master {:?}", nbr.dd.flags);
             } else {
                 return;
             }
@@ -922,7 +928,8 @@ pub fn ospf_ls_req_recv(
             }
             None => {
                 // LSA not found in LSDB -> BadLSReq.
-                tracing::info!(
+                ospf_pdu_trace!(
+                    oi.tracing,
                     "[LS Request] BadLSReq: LSA not found type={:?} id={} adv={}",
                     ls_type,
                     req.ls_id,
@@ -997,7 +1004,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
         OspfLsType::AsExternal | OspfLsType::SummaryAsbr
     ) && oi.area_type.is_stub_or_nssa()
     {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] Step 3: Discarding {:?} LSA in {:?} area: id={} adv={}",
             lsa.h.ls_type,
             oi.area_type,
@@ -1012,7 +1022,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
     // negotiation should have prevented the adjacency), but defend
     // against misconfigured neighbors that slip through.
     if matches!(lsa.h.ls_type, OspfLsType::NssaAsExternal) && !oi.area_type.is_nssa() {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] Step 3: Discarding Type-7 LSA in {:?} area: id={} adv={}",
             oi.area_type,
             lsa.h.ls_id,
@@ -1052,7 +1065,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
     // Step 4 special case: MaxAge LSA not in database.
     // If no neighbors in the area are in Exchange or Loading, ack and discard.
     if lsa.h.ls_age >= OSPF_MAX_AGE && current.is_none() && oi.exchange_loading_count == 0 {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] MaxAge not in DB, no Exchange/Loading neighbors: type={:?} id={} adv={}",
             lsa.h.ls_type,
             lsa.h.ls_id,
@@ -1091,7 +1107,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
             );
             return LsaProcessResult::DiscardNoAck;
         }
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] Installing newer LSA type={:?} id={} adv={} seq={:#x}",
             lsa.h.ls_type,
             lsa.h.ls_id,
@@ -1108,7 +1127,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
 
         // RFC 2328 Section 13.4: Self-originated LSA check.
         if ospf_is_self_originated(oi, lsa) {
-            tracing::info!(
+            ospf_packet_trace!(
+                oi.tracing,
+                LsUpdate,
+                Recv,
                 "[Self-Originated] Received own LSA type={:?} id={} adv={} seq={:#x}",
                 lsa.h.ls_type,
                 lsa.h.ls_id,
@@ -1125,7 +1147,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
 
     // Step 6: If LSA is on neighbor's request list, this is a BadLSReq event.
     if ospf_ls_request_lookup(nbr, &lsa.h).is_some() {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] BadLSReq: LSA on request list type={:?} id={} adv={}",
             lsa.h.ls_type,
             lsa.h.ls_id,
@@ -1137,7 +1162,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
 
     // Step 7: Same instance (duplicate).
     if ret == 0 {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] Same instance type={:?} id={} adv={}",
             lsa.h.ls_type,
             lsa.h.ls_id,
@@ -1157,7 +1185,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
     let current = current.unwrap();
     if current_age >= OSPF_MAX_AGE && current.h.ls_seq_number == OSPF_MAX_LSA_SEQ {
         // MaxAge + MaxSeqNumber: discard without acknowledging.
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[LS Update] DB copy at MaxAge+MaxSeq, discard: type={:?} id={} adv={}",
             lsa.h.ls_type,
             lsa.h.ls_id,
@@ -1190,7 +1221,10 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
     // Send database copy back to the neighbor, and stamp the
     // last-flood-out so the next stale instance lands in the
     // MinLSArrival skip above.
-    tracing::info!(
+    ospf_packet_trace!(
+        oi.tracing,
+        LsUpdate,
+        Recv,
         "[LS Update] DB copy newer, sending back: type={:?} id={} adv={} \
          rcv={{seq={:#x} csum={:#06x} age={}}} \
          db={{seq={:#x} csum={:#06x} age={}}}",
@@ -1282,14 +1316,14 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
         return;
     }
     if !oi.gr_config.helper_enabled {
-        tracing::info!(
+        tracing::warn!(
             "[GR Helper] reject Grace LSA from nbr {} (helper-enabled is false)",
             nbr.ident.router_id
         );
         return;
     }
     if nbr.state != NfsmState::Full {
-        tracing::info!(
+        tracing::warn!(
             "[GR Helper] reject Grace LSA from non-Full nbr {} (state={:?})",
             nbr.ident.router_id,
             nbr.state
@@ -1300,7 +1334,7 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
     let grace_period = match body.grace_period() {
         Some(p) if p > 0 && p <= max_grace => p,
         Some(p) => {
-            tracing::info!(
+            tracing::warn!(
                 "[GR Helper] reject Grace LSA from nbr {} (grace={}s out of [1, {}])",
                 nbr.ident.router_id,
                 p,
@@ -1309,7 +1343,7 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
             return;
         }
         None => {
-            tracing::info!(
+            tracing::warn!(
                 "[GR Helper] reject Grace LSA from nbr {} (no GracePeriod TLV)",
                 nbr.ident.router_id
             );

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -22,7 +22,7 @@ use super::{
     Identity, IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink,
     inst::OspfInterface,
 };
-use crate::ospf_pdu_trace;
+use crate::{ospf_packet_trace, ospf_pdu_trace};
 
 /// RFC 7166 §3.5 Apad — a per-algorithm hex pattern used to fill
 /// the Authentication Data field while computing the HMAC. The
@@ -388,7 +388,8 @@ pub fn ospfv3_hello_recv(
     // RFC 5340 inherits RFC 2328 §10.5 / RFC 3101 §2.5: drop the
     // Hello when the peer's E or N bit disagrees with our area type.
     if hello.options.e() != oi.area_type.e_bit() || hello.options.n() != oi.area_type.n_bit() {
-        tracing::info!(
+        ospf_pdu_trace!(
+            tracing,
             "[v3 Hello:Recv] dropping {}: option mismatch (peer E={} N={}, area {:?})",
             src,
             hello.options.e(),
@@ -1051,7 +1052,8 @@ pub fn ospfv3_ls_req_recv(
         match ospfv3_lsa_lookup_raw(oi, req.ls_type, req.link_state_id, req.advertising_router) {
             Some(lsa) => lsas.push(lsa.clone()),
             None => {
-                tracing::info!(
+                ospf_pdu_trace!(
+                    oi.tracing,
                     "[v3 LSReq] BadLSReq: not in LSDB ls_type=0x{:04x} id={} adv={}",
                     req.ls_type,
                     req.link_state_id,
@@ -1260,14 +1262,14 @@ fn gr_maybe_enter_helper_v3(
         return;
     }
     if !oi.gr_config.helper_enabled {
-        tracing::info!(
+        tracing::warn!(
             "[GR Helper v3] reject Grace LSA from nbr {} (helper-enabled is false)",
             nbr.ident.router_id
         );
         return;
     }
     if nbr.state != NfsmState::Full {
-        tracing::info!(
+        tracing::warn!(
             "[GR Helper v3] reject Grace LSA from non-Full nbr {} (state={:?})",
             nbr.ident.router_id,
             nbr.state
@@ -1278,7 +1280,7 @@ fn gr_maybe_enter_helper_v3(
     let grace_period = match body.grace_period() {
         Some(p) if p > 0 && p <= max_grace => p,
         Some(p) => {
-            tracing::info!(
+            tracing::warn!(
                 "[GR Helper v3] reject Grace LSA from nbr {} (grace={}s out of [1, {}])",
                 nbr.ident.router_id,
                 p,
@@ -1287,7 +1289,7 @@ fn gr_maybe_enter_helper_v3(
             return;
         }
         None => {
-            tracing::info!(
+            tracing::warn!(
                 "[GR Helper v3] reject Grace LSA from nbr {} (no GracePeriod TLV)",
                 nbr.ident.router_id
             );
@@ -1377,7 +1379,10 @@ fn ospfv3_ls_upd_proc(
 
     // Step 3: AS-scope LSAs aren't accepted in stub / NSSA areas.
     if scope == Ospfv3LsaScope::As && oi.area_type.is_stub_or_nssa() {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[v3 LSUpd] Step 3: discarding AS-scope LSA in {:?} area",
             oi.area_type
         );
@@ -1388,7 +1393,10 @@ fn ospfv3_ls_upd_proc(
     // usually prevents the adjacency in the first
     // place, but defend against misconfigured peers.
     if h.ls_type == OSPFV3_NSSA_LSA_TYPE && !oi.area_type.is_nssa() {
-        tracing::info!(
+        ospf_packet_trace!(
+            oi.tracing,
+            LsUpdate,
+            Recv,
             "[v3 LSUpd] Step 3: discarding Type-7 NSSA-LSA in {:?} area",
             oi.area_type
         );
@@ -1434,7 +1442,10 @@ fn ospfv3_ls_upd_proc(
             && install_time.elapsed()
                 < std::time::Duration::from_millis(oi.min_ls_arrival_ms as u64)
         {
-            tracing::info!(
+            ospf_packet_trace!(
+                oi.tracing,
+                LsUpdate,
+                Recv,
                 "[v3 LSUpd] Step 5(a) MinLSArrival: discarding (no ack) LSA type={:#x} id={} adv={} seq={:#x}",
                 h.ls_type,
                 h.link_state_id,
@@ -1452,15 +1463,17 @@ fn ospfv3_ls_upd_proc(
                 // capability TLVs on E-Router-LSAs (SRGB / SRLB)
                 // update `label_map[adv_router]` before the LSA hits
                 // the LSDB. Mirrors v2's `insert_received` shape.
-                oi.lsdb.insert_received_v3(cloned, oi.tx, Some(area_id));
+                oi.lsdb
+                    .insert_received_v3(cloned, oi.tx, Some(area_id), oi.tracing);
                 area_lsa_installed = true;
             }
             Ospfv3LsaScope::As => {
-                oi.lsdb_as.install_lsa(cloned, oi.tx, None);
+                oi.lsdb_as.install_lsa(cloned, oi.tx, None, oi.tracing);
                 as_lsa_installed = true;
             }
             Ospfv3LsaScope::Link => {
-                oi.link_lsdb.install_lsa(cloned, oi.tx, Some(area_id));
+                oi.link_lsdb
+                    .install_lsa(cloned, oi.tx, Some(area_id), oi.tracing);
                 // A peer Link-LSA can carry the neighbor's global /128
                 // (LA-bit) — the preferred SRv6 End.X nexthop. Nudge
                 // the instance to re-evaluate installs on this link.

--- a/zebra-rs/src/ospf/tracing.rs
+++ b/zebra-rs/src/ospf/tracing.rs
@@ -241,6 +241,7 @@ impl FsmType {
 pub enum EventType {
     Spf,
     Lsdb,
+    Bfd,
 }
 
 impl EventType {
@@ -248,6 +249,7 @@ impl EventType {
         match self {
             EventType::Spf => "spf",
             EventType::Lsdb => "lsdb",
+            EventType::Bfd => "bfd",
         }
     }
 }
@@ -334,6 +336,7 @@ pub struct OspfTracing {
     pub fsm: FsmTracing,
     pub spf: EventConfig,
     pub lsdb: EventConfig,
+    pub bfd: EventConfig,
 }
 
 impl Default for OspfTracing {
@@ -345,6 +348,7 @@ impl Default for OspfTracing {
             fsm: FsmTracing::default(),
             spf: EventConfig::default(),
             lsdb: EventConfig::default(),
+            bfd: EventConfig::default(),
         }
     }
 }
@@ -410,6 +414,7 @@ impl OspfTracing {
         match ty {
             EventType::Spf => self.spf.enabled,
             EventType::Lsdb => self.lsdb.enabled,
+            EventType::Bfd => self.bfd.enabled,
         }
     }
 }
@@ -490,6 +495,7 @@ fn apply_tracing(t: &mut OspfTracing, rest: &str, args: &mut Args, op: ConfigOp)
         "/all" => t.all = op.is_set(),
         "/spf" => t.spf.enabled = op.is_set(),
         "/lsdb" => t.lsdb.enabled = op.is_set(),
+        "/bfd" => t.bfd.enabled = op.is_set(),
         other => {
             if let Some(pkt) = other.strip_prefix("/packet/") {
                 let (typ, sub) = match pkt.split_once('/') {
@@ -564,9 +570,12 @@ mod tests {
 
         apply_tracing(&mut t, "/spf", &mut args(&[]), ConfigOp::Set);
         apply_tracing(&mut t, "/lsdb", &mut args(&[]), ConfigOp::Set);
-        assert!(t.spf.enabled && t.lsdb.enabled);
+        apply_tracing(&mut t, "/bfd", &mut args(&[]), ConfigOp::Set);
+        assert!(t.spf.enabled && t.lsdb.enabled && t.bfd.enabled);
         apply_tracing(&mut t, "/spf", &mut args(&[]), ConfigOp::Delete);
         assert!(!t.spf.enabled);
+        apply_tracing(&mut t, "/bfd", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.bfd.enabled);
     }
 
     #[test]
@@ -719,6 +728,7 @@ mod tests {
         assert!(t.should_trace_fsm(FsmType::Ifsm, false));
         assert!(t.should_trace_event(EventType::Spf));
         assert!(t.should_trace_event(EventType::Lsdb));
+        assert!(t.should_trace_event(EventType::Bfd));
         // `all` is summary-level only — it does not imply detail.
         assert!(!t.packet_detail(PacketType::LsAck, PacketDirection::Recv));
     }

--- a/zebra-rs/src/ospf/vrf.rs
+++ b/zebra-rs/src/ospf/vrf.rs
@@ -126,7 +126,9 @@ pub fn spawn_ospf_vrf_v2(
     let cm_tx = ospf.cm.tx.clone();
     let show_tx = ospf.show.tx.clone();
     let task = inst::serve(ospf);
-    tracing::info!(vrf = %name, table_id, "ospf: spawned per-VRF instance");
+    if crate::rib::tracing::task() {
+        tracing::info!(vrf = %name, table_id, "ospf: spawned per-VRF instance");
+    }
     finish_spawn(&proto, cm_tx, show_tx, task, config_tx, buffered)
 }
 
@@ -157,7 +159,9 @@ pub fn spawn_ospf_vrf_v3(
     let cm_tx = ospf.cm.tx.clone();
     let show_tx = ospf.show.tx.clone();
     let task = inst::serve_v3(ospf);
-    tracing::info!(vrf = %name, table_id, "ospfv3: spawned per-VRF instance");
+    if crate::rib::tracing::task() {
+        tracing::info!(vrf = %name, table_id, "ospfv3: spawned per-VRF instance");
+    }
     finish_spawn(&proto, cm_tx, show_tx, task, config_tx, buffered)
 }
 
@@ -175,5 +179,7 @@ pub fn despawn_ospf_vrf(
     let proto = format!("{proto_base}:vrf:{name}");
     let _ = config_tx.try_send(Message::UnsubscribeShowVrf { key: proto.clone() });
     rib_subscriber.send_proto_cleanup(&proto);
-    tracing::info!(vrf = %name, proto = %proto, "ospf: despawned per-VRF instance");
+    if crate::rib::tracing::task() {
+        tracing::info!(vrf = %name, proto = %proto, "ospf: despawned per-VRF instance");
+    }
 }

--- a/zebra-rs/yang/zebra-ospf-tracing.yang
+++ b/zebra-rs/yang/zebra-ospf-tracing.yang
@@ -56,6 +56,15 @@ module zebra-ospf-tracing {
      config dispatch keys off set vs delete and never reads a value, so
      `type empty` is the honest type here.";
 
+  revision 2026-07-29 {
+    description
+      "Add the `bfd` leaf — gates the OSPF↔BFD interaction traces
+       (RFC 5882 session state changes that drive neighbor teardown),
+       which previously logged unconditionally. Mirrors the IS-IS
+       tracing block's `bfd` category. Covered by the `all` master
+       switch.";
+  }
+
   revision 2026-06-05 {
     description
       "Initial revision — shared OSPFv2 / OSPFv3 tracing block (an `all`
@@ -209,6 +218,14 @@ module zebra-ospf-tracing {
         type empty;
         description
           "Log LSA origination, installation, and flooding decisions.";
+      }
+
+      leaf bfd {
+        ext:help "Trace BFD interaction (RFC 5882)";
+        type empty;
+        description
+          "Log OSPF's interaction with BFD — session state changes
+           that drive RFC 5882 neighbor teardown.";
       }
     }
   }

--- a/zebra-rs/yang/zebra-rib-tracing.yang
+++ b/zebra-rs/yang/zebra-rib-tracing.yang
@@ -181,11 +181,12 @@ module zebra-rib-tracing {
         ext:help "Trace daemon task spawn / despawn lifecycle";
         type empty;
         description
-          "Log daemon task spawn / despawn lifecycle. Currently the BGP
-           per-VRF tasks: task spawn (with its RD / router-id / table /
+          "Log daemon task spawn / despawn lifecycle. Covers the BGP
+           per-VRF tasks — task spawn (with its RD / router-id / table /
            label / SID summary), the `Shutdown` sent on despawn, and the
            RIB subscribe race that surfaces when a task is respawned
-           before its earlier subscribe delivered its dump. Unlike `rib`
+           before its earlier subscribe delivered its dump — and the
+           OSPF / OSPFv3 per-VRF instance spawn / despawn. Unlike `rib`
            and `fib`, this is a cross-cutting category, not tied to a
            single forwarding plane.";
       }


### PR DESCRIPTION
OSPF had the full conditional-tracing machinery (`ospf_packet_trace!` / `ospf_fsm_trace!` / `ospf_event_trace!`, wired to `router ospf|ospfv3 tracing`) but ~80 `tracing::info!` sites never went through it, so the default log was noisy where IS-IS is silent. This PR completes the sweep, following the IS-IS model.

## What changed

- **Packet path** → `ospf_packet_trace!`/`ospf_pdu_trace!` under the message type + direction: Hello drops (prefixlen/option mismatch, v2+v3), DD negotiation (ExStart, Becoming Master/Slave, slave processing), LS-Req BadLSReq, every LS-Update processing step (stub/NSSA discards, MinLSArrival, install-newer, duplicate, MaxAge cases, send-back), flood/retransmit/DBD-retransmit/delayed-ack sends.
- **FSM** → `ospf_fsm_trace!`: BackupSeen, ExchangeDone, NFSM state changes and Full transitions (v2+v3), virtual-link up/down/refresh; NegotiationDone/DD-resend become nfsm `detail`-level.
- **LSDB / SPF** → `ospf_event_trace!`: Router-LSA (re)origination, the whole `[Self-Originated]` re-origination block (15 sites), refresh/hold-timer expiry, LSDB install paths, SPF dispatch. `Lsdb::install_lsa`/`install_originated` (and the `insert_*` wrappers) now take `&OspfTracing`, threaded through all ~35 call sites.
- **New `bfd` category** (`zebra-ospf-tracing.yang` rev 2026-07-29, covered by `all` — mirrors the IS-IS block): gates the OSPF↔BFD session state-change trace. Settability test added; book chapters (v2+v3) gained the row.
- **Per-VRF spawn/despawn** joins BGP under the existing `system tracing task` category (rib-tracing YANG description updated).

## Deliberately not gated

- **GR lifecycle** (staged/committed/restored/aborted/exit, helper enter/extend/exit/expire) stays unconditional info — rare, operator-initiated audit events.
- **Grace-LSA rejects** become `warn!` (8 sites, v2+v3): a refused Grace LSA means the peer's graceful restart will fail.
- Checkpoint debug-helper outcomes and stub-router windows stay unconditional; the STAMP metric update becomes `debug!`.

## Verification

- `cargo clippy --workspace` clean; full `cargo test --workspace --exclude bdd` green (39/39), incl. new `bfd` toggle unit tests + `ospf_tracing_bfd_is_settable`.
- `make install` + `ospf_clear_neighbor` BDD: passes, and the fresh run's daemon log window contains **zero** of the previously-unconditional lines (older appended runs in the same file show 90+), proving default silence with adjacency formation intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)