### PR TITLE
ospf: primary-address discipline for multi-address interfaces

### DIFF
--- a/zebra-rs/src/ospf/addr.rs
+++ b/zebra-rs/src/ospf/addr.rs
@@ -7,11 +7,19 @@ use super::OspfVersion;
 #[derive(Debug, Clone)]
 pub struct OspfAddr<V: OspfVersion> {
     pub prefix: V::Prefix,
+    /// Kernel IFA_F_SECONDARY: a same-subnet duplicate of an existing
+    /// primary. Never the interface identity, never advertised as its
+    /// own Router-LSA link (its subnet is already covered by the
+    /// primary). Always false for v3 — IPv6 has no secondary concept.
+    pub secondary: bool,
 }
 
 impl<V: OspfVersion> OspfAddr<V> {
-    pub fn from(_addr: &LinkAddr, prefix: &V::Prefix) -> Self {
-        Self { prefix: *prefix }
+    pub fn from(addr: &LinkAddr, prefix: &V::Prefix) -> Self {
+        Self {
+            prefix: *prefix,
+            secondary: addr.secondary,
+        }
     }
 }
 
@@ -22,12 +30,36 @@ where
     fn default() -> Self {
         Self {
             prefix: V::Prefix::default(),
+            secondary: false,
         }
     }
 }
 
-/// Append `addr` to a link's address list only when no entry with the
-/// same prefix exists; returns whether it pushed.
+/// First address passing `pred` that is not kernel-secondary, falling
+/// back to the first passing one at all. Selection sites (identity,
+/// Hello netmask, Network-LSA ls_id, BFD, SR host prefix) go through
+/// this so a same-subnet secondary never becomes "the" interface
+/// address, matching Cisco/FRR — while a transient all-secondary list
+/// still yields a usable address.
+pub fn primary_addr_where<V: OspfVersion>(
+    addrs: &[OspfAddr<V>],
+    pred: impl Fn(&OspfAddr<V>) -> bool + Copy,
+) -> Option<&OspfAddr<V>> {
+    addrs
+        .iter()
+        .find(|a| !a.secondary && pred(a))
+        .or_else(|| addrs.iter().find(|a| pred(a)))
+}
+
+/// [`primary_addr_where`] with no extra predicate: the first
+/// non-secondary address, else the first address.
+pub fn primary_addr<V: OspfVersion>(addrs: &[OspfAddr<V>]) -> Option<&OspfAddr<V>> {
+    primary_addr_where(addrs, |_| true)
+}
+
+/// Insert `addr` into a link's address list, or update the existing
+/// same-prefix entry's `secondary` flag; returns whether anything
+/// changed.
 ///
 /// The RIB redistributes every AddrAdd *event*, not every address —
 /// one configured address arrives several times (config-exec push,
@@ -35,13 +67,17 @@ where
 /// consumers must be idempotent (IS-IS guards the same way in
 /// `isis::link::addr_add`). Without this, every duplicate delivery
 /// adds another copy of the prefix to the Router-LSA stub networks
-/// (v2) / Intra-Area-Prefix-LSA (v3).
+/// (v2) / Intra-Area-Prefix-LSA (v3). A re-delivery whose `secondary`
+/// verdict moved (kernel promotion/demotion) updates the entry in
+/// place.
 pub fn link_addr_push_unique<V: OspfVersion>(
     addrs: &mut Vec<OspfAddr<V>>,
     addr: OspfAddr<V>,
 ) -> bool {
-    if addrs.iter().any(|a| a.prefix == addr.prefix) {
-        return false;
+    if let Some(existing) = addrs.iter_mut().find(|a| a.prefix == addr.prefix) {
+        let changed = existing.secondary != addr.secondary;
+        existing.secondary = addr.secondary;
+        return changed;
     }
     addrs.push(addr);
     true
@@ -58,17 +94,91 @@ mod tests {
         let lo: ipnet::Ipv6Net = "2001:db8::1/128".parse().unwrap();
         let transit: ipnet::Ipv6Net = "2001:db8:1::1/64".parse().unwrap();
 
-        assert!(link_addr_push_unique(&mut addrs, OspfAddr { prefix: lo }));
+        assert!(link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: lo,
+                secondary: false
+            }
+        ));
         // Same prefix delivered again (kernel echo / DAD re-notify) —
         // must not grow the list.
-        assert!(!link_addr_push_unique(&mut addrs, OspfAddr { prefix: lo }));
+        assert!(!link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: lo,
+                secondary: false
+            }
+        ));
         assert_eq!(addrs.len(), 1);
 
         assert!(link_addr_push_unique(
             &mut addrs,
-            OspfAddr { prefix: transit }
+            OspfAddr {
+                prefix: transit,
+                secondary: false
+            }
         ));
         assert_eq!(addrs.len(), 2);
