### PR TITLE
bgp: originate the per-EVI A-D that lets a remote PE alias to us

### DIFF
--- a/bdd/docs/bgp_evpn_srv6_macip_multihoming.md
+++ b/bdd/docs/bgp_evpn_srv6_macip_multihoming.md
@@ -8,12 +8,15 @@ its Type-2 under the segment ESI (RFC 7432 §7.1), alongside both PEs'
 per-ES Type-1 A-D and Type-4 routes, so a receiver holds the complete
 input set for §8.4 aliasing and §8.2 mass withdraw.
 
-Scope is the SIGNAL set, not its consumption: zebra-rs does not yet
-alias MAC traffic across the segment's PEs nor mass-withdraw MACs on
-a per-ES A-D loss (both exist for VPWS only — `vpws_gather_remotes`
-gates on per-ES A-D liveness; the MAC install path does not). What is
-proven here is that every route a consumer would need is originated,
-exchanged and revoked correctly under `encapsulation srv6`.
+Scope is the SIGNAL set, not its consumption: zebra-rs originates the
+full input set — Type-2 under the ESI, per-ES A-D, per-EVI A-D, Type-4
+— but does not yet alias MAC traffic across the segment's PEs nor
+mass-withdraw MACs on a per-ES A-D loss (both exist for VPWS only —
+`vpws_gather_remotes` gates on per-ES A-D liveness; the MAC install
+path does not, and `MacEntry` only recently grew room for a second
+destination). What is proven here is that every route a consumer would
+need is originated, exchanged and revoked correctly under
+`encapsulation srv6`.
 
 The ES machinery itself (Type-4/ES-Import RT, membership, DF election)
 is covered by bgp_evpn_es under the default encapsulation with no MACs;

--- a/bdd/tests/features/bgp_evpn_srv6_macip_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_srv6_macip_multihoming.feature
@@ -7,12 +7,15 @@ Feature: EVPN Type-2 multihoming signals over SRv6 — ESI on the MAC route
   per-ES Type-1 A-D and Type-4 routes, so a receiver holds the complete
   input set for §8.4 aliasing and §8.2 mass withdraw.
 
-  Scope is the SIGNAL set, not its consumption: zebra-rs does not yet
-  alias MAC traffic across the segment's PEs nor mass-withdraw MACs on
-  a per-ES A-D loss (both exist for VPWS only — `vpws_gather_remotes`
-  gates on per-ES A-D liveness; the MAC install path does not). What is
-  proven here is that every route a consumer would need is originated,
-  exchanged and revoked correctly under `encapsulation srv6`.
+  Scope is the SIGNAL set, not its consumption: zebra-rs originates the
+  full input set — Type-2 under the ESI, per-ES A-D, per-EVI A-D, Type-4
+  — but does not yet alias MAC traffic across the segment's PEs nor
+  mass-withdraw MACs on a per-ES A-D loss (both exist for VPWS only —
+  `vpws_gather_remotes` gates on per-ES A-D liveness; the MAC install
+  path does not, and `MacEntry` only recently grew room for a second
+  destination). What is proven here is that every route a consumer would
+  need is originated, exchanged and revoked correctly under
+  `encapsulation srv6`.
 
   The ES machinery itself (Type-4/ES-Import RT, membership, DF election)
   is covered by bgp_evpn_es under the default encapsulation with no MACs;
@@ -75,6 +78,12 @@ Feature: EVPN Type-2 multihoming signals over SRv6 — ESI on the MAC route
     # The per-ES A-D (mass-withdraw carrier) with the all-active ESI Label EC.
     And show command "show bgp evpn" in namespace "z2" should eventually contain "[1]:[00:11:22:33:44:55:66:77:88:99]:[4294967295]"
     And show command "show bgp evpn" in namespace "z2" should contain "esi-label:all-active:0"
