### PR TITLE
bgp: implement `show evpn vni all`

### DIFF
--- a/playset/bgp-evpn-vxlan4-multi/README.md
+++ b/playset/bgp-evpn-vxlan4-multi/README.md
@@ -184,6 +184,33 @@ Two details worth noticing:
   `local-address`, facing `vtep3`), while its VNI 10 routes use
   `192.168.0.1`. Each tenant's tunnel rides the right underlay link.
 
+`show evpn vni all` shows the whole inventory at a glance. On the
+multi-tenant `vtep1`, both VNIs with their per-tenant VTEP addresses:
+
+``` shell
+vtep1>show evpn vni all
+Advertise All VNI flag: Enabled
+BUM flooding: Head-end replication
+Number of L2 VNIs: 2
+Number of L3 VNIs: 0
+Flags: * - Kernel VXLAN device
+  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
+* 10         L2   192.168.0.1               192.168.0.1:10         65001:10                   2           2             1  default
+* 20         L2   192.168.1.1               192.168.0.1:20         65001:20                   2           2             1  default
+```
+
+On single-tenant `vtep2` the other tenant's VNI 20 still appears — its
+routes arrive over iBGP — but without the `*` flag and with no local
+VTEP: BGP knows the VNI, the kernel serves only VNI 10:
+
+``` shell
+vtep2>show evpn vni all
+...
+  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
+* 10         L2   192.168.0.2               192.168.0.2:10         65001:10                   2           2             1  default
+  20         L2   -                         192.168.0.2:20         65001:20                   0           2             1  default
+```
+
 ## Kernel view: two tenants, two flood domains
 
 ``` shell

--- a/playset/bgp-evpn-vxlan4/README.md
+++ b/playset/bgp-evpn-vxlan4/README.md
@@ -143,6 +143,22 @@ Route Distinguisher: 192.168.0.2:10
 (The MAC addresses are the hosts' and bridges' randomly generated ones and
 differ per run.)
 
+`show evpn vni all` condenses the same state into a per-VNI inventory —
+the auto-derived RD and route-target, the MAC counts (local from the
+kernel FDB, remote from Type-2 routes), and the remote VTEPs learned from
+Type-3 IMET. The `*` flag marks a VNI backed by a kernel VXLAN device:
+
+``` shell
+vtep1>show evpn vni all
+Advertise All VNI flag: Enabled
+BUM flooding: Head-end replication
+Number of L2 VNIs: 1
+Number of L3 VNIs: 0
+Flags: * - Kernel VXLAN device
+  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
+* 10         L2   192.168.0.1               192.168.0.1:10         65001:10                   2           2             1  default
+```
+
 ## How the routes land in the kernel
 
 The vty shell is a full shell, so the standard `bridge` tooling works

--- a/playset/bgp-evpn-vxlan6-multi/README.md
+++ b/playset/bgp-evpn-vxlan6-multi/README.md
@@ -171,6 +171,27 @@ Three things to notice:
 * The Type-3 IMET NLRI is `[3]:[0]:[128]:[...]` — a 128-bit originating IP
   — and `RT:65001:10` vs `RT:65001:20` is the tenant boundary.
 
+`show evpn vni all` condenses it: on `vtep1` both VNIs with their own IPv6
+VTEP address and IPv4-derived RD; on `vtep3` the foreign VNI 10 appears
+un-flagged (no kernel device, no local VTEP) while VNI 20 is served:
+
+``` shell
+vtep1>show evpn vni all
+Advertise All VNI flag: Enabled
+BUM flooding: Head-end replication
+Number of L2 VNIs: 2
+Number of L3 VNIs: 0
+Flags: * - Kernel VXLAN device
+  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
+* 10         L2   2001:db8:ff::1            10.0.0.1:10            65001:10                   2           2             1  default
+* 20         L2   2001:db8:ee::1            10.0.0.1:20            65001:20                   2           2             1  default
+vtep3>show evpn vni all
+...
+  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
+  10         L2   -                         10.0.0.3:10            65001:10                   0           2             1  default
+* 20         L2   2001:db8:ee::2            10.0.0.3:20            65001:20                   2           2             1  default
+```
+
 ## Kernel view: two tenants, two IPv6 flood domains
 
 ``` shell

--- a/playset/bgp-evpn-vxlan6/README.md
+++ b/playset/bgp-evpn-vxlan6/README.md
@@ -142,6 +142,20 @@ require:
   and could not hold an IPv6 address). The **route-target** `RT:65001:10`
   is still auto-derived from the VNI.
 
