### PR TITLE
rib: refcount connected routes across same-prefix addresses

### DIFF
--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -1592,7 +1592,7 @@ mod tests {
         // different subnet does not; the address itself never counts.
         assert!(prefix_covered_by_other(&[a.clone(), b.clone()], &a));
         assert!(!prefix_covered_by_other(&[a.clone(), other_net], &a));
-        assert!(!prefix_covered_by_other(&[a.clone()], &a));
+        assert!(!prefix_covered_by_other(std::slice::from_ref(&a), &a));
 
         // A sibling the kernel no longer holds (fib=false recovery
         // candidate) does not keep the connected route alive.

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -417,26 +417,45 @@ pub fn link_show(rib: &Rib, mut args: Args, json: bool) -> String {
     buf
 }
 
+/// Outcome of merging an incoming LinkAddr into a link's address list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddrUpdate {
+    /// The address was not present and has been inserted.
+    Added,
+    /// The address was present and the incoming flags flipped `config` or
+    /// `fib` true — a config push landing on an already-known kernel
+    /// address, or the kernel confirming a config-driven (re-)install.
+    Merged,
+    /// The address was present and nothing changed (kernel re-notify).
+    Unchanged,
+}
+
 /// Insert a LinkAddr or merge it into an existing entry with the same address.
 ///