+    }
+
+    #[test]
+    fn primary_addr_skips_secondary() {
+        let p1: ipnet::Ipv4Net = "10.0.0.1/24".parse().unwrap();
+        let p2: ipnet::Ipv4Net = "10.0.0.2/24".parse().unwrap();
+        let addrs: Vec<OspfAddr<Ospfv2>> = vec![
+            OspfAddr {
+                prefix: p2,
+                secondary: true,
+            },
+            OspfAddr {
+                prefix: p1,
+                secondary: false,
+            },
+        ];
+        // The secondary is first in delivery order but must not win.
+        assert_eq!(primary_addr(&addrs).unwrap().prefix, p1);
+
+        // All-secondary (transient, e.g. primary deleted externally):
+        // fall back to the first address rather than none.
+        let only_sec: Vec<OspfAddr<Ospfv2>> = vec![OspfAddr {
+            prefix: p2,
+            secondary: true,
+        }];
+        assert_eq!(primary_addr(&only_sec).unwrap().prefix, p2);
+        assert!(primary_addr::<Ospfv2>(&[]).is_none());
+    }
+
+    #[test]
+    fn push_unique_updates_secondary_verdict() {
+        let p: ipnet::Ipv4Net = "10.0.0.2/24".parse().unwrap();
+        let mut addrs: Vec<OspfAddr<Ospfv2>> = Vec::new();
+        assert!(link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: p,
+                secondary: true
+            }
+        ));
+        // Promotion re-broadcast: same prefix, verdict now primary —
+        // updates in place and reports a change.
+        assert!(link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: p,
+                secondary: false
+            }
+        ));
+        assert_eq!(addrs.len(), 1);
+        assert!(!addrs[0].secondary);
+        // Identical re-delivery: no change.
+        assert!(!link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: p,
+                secondary: false
+            }
+        ));
     }
 
     #[test]
