### PR TITLE
book: integrate VLAN sub-interface chapter across the book

### DIFF
--- a/book/src/ch-00-03-vxlan-configuration.md
+++ b/book/src/ch-00-03-vxlan-configuration.md
@@ -1,11 +1,13 @@
 # VXLAN Configuration
 
-zebra-rs can create a **VXLAN tunnel device** from configuration. Unlike
-the [`interface`](ch-00-02-interface-configuration.md) block — which
-only attaches attributes to a device that already exists — the
-top-level `vxlan` list **creates** the kernel VXLAN netdevice (the
-equivalent of `ip link add <name> type vxlan ...`) and tears it down
-when the entry is removed.
+zebra-rs can create a **VXLAN tunnel device** from configuration. Like
+the [`bridge`](ch-00-04-bridge-configuration.md) and
+[`vlan`](ch-00-08-vlan-configuration.md) blocks — and unlike the
+[`interface`](ch-00-02-interface-configuration.md) block, which only
+attaches attributes to a device that already exists — the top-level
+`vxlan` list **creates** the kernel VXLAN netdevice (the equivalent of
+`ip link add <name> type vxlan ...`) and tears it down when the entry
+is removed.
 
 A VXLAN device is the data-plane endpoint (VTEP) for an EVPN overlay:
 once it is enslaved to a Linux [bridge](ch-00-04-bridge-configuration.md)

--- a/book/src/ch-00-04-bridge-configuration.md
+++ b/book/src/ch-00-04-bridge-configuration.md
@@ -1,7 +1,8 @@
 # Bridge Configuration
 
 zebra-rs can create a **Linux bridge device** from configuration. Like
-the [`vxlan`](ch-00-03-vxlan-configuration.md) block — and unlike
+the [`vxlan`](ch-00-03-vxlan-configuration.md) and
+[`vlan`](ch-00-08-vlan-configuration.md) blocks — and unlike
 [`interface`](ch-00-02-interface-configuration.md), which only attaches
 attributes to an existing device — the top-level `bridge` list
 **creates** the kernel bridge netdevice (`ip link add <name> type

--- a/book/src/ch-00-08-vlan-configuration.md
+++ b/book/src/ch-00-08-vlan-configuration.md
@@ -92,3 +92,18 @@ Interface: eth0.100
   VLAN id 100 parent eth0 (index 2)
   ...
 ```
+
+## Cross-reference — FRR / iproute2
+
+| zebra-rs | iproute2 |
+|---|---|
+| `vlan <n> interface <p>` + `vlan <n> vlan-id <v>` | `ip link add link <p> name <n> type vlan id <v>` |
+| *(automatic)* device up | `ip link set <n> up` |
+| `delete vlan <n>` | `ip link del <n>` |
+
+FRR has no equivalent configuration: its zebra daemon never creates
+interfaces of any kind. It only *learns* VLAN devices the kernel
+already has (netlink kind `vlan`, `IFLA_LINK`, `IFLA_VLAN_ID`) and
+reports them in `show interface`. zebra-rs behaves the same way for
+externally-created devices — the `vlan` list is the additional,
+configuration-driven creation path.

--- a/book/src/ch-14-01-show-system-rib.md
+++ b/book/src/ch-14-01-show-system-rib.md
@@ -84,7 +84,10 @@ where `router_id` is `null` for a VRF with no Router ID yet.
 ### `show interface [brief | <name>]`
 
 Interface state: hardware address, ifindex, MTU, flags, VRF binding,
-MPLS switching state, and the IPv4/IPv6 addresses on the link.
+MPLS switching state, and the IPv4/IPv6 addresses on the link. An
+802.1Q sub-interface — whether created from the
+[`vlan`](ch-00-08-vlan-configuration.md) list or learned from the
+kernel — additionally reports its tag and parent device.
 
 - `show interface` — every interface, in detail (the default view).
 - `show interface brief` — a one-line-per-interface summary table.
@@ -104,12 +107,22 @@ Interface: eth0
   VRF Binding: Not bound
   inet 10.0.0.1/24
   inet6 2001:db8::1/64
+
+r1> show interface eth0.100
+Interface: eth0.100
+  Hardware is Ethernet 00:11:22:33:44:55
+  index 12 metric 1 mtu 1500
+  VLAN id 100 parent eth0 (index 2)
+  Link is Up <UP,BROADCAST,RUNNING,MULTICAST>
+  ...
 ```
 
 JSON: an array of interface objects. The brief view carries `interface`,
 `status`, `vrf`, and `addresses`; the detailed view adds `hardware`,
 `index`, `metric`, `mtu`, `link_status`, `flags`, `vrf_binding`,
-`label_switching`, `inet_addresses`, and `inet6_addresses`.
+`label_switching`, `inet_addresses`, and `inet6_addresses`. A VLAN
+sub-interface also carries `vlan_id`, `parent` (the parent's name), and
+`parent_index`; the fields are omitted on ordinary interfaces.
 
 ## IPv4 / IPv6 routing tables
 


### PR DESCRIPTION
The VLAN sub-interface chapter (ch-00-08) landed with #2176; this PR wires it into the rest of the book. Documentation only — no code changes.

- **Show Commands (ch-14-01)**: `show interface` now documents the `VLAN id <vid> parent <name> (index <n>)` detail line with a sub-interface example, and the JSON field list gains `vlan_id`, `parent`, `parent_index` (omitted on ordinary interfaces).
- **VLAN chapter (ch-00-08)**: adds the *Cross-reference — FRR / iproute2* section its sibling device chapters (interface, bridge) already end with, including the note that FRR has no creation equivalent — it only learns VLAN devices from the kernel.
- **Bridge (ch-00-04) and VXLAN (ch-00-03) intros**: link `vlan` into the family of device-creating top-level lists, so all three creator chapters cross-reference each other consistently.

`mdbook build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)