### PR TITLE
config: make interface ipv6 address a leaf-list

### DIFF
--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -1224,47 +1224,56 @@ pub async fn link_config_exec(
             }
         }
     } else if path == "/interface/ipv6/address" {
-        let v6addr = args.v6net().context(IPV6_ADDR_ERR)?;
+        // `address` is a leaf-list: one callback can carry several
+        // addresses (config-file load, multi-value commit), so drain the
+        // args deque and apply each value independently — reading a
+        // single value would silently drop the rest.
+        let first = args.v6net().context(IPV6_ADDR_ERR)?;
+        let mut v6addrs = vec![first];
+        while let Some(more) = args.v6net() {
+            v6addrs.push(more);
+        }
+
+        let Some(ifindex) = link_lookup(rib, ifname.to_string()) else {
+            println!("Interface {} not found", ifname);
+            return Ok(());
+        };
 
         if op.is_set() {
-            // Validate against ::0 address
-            if v6addr.addr().is_unspecified() {
-                println!("Cannot configure ::0 as interface address");
-                return Ok(());
-            }
-
-            // Validate against zero prefix length
-            if v6addr.prefix_len() == 0 {
-                println!("Cannot configure address with zero prefix length");
-                return Ok(());
-            }
-
-            // Validate against loopback address on non-loopback interfaces
-            if v6addr.addr().is_loopback()
-                && let Some(ifindex) = link_lookup(rib, ifname.to_string())
-                && let Some(link) = rib.links.get(&ifindex)
-                && !link.is_loopback()
-            {
-                println!("Cannot configure loopback address on non-loopback interface");
-                return Ok(());
-            }
-
-            // Check if IPv6 address is already configured on the link
-            if let Some(ifindex) = link_lookup(rib, ifname.to_string()) {
-                if let Some(link) = rib.links.get(&ifindex) {
-                    // Check if this IPv6 address already exists on the interface
-                    for existing_addr in &link.addr6 {
-                        if let IpNet::V6(existing_v6) = existing_addr.addr
-                            && existing_v6 == v6addr
-                        {
-                            // println!(
-                            //     "IPv6 address {} is already configured on interface {}",
-                            //     v6addr, ifname
-                            // );
-                            return Ok(());
-                        }
-                    }
+            for v6addr in v6addrs {
+                // Validate against ::0 address
+                if v6addr.addr().is_unspecified() {
+                    println!("Cannot configure ::0 as interface address");
+                    continue;
                 }
+
+                // Validate against zero prefix length
+                if v6addr.prefix_len() == 0 {
+                    println!("Cannot configure address with zero prefix length");
+                    continue;
+                }
+
+                // Validate against loopback address on non-loopback interfaces
+                if v6addr.addr().is_loopback()
+                    && rib
+                        .links
+                        .get(&ifindex)
+                        .is_some_and(|link| !link.is_loopback())
+                {
+                    println!("Cannot configure loopback address on non-loopback interface");
+                    continue;
+                }
+
+                // Skip an address already present on the link (config replay
+                // or kernel echo already delivered it).
+                if rib
+                    .links
+                    .get(&ifindex)
+                    .is_some_and(|link| link.addr6.iter().any(|a| a.addr == IpNet::V6(v6addr)))
+                {
+                    continue;
+                }
+
                 let result = rib.fib_handle.addr_add_ipv6(ifindex, &v6addr).await;
                 match result {
                     Ok(_) => {
@@ -1279,12 +1288,9 @@ pub async fn link_config_exec(
                         println!("IPv6 address add failure");
                     }
                 }
-            } else {
-                println!("Interface {} not found", ifname);
             }
         } else {
-            // Handle IPv6 address deletion
-            if let Some(ifindex) = link_lookup(rib, ifname.to_string()) {
+            for v6addr in v6addrs {
                 // Clear `config` on the existing LinkAddr so the kernel's
                 // subsequent DelAddr notification removes the entry instead
                 // of keeping it as a recovery candidate.
@@ -1301,8 +1307,6 @@ pub async fn link_config_exec(
                     secondary: false,
                 };
                 rib.addr_del(addr);
-            } else {
-                println!("Interface {} not found", ifname);
             }
         }
     } else if path == "/interface/vrf" {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4891,9 +4891,15 @@ module config {
       }
       container ipv6 {
         ext:help "IPv6 configuration";
-        leaf address {
+        leaf-list address {
           ext:help "IPv6 interface address";
           type inet:ipv6-prefix;
+          description
+            "IPv6 addresses assigned to the interface. Unlike IPv4,
+             IPv6 interfaces routinely hold several addresses (a
+             link-local plus one or more globals); each entry is
+             installed to the kernel independently and removing one
+             leaves the others in place.";
         }
       }
     }


### PR DESCRIPTION
## Summary

PR 2 of the multiple-IPv6-address-per-interface series (follows #2169).

`interface <name> ipv6 address` was a single YANG `leaf`, so only one IPv6 address per interface was expressible: a second `set` silently replaced the first, and the commit diff deleted the old address from the kernel. IPv6 interfaces routinely hold several addresses (link-local + globals), so this models the node as a `leaf-list`.

### Changes

- **YANG**: `container ipv6 { leaf address }` → `leaf-list address` (`config.yang`), with a description documenting the per-entry install/remove semantics. IPv4 intentionally keeps its single leaf — the parallel secondary-address branch mirrors this with its own kernel-semantics constraints.
- **Handler** (`rib/link.rs` config exec): drain every value from the args deque instead of reading one — a leaf-list callback can carry all values in one call (config-file load, multi-value commit), and a single read would silently drop the rest. Per-value validation (`::`, zero prefix-len, loopback) now `continue`s to the next value instead of aborting the whole batch.

## Test plan

Live-verified against a root debug daemon on a dummy interface:

- `set interface zzz0 ipv6 address <addr>` twice → both addresses coexist in running-config and the kernel (previously the second overwrote the first).
- YAML apply with a 3-address array (two sharing one /64) → all three installed; running-config renders the multi-value block.
- `delete ... address <one value>` → exactly that address removed.
- Config replace 3 addresses → 1 → per-value deletes issued, only the kept address remains.
- Single-scalar YAML `address: <prefix>` (the shape every existing BDD config uses) still applies — backward compatible.
- With two addresses in one /64, removing one keeps the connected `/64` route (exercises #2169 live).

`cargo test --workspace --exclude bdd` passes; workspace clippy clean; fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)