@@ -76,8 +186,20 @@ mod tests {
         let mut addrs: Vec<OspfAddr<Ospfv2>> = Vec::new();
         let p: ipnet::Ipv4Net = "10.0.0.1/24".parse().unwrap();
 
-        assert!(link_addr_push_unique(&mut addrs, OspfAddr { prefix: p }));
-        assert!(!link_addr_push_unique(&mut addrs, OspfAddr { prefix: p }));
+        assert!(link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: p,
+                secondary: false
+            }
+        ));
+        assert!(!link_addr_push_unique(
+            &mut addrs,
+            OspfAddr {
+                prefix: p,
+                secondary: false
+            }
+        ));
         assert_eq!(addrs.len(), 1);
     }
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1962,6 +1962,11 @@ impl Ospf<Ospfv2> {
                     if addr.prefix.addr().octets()[0] == 127 {
                         continue;
                     }
+                    // A kernel-secondary shares the primary's subnet;
+                    // its P2p/Stub links would be byte-duplicates.
+                    if addr.secondary {
+                        continue;
+                    }
                     for nbr in link.nbrs.values() {
                         if nbr.state != NfsmState::Full {
                             continue;
@@ -1990,6 +1995,14 @@ impl Ospf<Ospfv2> {
             for addr in &link.addr {
                 // Skip loopback addresses (127.0.0.0/8).
                 if addr.prefix.addr().octets()[0] == 127 {
+                    continue;
+                }
+                // Skip kernel-secondary addresses: the primary already
+                // contributes the Transit link (RFC 2328 has one per
+                // interface) or the Stub for the shared subnet — a
+                // secondary would emit a duplicate with only
+                // `link_data` differing.
+                if addr.secondary {
                     continue;
                 }
                 let lsa_link = if use_transit {
@@ -2325,7 +2338,7 @@ impl Ospf<Ospfv2> {
                         let local_addr = self
                             .links
                             .get(&nh.ifindex)
-                            .and_then(|l| l.addr.first())
+                            .and_then(|l| super::addr::primary_addr(&l.addr))
                             .map(|a| a.prefix.addr())?;
                         Some(Viable {
                             cost: path.cost,
@@ -2373,13 +2386,17 @@ impl Ospf<Ospfv2> {
                     || vl.first_hop_addr != v.first_hop_addr
                     || vl.first_hop_ifindex != v.first_hop_ifindex
                     || link.output_cost != v.cost
-                    || link.addr.first().map(|a| a.prefix.addr()) != Some(v.local_addr)
+                    || super::addr::primary_addr(&link.addr).map(|a| a.prefix.addr())
+                        != Some(v.local_addr)
                 {
                     vl.peer_addr = v.peer_addr;
                     vl.first_hop_addr = v.first_hop_addr;
                     vl.first_hop_ifindex = v.first_hop_ifindex;
                     link.output_cost = v.cost;
-                    link.addr = vec![super::addr::OspfAddr { prefix }];
+                    link.addr = vec![super::addr::OspfAddr {
+                        prefix,
+                        secondary: false,
+                    }];
                     link.ident.prefix = prefix;
                     changed = true;
                     ospf_fsm_trace!(
@@ -2411,7 +2428,10 @@ impl Ospf<Ospfv2> {
                 Self::vl_apply_config(&mut link, cfg);
                 let prefix = Ipv4Net::new(v.local_addr, 32).unwrap();
                 link.output_cost = v.cost;
-                link.addr = vec![super::addr::OspfAddr { prefix }];
+                link.addr = vec![super::addr::OspfAddr {
+                    prefix,
+                    secondary: false,
+                }];
                 link.ident.prefix = prefix;
                 {
                     let vl = link.vl.as_mut().unwrap();
@@ -3020,7 +3040,8 @@ impl Ospf<Ospfv2> {
             && let Some(link) = self.links.get(&ifindex)
             && link.enabled
             && link.nbrs.values().any(|n| n.state == NfsmState::Full)
-            && let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback())
+            && let Some(addr) =
+                super::addr::primary_addr_where(&link.addr, |a| !a.prefix.addr().is_loopback())
         {
             let our_addr = addr.prefix.addr();
             // Per-link ASLA carrying this link's flex-algo affinity
@@ -3159,7 +3180,9 @@ impl Ospf<Ospfv2> {
         if should_originate {
             let link = link.unwrap();
             // Use the first non-loopback address as a /32 host prefix.
-            let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback()) else {
+            let Some(addr) =
+                super::addr::primary_addr_where(&link.addr, |a| !a.prefix.addr().is_loopback())
+            else {
                 return;
             };
             let prefix = ipnet::Ipv4Net::new(addr.prefix.addr(), 32).unwrap_or(addr.prefix);
@@ -4598,7 +4621,7 @@ impl Ospf<Ospfv2> {
                 return;
             }
 
-            let Some(primary_addr) = link.addr.first() else {
+            let Some(primary_addr) = super::addr::primary_addr(&link.addr) else {
                 return;
             };
 
@@ -4693,7 +4716,7 @@ impl Ospf<Ospfv2> {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
-        let Some(primary_addr) = link.addr.first() else {
+        let Some(primary_addr) = super::addr::primary_addr(&link.addr) else {
             return;
         };
         let ls_id = primary_addr.prefix.addr();
@@ -5405,7 +5428,7 @@ impl Ospf<Ospfv2> {
         let Some(link) = self.links.get(&ifindex) else {
             return false;
         };
-        let Some(addr) = link.addr.first() else {
+        let Some(addr) = super::addr::primary_addr(&link.addr) else {
             return false;
         };
         let if_addr = addr.prefix.addr();
@@ -5936,7 +5959,12 @@ impl Ospf<Ospfv2> {
         // Router-LSA repeats the stub network once per delivery.
         let ospf_addr = OspfAddr::from(&addr, prefix);
         super::addr::link_addr_push_unique(&mut link.addr, ospf_addr);
-        link.ident.prefix = *prefix;
+        // Identity follows the primary (first non-secondary) address:
+        // a last-delivered secondary must not steal the DR-election
+        // identity, and a promotion re-broadcast moves it back.
+        if let Some(primary) = super::addr::primary_addr(&link.addr) {
+            link.ident.prefix = primary.prefix;
+        }
 
         // If this address made an enabled-but-Down interface usable,
         // re-fire `InterfaceUp` so the FSM can progress past the
@@ -5972,6 +6000,15 @@ impl Ospf<Ospfv2> {
             return;
         };
         link.addr.retain(|a| a.prefix != *prefix);
+
+        // Repair the identity: it may have pointed at the removed
+        // address (historically it tracked the last-delivered one and
+        // was never cleaned up on delete). With no address left, the
+        // stale value is harmless — the IFSM refuses to run on an
+        // empty list and the next addr_add recomputes it.
+        if let Some(primary) = super::addr::primary_addr(&link.addr) {
+            link.ident.prefix = primary.prefix;
+        }
 
         // Re-evaluate enable state after address removal.
         let (next, next_id) = super::config::link_should_enable(link);
@@ -15841,7 +15878,8 @@ fn add_self_prefix_sids_to_ilm(top: &Ospf, ilm: &mut BTreeMap<u32, SpfIlm>) {
                 let Some(link) = self_link_by_prefix(top, area_id, tlv.prefix) else {
                     continue;
                 };
-                let Some(addr) = link.addr.first().map(|a| a.prefix.addr()) else {
+                let Some(addr) = super::addr::primary_addr(&link.addr).map(|a| a.prefix.addr())
+                else {
                     continue;
                 };
                 for sub in &tlv.subs {

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -283,7 +283,7 @@ pub fn ospf_hello_packet(
     chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Option<Ospfv2Packet> {
-    let addr = oi.addr.first()?;
+    let addr = crate::ospf::addr::primary_addr(&oi.addr)?;
     let mut hello = OspfHello {
         netmask: addr.prefix.netmask(),
         hello_interval: oi.hello_interval(),
@@ -352,7 +352,7 @@ pub fn ospf_hello_recv(
     src: &Ipv4Addr,
     tracing: &OspfTracing,
 ) {
-    let Some(addr) = oi.addr.first() else {
+    let Some(addr) = crate::ospf::addr::primary_addr(&oi.addr) else {
         return;
     };
 

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -447,7 +447,7 @@ impl OspfVersion for Ospfv2 {
         addrs: &[crate::ospf::addr::OspfAddr<Ospfv2>],
         nbr: &crate::ospf::Neighbor<Ospfv2>,
     ) -> Option<(std::net::IpAddr, std::net::IpAddr)> {
-        let local = addrs.first()?.prefix.addr();
+        let local = crate::ospf::addr::primary_addr(addrs)?.prefix.addr();
         let remote = nbr.ident.prefix.addr();
         Some((std::net::IpAddr::V4(local), std::net::IpAddr::V4(remote)))
     }
@@ -680,6 +680,7 @@ mod bfd_tests {
         let nbr = v2_neighbor("10.0.0.2/24");
         let local = OspfAddr::<Ospfv2> {
             prefix: Ipv4Net::from_str("10.0.0.1/24").unwrap(),
+            secondary: false,
         };
         assert_eq!(
             Ospfv2::bfd_addrs(&[local], &nbr),
@@ -711,9 +712,11 @@ mod bfd_tests {
         let nbr = v3_neighbor("fe80::2/128");
         let global = OspfAddr::<Ospfv3> {
             prefix: Ipv6Net::from_str("2001:db8::1/64").unwrap(),
+            secondary: false,
         };
         let link_local = OspfAddr::<Ospfv3> {
             prefix: Ipv6Net::from_str("fe80::1/64").unwrap(),
+            secondary: false,
         };
         assert_eq!(
             Ospfv3::bfd_addrs(&[global, link_local], &nbr),
@@ -730,6 +733,7 @@ mod bfd_tests {
         let nbr = v3_neighbor("fe80::2/128");
         let global = OspfAddr::<Ospfv3> {
             prefix: Ipv6Net::from_str("2001:db8::1/64").unwrap(),
+            secondary: false,
         };
         assert_eq!(Ospfv3::bfd_addrs(&[global], &nbr), None);
     }


### PR DESCRIPTION
## Summary

PR 4 of the multiple-IPv4-address series (follows #2168, #2175, #2178).

OSPFv2 kept a list of interface addresses but collapsed identity inconsistently, and the secondary flag never reached it (`OspfAddr::from` discarded the whole `LinkAddr`):

* `ident.prefix` (DR-election identity) was overwritten by every AddrAdd — last-delivered wins — and never repaired on delete, while Hello netmask / Network-LSA ls_id / Grace-LSA / virtual-link / SR Extended-Prefix/Link / BFD all took `addr.first()`. With multiple addresses these could be three different values (the kernel independently picks the actual packet source).
* The Router-LSA walked every address: a kernel-secondary emitted byte-duplicate Stub links, or a second Transit link for the same network on broadcast interfaces.

Changes:

* `OspfAddr` carries the secondary verdict; `link_addr_push_unique` updates it in place on re-delivery (a kernel promotion arrives as a Merged AddrAdd re-broadcast) and reports change.
* A shared `primary_addr`/`primary_addr_where` helper (first non-secondary, falling back to first) now feeds **all** selection sites, and `addr_add`/`addr_del` both recompute `ident.prefix` from it — fixing the last-delivered and stale-after-delete bugs.
* Router-LSA build skips secondaries in both the P2P and broadcast loops.

v3 untouched (IPv6 has no secondary; its `OspfAddr.secondary` is always false).

## Testing

* 3 new unit tests (primary selection incl. all-secondary fallback, verdict upsert, existing dedup preserved).
* Full workspace: 2687 passed, 0 failed. Clippy clean.
* Live netns: with `10.0.0.1/24` + `10.0.0.9/24` (kernel-secondary) + `10.1.0.1/24` on one interface, the self-originated Router-LSA has exactly 2 links (one per subnet) and `show ospf interface` reports the primary; config-deleting the primary promotes `10.0.0.9`, the identity follows, and the link count stays 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)