### PR TITLE
isis: secondary-address discipline for multi-address interfaces

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -411,7 +411,11 @@ impl Display for IsisTlvProtoSupported {
 
 impl Display for IsisTlvIpv4IfAddr {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  IPv4 Interface Address: {}", self.addr)
+        write!(
+            f,
+            "  IPv4 Interface Address: {}",
+            self.addrs.iter().format(" ")
+        )
     }
 }
 
@@ -441,13 +445,21 @@ impl Display for IsisTlvIpv6TeRouterId {
 
 impl Display for IsisTlvIpv6IfAddr {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  IPv6 Interface Address: {}", self.addr)
+        write!(
+            f,
+            "  IPv6 Interface Address: {}",
+            self.addrs.iter().format(" ")
+        )
     }
 }
 
 impl Display for IsisTlvIpv6GlobalIfAddr {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  IPv6 Global Interface Address: {}", self.addr)
+        write!(
+            f,
+            "  IPv6 Global Interface Address: {}",
+            self.addrs.iter().format(" ")
+        )
     }
 }
 

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1008,7 +1008,7 @@ impl ParseBe<IsisTlvIpv4IfAddr> for IsisTlvIpv4IfAddr {
         // An empty or non-multiple-of-4 value is malformed; fail so
         // parse_tlv degrades the TLV to Unknown (bytes preserved)
         // instead of accepting a truncated read.
-        if input.is_empty() || input.len() % 4 != 0 {
+        if input.is_empty() || !input.len().is_multiple_of(4) {
             return Err(Err::Error(nom::error::make_error(
                 input,
                 nom::error::ErrorKind::LengthValue,
@@ -1234,7 +1234,7 @@ impl From<IsisTlvIpv6TeRouterId> for IsisTlv {
 /// Interface Address). Same multi-address rule as TLV 132: one TLV
 /// instance may carry several addresses.
 fn parse_ipv6_addr_array(input: &[u8]) -> IResult<&[u8], Vec<Ipv6Addr>> {
-    if input.is_empty() || input.len() % 16 != 0 {
+    if input.is_empty() || !input.len().is_multiple_of(16) {
         return Err(Err::Error(nom::error::make_error(
             input,
             nom::error::ErrorKind::LengthValue,

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -988,9 +988,38 @@ impl From<IsisTlvProtoSupported> for IsisTlv {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+/// TLV 132 — IP Interface Address(es) (RFC 1195 §5.3). The value is a
+/// packed array of 4-byte addresses: FRR and Cisco emit one TLV
+/// instance carrying every interface address, so the parser must not
+/// stop at the first entry (it used to, silently dropping the rest of
+/// a multi-address interface).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvIpv4IfAddr {
-    pub addr: Ipv4Addr,
+    pub addrs: Vec<Ipv4Addr>,
+}
+
+impl IsisTlvIpv4IfAddr {
+    /// 255-byte value budget / 4 bytes per address.
+    pub const MAX_ADDRS: usize = 63;
+}
+
+impl ParseBe<IsisTlvIpv4IfAddr> for IsisTlvIpv4IfAddr {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        // An empty or non-multiple-of-4 value is malformed; fail so
+        // parse_tlv degrades the TLV to Unknown (bytes preserved)
+        // instead of accepting a truncated read.
+        if input.is_empty() || input.len() % 4 != 0 {
+            return Err(Err::Error(nom::error::make_error(
+                input,
+                nom::error::ErrorKind::LengthValue,
+            )));
+        }
+        let addrs = input
+            .chunks_exact(4)
+            .map(|c| Ipv4Addr::from([c[0], c[1], c[2], c[3]]))
+            .collect();
+        Ok((&input[input.len()..], Self { addrs }))
+    }
 }
 
 impl TlvEmitter for IsisTlvIpv4IfAddr {
@@ -999,11 +1028,13 @@ impl TlvEmitter for IsisTlvIpv4IfAddr {
     }
 
     fn len(&self) -> u8 {
-        IPV4_ADDR_LEN
+        (self.addrs.len().min(Self::MAX_ADDRS) * IPV4_ADDR_LEN as usize) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put(&self.addr.octets()[..])
+        for addr in self.addrs.iter().take(Self::MAX_ADDRS) {
+            buf.put(&addr.octets()[..]);
+        }
     }
 }
 
@@ -1198,9 +1229,45 @@ impl From<IsisTlvIpv6TeRouterId> for IsisTlv {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+/// Packed array of 16-byte IPv6 addresses — the value layout shared by
+/// TLV 232 (Interface Address, RFC 5308 §2) and TLV 233 (Global
+/// Interface Address). Same multi-address rule as TLV 132: one TLV
+/// instance may carry several addresses.
+fn parse_ipv6_addr_array(input: &[u8]) -> IResult<&[u8], Vec<Ipv6Addr>> {
+    if input.is_empty() || input.len() % 16 != 0 {
+        return Err(Err::Error(nom::error::make_error(
+            input,
+            nom::error::ErrorKind::LengthValue,
+        )));
+    }
+    let addrs = input
+        .chunks_exact(16)
+        .map(|c| {
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(c);
+            Ipv6Addr::from(octets)
+        })
+        .collect();
+    Ok((&input[input.len()..], addrs))
+}
+
+/// 255-byte value budget / 16 bytes per address.
+const MAX_IPV6_IF_ADDRS: usize = 15;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvIpv6IfAddr {
-    pub addr: Ipv6Addr,
+    pub addrs: Vec<Ipv6Addr>,
+}
+
+impl IsisTlvIpv6IfAddr {
+    pub const MAX_ADDRS: usize = MAX_IPV6_IF_ADDRS;
+}
+
+impl ParseBe<IsisTlvIpv6IfAddr> for IsisTlvIpv6IfAddr {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, addrs) = parse_ipv6_addr_array(input)?;
+        Ok((input, Self { addrs }))
+    }
 }
 
 impl TlvEmitter for IsisTlvIpv6IfAddr {
@@ -1209,11 +1276,13 @@ impl TlvEmitter for IsisTlvIpv6IfAddr {
     }
 
     fn len(&self) -> u8 {
-        IPV6_ADDR_LEN
+        (self.addrs.len().min(Self::MAX_ADDRS) * IPV6_ADDR_LEN as usize) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put(&self.addr.octets()[..])
+        for addr in self.addrs.iter().take(Self::MAX_ADDRS) {
+            buf.put(&addr.octets()[..]);
+        }
     }
 }
 
@@ -1223,9 +1292,20 @@ impl From<IsisTlvIpv6IfAddr> for IsisTlv {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvIpv6GlobalIfAddr {
-    pub addr: Ipv6Addr,
+    pub addrs: Vec<Ipv6Addr>,
+}
+
+impl IsisTlvIpv6GlobalIfAddr {
+    pub const MAX_ADDRS: usize = MAX_IPV6_IF_ADDRS;
+}
+
+impl ParseBe<IsisTlvIpv6GlobalIfAddr> for IsisTlvIpv6GlobalIfAddr {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, addrs) = parse_ipv6_addr_array(input)?;
+        Ok((input, Self { addrs }))
+    }
 }
 
 impl TlvEmitter for IsisTlvIpv6GlobalIfAddr {
@@ -1234,11 +1314,13 @@ impl TlvEmitter for IsisTlvIpv6GlobalIfAddr {
     }
 
     fn len(&self) -> u8 {
-        IPV6_ADDR_LEN
+        (self.addrs.len().min(Self::MAX_ADDRS) * IPV6_ADDR_LEN as usize) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put(&self.addr.octets()[..])
+        for addr in self.addrs.iter().take(Self::MAX_ADDRS) {
+            buf.put(&addr.octets()[..]);
+        }
     }
 }
 

--- a/crates/isis-packet/tests/parser.rs
+++ b/crates/isis-packet/tests/parser.rs
@@ -1,6 +1,7 @@
 use bytes::BytesMut;
 use hex_literal::hex;
 use isis_packet::*;
+use std::net::Ipv4Addr;
 
 fn parse_emit(buf: &[u8]) {
     let packet = parse(buf);
@@ -619,11 +620,9 @@ pub fn parse_p2p_hello_cisco_state_only_three_way() {
     assert_eq!(three_way.neighbor_circuit_id, None);
 
     // TLVs after 240 must be present.
-    assert!(
-        hello.tlvs.iter().any(
-            |tlv| matches!(tlv, IsisTlv::Ipv4IfAddr(v) if v.addr.octets() == [192, 168, 0, 2])
-        )
-    );
+    assert!(hello.tlvs.iter().any(
+        |tlv| matches!(tlv, IsisTlv::Ipv4IfAddr(v) if v.addrs == [Ipv4Addr::new(192, 168, 0, 2)])
+    ));
     assert!(
         hello
             .tlvs
@@ -692,6 +691,68 @@ pub fn three_way_tlv_round_trips_all_lengths() {
         assert!(rest.is_empty());
         assert_eq!(parsed, vec![IsisTlv::P2p3Way(original)]);
     }
+}
+
+/// TLV 132 as FRR/Cisco emit it for a multi-address interface: ONE TLV
+/// instance whose value packs every address. The parser used to read
+/// only the first 4 bytes, so a peer's secondary/extra addresses were
+/// silently dropped from the neighbor's address set.
+#[test]
+pub fn ipv4_if_addr_tlv_carries_multiple_addresses() {
+    const TLVS: &[u8] = &hex!("84 08 c0 a8 00 02 c0 a8 00 03");
+    let (rest, tlvs) = IsisTlv::parse_tlvs(TLVS).expect("stream must parse");
+    assert!(rest.is_empty());
+    assert_eq!(tlvs.len(), 1);
+    let IsisTlv::Ipv4IfAddr(v) = &tlvs[0] else {
+        panic!("expected Ipv4IfAddr, got {:?}", tlvs[0]);
+    };
+    assert_eq!(
+        v.addrs,
+        [Ipv4Addr::new(192, 168, 0, 2), Ipv4Addr::new(192, 168, 0, 3)]
+    );
+
+    // And it round-trips byte-identically.
+    let mut buf = BytesMut::new();
+    tlvs[0].emit(&mut buf);
+    assert_eq!(&buf[..], TLVS);
+}
+
+/// Multi-address forms of TLV 232 (link-local) and TLV 233 (global)
+/// must parse every 16-byte entry and round-trip.
+#[test]
+pub fn ipv6_if_addr_tlvs_carry_multiple_addresses() {
+    use std::net::Ipv6Addr;
+    let addrs = vec![
+        "fe80::1".parse::<Ipv6Addr>().unwrap(),
+        "fe80::2".parse::<Ipv6Addr>().unwrap(),
+    ];
+    for tlv in [
+        IsisTlv::Ipv6IfAddr(IsisTlvIpv6IfAddr {
+            addrs: addrs.clone(),
+        }),
+        IsisTlv::Ipv6GlobalIfAddr(IsisTlvIpv6GlobalIfAddr {
+            addrs: addrs.clone(),
+        }),
+    ] {
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(buf.len(), 2 + 32);
+        let (rest, parsed) = IsisTlv::parse_tlvs(&buf).expect("round-trip parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed, vec![tlv]);
+    }
+}
+
+/// An empty-value TLV 132 is malformed (RFC 1195 mandates at least one
+/// address) and must degrade to Unknown, not parse as an empty list.
+#[test]
+pub fn empty_ipv4_if_addr_tlv_degrades_to_unknown() {
+    const TLVS: &[u8] = &hex!("84 00  81 01 cc");
+    let (rest, tlvs) = IsisTlv::parse_tlvs(TLVS).expect("stream must parse");
+    assert!(rest.is_empty());
+    assert_eq!(tlvs.len(), 2);
+    assert!(matches!(&tlvs[0], IsisTlv::Unknown(u) if u.values.is_empty()));
+    assert!(matches!(tlvs[1], IsisTlv::ProtoSupported(_)));
 }
 
 /// A known TLV whose value fails its inner parser must degrade to

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -50,28 +50,33 @@ pub fn proto_supported(enable: &Afis<bool>) -> IsisTlvProtoSupported {
 /// honor. Shared by the LAN and P2P Hello generators.
 fn push_if_addr_tlvs(tlvs: &mut Vec<IsisTlv>, link: &LinkTop) {
     if link.config.enable.v4 {
-        for prefix in &link.state.v4addr {
+        // One packed TLV per MAX_ADDRS chunk (the FRR/Cisco form),
+        // secondaries included — they are real interface addresses.
+        let addrs: Vec<_> = link.state.v4addr.iter().map(|e| e.prefix.addr()).collect();
+        for chunk in addrs.chunks(IsisTlvIpv4IfAddr::MAX_ADDRS) {
             tlvs.push(
                 IsisTlvIpv4IfAddr {
-                    addr: prefix.addr(),
+                    addrs: chunk.to_vec(),
                 }
                 .into(),
             );
         }
     }
     if link.config.enable.v6 {
-        for prefix in &link.state.v6laddr {
+        let laddrs: Vec<_> = link.state.v6laddr.iter().map(|p| p.addr()).collect();
+        for chunk in laddrs.chunks(IsisTlvIpv6IfAddr::MAX_ADDRS) {
             tlvs.push(
                 IsisTlvIpv6IfAddr {
-                    addr: prefix.addr(),
+                    addrs: chunk.to_vec(),
                 }
                 .into(),
             );
         }
-        for prefix in &link.state.v6addr {
+        let gaddrs: Vec<_> = link.state.v6addr.iter().map(|p| p.addr()).collect();
+        for chunk in gaddrs.chunks(IsisTlvIpv6GlobalIfAddr::MAX_ADDRS) {
             tlvs.push(
                 IsisTlvIpv6GlobalIfAddr {
-                    addr: prefix.addr(),
+                    addrs: chunk.to_vec(),
                 }
                 .into(),
             );

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2123,7 +2123,7 @@ impl Isis {
         let mut actions: Vec<(crate::bfd::session::SessionKey, bool)> = Vec::new();
         for (ifindex, link) in self.links.iter() {
             let enable = link.config.bfd.resolve(&self.config.bfd).enable;
-            let local_v4 = link.state.v4addr.first().map(|p| p.addr());
+            let local_v4 = super::link::v4_primary(&link.state.v4addr).map(|e| e.prefix.addr());
             let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
             for level in [Level::L1, Level::L2] {
                 for nbr in link.state.nbrs.get(&level).values() {
@@ -2132,7 +2132,7 @@ impl Isis {
                     }
                     // v4-preferred / v6-link-local fallback, same selection as
                     // the NFSM subscribe path (see packet::bfd_session_key).
-                    let remote_v4 = nbr.addr4.keys().next().copied();
+                    let remote_v4 = super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
                     let remote_v6ll = nbr.addr6l.first().copied();
                     let Some((local, remote)) = super::packet::bfd_session_addrs(
                         local_v4,
@@ -2208,7 +2208,7 @@ impl Isis {
         // A v6-only adjacency thus yields a link-local v6 session whose
         // scope is the link's ifindex.
         let desired = if link.config.te_metric_measurement.enabled() && link.is_p2p() {
-            let local_v4 = link.state.v4addr.first().map(|p| p.addr());
+            let local_v4 = super::link::v4_primary(&link.state.v4addr).map(|e| e.prefix.addr());
             let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
             let nbr = [Level::L1, Level::L2].iter().find_map(|level| {
                 link.state
@@ -2217,7 +2217,8 @@ impl Isis {
                     .values()
                     .find(|nbr| nbr.state == NfsmState::Up)
             });
-            let remote_v4 = nbr.and_then(|n| n.addr4.keys().next().copied());
+            let remote_v4 =
+                nbr.and_then(|n| super::link::nbr_v4_pick(&link.state.v4addr, &n.addr4));
             let remote_v6ll = nbr.and_then(|n| n.addr6l.first().copied());
             super::packet::bfd_session_addrs(local_v4, remote_v4, local_v6ll, remote_v6ll).map(
                 |(local, remote)| {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -710,6 +710,59 @@ impl DisStatistics {
     }
 }
 
+/// One IPv4 address on an IS-IS link. `secondary` is the
+/// kernel-computed IFA_F_SECONDARY verdict carried on the RIB's
+/// `LinkAddr`: a same-subnet duplicate of an earlier (primary)
+/// address. Secondaries stay in Hello TLV 132 (they are real
+/// interface addresses) but must never be the link's identity —
+/// endpoint picks prefer the primary, and the primary's Extended IP
+/// Reachability entry already covers a secondary's subnet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkV4Addr {
+    pub prefix: Ipv4Net,
+    pub secondary: bool,
+}
+
+/// First non-secondary entry accepted by `pred`, falling back to the
+/// first accepted entry at all (a transient all-secondary list must
+/// not leave the link identity-less). Kernel event order makes entry
+/// 0 the kernel's own primary in the common case.
+pub fn v4_primary_where(
+    addrs: &[LinkV4Addr],
+    pred: impl Fn(&LinkV4Addr) -> bool + Copy,
+) -> Option<&LinkV4Addr> {
+    addrs
+        .iter()
+        .find(|a| !a.secondary && pred(a))
+        .or_else(|| addrs.iter().find(|a| pred(a)))
+}
+
+/// The link's primary IPv4 address, if any.
+pub fn v4_primary(addrs: &[LinkV4Addr]) -> Option<&LinkV4Addr> {
+    v4_primary_where(addrs, |_| true)
+}
+
+/// Choose the neighbor address to use as this link's peer endpoint
+/// (SPF nexthop, BFD/STAMP session key, SRLG remote). TLV 132 carries
+/// every interface address of the peer — including addresses from
+/// subnets we are not on — and `addr4` iterates in numeric order, so
+/// "first key" may be unreachable. Walk our own subnets primaries
+/// first and take the lowest peer address inside the first subnet
+/// that holds one; fall back to the lowest advertised address (the
+/// pre-multi-address behavior) so unnumbered setups keep working.
+pub fn nbr_v4_pick(
+    local: &[LinkV4Addr],
+    addr4: &BTreeMap<std::net::Ipv4Addr, super::NeighborAddr4>,
+) -> Option<std::net::Ipv4Addr> {
+    local
+        .iter()
+        .filter(|e| !e.secondary)
+        .chain(local.iter().filter(|e| e.secondary))
+        .find_map(|e| addr4.keys().find(|a| e.prefix.contains(*a)))
+        .or_else(|| addr4.keys().next())
+        .copied()
+}
+
 // Mutable data during operation.
 #[derive(Default, Debug)]
 pub struct LinkState {
@@ -720,7 +773,7 @@ pub struct LinkState {
     pub mac: Option<MacAddr>,
 
     // IP addresses.
-    pub v4addr: Vec<Ipv4Net>,
+    pub v4addr: Vec<LinkV4Addr>,
     pub v6addr: Vec<Ipv6Net>,
     pub v6laddr: Vec<Ipv6Net>,
 
@@ -1080,7 +1133,9 @@ impl Isis {
     /// the link's per-family address list (v4 skipping loopbacks, v6
     /// split into link-local vs global), apply the add/remove, and
     /// re-originate the Hello so the interface-address TLVs track the
-    /// kernel.
+    /// kernel — plus the self LSP, whose Extended IP Reachability
+    /// TLVs would otherwise only pick the change up at the next
+    /// periodic refresh (up to the LSP lifetime, 1800s).
     fn addr_update(&mut self, addr: LinkAddr, add: bool) {
         let Some(link) = self.links.get_mut(&addr.ifindex) else {
             return;
@@ -1089,7 +1144,14 @@ impl Isis {
         match addr.addr {
             IpNet::V4(prefix) => {
                 if !prefix.addr().is_loopback() {
-                    addr_list_update(&mut link.state.v4addr, prefix, add);
+                    v4addr_list_update(
+                        &mut link.state.v4addr,
+                        LinkV4Addr {
+                            prefix,
+                            secondary: addr.secondary,
+                        },
+                        add,
+                    );
                 }
             }
             IpNet::V6(prefix) => {
@@ -1105,6 +1167,8 @@ impl Isis {
         if link.config.enabled() {
             let msg = Message::Ifsm(IfsmEvent::HelloOriginate, addr.ifindex, None);
             let _ = self.tx.send(msg);
+            let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+            let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
         }
     }
 }
@@ -1118,6 +1182,22 @@ fn addr_list_update<T: PartialEq>(list: &mut Vec<T>, item: T, add: bool) {
         }
     } else {
         list.retain(|p| p != &item);
+    }
+}
+
+/// v4 variant keyed by prefix: an add for a prefix already present
+/// upserts the secondary flag instead of pushing a duplicate — the
+/// RIB re-broadcasts an AddrAdd when the kernel verdict flips (e.g. a
+/// primary delete promotes its same-subnet sibling).
+fn v4addr_list_update(list: &mut Vec<LinkV4Addr>, item: LinkV4Addr, add: bool) {
+    if add {
+        if let Some(existing) = list.iter_mut().find(|e| e.prefix == item.prefix) {
+            existing.secondary = item.secondary;
+        } else {
+            list.push(item);
+        }
+    } else {
+        list.retain(|e| e.prefix != item.prefix);
     }
 }
 
@@ -2217,7 +2297,12 @@ pub fn show_detail(
                     level_1_info: None,
                     level_2_info: None,
                     authentication: build_auth_info(link),
-                    ip_prefixes: link.state.v4addr.iter().map(|p| p.to_string()).collect(),
+                    ip_prefixes: link
+                        .state
+                        .v4addr
+                        .iter()
+                        .map(|p| p.prefix.to_string())
+                        .collect(),
                     ipv6_link_locals: link.state.v6laddr.iter().map(|p| p.to_string()).collect(),
                     ipv6_prefixes: link.state.v6addr.iter().map(|p| p.to_string()).collect(),
                 };
@@ -2285,8 +2370,9 @@ pub fn show_detail(
                 // IPv4 Address.
                 if !link.state.v4addr.is_empty() {
                     writeln!(buf, "  IP Prefix(es):")?;
-                    for prefix in link.state.v4addr.iter() {
-                        writeln!(buf, "    {}", prefix)?;
+                    for entry in link.state.v4addr.iter() {
+                        let tag = if entry.secondary { " (secondary)" } else { "" };
+                        writeln!(buf, "    {}{}", entry.prefix, tag)?;
                     }
                 }
                 if !link.state.v6laddr.is_empty() {
@@ -2861,5 +2947,89 @@ mod circuit_id_tests {
             None,
             "double release reports nothing held"
         );
+    }
+}
+
+#[cfg(test)]
+mod v4addr_tests {
+    use std::collections::BTreeMap;
+    use std::net::Ipv4Addr;
+
+    use super::super::NeighborAddr4;
+    use super::{LinkV4Addr, nbr_v4_pick, v4_primary, v4addr_list_update};
+
+    fn entry(s: &str, secondary: bool) -> LinkV4Addr {
+        LinkV4Addr {
+            prefix: s.parse().unwrap(),
+            secondary,
+        }
+    }
+
+    fn nbr_addrs(addrs: &[&str]) -> BTreeMap<Ipv4Addr, NeighborAddr4> {
+        addrs
+            .iter()
+            .map(|s| {
+                let a: Ipv4Addr = s.parse().unwrap();
+                (a, NeighborAddr4::new(a, None))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn primary_skips_secondary_entries() {
+        // Kernel event order can put the secondary first in the list
+        // (e.g. after a flag-flip upsert); the pick must not care.
+        let addrs = [entry("10.0.0.9/24", true), entry("10.0.0.1/24", false)];
+        assert_eq!(v4_primary(&addrs), Some(&addrs[1]));
+
+        // All-secondary (transient mid-promotion): fall back to first
+        // rather than leaving the link identity-less.
+        let addrs = [entry("10.0.0.9/24", true)];
+        assert_eq!(v4_primary(&addrs), Some(&addrs[0]));
+
+        assert_eq!(v4_primary(&[]), None);
+    }
+
+    #[test]
+    fn nbr_pick_prefers_primary_subnet_over_lowest_key() {
+        // Peer advertises 10.1.0.2 (numerically lowest, from a subnet
+        // shared only with our secondary-ordered walk's later entry)
+        // and 10.2.0.2 (our primary's subnet). The primary's subnet
+        // must win even though its address sorts higher.
+        let local = [entry("10.2.0.1/24", false), entry("10.1.0.1/24", true)];
+        let nbr = nbr_addrs(&["10.1.0.2", "10.2.0.2"]);
+        assert_eq!(nbr_v4_pick(&local, &nbr), Some("10.2.0.2".parse().unwrap()));
+
+        // No peer address in the primary's subnet: the secondary's
+        // subnet is the next stop in the walk.
+        let nbr = nbr_addrs(&["10.1.0.2", "192.168.0.2"]);
+        assert_eq!(nbr_v4_pick(&local, &nbr), Some("10.1.0.2".parse().unwrap()));
+
+        // No shared subnet at all (unnumbered): lowest advertised
+        // address, the pre-multi-address behavior.
+        let nbr = nbr_addrs(&["192.168.0.2", "172.16.0.2"]);
+        assert_eq!(
+            nbr_v4_pick(&local, &nbr),
+            Some("172.16.0.2".parse().unwrap())
+        );
+
+        assert_eq!(nbr_v4_pick(&local, &BTreeMap::new()), None);
+    }
+
+    #[test]
+    fn list_update_upserts_secondary_flag() {
+        let mut list = vec![entry("10.0.0.1/24", false)];
+
+        // Same prefix re-announced with a flipped verdict (the RIB
+        // re-broadcasts on Merged): update in place, no duplicate.
+        v4addr_list_update(&mut list, entry("10.0.0.1/24", true), true);
+        assert_eq!(list, vec![entry("10.0.0.1/24", true)]);
+
+        v4addr_list_update(&mut list, entry("10.0.0.2/24", true), true);
+        assert_eq!(list.len(), 2);
+
+        // Delete matches by prefix regardless of the event's flag.
+        v4addr_list_update(&mut list, entry("10.0.0.1/24", false), false);
+        assert_eq!(list, vec![entry("10.0.0.2/24", true)]);
     }
 }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 
 use bytes::BytesMut;
@@ -1149,25 +1149,21 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 .filter_map(|name| top.srlg_groups.get(name).map(|g| g.value))
                 .collect();
             if !values.is_empty() {
-                // Local v4 address: first interface address on the
-                // link. Remote v4 address: first known neighbor v4
-                // (best-effort — for LAN there's no single "remote"
-                // endpoint, so any peer address suffices as the
-                // disambiguator together with the neighbor sys-id +
-                // psn carried in the TLV).
-                let local_v4 = link
-                    .state
-                    .v4addr
-                    .first()
-                    .map(|p| p.addr())
+                // Local v4 address: the link's primary interface
+                // address. Remote v4 address: first known neighbor v4
+                // sharing one of our subnets (best-effort — for LAN
+                // there's no single "remote" endpoint, so any peer
+                // address suffices as the disambiguator together with
+                // the neighbor sys-id + psn carried in the TLV).
+                let local_v4 = super::link::v4_primary(&link.state.v4addr)
+                    .map(|e| e.prefix.addr())
                     .unwrap_or(Ipv4Addr::UNSPECIFIED);
                 let remote_v4 = link
                     .state
                     .nbrs
                     .get(&level)
                     .values()
-                    .flat_map(|nbr| nbr.addr4.keys().copied())
-                    .next()
+                    .find_map(|nbr| super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4))
                     .unwrap_or(Ipv4Addr::UNSPECIFIED);
                 // T-bit (numbered link) when we have a real local
                 // address. Unnumbered case (T=0, Link Local/Remote
@@ -1300,13 +1296,17 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         }
     }
 
-    // IPv4 Reachability.
+    // IPv4 Reachability. Two same-subnet addresses (a primary plus a
+    // kernel secondary) mask to the same prefix — advertise it once.
+    // First entry wins, which also keeps the primary's Prefix-SID
+    // sub-TLVs when a duplicate would have carried none.
     let mut ext_ip_reach = IsisTlvExtIpReach::default();
+    let mut seen_v4: BTreeSet<Ipv4Net> = BTreeSet::new();
     for (_, link) in top.links.iter() {
         if link.config.enable.v4 && has_level(link.state.level(), level) {
             for ifaddr in link.state.v4addr.iter() {
-                let prefix = ifaddr.apply_mask();
-                if !prefix.addr().is_loopback() {
+                let prefix = ifaddr.prefix.apply_mask();
+                if !prefix.addr().is_loopback() && seen_v4.insert(prefix) {
                     let sub_tlv = if let Some(sid) = &link.config.prefix_sid {
                         let prefix_sid = IsisSubPrefixSid {
                             // RFC 8667 §2.1.1: N (Node-SID) flag for a host

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -82,8 +82,10 @@ pub fn nbr_hold_timer_expire(
     let ifindex = nbr.ifindex;
     // Snapshot the peer's IPv4 and IPv6 link-local so we can send a BFD
     // Unsubscribe after dropping the nbr borrow. nbr's addr maps are about to
-    // be wiped along with the entire entry below.
-    let bfd_peer_v4 = nbr.addr4.keys().next().copied();
+    // be wiped along with the entire entry below. Must be the same pick the
+    // subscribe path used (packet::bfd_session_key) or the Unsubscribe key
+    // won't match the live session.
+    let bfd_peer_v4 = super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
     let bfd_peer_v6ll = nbr.addr6l.first().copied();
 
     // Originate Hello and LSP.

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -50,7 +50,7 @@ pub(super) fn bfd_session_key(
     peer_v4: Option<Ipv4Addr>,
     peer_v6ll: Option<Ipv6Addr>,
 ) -> Option<SessionKey> {
-    let local_v4 = link.state.v4addr.first().map(|p| p.addr());
+    let local_v4 = super::link::v4_primary(&link.state.v4addr).map(|e| e.prefix.addr());
     let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
     let (local, remote) = bfd_session_addrs(local_v4, peer_v4, local_v6ll, peer_v6ll)?;
     Some(SessionKey {
@@ -236,12 +236,14 @@ pub fn nbr_hello_interpret(
                 }
             }
             IsisTlv::Ipv4IfAddr(ifaddr) => {
-                addr4.insert(ifaddr.addr, NeighborAddr4::new(ifaddr.addr, None));
+                for &addr in &ifaddr.addrs {
+                    addr4.insert(addr, NeighborAddr4::new(addr, None));
+                }
             }
             IsisTlv::Ipv6GlobalIfAddr(ifaddr) => {
-                addr6.insert(ifaddr.addr);
+                addr6.extend(&ifaddr.addrs);
             }
-            IsisTlv::Ipv6IfAddr(ifaddr) => laddr6.push(ifaddr.addr),
+            IsisTlv::Ipv6IfAddr(ifaddr) => laddr6.extend(&ifaddr.addrs),
             IsisTlv::ProtoSupported(tlv) => {
                 nbr.proto = Some(tlv.clone());
             }
@@ -499,7 +501,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // transition point below — by that time nbr is no longer in
     // scope and we can no longer reach back into `link.state.nbrs`
     // while link.state.v4addr is also borrowed.
-    let bfd_peer_v4: Option<Ipv4Addr> = nbr.addr4.keys().next().copied();
+    let bfd_peer_v4: Option<Ipv4Addr> = super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
     // IPv6-only adjacency: the single-hop BFD session is keyed on the
     // neighbour's link-local (learned via TLV 232) and our own link-local.
     let bfd_peer_v6ll: Option<Ipv6Addr> = nbr.addr6l.first().copied();
@@ -749,7 +751,8 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         let mut state = nbr.state;
         let was_up = state == NfsmState::Up;
         // Snapshot before any mut-nbr work; see LAN handler comment.
-        let bfd_peer_v4: Option<Ipv4Addr> = nbr.addr4.keys().next().copied();
+        let bfd_peer_v4: Option<Ipv4Addr> =
+            super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
         let bfd_peer_v6ll: Option<Ipv6Addr> = nbr.addr6l.first().copied();
 
         // When it is three way handshake.

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -25,7 +25,7 @@ use super::flex_algo::FlexAlgoEntry;
 use super::graph::{LspMap, graph, graph_flex_algo, graph_mt2};
 use super::inst::{Isis, IsisTop, Message};
 use super::level::Level;
-use super::link::{Afi, LinkTop};
+use super::link::{Afi, IsisLink, LinkTop, nbr_v4_pick, v4_primary_where};
 use super::lsdb::Lsdb;
 use super::neigh::Neighbor;
 use super::srmpls::LabelConfig;
@@ -54,8 +54,12 @@ pub trait IsisRibFamily: Sized + 'static {
     /// TI-LFA protection into trivial / 1-segment / N-segment tallies.
     fn backup_sr_len(backup: &Self::Backup) -> usize;
 
-    /// Collect nexthop addresses for this family from one neighbor record.
-    fn nhop_addrs(nbr: &Neighbor) -> Vec<Self::Addr>;
+    /// Nexthop addresses for this family from one neighbor record on
+    /// `link`. One address per neighbor: the peer advertises every
+    /// interface address in its Hello (TLV 132 / 232), and treating
+    /// them all as ECMP nexthops both skewed load-balancing weights
+    /// and installed peer addresses from subnets this link is not on.
+    fn nhop_addrs(link: &IsisLink, nbr: &Neighbor) -> Vec<Self::Addr>;
 
     /// Look up the family's reach entries for `sys_id`.
     /// `mt2_mode` selects `mt2_reach_map_v6` vs `reach_map_v6` for V6;
@@ -135,8 +139,10 @@ impl IsisRibFamily for V4 {
         backup.labels.push(rib::Label::Explicit(sid));
     }
 
-    fn nhop_addrs(nbr: &Neighbor) -> Vec<Ipv4Addr> {
-        nbr.addr4.keys().copied().collect()
+    fn nhop_addrs(link: &IsisLink, nbr: &Neighbor) -> Vec<Ipv4Addr> {
+        nbr_v4_pick(&link.state.v4addr, &nbr.addr4)
+            .into_iter()
+            .collect()
     }
 
     fn reach_entries<'a>(
@@ -232,8 +238,10 @@ impl IsisRibFamily for V6 {
         backup.segs.len()
     }
 
-    fn nhop_addrs(nbr: &Neighbor) -> Vec<Ipv6Addr> {
-        nbr.addr6l.clone()
+    fn nhop_addrs(_link: &IsisLink, nbr: &Neighbor) -> Vec<Ipv6Addr> {
+        // Link-locals are on-link by definition; the first is the
+        // same one the BFD/STAMP session keys use.
+        nbr.addr6l.first().into_iter().copied().collect()
     }
 
     fn reach_entries<'a>(
@@ -838,16 +846,16 @@ fn build_adjacency_ilm(
         let mut nhops = BTreeMap::new();
 
         for (ifindex, link) in top.links.iter() {
-            if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
-                for addr in nbr.addr4.keys() {
-                    let nhop = SpfNexthop::<V4> {
-                        ifindex: *ifindex,
-                        adjacency: true,
-                        sys_id: Some(*nhop_id),
-                        backup: None,
-                    };
-                    nhops.insert(*addr, nhop);
-                }
+            if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id)
+                && let Some(addr) = nbr_v4_pick(&link.state.v4addr, &nbr.addr4)
+            {
+                let nhop = SpfNexthop::<V4> {
+                    ifindex: *ifindex,
+                    adjacency: true,
+                    sys_id: Some(*nhop_id),
+                    backup: None,
+                };
+                nhops.insert(addr, nhop);
             }
         }
 
@@ -956,7 +964,7 @@ fn build_rib_from_spf<F: IsisRibFamily>(
                 let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
                     continue;
                 };
-                for addr in F::nhop_addrs(nbr) {
+                for addr in F::nhop_addrs(link, nbr) {
                     spf_nhops.insert(
                         addr,
                         SpfNexthop::<F> {
@@ -2094,7 +2102,7 @@ fn build_rib6_from_flex_algo(
                 let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
                     continue;
                 };
-                for addr in nbr.addr6l.iter() {
+                if let Some(addr) = nbr.addr6l.first() {
                     spf_nhops.insert(
                         *addr,
                         SpfNexthop::<V6> {
@@ -2273,14 +2281,14 @@ fn build_rib_from_flex_algo(
                 let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
                     continue;
                 };
-                for addr in nbr.addr4.keys() {
+                if let Some(addr) = nbr_v4_pick(&link.state.v4addr, &nbr.addr4) {
                     let nhop = SpfNexthop::<V4> {
                         ifindex: *link_id,
                         adjacency: *node == nhop_id,
                         sys_id: Some(nhop_sys_id),
                         backup: None,
                     };
-                    spf_nhops.insert(*addr, nhop);
+                    spf_nhops.insert(addr, nhop);
                 }
             }
         }
@@ -2423,13 +2431,11 @@ pub(super) fn update_self_sid_ilm(isis: &mut Isis) {
                 continue;
             };
             // The local delivery nexthop is the loopback's own routable
-            // IPv4 address; skip the 127.0.0.0/8 literal range.
-            let Some(addr) = link
-                .state
-                .v4addr
-                .iter()
-                .map(|p| p.addr())
-                .find(|a| !a.is_loopback())
+            // IPv4 address — primary preferred; skip the 127.0.0.0/8
+            // literal range.
+            let Some(addr) =
+                v4_primary_where(&link.state.v4addr, |e| !e.prefix.addr().is_loopback())
+                    .map(|e| e.prefix.addr())
             else {
                 continue;
             };


### PR DESCRIPTION
## Summary

PR 5 of the multi-IPv4-address series (#2168 → #2175 → #2178 → #2180). Carries the kernel's `IFA_F_SECONDARY` verdict into IS-IS and makes every address consumer multi-address aware.

- **`LinkState.v4addr` → `Vec<LinkV4Addr>`** (prefix + secondary). Re-announce of an existing prefix upserts the flag, so a kernel promotion's flag flip (RIB `AddrUpdate::Merged` re-broadcast) updates in place instead of duplicating.
- **`addr_update` sends `LspOriginate`**: a new/removed prefix used to wait for the periodic LSP refresh (up to 1800s) before entering Extended IP Reachability; now it floods immediately (Hello already did).
- **TLV 135 dedup after `apply_mask()`**: a primary plus a same-subnet secondary advertised the subnet twice; now once, first entry wins (keeping its Prefix-SID sub-TLVs).
- **isis-packet: TLV 132/232/233 become packed address arrays** — the FRR/Cisco emit form. The old single-address structs silently dropped every address after the first on receive, so a multi-address FRR peer's extra addresses never reached the neighbor table. Malformed (empty / non-stride) values still degrade to `Unknown`. Hello emit now packs all addresses into one TLV per family, chunked at the 255-byte value budget.
- **SPF nexthops: one address per neighbor** (legacy V4/V6 builders, flex-algo, adjacency-SID ILM). Previously every TLV-132 address — including addresses from subnets this link is not on — became an ECMP nexthop, skewing load-balancing and installing unreachable nexthops. The pick walks our own subnets primaries-first and takes the lowest peer address in the first shared subnet, falling back to the lowest advertised (unnumbered case).
- **Endpoint picks prefer the primary** via shared `v4_primary` / `v4_primary_where` / `nbr_v4_pick` helpers: BFD session key (subscribe and the NFSM teardown snapshot — same pick, so Unsubscribe keys keep matching), STAMP, SRLG local/remote, self Prefix-SID ILM.
- `show isis interface detail` tags secondaries: `10.0.0.2/24 (secondary)`.

The TLV parse fix and the LspOriginate trigger are shared ground with the IPv6 multi-address branch (its PRs 6–7 can rebase onto this).

## Testing

- 3 new unit tests for the helpers (primary pick, subnet-preferring neighbor pick incl. unnumbered fallback, upsert semantics) and 3 new isis-packet tests (multi-address TLV 132 parse + byte-identical round-trip, multi-address TLV 232/233 round-trip, empty TLV 132 degrades to Unknown).
- `cargo test --workspace --exclude bdd`: 2695 passed, 0 failed. Workspace clippy clean.
- Live two-router netns (A: 10.0.0.1/24 + 10.0.0.2/24 kernel-secondary + 10.1.0.1/24; B: 10.0.0.9/24):
  - A shows `10.0.0.2/24 (secondary)`; A's LSP carries `10.0.0.0/24` once and `10.1.0.0/24` once.
  - B learns all three addresses from A's packed TLV 132.
  - B installs `10.1.0.0/24 via 10.0.0.1` — a single nexthop via the shared-subnet primary (previously three ECMP nexthops including the off-subnet 10.1.0.1).
  - `ip addr add 10.2.0.1/24` on A → route in B's RIB in ≤2s (LspOriginate trigger).
  - Kernel promotion (`promote_secondaries=1`, delete primary) moves the secondary tag off the promoted address via the Merged upsert.

Known edge (pre-existing, rib-layer, out of scope here): an external delete of a config-managed primary with `promote_secondaries=1` races the config-recovery reinstall against the kernel's promotion NEWADDR, leaving the RIB's flag for the reinstalled address diverged from the kernel until restart. Cosmetic for IGP advertisement (subnets still advertised once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)