+`show evpn vni all` puts that split on one line — an IPv6 local VTEP next
+to an IPv4-derived RD (counts are from after the hosts have talked):
+
+``` shell
+vtep1>show evpn vni all
+Advertise All VNI flag: Enabled
+BUM flooding: Head-end replication
+Number of L2 VNIs: 1
+Number of L3 VNIs: 0
+Flags: * - Kernel VXLAN device
+  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
+* 10         L2   2001:db8:ff::1            10.0.0.1:10            65001:10                   2           2             1  default
+```
+
 ## How the routes land in the kernel
 
 ``` shell

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2665,6 +2665,23 @@ impl EvpnFloodState {
         self.vnis.keys().copied().collect()
     }
 
+    /// Every remote VTEP endpoint recorded for `vni` — Ingress/Assisted
+    /// Replication IMET originators plus SR P2MP tree roots. Unlike
+    /// [`desired`](Self::desired) this is the raw membership view (no AR
+    /// collapse, no prune filtering), for `show evpn vni`.
+    pub fn remote_vteps(&self, vni: u32) -> Vec<IpAddr> {
+        self.vnis
+            .get(&vni)
+            .map(|v| {
+                v.remotes
+                    .keys()
+                    .chain(v.sr_remotes.keys())
+                    .copied()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// The flood-target set this node should program for `vni`, given its
     /// Assisted Replication role (RFC 9574 §5):
     ///
@@ -5409,7 +5426,7 @@ pub fn route_withdraw_evpn_to_peers(
 /// Announce and withdraw must agree — a withdraw carrying a different service
 /// field would not match its announce at the receiver — so both emit sites
 /// call this.
-fn macip_service_field(rib: &BgpRib) -> u32 {
+pub(super) fn macip_service_field(rib: &BgpRib) -> u32 {
     rib.label
         .as_ref()
         .map(|l| l.label)
@@ -17395,7 +17412,7 @@ fn smet_advertisable_group(group: IpAddr) -> bool {
 /// when the VNI exceeds 16 bits — Type-1 only has 2 bytes for the
 /// assigned-number field; supporting VNIs above 65535 needs the
 /// Type-0 (ASN) format and is a follow-up.
-fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistinguisher> {
+pub(super) fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistinguisher> {
     let vni_short: u16 = vni.try_into().ok()?;
     let mut rd = RouteDistinguisher::new(RouteDistinguisherType::IP);
     rd.val[0..4].copy_from_slice(&router_id.octets());

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -6881,18 +6881,308 @@ mod detail_tests {
     }
 }
 
+/// One row of `show evpn vni all`: a VNI this node participates in, drawn
+/// from any of its sources — a kernel VXLAN device (`local_vxlans`), a
+/// configured MPLS EVI (`evpn_evis`), a VRF's symmetric-IRB L3VNI, or
+/// remote Type-3 IMET state (`evpn_flood`). Shared by the text and JSON
+/// renderers so both views come from one collection pass.
+#[derive(Serialize)]
+struct EvpnVniJson {
+    vni: u32,
+    /// `"L2"`, or `"L3"` when some VRF uses this VNI as its EVPN
+    /// symmetric-IRB L3VNI.
+    #[serde(rename = "type")]
+    vni_type: &'static str,
+    /// True when a kernel VXLAN device has this VNI registered.
+    kernel: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_vtep: Option<String>,
+    /// The auto-derived Type-1 RD (`router-id:vni`, RFC 8365 §5.1.2).
+    /// Absent when the router-id is unset or the VNI exceeds 16 bits.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rd: Option<String>,
+    /// The auto-derived route target (`as:vni`) — import and export are
+    /// the same value.
+    route_target: String,
+    local_macs: usize,
+    remote_macs: usize,
+    remote_vteps: Vec<String>,
+    tenant_vrf: String,
+}
+
+#[derive(Serialize)]
+struct EvpnVniAllJson {
+    advertise_all_vni: bool,
+    bum_flooding: &'static str,
+    num_l2_vnis: usize,
+    num_l3_vnis: usize,
+    vnis: Vec<EvpnVniJson>,
+}
+
+/// The human name of the configured BUM flooding mechanism.
+fn evpn_bum_flooding_label(bgp: &Bgp) -> &'static str {
+    use super::inst::{AssistedReplicationRole, EvpnBumTunnel};
+    match bgp.local_rib.evpn_flood.bum_tunnel {
+        EvpnBumTunnel::IngressReplication => match bgp.local_rib.evpn_flood.role {
+            AssistedReplicationRole::Replicator => "Assisted replication (replicator)",
+            AssistedReplicationRole::Leaf => "Assisted replication (leaf)",
+            AssistedReplicationRole::None => "Head-end replication",
+        },
+        EvpnBumTunnel::SrMplsP2mp => "SR-MPLS P2MP replication tree",
+        EvpnBumTunnel::SrV6P2mp => "SRv6 P2MP replication tree",
+    }
+}
+
+fn evpn_vni_all_view(bgp: &Bgp) -> EvpnVniAllJson {
+    use std::collections::BTreeSet;
+
+    // vni → tenant VRF name for VNIs serving as a VRF's symmetric-IRB
+    // L3VNI (same predicate the Type-5 origination path uses).
+    let l3vnis: BTreeMap<u32, &str> = bgp
+        .vrfs
+        .iter()
+        .filter(|(_, c)| c.encapsulation == super::vrf_config::BgpVrfEncapsulation::Vxlan)
+        .filter_map(|(name, c)| c.l3vni.map(|vni| (vni, name.as_str())))
+        .collect();
+
+    // Union of every VNI this node knows about.
+    let mut vnis: BTreeSet<u32> = bgp.local_vxlans.keys().copied().collect();
+    vnis.extend(bgp.evpn_evis.keys().copied());
+    vnis.extend(bgp.local_rib.evpn_flood.vnis());
+    vnis.extend(l3vnis.keys().copied());
+
+    // Remote MACs per VNI: selected Type-2 paths we did not originate,
+    // deduplicated by MAC (one MAC may appear under several RDs during a
+    // move or with multihoming) and bucketed by the same service field
+    // (NLRI label, else RT-derived VNI) the import path uses.
+    let mut remote_macs: BTreeSet<(u32, [u8; 6])> = BTreeSet::new();
+    for table in bgp.local_rib.evpn.values() {
+        for (prefix, rib) in table.selected.iter() {
+            let EvpnPrefix::MacIp { mac, .. } = prefix else {
+                continue;
+            };
+            if rib.is_originated() {
+                continue;
+            }
+            let vni = super::route::macip_service_field(rib);
+            if vni != 0 {
+                remote_macs.insert((vni, *mac));
+            }
+        }
+    }
+
+    let rows: Vec<EvpnVniJson> = vnis
+        .into_iter()
+        .map(|vni| {
+            let (vni_type, tenant_vrf) = match l3vnis.get(&vni) {
+                Some(name) => ("L3", (*name).to_string()),
+                None => ("L2", "default".to_string()),
+            };
+            let rd = (!bgp.router_id.is_unspecified())
+                .then(|| super::route::rd_from_router_id_vni(bgp.router_id, vni))
+                .flatten()
+                .map(|rd| rd.to_string());
+            EvpnVniJson {
+                vni,
+                vni_type,
+                kernel: bgp.local_vxlans.contains_key(&vni),
+                local_vtep: bgp.local_vxlans.get(&vni).map(|ip| ip.to_string()),
+                rd,
+                // Wire encoding truncates the ASN to 16 bits (Type-0 RT
+                // with the low half of a 4-byte ASN) — display the value
+                // actually advertised.
+                route_target: format!("{}:{}", bgp.asn as u16, vni),
+                local_macs: bgp.local_fdb.keys().filter(|(v, _)| *v == vni).count(),
+                remote_macs: remote_macs.iter().filter(|(v, _)| *v == vni).count(),
+                remote_vteps: bgp
+                    .local_rib
+                    .evpn_flood
+                    .remote_vteps(vni)
+                    .iter()
+                    .map(|ip| ip.to_string())
+                    .collect(),
+                tenant_vrf,
+            }
+        })
+        .collect();
+
+    EvpnVniAllJson {
+        advertise_all_vni: bgp.advertise_all_vni,
+        bum_flooding: evpn_bum_flooding_label(bgp),
+        num_l2_vnis: rows.iter().filter(|r| r.vni_type == "L2").count(),
+        num_l3_vnis: rows.iter().filter(|r| r.vni_type == "L3").count(),
+        vnis: rows,
+    }
+}
+
+fn format_evpn_vni_table(view: &EvpnVniAllJson) -> std::result::Result<String, std::fmt::Error> {
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        "Advertise All VNI flag: {}",
+        if view.advertise_all_vni {
+            "Enabled"
+        } else {
+            "Disabled"
+        }
+    )?;
+    writeln!(buf, "BUM flooding: {}", view.bum_flooding)?;
+    writeln!(buf, "Number of L2 VNIs: {}", view.num_l2_vnis)?;
+    writeln!(buf, "Number of L3 VNIs: {}", view.num_l3_vnis)?;
+    if view.vnis.is_empty() {
+        return Ok(buf);
+    }
+    writeln!(buf, "Flags: * - Kernel VXLAN device")?;
+    writeln!(
+        buf,
+        "  {:<10} {:<4} {:<25} {:<22} {:<17} {:>10} {:>11} {:>13}  Tenant VRF",
+        "VNI",
+        "Type",
+        "Local VTEP",
+        "RD",
+        "Import/Export RT",
+        "#MACs(loc)",
+        "#MACs(rem)",
+        "#Remote VTEPs"
+    )?;
+    for row in view.vnis.iter() {
+        let flag = if row.kernel { '*' } else { ' ' };
+        writeln!(
+            buf,
+            "{flag} {:<10} {:<4} {:<25} {:<22} {:<17} {:>10} {:>11} {:>13}  {}",
+            row.vni,
+            row.vni_type,
+            row.local_vtep.as_deref().unwrap_or("-"),
+            row.rd.as_deref().unwrap_or("-"),
+            row.route_target,
+            row.local_macs,
+            row.remote_macs,
+            row.remote_vteps.len(),
+            row.tenant_vrf
+        )?;
+    }
+    Ok(buf)
+}
+
 fn show_evpn_vni_all(
-    _bgp: &Bgp,
+    bgp: &Bgp,
     _args: Args,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
-    // Placeholder: the EVPN VNI inventory isn't wired up here yet (the
-    // per-VNI MAC state lives in the RIB — see `show l2 mac table`).
-    // Honor `-j` with an empty array so the flag isn't a silent no-op.
+    let view = evpn_vni_all_view(bgp);
     if json {
-        return Ok("[]".to_string());
+        return Ok(serde_json::to_string_pretty(&view)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
     }
-    Ok(String::from("EVPN output here"))
+    format_evpn_vni_table(&view)
+}
+
+#[cfg(test)]
+mod evpn_vni_show_tests {
+    use super::*;
+
+    fn sample_view() -> EvpnVniAllJson {
+        EvpnVniAllJson {
+            advertise_all_vni: true,
+            bum_flooding: "Head-end replication",
+            num_l2_vnis: 2,
+            num_l3_vnis: 1,
+            vnis: vec![
+                EvpnVniJson {
+                    vni: 10,
+                    vni_type: "L2",
+                    kernel: true,
+                    local_vtep: Some("192.168.0.1".to_string()),
+                    rd: Some("192.168.0.1:10".to_string()),
+                    route_target: "65001:10".to_string(),
+                    local_macs: 2,
+                    remote_macs: 2,
+                    remote_vteps: vec!["192.168.0.2".to_string()],
+                    tenant_vrf: "default".to_string(),
+                },
+                // A remote-only VNI: IMET state arrived but no kernel
+                // VXLAN device registers the VNI locally.
+                EvpnVniJson {
+                    vni: 20,
+                    vni_type: "L2",
+                    kernel: false,
+                    local_vtep: None,
+                    rd: Some("192.168.0.1:20".to_string()),
+                    route_target: "65001:20".to_string(),
+                    local_macs: 0,
+                    remote_macs: 1,
+                    remote_vteps: vec!["192.168.1.2".to_string()],
+                    tenant_vrf: "default".to_string(),
+                },
+                EvpnVniJson {
+                    vni: 4001,
+                    vni_type: "L3",
+                    kernel: true,
+                    local_vtep: Some("2001:db8:ff::1".to_string()),
+                    rd: Some("192.168.0.1:4001".to_string()),
+                    route_target: "65001:4001".to_string(),
+                    local_macs: 0,
+                    remote_macs: 0,
+                    remote_vteps: vec![],
+                    tenant_vrf: "cust1".to_string(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn evpn_vni_table_renders_rows_and_flags() {
+        let out = format_evpn_vni_table(&sample_view()).unwrap();
+        for needle in [
+            "Advertise All VNI flag: Enabled",
+            "BUM flooding: Head-end replication",
+            "Number of L2 VNIs: 2",
+            "Number of L3 VNIs: 1",
+            "Flags: * - Kernel VXLAN device",
+        ] {
+            assert!(out.contains(needle), "missing {needle:?} in:\n{out}");
+        }
+        // Kernel VNIs get the `*` flag; the remote-only one does not.
+        assert!(out.contains("* 10         L2   192.168.0.1"), "{out}");
+        assert!(out.contains("  20         L2   -"), "{out}");
+        // The L3 row carries its tenant VRF and IPv6 VTEP.
+        assert!(out.contains("* 4001       L3   2001:db8:ff::1"), "{out}");
+        assert!(out.contains("cust1"), "{out}");
+        // RD / RT columns.
+        assert!(out.contains("192.168.0.1:10"), "{out}");
+        assert!(out.contains("65001:10"), "{out}");
+    }
+
+    #[test]
+    fn evpn_vni_table_empty_omits_table() {
+        let view = EvpnVniAllJson {
+            advertise_all_vni: false,
+            bum_flooding: "Head-end replication",
+            num_l2_vnis: 0,
+            num_l3_vnis: 0,
+            vnis: vec![],
+        };
+        let out = format_evpn_vni_table(&view).unwrap();
+        assert!(out.contains("Advertise All VNI flag: Disabled"), "{out}");
+        assert!(!out.contains("VNI        Type"), "{out}");
+    }
+
+    #[test]
+    fn evpn_vni_json_shape() {
+        let js = serde_json::to_value(sample_view()).unwrap();
+        assert_eq!(js["advertise_all_vni"], true);
+        assert_eq!(js["num_l2_vnis"], 2);
+        let row = &js["vnis"][0];
+        assert_eq!(row["vni"], 10);
+        assert_eq!(row["type"], "L2");
+        assert_eq!(row["kernel"], true);
+        assert_eq!(row["local_vtep"], "192.168.0.1");
+        assert_eq!(row["rd"], "192.168.0.1:10");
+        assert_eq!(row["route_target"], "65001:10");
+        assert_eq!(row["remote_vteps"][0], "192.168.0.2");
+        // Absent optionals are omitted, not null.
+        assert!(js["vnis"][1].get("local_vtep").is_none());
+    }
 }
 
 fn show_bgp_rtcv4(


### PR DESCRIPTION
## Summary

`show evpn vni all` has been a grammar-exposed stub since it was added (3730c89c) — it printed the literal string `EVPN output here`, which testers running the EVPN playsets reported as "no response". This implements the real per-VNI inventory from state BGP already holds.

Text view (vtep1 of the `bgp-evpn-vxlan4-multi` playset, live):

```
vtep1>show evpn vni all
Advertise All VNI flag: Enabled
BUM flooding: Head-end replication
Number of L2 VNIs: 2
Number of L3 VNIs: 0
Flags: * - Kernel VXLAN device
  VNI        Type Local VTEP                RD                     Import/Export RT  #MACs(loc)  #MACs(rem) #Remote VTEPs  Tenant VRF
