### PR TITLE
playset: add Tear down section to bgp-evpn-vxlan4 README

### DIFF
--- a/playset/bgp-evpn-vxlan4/README.md
+++ b/playset/bgp-evpn-vxlan4/README.md
@@ -223,6 +223,12 @@ You can see all of it with `bridge -d link show dev vxlan10`,
 `bridge vlan tunnelshow`, and `ip -d link show vxlan10` inside the VTEP's
 vty shell.
 
+## Tear down
+
+``` shell
+$ ./down.sh
+```
+
 ## Appendix: Addresses
 
 | node  | role | underlay      | overlay        |


### PR DESCRIPTION
## Summary

The other three EVPN playset READMEs (`bgp-evpn-vxlan6`, `bgp-evpn-vxlan4-multi`, `bgp-evpn-vxlan6-multi`) end their walkthrough with a **Tear down** section pointing at `./down.sh`; the base IPv4 lab was the only one missing it. This adds the same section in the same place (before the address appendix).

Found during a full README-vs-live-output verification of all four EVPN playsets (every documented command was re-run live; this was one of only two genuine documentation gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)