+    # The per-EVI A-D (Ethernet Tag 0 — one bridge domain per VNI), which is
+    # the route that makes aliasing possible at all: it says "this PE can
+    # reach MACs on this segment in this EVI" WITHOUT having learned any of
+    # them. Its EVI membership is resolved from the access port's bridge, so
+    # its presence also proves host0 was tied to vxlan10's VNI.
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "[1]:[00:11:22:33:44:55:66:77:88:99]:[0]"
     # Membership agrees on both nodes; the usual 2-PE service carving elects
     # the lower VTEP (z1) as DF for tag 0.
     And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Member VTEPs (2)"
@@ -116,6 +125,11 @@ Feature: EVPN Type-2 multihoming signals over SRv6 — ESI on the MAC route
     # itself survives, because the MAC is still a local host on z1.
     When I apply command "delete router bgp afi-safi evpn ethernet-segment es1" in namespace "z1"
     Then show command "show bgp evpn" in namespace "z2" should eventually not contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.1]"
+    # The per-EVI A-D goes with it. It has to be revoked from the segment
+    # teardown rather than from port reconciliation: once es1 is gone nothing
+    # associates the ESI with a port any more, so a port-driven pass could no
+    # longer tell the route had ever been ours, and it would linger forever.
+    And show command "show bgp evpn" in namespace "z2" should eventually not contain "[1]:[00:11:22:33:44:55:66:77:88:99]:[0]"
     And show command "show bgp evpn" in namespace "z2" should eventually not contain "ESI: 00:11:22:33:44:55:66:77:88:99"
     And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Member VTEPs (1)"
     And show command "show bgp evpn" in namespace "z2" should contain "aa:bb:cc:dd:ee:01"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1833,6 +1833,9 @@ fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     // MACs already learned on the segment's access port carry its ESI on their
     // Type-2s, so adding or removing the segment changes what we advertise.
     bgp.evpn_resync_macip_esi();
+    // ... and the per-EVI A-D routes that let a remote PE alias toward us
+    // for MACs on the segment it has not learned itself (RFC 7432 §8.4).
+    bgp.evpn_resync_ad_evi();
     Some(())
 }
 
@@ -1879,6 +1882,9 @@ fn config_ethernet_segment_esi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
     // Type-2s carry the ESI on the path rather than in the key, so they only
     // need refreshing under the new value — not withdrawing first.
     bgp.evpn_resync_macip_esi();
+    // ... and the per-EVI A-D routes that let a remote PE alias toward us
+    // for MACs on the segment it has not learned itself (RFC 7432 §8.4).
+    bgp.evpn_resync_ad_evi();
     Some(())
 }
 
@@ -2032,6 +2038,9 @@ fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp
     // This leaf is what decides whether a learned MAC's port is on a segment
     // at all, so it moves Type-2s between single- and multi-homed.
     bgp.evpn_resync_macip_esi();
