### PR TITLE
fib: read kernel IFA_F_SECONDARY into interface address state

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -3035,20 +3035,16 @@ impl FibHandle {
         Ok(())
     }
 
-    pub async fn addr_add_ipv4(
-        &self,
-        ifindex: u32,
-        prefix: &Ipv4Net,
-        secondary: bool,
-    ) -> anyhow::Result<()> {
+    /// Add an IPv4 address via `RTM_NEWADDR`. No `IFA_F_SECONDARY` is
+    /// ever requested: the kernel clears the userspace flag and
+    /// recomputes it itself (secondary iff same mask+subnet as an
+    /// existing primary), so the flag is read back, never written.
+    pub async fn addr_add_ipv4(&self, ifindex: u32, prefix: &Ipv4Net) -> anyhow::Result<()> {
         let mut msg = AddressMessage::default();
         msg.header.family = AddressFamily::Inet;
         msg.header.prefix_len = prefix.prefix_len();
         msg.header.index = ifindex;
         msg.header.scope = AddressScope::Universe;
-        if secondary {
-            msg.header.flags = AddressHeaderFlags::Secondary;
-        }
         let attr = AddressAttribute::Local(IpAddr::V4(prefix.addr()));
         msg.attributes.push(attr);
 
@@ -3090,20 +3086,15 @@ impl FibHandle {
         }
     }
 
-    pub async fn addr_add_ipv6(
-        &self,
-        ifindex: u32,
-        prefix: &Ipv6Net,
-        secondary: bool,
-    ) -> anyhow::Result<()> {
+    /// Add an IPv6 address via `RTM_NEWADDR`. Never sets header flag
+    /// bit 0x01: on IPv6 it is `IFA_F_TEMPORARY` (privacy address),
+    /// not "secondary" — IPv6 has no secondary concept.
+    pub async fn addr_add_ipv6(&self, ifindex: u32, prefix: &Ipv6Net) -> anyhow::Result<()> {
         let mut msg = AddressMessage::default();
         msg.header.family = AddressFamily::Inet6;
         msg.header.prefix_len = prefix.prefix_len();
         msg.header.index = ifindex;
         msg.header.scope = AddressScope::Universe;
-        if secondary {
-            msg.header.flags = AddressHeaderFlags::Secondary;
-        }
         let attr = AddressAttribute::Local(IpAddr::V6(prefix.addr()));
         msg.attributes.push(attr);
 
@@ -4075,6 +4066,12 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
 pub fn addr_from_msg(msg: AddressMessage) -> FibAddr {
     let mut os_addr = FibAddr::new();
     os_addr.link_index = msg.header.index;
+    // IFA_F_SECONDARY is kernel-computed for IPv4: the kernel sets it
+    // when an address shares mask+subnet with an existing primary on
+    // the device. The same bit on an IPv6 address is IFA_F_TEMPORARY
+    // (a privacy address), so it must not map to `secondary`.
+    os_addr.secondary = msg.header.family == AddressFamily::Inet
+        && msg.header.flags.contains(AddressHeaderFlags::Secondary);
     for attr in msg.attributes.into_iter() {
         match attr {
             AddressAttribute::Address(addr) => match addr {
@@ -4491,6 +4488,54 @@ mod tests {
             "RTM_NEWNEXTHOP decode regressed: {:?}",
             parsed.err()
         );
+    }
+
+    fn addr_msg(family: AddressFamily, flags: AddressHeaderFlags, addr: IpAddr) -> AddressMessage {
+        let mut msg = AddressMessage::default();
+        msg.header.family = family;
+        msg.header.prefix_len = 24;
+        msg.header.index = 3;
+        msg.header.flags = flags;
+        msg.attributes.push(AddressAttribute::Address(addr));
+        msg
+    }
+
+    #[test]
+    fn addr_from_msg_reads_v4_secondary_flag() {
+        use std::net::Ipv4Addr;
+        let msg = addr_msg(
+            AddressFamily::Inet,
+            AddressHeaderFlags::Secondary,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        );
+        let addr = addr_from_msg(msg);
+        assert!(addr.secondary);
+        assert_eq!(addr.link_index, 3);
+        assert_eq!(addr.addr.to_string(), "10.0.0.2/24");
+    }
+
+    #[test]
+    fn addr_from_msg_v4_primary_is_not_secondary() {
+        use std::net::Ipv4Addr;
+        let msg = addr_msg(
+            AddressFamily::Inet,
+            AddressHeaderFlags::empty(),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        );
+        assert!(!addr_from_msg(msg).secondary);
+    }
+
+    #[test]
+    fn addr_from_msg_v6_temporary_bit_is_not_secondary() {
+        // On IPv6 the 0x01 header flag is IFA_F_TEMPORARY (a privacy
+        // address), not "secondary" — it must never map to the flag.
+        use std::net::Ipv6Addr;
+        let msg = addr_msg(
+            AddressFamily::Inet6,
+            AddressHeaderFlags::Secondary,
+            IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+        );
+        assert!(!addr_from_msg(msg).secondary);
     }
 
     #[test]

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -1137,7 +1137,7 @@ pub async fn link_config_exec(
                     }
                 }
 
-                let result = rib.fib_handle.addr_add_ipv4(ifindex, &v4addr, false).await;
+                let result = rib.fib_handle.addr_add_ipv4(ifindex, &v4addr).await;
                 match result {
                     Ok(_) => {
                         let addr = FibAddr {
@@ -1215,7 +1215,7 @@ pub async fn link_config_exec(
                         }
                     }
                 }
-                let result = rib.fib_handle.addr_add_ipv6(ifindex, &v6addr, false).await;
+                let result = rib.fib_handle.addr_add_ipv6(ifindex, &v6addr).await;
                 match result {
                     Ok(_) => {
                         let addr = FibAddr {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -108,7 +108,7 @@ impl Rib {
                         net
                     );
                 }
-                if let Err(e) = self.fib_handle.addr_add_ipv4(ifindex, net, false).await {
+                if let Err(e) = self.fib_handle.addr_add_ipv4(ifindex, net).await {
                     tracing::warn!(
                         "addr_reinstall: {} failed to re-install IPv4 {}: {}",
                         link_name,
@@ -125,7 +125,7 @@ impl Rib {
                         net
                     );
                 }
-                if let Err(e) = self.fib_handle.addr_add_ipv6(ifindex, net, false).await {
+                if let Err(e) = self.fib_handle.addr_add_ipv6(ifindex, net).await {
                     tracing::warn!(
                         "addr_reinstall: {} failed to re-install IPv6 {}: {}",
                         link_name,


### PR DESCRIPTION
## Summary

PR 1 of the multiple-IPv4-address-per-interface series.

The Linux kernel computes `IFA_F_SECONDARY` itself — an IPv4 address is secondary iff it shares mask+subnet with an existing primary on the device (`__inet_insert_ifa()` clears any userspace-supplied flag and recomputes). zebra-rs never read the flag back: `addr_from_msg()` ignored the netlink header flags, so `LinkAddr.secondary` was always `false` and the `secondary` annotation in `show interface` (text and JSON both already render it) could never appear.

* `addr_from_msg()`: parse `IFA_F_SECONDARY` from `RTM_NEWADDR` header flags, **IPv4 only** — on IPv6 the same bit is `IFA_F_TEMPORARY` (privacy address), which must not map to `secondary`.
* Drop the `secondary` parameter from `addr_add_ipv4()` / `addr_add_ipv6()`: all callers passed `false`; writing the flag is a no-op for IPv4 and would mean "temporary" on IPv6. The flag is read back, never written.

## Testing

* 3 new unit tests for `addr_from_msg` (v4 secondary set, v4 primary, v6 temporary bit must not map).
* Full workspace suite: 2668 passed, 0 failed. Clippy clean.
* Live netns check: `10.0.0.1/24`, `10.0.0.2/24`, `10.1.0.1/24` on one dummy interface — `show interface` renders primary/secondary/primary in text and JSON, matching `ip -4 addr show` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)