### PR TITLE
rib: learn VLAN sub-interface parent and VLAN id from netlink

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7530,6 +7530,8 @@ mod neighbor_group_wiring_tests {
             vrf_table: None,
             bridge: false,
             vxlan_local: None,
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         };
         bgp.process_rib_msg(crate::rib::api::RibRx::LinkAdd(link));
@@ -9042,6 +9044,8 @@ mod es_linkadd_resync_tests {
             vrf_table: None,
             bridge: false,
             vxlan_local: None,
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         };
         bgp.process_rib_msg(crate::rib::api::RibRx::LinkAdd(link));

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -56,6 +56,15 @@ pub struct FibLink {
     /// bridge ⇒ L2 port in the bridge's flood domain, VRF ⇒ routed port
     /// in that table.
     pub bridge: bool,
+    /// Lower-device ifindex from `IFLA_LINK` — set on stacked devices
+    /// such as 802.1Q VLAN sub-interfaces, where it is the interface
+    /// the VLAN rides on. None for top-level links.
+    pub parent: Option<u32>,
+    /// 802.1Q VLAN id from `IFLA_VLAN_ID`
+    /// (`LinkInfo::Data(InfoData::Vlan(InfoVlan::Id(_)))`). Presence is
+    /// what marks the link as a VLAN sub-interface — the name is never
+    /// parsed; `eth0.100` is only a convention.
+    pub vlan_id: Option<u16>,
 }
 
 impl FibLink {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -12,7 +12,7 @@ use netlink_packet_route::address::{
 };
 use netlink_packet_route::link::{
     AfSpecInet6, AfSpecUnspec, InfoBridgePort, InfoData, InfoKind, InfoPortData, InfoPortKind,
-    InfoVrf, InfoVxlan, LinkAttribute, LinkFlags, LinkInfo, LinkLayerType, LinkMessage,
+    InfoVlan, InfoVrf, InfoVxlan, LinkAttribute, LinkFlags, LinkInfo, LinkLayerType, LinkMessage,
 };
 use netlink_packet_route::neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage};
 use netlink_packet_route::nexthop::{NexthopAttribute, NexthopFlags, NexthopGroup, NexthopMessage};
@@ -4028,13 +4028,20 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
                 // slave-of-VRF membership.
                 link.master = Some(idx);
             }
+            LinkAttribute::Link(idx) => {
+                // `IFLA_LINK` — the lower device of a stacked link
+                // (the parent of a VLAN sub-interface). Distinct from
+                // `IFLA_MASTER` above, which is enslavement.
+                link.parent = Some(idx);
+            }
             LinkAttribute::LinkInfo(infos) => {
                 // VXLAN link data carries both the VNI (`IFLA_VXLAN_ID`)
                 // and the local VTEP source IP (`IFLA_VXLAN_LOCAL` or
                 // `IFLA_VXLAN_LOCAL6`); VRF master devices carry their
-                // kernel routing table (`IFLA_VRF_TABLE`). Walk every
-                // sub-attr and capture them. Other link types
-                // contribute nothing.
+                // kernel routing table (`IFLA_VRF_TABLE`); VLAN
+                // sub-interfaces carry their 802.1Q id
+                // (`IFLA_VLAN_ID`). Walk every sub-attr and capture
+                // them. Other link types contribute nothing.
                 for info in infos {
                     if let LinkInfo::Data(InfoData::Vxlan(vxlan_attrs)) = info {
                         for v in vxlan_attrs {
@@ -4058,6 +4065,12 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
                         for v in vrf_attrs {
                             if let InfoVrf::TableId(t) = v {
                                 link.vrf_table = Some(t);
+                            }
+                        }
+                    } else if let LinkInfo::Data(InfoData::Vlan(vlan_attrs)) = info {
+                        for v in vlan_attrs {
+                            if let InfoVlan::Id(id) = v {
+                                link.vlan_id = Some(id);
                             }
                         }
                     } else if let LinkInfo::Kind(InfoKind::Bridge) = info {
@@ -4558,5 +4571,36 @@ mod tests {
             })
             .expect("RTA_TABLE attribute emitted");
         assert_eq!(table_attr, 1000);
+    }
+
+    #[test]
+    fn link_from_msg_parses_vlan_sub_interface() {
+        let mut msg = LinkMessage::default();
+        msg.attributes
+            .push(LinkAttribute::IfName("eth0.100".into()));
+        msg.attributes.push(LinkAttribute::Link(2));
+        msg.attributes.push(LinkAttribute::LinkInfo(vec![
+            LinkInfo::Kind(InfoKind::Vlan),
+            LinkInfo::Data(InfoData::Vlan(vec![InfoVlan::Id(100)])),
+        ]));
+        let link = link_from_msg(msg);
+        assert_eq!(link.name, "eth0.100");
+        assert_eq!(link.parent, Some(2), "IFLA_LINK parent ifindex");
+        assert_eq!(link.vlan_id, Some(100), "IFLA_VLAN_ID");
+        assert!(!link.bridge);
+    }
+
+    #[test]
+    fn link_from_msg_without_linkinfo_leaves_vlan_fields_unset() {
+        // A partial RTM_NEWLINK (e.g. an enslave notification) carries
+        // no IFLA_LINKINFO; the parser must report absence, letting the
+        // RIB's adopt-if-present update keep the previously learned
+        // values instead of clearing them.
+        let mut msg = LinkMessage::default();
+        msg.attributes
+            .push(LinkAttribute::IfName("eth0.100".into()));
+        let link = link_from_msg(msg);
+        assert_eq!(link.parent, None);
+        assert_eq!(link.vlan_id, None);
     }
 }

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -473,6 +473,8 @@ mod tests {
             vrf_table: None,
             bridge: false,
             vxlan_local: None,
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         }
     }