-/// Returns `Some(())` if the address was newly inserted, `None` if a matching
-/// entry already existed. In the merge case, the existing entry's `config`
-/// and `fib` flags are OR-ed with the incoming flags — this lets the kernel's
-/// netlink confirmation of a config-driven address flip `fib` true on the
-/// already-present LinkAddr without creating a duplicate.
-pub fn link_addr_update(link: &mut Link, addr: LinkAddr) -> Option<()> {
+/// In the merge case, the existing entry's `config` and `fib` flags are
+/// OR-ed with the incoming flags — this lets the kernel's netlink
+/// confirmation of a config-driven address flip `fib` true on the
+/// already-present LinkAddr without creating a duplicate. The returned
+/// [`AddrUpdate`] tells the caller whether anything actually changed, so
+/// redundant kernel notifications aren't re-broadcast to protocol clients.
+pub fn link_addr_update(link: &mut Link, addr: LinkAddr) -> AddrUpdate {
     let bucket = if addr.is_v4() {
         &mut link.addr4
     } else {
         &mut link.addr6
     };
     if let Some(existing) = bucket.iter_mut().find(|a| a.addr == addr.addr) {
+        let changed = (addr.config && !existing.config) || (addr.fib && !existing.fib);
         existing.config |= addr.config;
         existing.fib |= addr.fib;
-        return None;
+        return if changed {
+            AddrUpdate::Merged
+        } else {
+            AddrUpdate::Unchanged
+        };
     }
     bucket.push(addr);
-    Some(())
+    AddrUpdate::Added
 }
 
 /// Handle a kernel-side address removal, branching on `config`:
@@ -446,9 +465,10 @@ pub fn link_addr_update(link: &mut Link, addr: LinkAddr) -> Option<()> {
 ///   intent survives so `link_up` can re-install it later.
 /// - If the existing entry was kernel-only (`config = false`), remove it.
 ///
-/// Returns `Some(())` if a matching entry was found and processed, `None`
-/// otherwise. Callers do not currently differentiate the two branches via
-/// the return value.
+/// Returns `Some(())` only when the call changed state. A missing entry, or
+/// a configured entry whose `fib` flag is already false (a repeated DelAddr
+/// notification), returns `None` so callers don't tear down connected
+/// routes or re-broadcast the removal for an address we no longer hold.
 pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
     let bucket = if addr.is_v4() {
         &mut link.addr4
@@ -457,11 +477,27 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
     };
     let pos = bucket.iter().position(|x| x.addr == addr.addr)?;
     if bucket[pos].config {
+        if !bucket[pos].fib {
+            return None;
+        }
         bucket[pos].fib = false;
     } else {
         bucket.remove(pos);
     }
     Some(())
+}
+
+/// True when another kernel-installed address in `bucket` shares `addr`'s
+/// connected prefix. Mirrors the kernel's own prefix-route refcount
+/// (`cleanup_prefix_route`): the connected route for a prefix is installed
+/// with its first covering address and withdrawn with its last, so adding
+/// or deleting an address while a sibling still covers the prefix must not
+/// touch the route.
+fn prefix_covered_by_other(bucket: &[LinkAddr], addr: &LinkAddr) -> bool {
+    let prefix = addr.addr.apply_mask();
+    bucket
+        .iter()
+        .any(|e| e.fib && e.addr != addr.addr && e.addr.apply_mask() == prefix)
 }
 
 impl Rib {
@@ -985,75 +1021,89 @@ impl Rib {
             addr.config = true;
         }
         if let Some(link) = self.links.get_mut(&addr.ifindex) {
-            let was_addr_added = link_addr_update(link, addr.clone()).is_some();
+            let update = link_addr_update(link, addr.clone());
 
-            // If address was successfully added and the interface is up and running,
-            // create a connected route
-            if was_addr_added && link.is_up() {
-                match addr.addr {
-                    IpNet::V4(v4_addr) => {
-                        let prefix = v4_addr.apply_mask();
-                        // println!("Connected: {:?} - adding to RIB (interface up)", prefix);
-                        let mut rib = RibEntry::new(RibType::Connected);
-                        rib.ifindex = addr.ifindex;
-                        rib.set_valid(true);
-                        let msg = Message::Ipv4Add { prefix, rib };
-                        let _ = self.tx.send(msg);
-                    }
-                    IpNet::V6(v6_addr) => {
-                        let prefix = v6_addr.apply_mask();
-                        // println!(
-                        //     "Connected IPv6: {:?} - adding to RIB (interface up)",
-                        //     prefix
-                        // );
-                        let mut rib = RibEntry::new(RibType::Connected);
-                        rib.ifindex = addr.ifindex;
-                        rib.set_valid(true);
-                        let msg = Message::Ipv6Add { prefix, rib };
-                        let _ = self.tx.send(msg);
+            // Install the connected route only for the first address that
+            // covers the prefix — a sibling address in the same subnet
+            // already brought the route up (kernel prefix-route refcount
+            // semantics). The interface must be up; link_up replays the
+            // connected routes for addresses learned while it was down.
+            if update == AddrUpdate::Added && link.is_up() {
+                let bucket = if addr.is_v4() {
+                    &link.addr4
+                } else {
+                    &link.addr6
+                };
+                if !prefix_covered_by_other(bucket, &addr) {
+                    match addr.addr {
+                        IpNet::V4(v4_addr) => {
+                            let prefix = v4_addr.apply_mask();
+                            let mut rib = RibEntry::new(RibType::Connected);
+                            rib.ifindex = addr.ifindex;
+                            rib.set_valid(true);
+                            let msg = Message::Ipv4Add { prefix, rib };
+                            let _ = self.tx.send(msg);
+                        }
+                        IpNet::V6(v6_addr) => {
+                            let prefix = v6_addr.apply_mask();
+                            let mut rib = RibEntry::new(RibType::Connected);
+                            rib.ifindex = addr.ifindex;
+                            rib.set_valid(true);
+                            let msg = Message::Ipv6Add { prefix, rib };
+                            let _ = self.tx.send(msg);
+                        }
                     }
                 }
             }
-            self.api_addr_add(&addr);
+            // Don't re-broadcast a notification that changed nothing (the
+            // kernel echoing an address we already hold) — consumers that
+            // count events rather than addresses would drift.
+            if update != AddrUpdate::Unchanged {
+                self.api_addr_add(&addr);
+            }
         }
     }
 
     pub fn addr_del(&mut self, osaddr: FibAddr) {
         let addr = LinkAddr::from(osaddr);
         if let Some(link) = self.links.get_mut(&addr.ifindex) {
-            // TODO: When the deleted address is configured address, we remove
-            // installed flag from the address so that when interface goes up we
-            // can reinstall the address again.
+            // Ignore a DelAddr for an address we don't hold — the kernel's
+            // echo of a config-driven delete, or a repeated notification.
+            // Acting on it would tear down the connected route and
+            // re-broadcast the removal to every protocol client.
+            if link_addr_del(link, addr.clone()).is_none() {
+                return;
+            }
 
-            // Before removing the address, create connected route removal message if interface is up
+            // Withdraw the connected route only when the last address
+            // covering the prefix went away — a remaining sibling in the
+            // same subnet keeps the route alive (kernel prefix-route
+            // refcount semantics).
             if link.is_up() {
-                match addr.addr {
-                    IpNet::V4(v4_addr) => {
-                        let prefix = v4_addr.apply_mask();
-                        // println!(
-                        //     "Connected: {:?} - removing from RIB (address deleted)",
-                        //     prefix
-                        // );
-                        let mut rib = RibEntry::new(RibType::Connected);
-                        rib.ifindex = addr.ifindex;
-                        let msg = Message::Ipv4Del { prefix, rib };
-                        let _ = self.tx.send(msg);
-                    }
-                    IpNet::V6(v6_addr) => {
-                        let prefix = v6_addr.apply_mask();
-                        // println!(
-                        //     "Connected IPv6: {:?} - removing from RIB (address deleted)",
-                        //     prefix
-                        // );
-                        let mut rib = RibEntry::new(RibType::Connected);
-                        rib.ifindex = addr.ifindex;
-                        let msg = Message::Ipv6Del { prefix, rib };
-                        let _ = self.tx.send(msg);
+                let bucket = if addr.is_v4() {
+                    &link.addr4
+                } else {
+                    &link.addr6
+                };
+                if !prefix_covered_by_other(bucket, &addr) {
+                    match addr.addr {
+                        IpNet::V4(v4_addr) => {
+                            let prefix = v4_addr.apply_mask();
+                            let mut rib = RibEntry::new(RibType::Connected);
+                            rib.ifindex = addr.ifindex;
+                            let msg = Message::Ipv4Del { prefix, rib };
+                            let _ = self.tx.send(msg);
+                        }
+                        IpNet::V6(v6_addr) => {
+                            let prefix = v6_addr.apply_mask();
+                            let mut rib = RibEntry::new(RibType::Connected);
+                            rib.ifindex = addr.ifindex;
+                            let msg = Message::Ipv6Del { prefix, rib };
+                            let _ = self.tx.send(msg);
+                        }
                     }
                 }
             }
-
-            link_addr_del(link, addr.clone());
 
             self.api_addr_del(&addr);
         }
@@ -1469,13 +1519,12 @@ mod tests {
 
         // Test adding a new address
         let result = link_addr_update(&mut link, addr.clone());
-        assert!(result.is_some(), "Adding new address should succeed");
+        assert_eq!(result, AddrUpdate::Added);
         assert_eq!(link.addr4.len(), 1, "Link should have 1 IPv4 address");
 
-        // Test adding duplicate address — link_addr_update returns None and
-        // does not duplicate the entry.
+        // A duplicate add changes nothing and does not duplicate the entry.
         let result = link_addr_update(&mut link, addr);
-        assert!(result.is_none(), "Duplicate add should not insert");
+        assert_eq!(result, AddrUpdate::Unchanged);
         assert_eq!(link.addr4.len(), 1, "Link should still have 1 IPv4 address");
     }
 
@@ -1490,10 +1539,15 @@ mod tests {
         // Kernel netlink confirmation arrives — should flip fib true on the
         // existing entry, not create a duplicate.
         let kernel = test_addr_v4(Ipv4Addr::new(10, 0, 0, 1), 24, false, true);
-        let result = link_addr_update(&mut link, kernel);
-        assert!(result.is_none(), "Merge case returns None");
+        let result = link_addr_update(&mut link, kernel.clone());
+        assert_eq!(result, AddrUpdate::Merged, "flag flip reports Merged");
         assert_eq!(link.addr4.len(), 1);
         assert!(link.addr4[0].config && link.addr4[0].fib);
+
+        // A second identical kernel notification changes nothing.
+        let result = link_addr_update(&mut link, kernel);
+        assert_eq!(result, AddrUpdate::Unchanged);
+        assert_eq!(link.addr4.len(), 1);
     }
 
     #[test]
@@ -1505,11 +1559,57 @@ mod tests {
         );
         // Kernel removed the address (e.g. interface down + IPv6 flush style).
         let kernel_del = test_addr_v4(Ipv4Addr::new(10, 0, 0, 1), 24, false, true);
-        let result = link_addr_del(&mut link, kernel_del);
+        let result = link_addr_del(&mut link, kernel_del.clone());
         assert!(result.is_some());
         assert_eq!(link.addr4.len(), 1, "config=true entry kept");
         assert!(link.addr4[0].config);
         assert!(!link.addr4[0].fib, "fib flipped to false");
+
+        // A repeated DelAddr for the same kept entry changes nothing and
+        // must report None so callers don't re-broadcast the removal.
+        let result = link_addr_del(&mut link, kernel_del);
+        assert!(result.is_none(), "repeated delete is a no-op");
+        assert_eq!(link.addr4.len(), 1);
+    }
+
+    fn test_addr_v6(addr: &str, config: bool, fib: bool) -> LinkAddr {
+        LinkAddr {
+            addr: addr.parse().unwrap(),
+            ifindex: 1,
+            secondary: false,
+            config,
+            fib,
+        }
+    }
+
+    #[test]
+    fn test_prefix_covered_by_other_v4() {
+        let a = test_addr_v4(Ipv4Addr::new(192, 168, 1, 1), 24, false, true);
+        let b = test_addr_v4(Ipv4Addr::new(192, 168, 1, 2), 24, false, true);
+        let other_net = test_addr_v4(Ipv4Addr::new(10, 0, 0, 1), 24, false, true);
+
+        // A sibling in the same subnet covers the prefix; an address in a
+        // different subnet does not; the address itself never counts.
+        assert!(prefix_covered_by_other(&[a.clone(), b.clone()], &a));
+        assert!(!prefix_covered_by_other(&[a.clone(), other_net], &a));
+        assert!(!prefix_covered_by_other(&[a.clone()], &a));
+
+        // A sibling the kernel no longer holds (fib=false recovery
+        // candidate) does not keep the connected route alive.
+        let mut b_gone = b;
+        b_gone.fib = false;
+        b_gone.config = true;
+        assert!(!prefix_covered_by_other(&[a.clone(), b_gone], &a));
+    }
+
+    #[test]
+    fn test_prefix_covered_by_other_v6() {
+        let a = test_addr_v6("2001:db8:1::1/64", false, true);
+        let b = test_addr_v6("2001:db8:1::2/64", false, true);
+        let other_net = test_addr_v6("2001:db8:2::1/64", false, true);
+
+        assert!(prefix_covered_by_other(&[a.clone(), b], &a));
+        assert!(!prefix_covered_by_other(&[a.clone(), other_net], &a));
     }
 
     #[test]

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -2177,13 +2177,18 @@ fn rib_replace_system(
     prefix: &Ipv4Net,
     entry: RibEntry,
 ) -> Vec<RibEntry> {
-    // println!("rib_replace_system {}", prefix);
     let entries = table.entry(*prefix).or_default();
-    let index = rib_rtype(entries, entry.rtype);
+    let index = if entry.is_connected() {
+        // Connected entries are keyed by (type, ifindex) — mirror
+        // rib_add_system, so a shared-prefix entry on another interface
+        // is neither examined nor evicted here.
+        rib_rtype_ifindex(entries, entry.rtype, entry.ifindex)
+    } else {
+        rib_rtype(entries, entry.rtype)
+    };
     let Some(index) = index else {
         return vec![];
     };
-    // println!("index {}", index);
     let e = entries.get_mut(index).unwrap();
     let replace = match &mut e.nexthop {
         Nexthop::Uni(uni) => uni.metric == entry.metric,
@@ -2208,9 +2213,12 @@ fn rib_replace_system(
         Nexthop::Protect(_) => false,
         Nexthop::Blackhole(m) => *m == entry.metric,
     };
-    // println!("replace {}", replace);
     if replace {
-        return rib_replace(table, prefix, entry.rtype);
+        return if entry.is_connected() {
+            rib_replace_connected(table, prefix, entry.rtype, entry.ifindex)
+        } else {
+            rib_replace(table, prefix, entry.rtype)
+        };
     }
     vec![]
 }
@@ -2224,6 +2232,25 @@ fn rib_replace(
         return vec![];
     };
     let (remain, replace): (Vec<_>, Vec<_>) = entries.drain(..).partition(|x| x.rtype != rtype);
+    *entries = remain;
+    replace
+}
+
+/// Remove only the connected entry belonging to `ifindex`. Two interfaces
+/// can each hold a Connected entry for the same prefix, and deleting an
+/// address on one must not evict the other's.
+fn rib_replace_connected(
+    table: &mut PrefixMap<Ipv4Net, RibEntries>,
+    prefix: &Ipv4Net,
+    rtype: RibType,
+    ifindex: u32,
+) -> Vec<RibEntry> {
+    let Some(entries) = table.get_mut(prefix) else {
+        return vec![];
+    };
+    let (remain, replace): (Vec<_>, Vec<_>) = entries
+        .drain(..)
+        .partition(|x| !(x.rtype == rtype && x.ifindex == ifindex));
     *entries = remain;
     replace
 }
@@ -2452,7 +2479,14 @@ fn rib_replace_system_v6(
     entry: RibEntry,
 ) -> Vec<RibEntry> {
     let entries = table.entry(*prefix).or_default();
-    let index = rib_rtype(entries, entry.rtype);
+    let index = if entry.is_connected() {
+        // Connected entries are keyed by (type, ifindex) — mirror
+        // rib_add_system_v6, so a shared-prefix entry on another
+        // interface is neither examined nor evicted here.
+        rib_rtype_ifindex(entries, entry.rtype, entry.ifindex)
+    } else {
+        rib_rtype(entries, entry.rtype)
+    };
     let Some(index) = index else {
         return vec![];
     };
@@ -2481,9 +2515,32 @@ fn rib_replace_system_v6(
         Nexthop::Blackhole(m) => *m == entry.metric,
     };
     if replace {
-        return rib_replace_v6(table, prefix, entry.rtype);
+        return if entry.is_connected() {
+            rib_replace_connected_v6(table, prefix, entry.rtype, entry.ifindex)
+        } else {
+            rib_replace_v6(table, prefix, entry.rtype)
+        };
     }
     vec![]
+}
+
+/// Remove only the connected entry belonging to `ifindex`. Two interfaces
+/// can each hold a Connected entry for the same prefix, and deleting an
+/// address on one must not evict the other's.
+fn rib_replace_connected_v6(
+    table: &mut PrefixMap<Ipv6Net, RibEntries>,
+    prefix: &Ipv6Net,
+    rtype: RibType,
+    ifindex: u32,
+) -> Vec<RibEntry> {
+    let Some(entries) = table.get_mut(prefix) else {
+        return vec![];
+    };
+    let (remain, replace): (Vec<_>, Vec<_>) = entries
+        .drain(..)
+        .partition(|x| !(x.rtype == rtype && x.ifindex == ifindex));
+    *entries = remain;
+    replace
 }
 
 fn rib_replace_v6(
@@ -2873,6 +2930,68 @@ mod tests {
         a.distance = 50;
         b.distance = 50;
         assert_eq!(ilm_next(&[a, b]), Some(1));
+    }
+
+    fn connected_entry(ifindex: u32) -> super::RibEntry {
+        use crate::rib::RibType;
+        let mut e = super::RibEntry::new(RibType::Connected);
+        e.ifindex = ifindex;
+        e.set_valid(true);
+        e
+    }
+
+    #[test]
+    fn replace_system_connected_is_ifindex_scoped_v4() {
+        use super::{rib_add_system, rib_replace_system};
+        use crate::rib::entry::RibEntries;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        // Two interfaces hold a Connected entry for the same prefix.
+        let mut table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
+        rib_add_system(&mut table, &prefix, connected_entry(1));
+        rib_add_system(&mut table, &prefix, connected_entry(2));
+        assert_eq!(table.get(&prefix).unwrap().len(), 2);
+
+        // Deleting interface 2's connected route must evict only its
+        // entry, not interface 1's.
+        let removed = rib_replace_system(&mut table, &prefix, connected_entry(2));
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].ifindex, 2);
+        let remain = table.get(&prefix).unwrap();
+        assert_eq!(remain.len(), 1);
+        assert_eq!(remain[0].ifindex, 1);
+
+        // A delete keyed to an interface with no entry is a no-op.
+        let removed = rib_replace_system(&mut table, &prefix, connected_entry(7));
+        assert!(removed.is_empty());
+        assert_eq!(table.get(&prefix).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn replace_system_connected_is_ifindex_scoped_v6() {
+        use super::{rib_add_system_v6, rib_replace_system_v6};
+        use crate::rib::entry::RibEntries;
+        use ipnet::Ipv6Net;
+        use prefix_trie::PrefixMap;
+
+        let mut table: PrefixMap<Ipv6Net, RibEntries> = PrefixMap::new();
+        let prefix: Ipv6Net = "2001:db8:1::/64".parse().unwrap();
+        rib_add_system_v6(&mut table, &prefix, connected_entry(1));
+        rib_add_system_v6(&mut table, &prefix, connected_entry(2));
+        assert_eq!(table.get(&prefix).unwrap().len(), 2);
+
+        let removed = rib_replace_system_v6(&mut table, &prefix, connected_entry(2));
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].ifindex, 2);
+        let remain = table.get(&prefix).unwrap();
+        assert_eq!(remain.len(), 1);
+        assert_eq!(remain[0].ifindex, 1);
+
+        let removed = rib_replace_system_v6(&mut table, &prefix, connected_entry(7));
+        assert!(removed.is_empty());
+        assert_eq!(table.get(&prefix).unwrap().len(), 1);
     }
 
     #[test]

--- a/zebra-rs/src/rib/util.rs
+++ b/zebra-rs/src/rib/util.rs
@@ -1,6 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use ipnet::{Ipv4Net, Ipv6Net};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 
 pub trait IpAddrExt<T> {
     fn to_host_prefix(&self) -> T;
@@ -31,5 +31,14 @@ impl IpNetExt<Ipv4Net> for Ipv4Net {
 impl IpNetExt<Ipv6Net> for Ipv6Net {
     fn apply_mask(&self) -> Ipv6Net {
         Ipv6Net::new(self.network(), self.prefix_len()).unwrap()
+    }
+}
+
+impl IpNetExt<IpNet> for IpNet {
+    fn apply_mask(&self) -> IpNet {
+        match self {
+            IpNet::V4(v4) => IpNet::V4(v4.apply_mask()),
+            IpNet::V6(v6) => IpNet::V6(v6.apply_mask()),
+        }
     }
 }


### PR DESCRIPTION
## Summary

First PR of the multiple-IPv6-address-per-interface series (shared groundwork with the parallel IPv4 secondary-address work).

The kernel keeps **one prefix route per connected prefix** and removes it only when the *last* address covering that prefix goes away (`cleanup_prefix_route`). zebra-rs emitted a connected route add/del per address event, so with two addresses in one subnet — routine for IPv6, where SLAAC plus a configured address share a /64 — deleting one address tore down the connected route (and its redistribution to BGP etc.) while the other address still held the prefix.

### Changes

- **Last-cover refcount at the emission site** (`rib/link.rs`): `addr_add` installs the connected route only for the first kernel-held address covering the prefix; `addr_del` withdraws it only when the last one goes. `prefix_covered_by_other` mirrors the kernel semantics, ignoring `fib=false` recovery candidates.
- **Spurious-delete guard**: `addr_del` previously acted on addresses it didn't hold (kernel echo of a config-driven delete, repeated DelAddr) — tearing down the connected route and re-broadcasting `AddrDel` to every protocol client, which double-decrements event-counting consumers (BGP `ConnectedSubnets`). It now bails out unless the delete changed state; `link_addr_del` reports a repeated delete of a config-kept entry as a no-op.
- **Duplicate-add guard**: `link_addr_update` now returns `Added` / `Merged` / `Unchanged`, and `addr_add` broadcasts `AddrAdd` only on a state change. A link-bounce reinstall (fib flag flipping true) still notifies; a pure kernel re-notify no longer does.
- **Ifindex-scoped connected replace** (`rib/route.rs`): `rib_replace_system{,_v6}` looked up connected entries by type only and evicted *every* connected entry for the prefix, so two interfaces sharing a prefix could drop or strand each other's entry. Lookup and eviction are now keyed by (type, ifindex), mirroring `rib_add_system{,_v6}`.

## Test plan

- New unit tests: `prefix_covered_by_other` v4+v6 (sibling coverage, fib=false exclusion), `link_addr_update` Added/Merged/Unchanged transitions, repeated `link_addr_del` no-op, and ifindex-scoped `rib_replace_system{,_v6}` eviction with a shared prefix on two interfaces.
- `cargo test --workspace --exclude bdd`: all suites pass.
- `cargo clippy --workspace --all-targets`: clean; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)