### PR TITLE
mcp(vtyctl): document 2026-07-28 protocol support

### DIFF
--- a/book/src/ch-13-00-mcp-server.md
+++ b/book/src/ch-13-00-mcp-server.md
@@ -41,6 +41,23 @@ to any MCP client and your assistant can reach the router straight away:
 }
 ```
 
+## Current protocol, older clients welcome
+
+The server speaks the stateless [MCP 2026-07-28
+revision](https://modelcontextprotocol.io/specification/2026-07-28) and stays
+compatible with earlier handshake-based clients, following the spec's dual-era
+rules:
+
+- **Modern clients** declare their protocol version on every request (and may
+  probe with `server/discover` first); requests are served statelessly, and
+  `tools/list` results carry cache hints so the client need not refetch them.
+- **Legacy clients** negotiate `2025-06-18` or `2024-11-05` through the classic
+  `initialize` handshake, unchanged.
+
+Either way the transport is stdio: the server runs as a local subprocess of
+your MCP client, so the daemon sees your own OS identity — no tokens, no
+network listener.
+
 This is what *AI native* means for a routing stack: the network is no longer a
 black box your tools poke at from the outside — it is a first-class participant
 in the conversation.

--- a/docs/design/mcp-server-auth-plan.md
+++ b/docs/design/mcp-server-auth-plan.md
@@ -82,8 +82,8 @@ Two invariants:
 
 ## 3. Tool surface (read + write)
 
-Today the server exposes a single tool, `get-isis-graph` (read-only,
-backed by `Show`). For read+write it becomes a small generic set, each
+Phase 0 landed the read-only set (`list-show-commands`, `show`, and the
+kept `get-isis-graph`). For read+write it becomes a small generic set, each
 tagged with a required role the server enforces *and* the daemon
 re-checks:
 
@@ -192,6 +192,22 @@ touched.
 
 ## Status
 
+- **2026-07-30** — **Protocol upgraded to MCP 2026-07-28 (PRs #2170,
+  #2177).** The server is now "dual-era" per the spec's versioning rules:
+  a request carrying `_meta` `io.modelcontextprotocol/protocolVersion` is
+  served under the stateless 2026-07-28 revision (mandatory
+  `server/discover`, per-request version enforcement with `-32022`,
+  `resultType`/`serverInfo` stamping on every result, `ttlMs`/`cacheScope`
+  on list results), while `initialize`-handshake clients negotiate
+  `2025-06-18` or `2024-11-05` unchanged. `2025-03-26` is deliberately
+  unsupported: it is the only revision requiring JSON-RPC batching, which
+  the newline-delimited server does not accept. None of this changes the
+  auth story — identity remains `SO_PEERCRED`, and the 2026-07-28
+  authorization framework is HTTP-only (the spec directs stdio servers to
+  take credentials from the environment instead). **Phase 1 note:**
+  2026-07-28 deprecates server-initiated elicitation; if the write tools
+  want a confirm-before-apply interaction, the Multi Round-Trip Request
+  pattern (`resultType: "input_required"`) is the native replacement.
 - **2026-06-27** — **Scope reduced to stdio only; HTTP transport and
   OAuth 2.1 dropped.** This removes the entire trusted-asserter /
   asserted-identity design (former decisions D27–D31), the OAuth 2.1


### PR DESCRIPTION
## Summary

PR 3 of 3 in the MCP 2026-07-28 upgrade series (follows #2170 and #2177) — documentation only.

- **`book/src/ch-13-00-mcp-server.md`**: new "Current protocol, older clients welcome" section explaining the dual-era support — stateless 2026-07-28 with `server/discover` and cacheable `tools/list`, plus unchanged `initialize`-handshake support for `2025-06-18`/`2024-11-05` clients — and reiterating the stdio/OS-identity model.
- **`docs/design/mcp-server-auth-plan.md`**: status entry recording the protocol upgrade (PRs #2170/#2177), the deliberate non-support of `2025-03-26` (only revision requiring JSON-RPC batching), the note that the 2026-07-28 auth framework is HTTP-only so the `SO_PEERCRED` story is unchanged, and a Phase 1 pointer that MRTR (`resultType: "input_required"`) is the native replacement for the now-deprecated elicitation if write tools want confirm-before-apply. Also fixes the stale "single tool" sentence in §3 to reflect the Phase 0 read-only set.

CHANGELOG.yaml is intentionally untouched — entries are added by the release-time `version: bump` commit, so the MCP notes belong in the next 26.7.9 bump.

## Testing

- `mdbook build` succeeds on the edited chapter.
- No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)