--- a/zebra-rs/src/nd/show.rs
+++ b/zebra-rs/src/nd/show.rs
@@ -659,6 +659,8 @@ mod tests {
             vrf_table: None,
             bridge: false,
             vxlan_local: None,
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         }
     }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -70,6 +70,16 @@ pub struct Link {
     /// bridge ⇒ L2 port in the bridge's flood domain, VRF ⇒ routed port.
     #[serde(skip)]
     pub bridge: bool,
+    /// Lower-device ifindex from `IFLA_LINK` on stacked devices — for
+    /// an 802.1Q sub-interface, the interface the VLAN rides on. None
+    /// for top-level links. Not the same as `master` (enslavement).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<u32>,
+    /// 802.1Q VLAN id from `IFLA_VLAN_ID` on VLAN sub-interfaces.
+    /// Presence is what classifies the link as a VLAN device — the
+    /// name is never parsed; `eth0.100` is only a convention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_id: Option<u16>,
     /// Last failure reason from applying the operator-configured MTU
     /// (`mtu_config` keyed by name on `Rib`). `None` once a set
     /// succeeds. Rendered by `show interface` so a kernel rejection
@@ -99,6 +109,8 @@ impl Link {
             vxlan_local: link.vxlan_local,
             vrf_table: link.vrf_table,
             bridge: link.bridge,
+            parent: link.parent,
+            vlan_id: link.vlan_id,
             mtu_error: None,
         }
     }