* 10         L2   192.168.0.1               192.168.0.1:10         65001:10                   2           2             1  default
* 20         L2   192.168.1.1               192.168.0.1:20         65001:20                   2           2             1  default
```

A VNI known only from remote IMET state (no local VXLAN device) renders un-flagged with `-` for the local VTEP, so a missing kernel device is visible at a glance. `-j` emits the same view as JSON through one shared collection pass.

## Details

* Rows union every VNI source: kernel VXLAN devices (`local_vxlans`), configured MPLS EVIs (`evpn_evis`), VRF symmetric-IRB L3VNIs (Type = L3, Tenant VRF = the VRF name, same predicate as the Type-5 origination path), and per-VNI remote Type-3 flood state.
* RD/RT columns show what is actually advertised: the auto-derived Type-1 RD (`router-id:vni`, RFC 8365 §5.1.2, `-` when the router-id is unset or the VNI exceeds 16 bits) and the `as:vni` route target (ASN truncated to 16 bits exactly as `evpn_route_target` encodes it).
* Local MACs count the kernel FDB shadow (`local_fdb`); remote MACs count selected non-originated Type-2 paths, deduplicated by MAC and bucketed by the same service field (`macip_service_field`: NLRI label, else RT-derived VNI) the import path uses; remote VTEPs come from a new `EvpnFloodState::remote_vteps` accessor (raw membership — IR/AR remotes plus SR P2MP tree roots, no AR collapse or prune filtering).
* BUM flooding header reflects the configured mechanism: head-end replication, the RFC 9574 AR role, or an SR P2MP replication tree.

## Testing

* Unit tests for the table renderer (flags, remote-only rows, L3 tenant column, empty view) and the JSON shape (omitted optionals).
* `cargo test --workspace --exclude bdd` — all suites pass; workspace clippy clean.
* Live on `playset/bgp-evpn-vxlan4-multi`: outputs above from vtep1/vtep2/vtep3; a namespace without BGP answers `BGP is not configured or running`; topology tore down clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)