### PR TITLE
bdd: convert load-margin convergence asserts to polling steps

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1230,6 +1230,75 @@ async fn verify_bgp_route_not(world: &mut World, namespace: String, unexpected_p
     );
 }
 
+/// Poll `show bgp` (JSON) until `prefix` is present (`want_present =
+/// true`) or absent (`want_present = false`). Returns
+/// `(satisfied, last_output)`. Polling siblings of [`verify_bgp_route`] /
+/// [`verify_bgp_route_not`] for convergence-dependent asserts — a fixed
+/// wait plus a bare assert is the c=16 load-margin floor.
+async fn poll_bgp_route_presence(scoped: &str, prefix: &str, want_present: bool) -> (bool, String) {
+    const ATTEMPTS: u32 = 60;
+    let mut last = String::new();
+    for i in 0..ATTEMPTS {
+        last = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show bgp"])
+            .await
+            .expect("Failed to get BGP routes");
+        let present = serde_json::from_str::<Value>(&last)
+            .ok()
+            .and_then(|v| {
+                v.as_array().map(|arr| {
+                    arr.iter()
+                        .any(|route| route.get("prefix").and_then(|p| p.as_str()) == Some(prefix))
+                })
+            })
+            .unwrap_or(false);
+        if present == want_present {
+            return (true, last);
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    (false, last)
+}
+
+#[then(expr = "BGP route in {string} should eventually have {string}")]
+async fn verify_bgp_route_eventually(
+    world: &mut World,
+    namespace: String,
+    expected_prefix: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (ok, last) = poll_bgp_route_presence(&scoped, &expected_prefix, true).await;
+    assert!(
+        ok,
+        "BGP route {} never appeared in namespace {}; last output:\n{}",
+        expected_prefix, scoped, last
+    );
+    println!(
+        "✓ BGP route {} found in namespace {}",
+        expected_prefix, scoped
+    );
+}
+
+#[then(expr = "BGP route in {string} should eventually not have {string}")]
+async fn verify_bgp_route_eventually_not(
+    world: &mut World,
+    namespace: String,
+    unexpected_prefix: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (ok, last) = poll_bgp_route_presence(&scoped, &unexpected_prefix, false).await;
+    assert!(
+        ok,
+        "BGP route {} never left namespace {}; last output:\n{}",
+        unexpected_prefix, scoped, last
+    );
+    println!(
+        "✓ BGP route {} not present in namespace {}",
+        unexpected_prefix, scoped
+    );
+}
+
 #[then(expr = "BGP route in {string} has {string} with {string} value {string}")]
 async fn verify_bgp_route_field(
     world: &mut World,

--- a/bdd/tests/features/bgp_as_path_match.feature
+++ b/bdd/tests/features/bgp_as_path_match.feature
@@ -59,13 +59,17 @@ Feature: BGP match as-path-set with FRR-compatible regular expressions
     And I apply config "z1.yaml" to namespace "z1"
     And I apply config "z2.yaml" to namespace "z2"
     And I apply config "z3-base.yaml" to namespace "z3"
-    And I wait 10 seconds for BGP to operate
-    Then BGP session in "z2" to "192.168.0.1" should be "Established"
-    And BGP session in "z2" to "192.168.0.3" should be "Established"
-    And BGP session in "z3" to "192.168.0.2" should be "Established"
-    And BGP route in "z3" has "10.0.0.1/32"
-    And BGP route in "z3" has "10.0.0.2/32"
+    Then BGP session in "z2" to "192.168.0.1" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.3" should eventually be "Established"
+    And BGP session in "z3" to "192.168.0.2" should eventually be "Established"
+    And BGP route in "z3" should eventually have "10.0.0.1/32"
+    And BGP route in "z3" should eventually have "10.0.0.2/32"
 
+  # The "accepts" scenarios assert the routes SURVIVED re-evaluation.
+  # They are already present from the previous scenario, so a polling
+  # "eventually have" would pass vacuously before the policy even ran —
+  # keep the fixed wait plus the bare assert (which cannot flake: the
+  # routes stay continuously present when the policy accepts them).
   Scenario: exact match accepts the whole AS_PATH anchored with ^ and $
     Given the test topology exists
     When I apply config "z3-exact-pass.yaml" to namespace "z3"
@@ -76,9 +80,8 @@ Feature: BGP match as-path-set with FRR-compatible regular expressions
   Scenario: exact match rejects the same ASNs in the wrong order
     Given the test topology exists
     When I apply config "z3-exact-fail.yaml" to namespace "z3"
-    And I wait 5 seconds for BGP to operate
-    Then BGP route in "z3" does not have "10.0.0.1/32"
-    And BGP route in "z3" does not have "10.0.0.2/32"
+    Then BGP route in "z3" should eventually not have "10.0.0.1/32"
+    And BGP route in "z3" should eventually not have "10.0.0.2/32"
 
   Scenario: _ASN$ accepts routes originated by that AS
     Given the test topology exists
@@ -90,9 +93,8 @@ Feature: BGP match as-path-set with FRR-compatible regular expressions
   Scenario: _ASN$ rejects routes not originated by that AS
     Given the test topology exists
     When I apply config "z3-origin-fail.yaml" to namespace "z3"
-    And I wait 5 seconds for BGP to operate
-    Then BGP route in "z3" does not have "10.0.0.1/32"
-    And BGP route in "z3" does not have "10.0.0.2/32"
+    Then BGP route in "z3" should eventually not have "10.0.0.1/32"
+    And BGP route in "z3" should eventually not have "10.0.0.2/32"
 
   Scenario: ^ASN_ accepts routes whose neighbor (leftmost) AS matches
     Given the test topology exists
@@ -104,9 +106,8 @@ Feature: BGP match as-path-set with FRR-compatible regular expressions
   Scenario: _ASN_ rejects routes that do not transit that AS
     Given the test topology exists
     When I apply config "z3-transit-fail.yaml" to namespace "z3"
-    And I wait 5 seconds for BGP to operate
-    Then BGP route in "z3" does not have "10.0.0.1/32"
-    And BGP route in "z3" does not have "10.0.0.2/32"
+    Then BGP route in "z3" should eventually not have "10.0.0.1/32"
+    And BGP route in "z3" should eventually not have "10.0.0.2/32"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_neighbor_group.feature
+++ b/bdd/tests/features/bgp_neighbor_group.feature
@@ -49,22 +49,19 @@ Feature: BGP neighbor-group inheritance end-to-end
     Given the test topology exists
     When I apply config "z1-1.yaml" to namespace "z1"
     And I apply config "z2-1.yaml" to namespace "z2"
-    And I wait 30 seconds for BGP to operate
-    Then BGP session in "z1" to "192.168.0.2" should be "Established"
-    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually be "Established"
 
   Scenario: Reactive sweep — changing the group's remote-as drops the session
     Given the test topology exists
     When I apply config "z1-2.yaml" to namespace "z1"
-    And I wait 5 seconds for BGP to operate
-    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+    Then BGP session in "z2" to "192.168.0.1" should eventually not be "Established"
 
   Scenario: Reactive sweep — restoring the group's remote-as brings it back
     Given the test topology exists
     When I apply config "z1-1.yaml" to namespace "z1"
-    And I wait 30 seconds for BGP to operate
-    Then BGP session in "z1" to "192.168.0.2" should be "Established"
-    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually be "Established"
 
   Scenario: Inherited ttl-security — group GTSM interoperates with a per-neighbor GTSM far end
     Given the test topology exists
@@ -73,11 +70,16 @@ Feature: BGP neighbor-group inheritance end-to-end
     # ritual as the per-neighbor knob), and GTSM only re-establishes
     # when BOTH ends send TTL 255 — so Established below is proof the
     # group-inherited knob reached z1's socket.
+    #
+    # The session is Established BEFORE the flips, so a bare polling
+    # assert could sample the pre-bounce session and pass vacuously.
+    # The fixed wait outlasts the bounce; the polling assert then
+    # absorbs however long re-establishment takes under load.
     When I apply config "z1-3.yaml" to namespace "z1"
     And I apply config "z2-2.yaml" to namespace "z2"
     And I wait 30 seconds for BGP to operate
-    Then BGP session in "z1" to "192.168.0.2" should be "Established"
-    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "TTL security (GTSM) enabled"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "Neighbor-group: RR"
 


### PR DESCRIPTION
## Summary

`bgp_as_path_match` and `bgp_neighbor_group` are the two remaining c=16 full-suite load-margin regulars (3 and 2 failures across recent full runs, most recently 2026-07-30 on main @ a37c0d65 — 270/272). Both failed the same way: a fixed `I wait N seconds` followed by a bare assert on convergence-dependent state — initial route propagation (`bgp_as_path_match.feature:66`) and session re-establishment (`bgp_neighbor_group.feature:79`). Both pass solo at c=1, so these are test-side timing margins, not daemon bugs.

This applies the same treatment that previously took a full run from 2 failures to 246/246 (49eb9581): convert convergence asserts to 60×1s polling steps that exit immediately in the common case.

## Changes

- **New step definitions** (`bdd/tests/cucumber.rs`): `BGP route in {string} should eventually have {string}` and `... should eventually not have {string}` — polling siblings of the existing bare route asserts, modeled on the existing `BGP session ... should eventually be` steps.
- **`bgp_as_path_match.feature`**: setup-chain session/route asserts and the three "rejects" scenarios now poll (route removal after a policy swap is a genuine convergence event).
- **`bgp_neighbor_group.feature`**: all session-state asserts now poll.

## Deliberately NOT converted (vacuous-pass hazard)

- The three **"accepts" scenarios** in `bgp_as_path_match` assert the routes *survived* policy re-evaluation while already present from the previous scenario — a polling assert would pass instantly on leftover state before the new policy ran. They keep the fixed wait + bare assert (which cannot flake: accepted routes stay continuously present).
- The **GTSM scenario** in `bgp_neighbor_group` bounces an already-Established session; polling alone could sample the pre-bounce session. It keeps its 30s wait to outlast the bounce, with polling absorbing the re-establishment. Both spots carry comments explaining the reasoning.

## Testing

- Both features pass solo at c=1 with every polling step confirmed executed (18 polling assert executions, zero silently-skipped steps).
- No leaked namespaces or daemons after the runs; `cargo fmt --all` and `cargo clippy -p bdd --tests` clean.
- `bdd/docs/` needed no regeneration (docs render only scenario titles, which are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)