### PR TITLE
isis: render allocated circuit id in show views, debug-trace alloc/release

### DIFF
--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1879,6 +1879,7 @@ fn hello_reoriginate(link: &IsisLink, tx: &UnboundedSender<Message>) {
 struct LinkInfo {
     name: String,
     ifindex: u32,
+    circuit_id: String,
     is_up: bool,
     network_type: String,
     level: String,
@@ -1936,6 +1937,7 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
                 links.push(LinkInfo {
                     name: link.state.name.clone(),
                     ifindex: link.ifindex,
+                    circuit_id: format!("0x{:02X}", link.circuit_id),
                     is_up: link.state.is_up(),
                     network_type: link.config.network_type().to_string(),
                     level: link.state.level.to_string(),
@@ -1958,7 +1960,10 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
         }
         let level = summary_level(link);
         let link_state = if link.state.is_up() { "Up" } else { "Down" };
-        let circ_id = format!("0x{:02X}", link.ifindex);
+        // The allocated circuit id (also the pseudonode number while DIS
+        // here), NOT the ifindex — the two coincided often enough on
+        // small boxes that the ifindex rendering went unnoticed.
+        let circ_id = format!("0x{:02X}", link.circuit_id);
         writeln!(
             buf,
             "  {:<11} {:<8} {:<8} {:<8} {:<5} {:<9} {}",
@@ -2204,7 +2209,7 @@ pub fn show_detail(
                 writeln!(
                     buf,
                     "Interface: {}, State: {}, Active, Circuit Id: 0x{:02X}",
-                    link.state.name, link_state, link.ifindex
+                    link.state.name, link_state, link.circuit_id
                 )?;
                 writeln!(
                     buf,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1313,11 +1313,10 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
             if !enabled {
                 match isis.circuit_ids.alloc(&name) {
                     Some(id) => {
-                        // Unconditional: alloc/release fire only on config
-                        // transitions, and the log is the audit trail for
-                        // "why is this circuit 0x03, not 0x02" — holes come
-                        // from enables/disables that leave no other trace.
-                        tracing::info!("isis: circuit id 0x{id:02X} allocated to {name}");
+                        // Debug-level: silent in normal operation, but a
+                        // RUST_LOG bump recovers the alloc/release history
+                        // when a circuit's id needs explaining.
+                        tracing::debug!("isis: circuit id 0x{id:02X} allocated to {name}");
                         link.circuit_id = id;
                     }
                     None => {
@@ -1356,7 +1355,7 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
             // is purged via the normal DIS-loss path; a same-commit
             // re-enable of another interface may pick this id up.
             if let Some(id) = isis.circuit_ids.release(&name) {
-                tracing::info!("isis: circuit id 0x{id:02X} released from {name}");
+                tracing::debug!("isis: circuit id 0x{id:02X} released from {name}");
             }
             link.circuit_id = 0;
             let msg = Message::Ifsm(IfsmEvent::Stop, link.ifindex, None);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1312,7 +1312,14 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
             // function of config order.
             if !enabled {
                 match isis.circuit_ids.alloc(&name) {
-                    Some(id) => link.circuit_id = id,
+                    Some(id) => {
+                        // Unconditional: alloc/release fire only on config
+                        // transitions, and the log is the audit trail for
+                        // "why is this circuit 0x03, not 0x02" — holes come
+                        // from enables/disables that leave no other trace.
+                        tracing::info!("isis: circuit id 0x{id:02X} allocated to {name}");
+                        link.circuit_id = id;
+                    }
                     None => {
                         tracing::warn!(
                             "isis: circuit ids exhausted (255 in use); refusing to enable \
@@ -1348,7 +1355,9 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
             // pseudonode LSP still floating under the old id ages out or
             // is purged via the normal DIS-loss path; a same-commit
             // re-enable of another interface may pick this id up.
-            isis.circuit_ids.release(&name);
+            if let Some(id) = isis.circuit_ids.release(&name) {
+                tracing::info!("isis: circuit id 0x{id:02X} released from {name}");
+            }
             link.circuit_id = 0;
             let msg = Message::Ifsm(IfsmEvent::Stop, link.ifindex, None);
             let _ = isis.tx.send(msg);


### PR DESCRIPTION
## Summary

Follow-ups to #2163 (enable-time circuit id allocator):

- **Show views rendered the ifindex, not the allocated id.** The brief `show isis interface` table and the detail text view both formatted `link.ifindex` in their Circuit Id columns (the brief JSON carried no circuit id at all); only the detail JSON read the allocated id. On small topologies the two values coincide often enough that this went unnoticed — and made allocation look non-sequential when they diverged. All four renderers (brief table, brief JSON, detail text, detail JSON) now read `IsisLink::circuit_id`.
- **Debug-level alloc/release traces.** Each circuit id grant and return logs via `tracing::debug!` — silent in normal operation, recoverable with a `RUST_LOG` bump when a circuit's id needs explaining.

## Test plan

- `cargo test -p zebra-rs`: 1837 passed.
- Verified live (`make run`) that the allocation log matches config order; no BDD feature asserts on the CircId column or brief JSON shape.

Generated with [Claude Code](https://claude.com/claude-code)