@@ -185,6 +197,17 @@ fn link_info_show(rib: &Rib, link: &Link, buf: &mut String, cb: &impl Fn(&String
     if let Some(err) = &link.mtu_error {
         writeln!(buf, "  {}", err).unwrap();
     }
+    if let Some(vid) = link.vlan_id {
+        write!(buf, "  VLAN id {}", vid).unwrap();
+        if let Some(parent) = link.parent {
+            match rib.links.get(&parent) {
+                Some(p) => writeln!(buf, " parent {} (index {})", p.name, parent).unwrap(),
+                None => writeln!(buf, " parent index {}", parent).unwrap(),
+            }
+        } else {
+            writeln!(buf).unwrap();
+        }
+    }
     write!(
         buf,
         "  Link is {}",
@@ -235,6 +258,12 @@ pub struct InterfaceDetailed {
     pub mtu_error: Option<String>,
     pub link_status: String,
     pub flags: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_id: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_index: Option<u32>,
     pub vrf_binding: String,
     pub label_switching: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -366,6 +395,12 @@ fn link_to_detailed_json(rib: &Rib, link: &Link) -> InterfaceDetailed {
             "Down".to_string()
         },
         flags: format!("{}", link.flags),
+        vlan_id: link.vlan_id,
+        parent: link
+            .parent
+            .and_then(|p| rib.links.get(&p))
+            .map(|p| p.name.clone()),
+        parent_index: link.parent,
         vrf_binding: link_vrf_name(rib, link)
             .map(|n| format!("vrf {}", n))
             .unwrap_or_else(|| "Not bound".to_string()),
@@ -597,6 +632,18 @@ impl Rib {
             // FDB resolution gets the right bridge.
             link.master = fib_link.master;
             link.vni = fib_link.vni;
+            // Parent ifindex / VLAN id: adopt-if-present, never clear.
+            // A partial RTM_NEWLINK (e.g. the enslave notification, see
+            // the VXLAN refill comment above) omits `IFLA_LINKINFO`
+            // entirely, and the kernel never changes either value on a
+            // live link, so a missing attribute means "unchanged", not
+            // "gone".
+            if fib_link.parent.is_some() {
+                link.parent = fib_link.parent;
+            }
+            if fib_link.vlan_id.is_some() {
+                link.vlan_id = fib_link.vlan_id;
+            }
             // Adopt the kernel's current MTU (it may have changed since
             // we last saw this link — our own `link_set_mtu` echoes back
             // here, as does an external `ip link set`). The fan-out to
@@ -1448,6 +1495,8 @@ mod tests {
             vrf_table: None,
             bridge: false,
             vxlan_local: None,
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         }
     }
@@ -1623,6 +1672,8 @@ mod l2_port_evi_tests {
             vxlan_local: None,
             vrf_table: None,
             bridge: master.is_none(),
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         }
     }

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -157,6 +157,8 @@ mod tests {
             vrf_table: None,
             bridge: false,
             vxlan_local: None,
+            parent: None,
+            vlan_id: None,
             mtu_error: None,
         }
     }


### PR DESCRIPTION
## Summary

First PR of the VLAN sub-interface feature: the netlink **read side**. zebra-rs now learns 802.1Q VLAN sub-interfaces from the kernel:

- `link_from_msg` parses `IFLA_LINK` (lower-device/parent ifindex of a stacked link) and `IFLA_VLAN_ID` (from the nested `IFLA_LINKINFO` vlan data) into new `FibLink`/`Link` fields `parent` and `vlan_id`.
- `show interface` (text and JSON) renders them: `VLAN id 100 parent eth0 (index 2)` / `"vlan_id": 100, "parent": "eth0", "parent_index": 2`. The line is only emitted for VLAN links, so existing show output is unchanged for other device kinds.
- Classification is attribute-based only — the interface name is never parsed (`eth0.100` is just a convention). Same principle as FRR's zebra, which keys off `IFLA_INFO_KIND == "vlan"`.
- On existing-link updates the two fields are **adopt-if-present, never cleared**: partial RTM_NEWLINK messages (e.g. the enslave notification) omit `IFLA_LINKINFO` entirely, and the kernel never changes parent or vid on a live link — the same hazard the VXLAN VNI refill already guards against.

Follow-up PR will add config-driven create/delete: a top-level `vlan` list (`set vlan eth0.100 interface eth0` + mandatory `vlan-id`) mirroring the bridge/vxlan/vrf builders, with pending-parent replay and adopt-on-restart.

## Testing

- Two new unit tests: VLAN attribute parsing, and absence-of-linkinfo leaving the fields unset (guards the adopt-if-present contract).
- Full workspace suite (`--exclude bdd`) passes: 1839 zebra-rs tests.
- Verified live in a netns (dummy parent + `ip link add ... type vlan`): startup dump and hot-add both show id/parent, the id survives an MTU-change RTM_NEWLINK, kernel deletion removes the interface, JSON fields present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)