+    // ... and the per-EVI A-D routes that let a remote PE alias toward us
+    // for MACs on the segment it has not learned itself (RFC 7432 §8.4).
+    bgp.evpn_resync_ad_evi();
     Some(())
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -824,6 +824,13 @@ pub struct Bgp {
     /// — and replays on `advertise_all_vni` / `router_id` transitions
     /// just like `local_fdb`.
     pub local_vxlans: BTreeMap<u32, std::net::IpAddr>,
+    /// Which L2VPN EVIs each bridge port participates in, from
+    /// `RibRx::L2PortEvis`. The RIB resolves it (only it knows what a
+    /// bridge is); this is the mirror an Ethernet Segment's access port is
+    /// looked up in to decide which per-EVI Type-1 A-D routes to originate
+    /// (RFC 7432 §8.4). Absent means "no EVI", which is also what a port
+    /// that left its bridge reports.
+    pub l2_port_evis: BTreeMap<u32, std::collections::BTreeSet<u32>>,
     /// Local snooped IGMP/MLD membership shadow, keyed by
     /// `(vni, group, source)` → local VTEP IP. Populated from
     /// `RibRx::SnoopJoin`, removed on `RibRx::SnoopLeave`. Drives
@@ -1311,6 +1318,7 @@ impl Bgp {
             mup_segment_desired: BTreeMap::new(),
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
+            l2_port_evis: BTreeMap::new(),
             local_smet: BTreeMap::new(),
             ethernet_segments: BTreeMap::new(),
             hostname: None,
@@ -4215,6 +4223,20 @@ impl Bgp {
             RibRx::VxlanDel { vni } => {
                 if let Some(vtep_local) = self.local_vxlans.remove(&vni) {
                     self.evpn_withdraw_imet(vni, vtep_local);
+                }
+            }
+            RibRx::L2PortEvis { ifindex, vnis } => {
+                // A snapshot, so an unchanged set is a no-op — the RIB
+                // re-publishes a whole bridge whenever any part of it
+                // moves, and re-originating every A-D on every such event
+                // would churn the Adj-RIB-Out for nothing.
+                let previous = if vnis.is_empty() {
+                    self.l2_port_evis.remove(&ifindex)
+                } else {
+                    self.l2_port_evis.insert(ifindex, vnis.clone())
+                };
+                if previous.unwrap_or_default() != vnis {
+                    self.evpn_reconcile_ad_evi_for_port(ifindex);
                 }
             }
             RibRx::SnoopJoin {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -16286,6 +16286,162 @@ impl Bgp {
         self.evpn_originate_synch(rd, prefix, rib);
     }
 
+    /// Originate the per-EVI Ethernet Auto-Discovery route (Type-1, RFC
+    /// 7432 §8.4) for `esi` in `vni`: RD = `<router-id>:<vni>`, Ethernet
+    /// Tag 0 (one bridge domain per VNI, matching Type-2), the EVI RT, and
+    /// this PE's service binding for the EVI — the End.DT2U SID under
+    /// SRv6, the EVI service label under MPLS.
+    ///
+    /// **This is what makes aliasing possible.** A remote PE that has a
+    /// Type-2 for a MAC on this segment from *another* PE learns from this
+    /// route that we can reach it too, without ever having seen the MAC
+    /// ourselves — which is the entire point: the PE that has not learned
+    /// the MAC is exactly the one traffic would otherwise never reach.
+    pub fn evpn_originate_ethernet_ad_evi(&mut self, esi: [u8; 10], vni: u32) {
+        if self.router_id.is_unspecified() {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::EthernetAd { esi, eth_tag: 0 };
+        let mut attr = BgpAttr::new();
+        let mut ecom = ExtCommunity::from([evpn_route_target(self.asn, vni)]);
+        if !self.evpn_encap.is_mpls() {
+            ecom.0.insert(evpn_encap_vxlan());
+        }
+        attr.ecom = Some(ecom);
+        attr.nexthop = Some(BgpNexthop::Evpn(self.evpn_nexthop_for_vni(vni)));
+        if self.evpn_encap.is_srv6() {
+            attr.prefix_sid = self.vni_dt2u_prefix_sid(vni);
+        }
+        let evi_label = self
+            .evpn_encap
+            .is_mpls()
+            .then(|| self.evpn_evis.get(&vni).and_then(|cfg| cfg.label))
+            .flatten();
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            evi_label.map(|label| bgp_packet::Label {
+                label,
+                exp: 0,
+                bos: true,
+            }),
+            None,
+            false,
+        );
+        rib.esi = Some(esi);
+        self.evpn_originate_synch(rd, prefix, rib);
+    }
+
+    /// Inverse of `evpn_originate_ethernet_ad_evi`.
+    pub fn evpn_withdraw_ethernet_ad_evi(&mut self, esi: [u8; 10], vni: u32) {
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::EthernetAd { esi, eth_tag: 0 };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// The next hop an EVPN route for `vni` carries: the VNI's VTEP when
+    /// one is known, else the router-id. Under MPLS the router-id IS the
+    /// next hop — there is no VTEP and the transport LSP resolves on it —
+    /// so the fallback is the intended answer rather than a degraded one.
+    fn evpn_nexthop_for_vni(&self, vni: u32) -> IpAddr {
+        self.local_vxlans
+            .get(&vni)
+            .copied()
+            .unwrap_or(IpAddr::V4(self.router_id))
+    }
+
+    /// Re-reconcile per-EVI A-D for every configured Ethernet Segment's
+    /// access port. Called after an ES config edit, which is the other
+    /// direction the binding can change: `RibRx::L2PortEvis` covers the
+    /// port moving under a fixed config, this covers the config moving
+    /// under a fixed port. Cheap — segments are operator-configured and
+    /// few, and each reconcile is a Loc-RIB lookup per candidate EVI.
+    pub fn evpn_resync_ad_evi(&mut self) {
+        let ports: Vec<u32> = self
+            .ethernet_segments
+            .values()
+            .filter(|es| es.esi.is_some())
+            .filter_map(|es| es.interface.as_ref())
+            .filter_map(|name| self.link_index_by_name.get(name).copied())
+            .collect();
+        for ifindex in ports {
+            self.evpn_reconcile_ad_evi_for_port(ifindex);
+        }
+    }
+
+    /// Bring the per-EVI A-D routes for every Ethernet Segment bound to
+    /// `ifindex` in line with that port's current EVI membership: one
+    /// route per EVI it is in, and none for an EVI it has left.
+    ///
+    /// Driven by `RibRx::L2PortEvis` and by ES config edits, so a segment
+    /// declared before its port was enslaved — or enslaved before the
+    /// segment was declared — converges either way round.
+    pub fn evpn_reconcile_ad_evi_for_port(&mut self, ifindex: u32) {
+        let Some(port) =
+            super::ethernet_segment::ac_name_for_ifindex(ifindex, &self.link_index_by_name)
+        else {
+            return;
+        };
+        let wanted: std::collections::BTreeSet<u32> =
+            self.l2_port_evis.get(&ifindex).cloned().unwrap_or_default();
+        let segments: Vec<[u8; 10]> = self
+            .ethernet_segments
+            .values()
+            .filter(|es| es.interface.as_deref() == Some(port.as_str()))
+            .filter_map(|es| es.esi)
+            .collect();
+        // Every EVI we could conceivably have advertised for: the ones the
+        // port is in now, plus every local VNI — an EVI the port has left
+        // is no longer in `wanted`, so the withdraw has to come from
+        // somewhere that still remembers it exists.
+        let candidates: std::collections::BTreeSet<u32> = wanted
+            .iter()
+            .copied()
+            .chain(self.local_vxlans.keys().copied())
+            .collect();
+        for esi in segments {
+            for &vni in &candidates {
+                match (
+                    wanted.contains(&vni),
+                    self.evpn_ad_evi_originated(&esi, vni),
+                ) {
+                    (true, false) => self.evpn_originate_ethernet_ad_evi(esi, vni),
+                    (false, true) => self.evpn_withdraw_ethernet_ad_evi(esi, vni),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Whether we already originate a per-EVI A-D for `esi` in `vni`, read
+    /// back from the Loc-RIB rather than tracked separately — the routes
+    /// are the state, so there is nothing to keep in sync with them.
+    fn evpn_ad_evi_originated(&self, esi: &[u8; 10], vni: u32) -> bool {
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return false;
+        };
+        let prefix = EvpnPrefix::EthernetAd {
+            esi: *esi,
+            eth_tag: 0,
+        };
+        self.local_rib
+            .evpn
+            .get(&rd)
+            .and_then(|table| table.selected.get(&prefix))
+            .is_some_and(|rib| rib.typ == BgpRibType::Originated)
+    }
+
     /// Inverse of `evpn_originate_ethernet_ad_es`.
     pub fn evpn_withdraw_ethernet_ad_es(&mut self, esi: [u8; 10]) {
         let Some(rd) = rd_from_router_id_vni(self.router_id, 0) else {
@@ -16702,6 +16858,18 @@ impl Bgp {
     pub fn evpn_withdraw_es_routes(&mut self, esi: [u8; 10], vtep_local: IpAddr) {
         self.evpn_withdraw_ethernet_seg(esi, vtep_local);
         self.evpn_withdraw_ethernet_ad_es(esi);
+        // The per-EVI A-Ds go too. They must be withdrawn from here rather
+        // than from the port reconciler: by the time the segment is gone
+        // nothing still associates it with a port, so the reconciler can no
+        // longer tell these routes were ever ours. Every local VNI is
+        // swept because that is the set the routes could have been
+        // originated for.
+        let vnis: Vec<u32> = self.local_vxlans.keys().copied().collect();
+        for vni in vnis {
+            if self.evpn_ad_evi_originated(&esi, vni) {
+                self.evpn_withdraw_ethernet_ad_evi(esi, vni);
+            }
+        }
     }
 
     /// The DF-election candidates for an ES, computed from the EVPN Loc-RIB:

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -135,6 +135,25 @@ pub enum RibRx {
     VxlanDel {
         vni: u32,
     },
+    /// Every L2VPN EVI a bridge port participates in: the VNIs carried by
+    /// the VXLAN slaves of the bridge this port is enslaved to.
+    ///
+    /// A **snapshot, not a delta** — membership moves for several unrelated
+    /// reasons (the port is enslaved or freed, a VXLAN joins or leaves the
+    /// bridge, a VXLAN's VNI changes), and reconciling deltas from all of
+    /// them is far easier to get wrong than replacing the set. An empty
+    /// `vnis` therefore means "in no EVI", which is how a port leaving its
+    /// bridge is reported; there is no separate removal message.
+    ///
+    /// Resolved here rather than in the subscriber because `Link.master`
+    /// and `Link.vni` live here: BGP needs to know which EVIs an Ethernet
+    /// Segment's access port covers (RFC 7432 §8.4 aliasing needs a
+    /// per-EVI Type-1 A-D for each), and that is the only thing it needs —
+    /// not a model of bridges.
+    L2PortEvis {
+        ifindex: u32,
+        vnis: std::collections::BTreeSet<u32>,
+    },
     /// Local IGMP/MLD membership snooped by the kernel bridge
     /// (`RTM_NEWMDB`), resolved to its VNI. The EVPN advertise path
     /// consumes this to originate a Type-6 SMET route. `source` is
@@ -430,6 +449,19 @@ impl Rib {
     pub fn api_vxlan_add(&self, vni: u32, vtep_local: IpAddr) {
         for (_, sub) in self.client_registry.iter() {
             let _ = sub.rib_rx_tx.send(RibRx::VxlanAdd { vni, vtep_local });
+        }
+    }
+
+    /// Announce a bridge port's current EVI membership (see
+    /// [`RibRx::L2PortEvis`]). Always a full snapshot, so re-sending an
+    /// unchanged set is harmless — subscribers compare and act only on a
+    /// change, which is why this side keeps no per-port cache.
+    pub fn api_l2_port_evis(&self, ifindex: u32, vnis: std::collections::BTreeSet<u32>) {
+        for (_, sub) in self.client_registry.iter() {
+            let _ = sub.rib_rx_tx.send(RibRx::L2PortEvis {
+                ifindex,
+                vnis: vnis.clone(),
+            });
         }
     }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2171,6 +2171,22 @@ impl Rib {
                 });
             }
         }
+        // Bridge-port EVI membership dump, for the same cold-start race:
+        // `publish_l2_evis` walks `client_registry`, which was empty while
+        // `fib_dump` was building the link table, so without this replay a
+        // subscriber learns nothing about ports that already existed and an
+        // Ethernet Segment on one of them never gets its per-EVI A-D. Only
+        // ports that resolve to at least one EVI are worth sending; an
+        // empty set is the subscriber's default.
+        for link in self.links.values() {
+            let vnis = crate::rib::link::port_evis(&self.links, link.index);
+            if !vnis.is_empty() {
+                let _ = tx.send(RibRx::L2PortEvis {
+                    ifindex: link.index,
+                    vnis,
+                });
+            }
+        }
         // FDB dump. Replay every existing AF_BRIDGE neighbor that
         // resolves to a known VNI. Without this, FDB entries learned
         // during `fib_dump` — i.e. *before* BGP subscribed — would

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use ipnet::IpNet;
 use netlink_packet_route::link::LinkFlags;
 use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Write};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -814,6 +815,15 @@ impl Rib {
             self.rescan_fdb_for_bridge(bridge);
         }
 
+        // Publish EVI membership for everything this event could have
+        // moved. Both masters matter: a port changing bridges leaves one
+        // EVI set and joins another, and only re-reading both reports the
+        // departure. Every port of those bridges is re-read, not just this
+        // one — a VXLAN arriving, leaving, or changing its VNI changes the
+        // EVI set of every port sharing its bridge, and that VXLAN is the
+        // link this event is about.
+        self.publish_l2_evis([prev_master, now_master], ifindex);
+
         // If a VRF binding is pending for this interface (operator
         // configured it before the kernel device appeared, or before
         // the VRF master was created), replay it now.
@@ -879,7 +889,37 @@ impl Rib {
         // VRF lookup in `api_link_del` still resolves to the right
         // subscribers instead of falling through to default VRF.
         self.api_link_del(oslink.index);
+        let master = self.links.get(&oslink.index).and_then(|l| l.master);
         self.links.remove(&oslink.index);
+        // Re-publish AFTER the removal so the surviving ports are read
+        // against a table this link is already out of: deleting the
+        // bridge's VXLAN is exactly how they lose an EVI, and reading
+        // first would report the set that just stopped being true. The
+        // deleted link is published as well, since its own membership is
+        // now empty.
+        self.publish_l2_evis([master], oslink.index);
+    }
+
+    /// Publish [`RibRx::L2PortEvis`] for `port` and for every port of
+    /// `bridges`, re-read from the current link table.
+    ///
+    /// Deliberately unconditional: the snapshot is idempotent, so
+    /// re-sending an unchanged set costs a message and nothing else,
+    /// whereas tracking what was last sent per port would be a cache to
+    /// keep coherent with the kernel. Subscribers compare against what
+    /// they hold, which they must do regardless.
+    fn publish_l2_evis(&self, bridges: impl IntoIterator<Item = Option<u32>>, port: u32) {
+        let mut ports: BTreeSet<u32> = BTreeSet::new();
+        ports.insert(port);
+        for bridge in bridges.into_iter().flatten() {
+            ports.extend(bridge_ports(&self.links, bridge));
+        }
+        for port in ports {
+            if port == 0 {
+                continue;
+            }
+            self.api_l2_port_evis(port, port_evis(&self.links, port));
+        }
     }
 
     pub fn link_name(&self, link_index: u32) -> String {
@@ -1520,5 +1560,176 @@ mod tests {
             "Deleting remaining address should succeed"
         );
         assert_eq!(link.addr4.len(), 0, "Link should have no IPv4 addresses");
+    }
+}
+
+/// The L2VPN EVIs a bridge port participates in: the VNIs of the VXLAN
+/// slaves sharing its bridge. Empty when the port is not enslaved, when
+/// its bridge carries no VXLAN, or when `port` is 0 — index 0 is "no
+/// port" and must never resolve to whichever link happens to sit there.
+///
+/// A VXLAN slave is itself a bridge port, so it reports the VNI it
+/// carries; that is consistent rather than special-cased.
+///
+/// Pure over the link table so the bridge walk is testable without a
+/// live `Rib` — it is the whole basis of `RibRx::L2PortEvis`.
+pub fn port_evis(links: &BTreeMap<u32, Link>, port: u32) -> BTreeSet<u32> {
+    if port == 0 {
+        return BTreeSet::new();
+    }
+    let Some(bridge) = links.get(&port).and_then(|link| link.master) else {
+        return BTreeSet::new();
+    };
+    links
+        .values()
+        .filter(|link| link.master == Some(bridge))
+        .filter_map(|link| link.vni)
+        .collect()
+}
+
+/// Every port enslaved to `bridge`, including its VXLAN slaves. Used to
+/// re-publish membership for a whole bridge when anything about it moves,
+/// since one VXLAN change alters the EVI set of every port on it.
+pub fn bridge_ports(links: &BTreeMap<u32, Link>, bridge: u32) -> Vec<u32> {
+    if bridge == 0 {
+        return Vec::new();
+    }
+    links
+        .values()
+        .filter(|link| link.master == Some(bridge))
+        .map(|link| link.index)
+        .collect()
+}
+
+#[cfg(test)]
+mod l2_port_evi_tests {
+    use super::*;
+
+    fn link(index: u32, name: &str, master: Option<u32>, vni: Option<u32>) -> Link {
+        Link {
+            index,
+            name: name.into(),
+            mtu: 1500,
+            original_mtu: 1500,
+            metric: 1,
+            flags: LinkFlags::Up,
+            link_type: LinkType::Ethernet,
+            label: false,
+            mac: None,
+            addr4: Vec::new(),
+            addr6: Vec::new(),
+            master,
+            vni,
+            vxlan_local: None,
+            vrf_table: None,
+            bridge: master.is_none(),
+            mtu_error: None,
+        }
+    }
+
+    fn table(links: Vec<Link>) -> BTreeMap<u32, Link> {
+        links.into_iter().map(|l| (l.index, l)).collect()
+    }
+
+    /// The case aliasing needs: an access port shares a bridge with a
+    /// VXLAN, so it participates in that VXLAN's EVI.
+    #[test]
+    fn access_port_inherits_its_bridges_vni() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+            link(12, "host0", Some(10), None),
+        ]);
+        assert_eq!(port_evis(&t, 12), BTreeSet::from([100]));
+    }
+
+    /// A VLAN-aware bridge can carry several VNIs; a port on it is in all
+    /// of them, so the answer is a set rather than an Option.
+    #[test]
+    fn a_port_can_be_in_several_evis() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+            link(13, "vxlan20", Some(10), Some(200)),
+            link(12, "host0", Some(10), None),
+        ]);
+        assert_eq!(port_evis(&t, 12), BTreeSet::from([100, 200]));
+    }
+
+    /// A port on a bridge with no VXLAN is in no EVI — it is plain L2,
+    /// and advertising an A-D for it would attract traffic we cannot
+    /// deliver.
+    #[test]
+    fn a_bridge_without_a_vxlan_yields_no_evi() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(12, "host0", Some(10), None),
+        ]);
+        assert!(port_evis(&t, 12).is_empty());
+    }
+
+    /// An unenslaved port is in no EVI, and must not pick up the VNIs of
+    /// some unrelated bridge.
+    #[test]
+    fn an_unenslaved_port_is_in_no_evi() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+            link(12, "host0", None, None),
+        ]);
+        assert!(port_evis(&t, 12).is_empty());
+    }
+
+    /// Ports of a different bridge must not leak in — the filter is on
+    /// the master, not on "any VXLAN anywhere".
+    #[test]
+    fn a_second_bridges_vni_does_not_leak() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+            link(12, "host0", Some(10), None),
+            link(20, "br20", None, None),
+            link(21, "vxlan20", Some(20), Some(200)),
+        ]);
+        assert_eq!(port_evis(&t, 12), BTreeSet::from([100]));
+    }
+
+    /// Index 0 is "no port". Resolving it would hand every unattributed
+    /// caller whichever link sits at index 0.
+    #[test]
+    fn port_zero_never_resolves() {
+        let t = table(vec![
+            link(0, "weird", Some(10), None),
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+        ]);
+        assert!(port_evis(&t, 0).is_empty());
+        assert!(bridge_ports(&t, 0).is_empty());
+    }
+
+    /// A VXLAN slave is a bridge port too and reports its own VNI, so a
+    /// caller need not special-case it.
+    #[test]
+    fn a_vxlan_slave_reports_its_own_vni() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+        ]);
+        assert_eq!(port_evis(&t, 11), BTreeSet::from([100]));
+    }
+
+    /// Re-publishing a bridge must cover every port on it: one VXLAN
+    /// joining changes the EVI set of all of them at once.
+    #[test]
+    fn bridge_ports_lists_every_slave() {
+        let t = table(vec![
+            link(10, "br10", None, None),
+            link(11, "vxlan10", Some(10), Some(100)),
+            link(12, "host0", Some(10), None),
+            link(21, "elsewhere", Some(20), None),
+        ]);
+        let mut ports = bridge_ports(&t, 10);
+        ports.sort();
+        assert_eq!(ports, vec![11, 12]);
     }
 }


