### PR TITLE
bdd: raise BFD/IS-IS adjacency poll budgets to the 60s standard

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -2030,9 +2030,10 @@ async fn isis_neighbor_up(scoped: &str, level: u64, interface: &str) -> (bool, S
 /// Assert an IS-IS adjacency at the given level on the given interface is
 /// Up — e.g. the area-independent Level-2 backbone adjacency.
 ///
-/// Polls for up to 30 seconds: after BFD recovers the hold-down pin is cleared
-/// immediately, but the adjacency only promotes Init→Up on the next inbound IIH
-/// (default 3 s interval), so a single-shot check races that window.
+/// Polls for up to 60 seconds (the suite's standard convergence budget): after
+/// BFD recovers the hold-down pin is cleared immediately, but the adjacency
+/// only promotes Init→Up on the next inbound IIH (default 3 s interval), so a
+/// single-shot check races that window.
 #[then(
     expr = "isis neighbor in namespace {string} at level {int} on interface {string} should be up"
 )]
@@ -2043,7 +2044,7 @@ async fn isis_neighbor_should_be_up(
     interface: String,
 ) {
     let scoped = world.ns(&namespace);
-    const ATTEMPTS: u32 = 30;
+    const ATTEMPTS: u32 = 60;
     let mut up = false;
     let mut output = String::new();
     for i in 0..ATTEMPTS {
@@ -2137,13 +2138,14 @@ async fn bfd_session_up(scoped: &str, interface: &str) -> (bool, String) {
     (up, output)
 }
 
-/// Assert a single-hop BFD session on the given interface reaches Up. Polls for
-/// a short window so the step tolerates the session's negotiation / detection
-/// latency without the feature needing a hard-coded long wait.
+/// Assert a single-hop BFD session on the given interface reaches Up. Polls
+/// for up to 60 seconds (the suite's standard convergence budget) so the step
+/// tolerates the session's negotiation / detection latency without the
+/// feature needing a hard-coded long wait.
 #[then(expr = "bfd session in namespace {string} on interface {string} should be up")]
 async fn bfd_session_should_be_up(world: &mut World, namespace: String, interface: String) {
     let scoped = world.ns(&namespace);
-    const ATTEMPTS: u32 = 20;
+    const ATTEMPTS: u32 = 60;
     let mut up = false;
     let mut output = String::new();
     for i in 0..ATTEMPTS {
@@ -2173,7 +2175,7 @@ async fn bfd_session_should_be_up(world: &mut World, namespace: String, interfac
 #[then(expr = "bfd session in namespace {string} on interface {string} should be down")]
 async fn bfd_session_should_be_down(world: &mut World, namespace: String, interface: String) {
     let scoped = world.ns(&namespace);
-    const ATTEMPTS: u32 = 20;
+    const ATTEMPTS: u32 = 60;
     let mut up = true;
     let mut output = String::new();
     for i in 0..ATTEMPTS {
@@ -2213,7 +2215,7 @@ async fn bfd_session_should_have_echo(
     role: String,
 ) {
     let scoped = world.ns(&namespace);
-    const ATTEMPTS: u32 = 20;
+    const ATTEMPTS: u32 = 60;
     let mut ok = false;
     let mut output = String::new();
     for i in 0..ATTEMPTS {


### PR DESCRIPTION
## Summary

`isis_bfd_ipv4_lan` (Echo-both scenario) failed the 2026-07-30 c=16 full-suite run (271/273 on main @ 9d2304b5): `bfd session ... should be up` gave up with the session still negotiating, then passed 3/3 solo at c=1 — pure load margin, not a daemon bug (and not a regression from that day's `rib/link.rs` changes, which triage disproved).

Unlike the #2181 flakes this was **not** a bare assert: the step already polls, but only for 20×1s. The feature's 15s settle wait plus a 20s poll was not enough margin with the host 16-way oversubscribed (`nproc`=12). The fix class here is raising short poll budgets to the 60×1s the suite's other polling steps use.

## Changes

`bdd/tests/cucumber.rs` only — no feature files touched:

- BFD session up / down / echo-role steps: 20 → 60 attempts
- IS-IS neighbor should-be-up: 30 → 60 attempts
- IS-IS neighbor should-**not**-be-up deliberately stays at 10: besides teardown convergence it guards the L1 common-area refusal check, a steady-state invariant where a longer poll-until-down window would weaken the assertion (an adjacency that wrongly came up and later dropped would pass).

A poll-until-condition budget increase cannot create a false pass — it only adds tolerance, at the cost of a slower verdict when a scenario genuinely fails. Every feature sharing these steps (`isis_bfd_ipv6_p2p`, `ospfv2_bfd_frr`, `ecmp_bfd_evict`, `tilfa_bfd`, …) inherits the margin.

## Testing

- `isis_bfd_ipv4_lan` passes solo — all scenarios including both Echo ones (cradle engine + XDP).
- No leaked namespaces or daemons after the run; `cargo fmt --all` and `cargo clippy -p bdd --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)