### PR DESCRIPTION
## Summary

RFC 7432 §8.4 aliasing requires the **per-EVI Ethernet A-D route**: it tells a remote PE "this PE can reach MACs on this segment in this EVI" without the PE having learned any of them. zebra-rs originated only the per-ES A-D (the §8.2 mass-withdraw carrier); the per-EVI sibling existed for VPWS alone, so a remote PE holding our Type-4 and per-ES A-D still had no route to alias to on a bridged EVI.

## Design

- **The RIB resolves segment→EVI membership**, not BGP: `Link.master` / `Link.vni` already live in the link table, so the RIB walks an ES access port's bridge to its VXLAN VNIs and publishes the answer as a new `RibRx::L2PortEvis` message. BGP stores the mapping and never learns what a bridge is.
- **The message is a snapshot, not a delta**: membership moves for several unrelated reasons (port enslaved/freed, VXLAN joins/leaves the bridge, VNI changes); replacing a set is far easier to get right than reconciling deltas. An empty set means "in no EVI" — there is no separate removal message. The publisher keeps no per-port cache; BGP compares before acting to avoid churning the Adj-RIB-Out.
- **`link_delete` re-publishes after dropping the link**, so surviving ports are read against a table the deleted link is already out of — deleting a bridge's VXLAN is precisely how ports lose an EVI.
- **Reconciliation runs from both directions**: `L2PortEvis` covers the port changing under fixed config; `evpn_resync_ad_evi` (hooked into the same three ES config handlers as the Type-2 ESI resync) covers the config changing under a fixed port. Already-advertised routes are read back from the Loc-RIB — the routes are the state.
- **Withdrawal on segment teardown belongs to `evpn_withdraw_es_routes`**: once the segment is gone, no port-driven pass can tell the routes were ours.

Originating for every local VNI instead was rejected: it attracts traffic for EVIs the segment is not in — a blackhole, not a missing optimisation.

## Testing

- 1829 unit tests pass (8 new, on the bridge walk — pure over the link table).
- Workspace clippy and `cargo fmt` clean.
- BDD: `@bgp_evpn_srv6_macip_multihoming` grows assertions that the per-EVI A-D reaches z2 and is revoked on segment delete, asserted on the **remote** PE where only this route can produce the string; 6/6. Regression: `bgp_evpn_srv6_macip` 9/9, `bgp_evpn_es` 7/7, `bgp_evpn_srv6_irb` 6/6.

## Scope

This completes the **origination** side of aliasing. Consumption is future work: nothing yet resolves a received Type-2's ESI to the set of PEs advertising a per-EVI A-D for it, and the FIB still installs one destination per MAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)