### PR TITLE
bdd: multi-address IPv4 secondary feature + the OSPF defects it exposed

### DIFF
--- a/bdd/tests/configs/ipv4_address_secondary/z1.yaml
+++ b/bdd/tests/configs/ipv4_address_secondary/z1.yaml
@@ -1,0 +1,33 @@
+# z1: three addresses on the LAN veth — 10.0.1.1/24 (kernel primary,
+# first installed), 10.0.1.2/24 (same subnet+mask → kernel marks it
+# IFA_F_SECONDARY), 10.2.0.1/24 (distinct subnet → primary). No
+# `secondary` keyword exists in the config: the kernel computes the
+# flag and zebra-rs reads it back / mirrors it on config-driven
+# installs.
+#
+# OSPFv2 and IS-IS both run on the veth so one topology proves both
+# advertisement disciplines: OSPF Router-LSA links and IS-IS Extended
+# IP Reachability must count subnets, not addresses.
+interface:
+- if-name: vz1ns
+  ipv4:
+    address:
+    - 10.0.1.1/24
+    - 10.0.1.2/24
+    - 10.2.0.1/24
+router:
+  ospf:
+    router-id: 1.1.1.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: vz1ns
+        enabled: true
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: vz1ns
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/ipv4_address_secondary/z2.yaml
+++ b/bdd/tests/configs/ipv4_address_secondary/z2.yaml
@@ -1,0 +1,25 @@
+# z2: single-address neighbor on the shared 10.0.1.0/24 subnet. It
+# learns z1's 10.2.0.0/24 via OSPF and IS-IS; the route's nexthop
+# proves which of z1's same-subnet addresses the protocols treat as
+# the interface identity (the primary).
+interface:
+- if-name: vz2ns
+  ipv4:
+    address:
+    - 10.0.1.9/24
+router:
+  ospf:
+    router-id: 2.2.2.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: vz2ns
+        enabled: true
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: vz2ns
+      ipv4:
+        enabled: true

--- a/bdd/tests/features/ipv4_address_secondary.feature
+++ b/bdd/tests/features/ipv4_address_secondary.feature
@@ -1,0 +1,121 @@
+@ipv4_address_secondary
+@rib
+Feature: Multiple IPv4 addresses per interface with kernel secondary flag
+  As a network operator
+  I want to configure several IPv4 addresses on one interface
+  So that same-subnet duplicates carry the kernel's IFA_F_SECONDARY
+  verdict — no config keyword — while routing protocols keep treating
+  the interface as one link per subnet: the connected route survives a
+  secondary's removal, advertisements count subnets not addresses, and
+  nexthops/endpoints always use the primary.
+
+  Test Topology (shared bridge):
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+      10.0.1.1/24 (primary)  10.0.1.9/24
+      10.0.1.2/24 (secondary)  (vz2ns)
+      10.2.0.1/24 (primary)
+            (vz1ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1.yaml: three addresses on vz1ns; OSPFv2 area 0 + IS-IS L2 on it
+  - z2.yaml: one address on vz2ns; same protocols
+
+  Scenario: Setup topology and the kernel computes the secondary verdict
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    # Pin the kernel default: deleting a primary must cascade its
+    # same-subnet secondaries away, not promote them (the daemon
+    # mirrors that cascade for configured siblings).
+    And I execute "sysctl -w net.ipv4.conf.all.promote_secondaries=0" in namespace "z1"
+    And I execute "sysctl -w net.ipv4.conf.default.promote_secondaries=0" in namespace "z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    # Kernel truth: same subnet + same mask as an earlier address →
+    # IFA_F_SECONDARY; the distinct-subnet 10.2.0.1 stays primary.
+    Then command "ip -4 addr show vz1ns" in namespace "z1" should eventually contain "10.0.1.2/24 scope global secondary"
+    And command "ip -4 addr show vz1ns" in namespace "z1" should eventually contain "10.2.0.1/24 scope global vz1ns"
+    # The daemon reads the flag back (config-driven install has no
+    # netlink self-echo, so this proves the local verdict mirror).
+    And show command "show interface vz1ns" in namespace "z1" should eventually contain "inet 10.0.1.2/24 secondary"
+    And show command "show interface vz1ns" in namespace "z1" should not contain "inet 10.0.1.1/24 secondary"
+    And show command "show interface vz1ns" in namespace "z1" should not contain "inet 10.2.0.1/24 secondary"
+    # One kernel connected route per subnet, never one per address.
+    And kernel route "10.0.1.0/24" in namespace "z1" should eventually contain "dev vz1ns"
+    And kernel route "10.2.0.0/24" in namespace "z1" should eventually contain "dev vz1ns"
+
+  Scenario: Protocols advertise subnets once and pick the primary as nexthop
+    Given the test topology exists
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And show command "show ospf neighbor" in namespace "z1" should eventually contain "Full"
+    # z2 learns every z1 interface address from one packed TLV 132 —
+    # the parser must not stop at the first entry.
+    And show command "show isis neighbor detail" in namespace "z2" should eventually contain "10.0.1.2"
+    And show command "show isis neighbor detail" in namespace "z2" should eventually contain "10.2.0.1"
+    # z1's Router-LSA: transit 10.0.1.0/24 + stub 10.2.0.0/24 = 2
+    # links. A counted secondary would make it 3. (z2's own LSA has 1.)
+    And show command "show ospf database detail" in namespace "z2" should eventually contain "Number of Links: 2"
+    And show command "show ospf database detail" in namespace "z2" should not contain "Number of Links: 3"
+    # IS-IS reachability is deduped: both subnets present.
+    And show command "show isis database detail" in namespace "z2" should eventually contain "10.0.1.0/24"
+    And show command "show isis database detail" in namespace "z2" should eventually contain "10.2.0.0/24"
+    # The learned route uses z1's primary as nexthop; the secondary is
+    # never a nexthop anywhere in the table (OSPF and IS-IS both).
+    And show command "show ip route" in namespace "z2" should eventually contain "10.2.0.0/24"
+    And show command "show ip route" in namespace "z2" should eventually contain "via 10.0.1.1"
+    And show command "show ip route" in namespace "z2" should not contain "via 10.0.1.2"
+    And ping from "z2" to "10.2.0.1" should eventually succeed
+
+  Scenario: Deleting the secondary keeps the connected route and the advertisement
+    Given the test topology exists
+    When I apply command "delete interface vz1ns ipv4 address 10.0.1.2/24" in namespace "z1"
+    Then command "ip -4 addr show vz1ns" in namespace "z1" should eventually not contain "10.0.1.2/24"
+    # The subnet is still covered by the primary: connected route
+    # stays, both protocols keep advertising it, forwarding keeps
+    # working.
+    And kernel route "10.0.1.0/24" in namespace "z1" should eventually contain "dev vz1ns"
+    And show command "show ip route" in namespace "z1" should eventually contain "10.0.1.0/24"
+    And show command "show isis database detail" in namespace "z2" should eventually contain "10.0.1.0/24"
+    And show command "show ip route" in namespace "z2" should eventually contain "via 10.0.1.1"
+    And ping from "z2" to "10.2.0.1" should eventually succeed
+
+  Scenario: Deleting the primary hands the subnet to the configured sibling
+    Given the test topology exists
+    # Restore the secondary first; it must come back as a secondary.
+    When I apply command "set interface vz1ns ipv4 address 10.0.1.2/24" in namespace "z1"
+    Then show command "show interface vz1ns" in namespace "z1" should eventually contain "inet 10.0.1.2/24 secondary"
+    # Config-deleting the primary makes the kernel cascade 10.0.1.2
+    # away (promote_secondaries=0); the daemon mirrors the cascade and
+    # re-installs the still-configured sibling, which the kernel now
+    # accepts as the subnet's primary.
+    When I apply command "delete interface vz1ns ipv4 address 10.0.1.1/24" in namespace "z1"
+    Then command "ip -4 addr show vz1ns" in namespace "z1" should eventually not contain "10.0.1.1/24"
+    And command "ip -4 addr show vz1ns" in namespace "z1" should eventually contain "10.0.1.2/24 scope global vz1ns"
+    And command "ip -4 addr show vz1ns" in namespace "z1" should not contain "secondary"
+    And kernel route "10.0.1.0/24" in namespace "z1" should eventually contain "dev vz1ns"
+    # Hellos re-source and LSAs/LSPs re-originate promptly: z2's
+    # nexthop follows the new primary without waiting for a refresh.
+    And show command "show ip route" in namespace "z2" should eventually contain "via 10.0.1.2"
+    And show command "show ip route" in namespace "z2" should eventually not contain "via 10.0.1.1"
+    And ping from "z2" to "10.2.0.1" should eventually succeed
+
+  Scenario: Teardown topology
+    # Separate scenario so cleanup still runs when a step above fails
+    # (a failed step skips the rest of its own scenario only).
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2005,7 +2005,16 @@ impl Ospf<Ospfv2> {
                 if addr.secondary {
                     continue;
                 }
-                let lsa_link = if use_transit {
+                // Only the address on the DR's network sits on the
+                // transit network — the Hello protocol (and thus the
+                // election) runs on the primary's subnet. An
+                // additional address from another subnet is a Stub
+                // link (the Cisco secondary-subnet model): making it
+                // Transit would point a second transit edge at a DR
+                // that is not on that network, and drop the subnet's
+                // reachability from SPF entirely.
+                let on_transit_net = addr.prefix.trunc().contains(&link.ident.d_router);
+                let lsa_link = if use_transit && on_transit_net {
                     RouterLsaLink {
                         // Transit link points to DR interface address.
                         link_id: link.ident.d_router,
@@ -5524,6 +5533,7 @@ impl Ospf<Ospfv2> {
                 packet,
                 nbr.ifindex,
                 Some(nbr.ident.prefix.addr()),
+                None,
             ));
         }
     }
@@ -5634,6 +5644,7 @@ impl Ospf<Ospfv2> {
                     packet,
                     nbr.ifindex,
                     Some(nbr.ident.prefix.addr()),
+                    None,
                 ));
             }
         }
@@ -5700,6 +5711,7 @@ impl Ospf<Ospfv2> {
             packet,
             nbr.ifindex,
             Some(nbr.ident.prefix.addr()),
+            None,
         ));
         // Restart retransmit timer.
         nbr.timer.ls_rxmt = Some(super::flood::ospf_retransmit_timer(
@@ -5744,6 +5756,7 @@ impl Ospf<Ospfv2> {
             packet,
             nbr.ifindex,
             Some(nbr.ident.prefix.addr()),
+            None,
         ));
     }
 
@@ -5792,9 +5805,11 @@ impl Ospf<Ospfv2> {
             Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
         apply_link_auth(&mut packet, &link.auth_send_ctx(chains, now));
         // AllSPFRouters multicast on physical interfaces; unicast to
-        // the far ABR on a virtual link.
+        // the far ABR on a virtual link. Multicast pins the source to
+        // the interface identity (see `Message::Send`).
         let dest = link.vl.as_ref().map(|vl| vl.peer_addr);
-        let _ = link.ptx.send(Message::Send(packet, ifindex, dest));
+        let src = dest.is_none().then(|| link.ident.prefix.addr());
+        let _ = link.ptx.send(Message::Send(packet, ifindex, dest, src));
     }
 
     /// Queue delayed ack headers and start delayed ack timer if needed.
@@ -5990,6 +6005,14 @@ impl Ospf<Ospfv2> {
         // without SR + a configured prefix-sid). Mirrors the v3
         // `addr_add` fix.
         self.ext_prefix_lsa_originate(addr.ifindex);
+
+        // The Router-LSA's stub links and transit Link Data are built
+        // from the address list / identity that just changed; without
+        // re-origination a new subnet (or a promoted primary) only
+        // reaches peers at the next unrelated refresh, and their SPF
+        // keeps resolving nexthops from the stale Link Data.
+        // MinLSInterval-throttled, so an address burst coalesces.
+        self.router_lsa_originate();
     }
 
     fn addr_del(&mut self, addr: LinkAddr) {
@@ -6018,6 +6041,10 @@ impl Ospf<Ospfv2> {
         // host prefix may have just gone away or a different
         // remaining address now wins.
         self.ext_prefix_lsa_originate(addr.ifindex);
+
+        // See `addr_add`: drop the removed subnet / stale Link Data
+        // from the Router-LSA immediately.
+        self.router_lsa_originate();
     }
 
     async fn process_recv(
@@ -11963,10 +11990,18 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// src/dst/ifaddr per its raw IPv6 socket layer.
     Recv(V::Packet, V::Addr, V::Addr, u32, V::Addr),
     /// Packet to send. v2 carries
-    /// `(Ospfv2Packet, ifindex, Option<Ipv4Addr>)` — the optional
-    /// destination is the multicast group or unicast nbr address.
+    /// `(Ospfv2Packet, ifindex, Option<Ipv4Addr>, Option<Ipv4Addr>)`
+    /// — the first option is the destination (multicast group when
+    /// `None`, unicast nbr address otherwise), the second the source
+    /// to pin via `ipi_spec_dst`. Multicast sends MUST pin the
+    /// interface's OSPF identity: with `spec_dst = 0` the kernel
+    /// free-picks the device's first primary address, which on a
+    /// multi-subnet interface can be an address outside the OSPF
+    /// network — peers then key a phantom neighbor on the bogus
+    /// source. Unicast sends pass `None`; kernel source selection
+    /// follows the route to the destination and is subnet-correct.
     /// v3 uses `V::Addr = Ipv6Addr` accordingly.
-    Send(V::Packet, u32, Option<V::Addr>),
+    Send(V::Packet, u32, Option<V::Addr>, Option<V::Addr>),
     Lsdb(LsdbEvent, Option<Ipv4Addr>, OspfLsaKey),
     /// Flood LSA through area, excluding source neighbor.
     /// (area_id, lsa, source_ifindex, source_nbr_addr)

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -169,6 +169,9 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     pub ls_req_last: Option<V::LsRequest>,
     pub ls_rxmt: BTreeMap<OspfLsaKey, V::Lsa>,
     pub uptime: Instant,
+    /// RouterDeadInterval (seconds) governing this neighbor's
+    /// inactivity timer — captured from the interface at creation.
+    pub dead_interval: u64,
     pub last_progressive: Option<Instant>,
     pub last_regressive: Option<Instant>,
     pub last_regressive_reason: Option<NfsmEvent>,
@@ -263,7 +266,7 @@ where
         ifindex: u32,
         prefix: V::Prefix,
         router_id: &Ipv4Addr,
-        _dead_interval: u64,
+        dead_interval: u64,
         ptx: UnboundedSender<Message<V>>,
     ) -> Self {
         let mut nbr = Self {
@@ -283,6 +286,7 @@ where
             ls_req_last: None,
             ls_rxmt: BTreeMap::new(),
             uptime: Instant::now(),
+            dead_interval,
             last_progressive: None,
             last_regressive: None,
             last_regressive_reason: None,

--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -108,7 +108,7 @@ pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<
     // Exits the loop when the event loop drops the sender on
     // instance teardown — mirrors `network_v6::write_packet_v6`.
     while let Some(msg) = rx.recv().await {
-        let Message::Send(packet, ifindex, dest) = msg else {
+        let Message::Send(packet, ifindex, dest, src) = msg else {
             continue;
         };
 
@@ -133,9 +133,13 @@ pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<
         } else {
             ifindex as i32
         };
+        // `ipi_spec_dst` pins the source address when the sender
+        // provided one (multicast Hellos/Acks — see `Message::Send`);
+        // 0 leaves selection to the kernel (unicast).
+        let spec_dst = src.map(|s| u32::from(s).to_be()).unwrap_or(0);
         let pktinfo = libc::in_pktinfo {
             ipi_ifindex: egress_ifindex,
-            ipi_spec_dst: libc::in_addr { s_addr: 0 },
+            ipi_spec_dst: libc::in_addr { s_addr: spec_dst },
             ipi_addr: libc::in_addr { s_addr: 0 },
         };
         let cmsg = [socket::ControlMessage::Ipv4PacketInfo(&pktinfo)];

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -211,11 +211,23 @@ pub fn ospf_nfsm_reset_nbr<V: super::version::OspfVersion>(nbr: &mut Neighbor<V>
     nbr.timer.ls_rxmt = None;
 }
 
+/// Runs after EVERY NFSM event (not just state changes), so it must
+/// never clear the inactivity timer for a live state: HelloReceived
+/// arms it and this function runs right after — clearing it here left
+/// every Full (and Init/TwoWay) neighbor without the RFC 2328 §10.5
+/// dead-man, so a neighbor whose Hellos stopped (or moved to another
+/// source address) survived as a zombie forever. FRR's
+/// `nsm_timer_set` clears `t_inactivity` only for Down/Deleted.
 pub fn ospf_nfsm_timer_set<V: OspfVersion>(nbr: &mut Neighbor<V>) {
     use NfsmState::*;
     match nbr.state {
-        Down | Init | TwoWay => {
+        Down => {
             nbr.timer.inactivity = None;
+            nbr.timer.db_desc = None;
+            nbr.timer.db_desc_free = None;
+            nbr.timer.ls_upd = None;
+        }
+        Init | TwoWay => {
             nbr.timer.db_desc = None;
             nbr.timer.db_desc_free = None;
             nbr.timer.ls_upd = None;
@@ -237,7 +249,6 @@ pub fn ospf_nfsm_timer_set<V: OspfVersion>(nbr: &mut Neighbor<V>) {
             nbr.timer.db_desc_free = None;
         }
         Full => {
-            nbr.timer.inactivity = None;
             nbr.timer.db_desc = None;
             nbr.timer.ls_upd = None;
         }
@@ -286,7 +297,7 @@ pub fn ospf_inactivity_timer<V: OspfVersion>(nbr: &Neighbor<V>) -> Timer {
     let tx = nbr.tx.clone();
     let nbr_addr = V::nbr_addr(&nbr.ident);
     let ifindex = nbr.ifindex;
-    Timer::new(40, TimerType::Once, move || {
+    Timer::new(nbr.dead_interval, TimerType::Once, move || {
         use NfsmEvent::*;
         let tx = tx.clone();
         async move {

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -380,6 +380,24 @@ pub fn ospf_hello_recv(
         return;
     }
 
+    // RFC 2328 §10.5: on broadcast/NBMA the source must lie on the
+    // interface's own network. A multi-address peer whose kernel
+    // sourced a Hello from one of its *other* subnets must not be
+    // keyed as a neighbor here — the entry can never complete an
+    // exchange (its unicast replies come from the on-link address)
+    // and wedges in ExStart. P2P adjacencies are address-agnostic
+    // (§10.5 checks the mask only there) and virtual links unicast
+    // through the transit area, so both skip the check.
+    if !oi.is_pointopoint() && oi.vl.is_none() && !addr.prefix.trunc().contains(src) {
+        ospf_pdu_trace!(
+            tracing,
+            "[Hello:Recv] dropping {}: source not on network {}",
+            src,
+            addr.prefix.trunc(),
+        );
+        return;
+    }
+
     // RFC 2328 §10.5 / RFC 3101 §2.5: the E-bit and N-bit in the
     // Hello Options MUST match our local area-type, else drop the
     // packet. An NSSA neighbor seen on a normal link (or vice
@@ -491,8 +509,12 @@ pub fn ospf_hello_send(
     let packet = ospf_hello_packet(oi, chains, now).unwrap();
     // Virtual links unicast their Hellos to the far ABR (RFC 2328
     // §15); physical interfaces multicast to AllSPFRouters (None).
+    // Multicast pins the source to the interface's OSPF identity —
+    // the kernel would otherwise free-pick across subnets on a
+    // multi-address interface.
     let dest = oi.vl.as_ref().map(|vl| vl.peer_addr);
-    if let Err(e) = oi.ptx.send(Message::Send(packet, oi.index, dest)) {
+    let src = dest.is_none().then(|| oi.ident.prefix.addr());
+    if let Err(e) = oi.ptx.send(Message::Send(packet, oi.index, dest, src)) {
         tracing::warn!("[Hello:Send] channel send failed: {}", e);
         return;
     }
@@ -571,6 +593,7 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
         packet,
         nbr.ifindex,
         Some(nbr.ident.prefix.addr()),
+        None,
     ));
 }
 
@@ -600,6 +623,7 @@ pub fn ospf_ls_req_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &I
             packet,
             nbr.ifindex,
             Some(nbr.ident.prefix.addr()),
+            None,
         ))
         .unwrap();
 }
@@ -848,6 +872,7 @@ fn ospf_db_desc_resend(oi: &OspfInterface, nbr: &Neighbor) {
         packet,
         nbr.ifindex,
         Some(nbr.ident.prefix.addr()),
+        None,
     ));
 }
 
@@ -868,6 +893,7 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
             packet,
             nbr.ifindex,
             Some(nbr.ident.prefix.addr()),
+            None,
         ))
         .unwrap();
 }
@@ -889,6 +915,7 @@ pub fn ospf_ls_ack_send(oi: &OspfInterface, nbr: &Neighbor, lsa_headers: Vec<Osp
             packet,
             nbr.ifindex,
             Some(nbr.ident.prefix.addr()),
+            None,
         ))
         .unwrap();
 }


### PR DESCRIPTION
## Summary

PR 6 (final) of the multi-IPv4-address series (#2168 → #2175 → #2178 → #2180 → #2185).

**New BDD feature `ipv4_address_secondary`**: two routers on a bridge LAN; z1 carries `10.0.1.1/24` (primary) + `10.0.1.2/24` (kernel `IFA_F_SECONDARY`) + `10.2.0.1/24`, with OSPFv2 and IS-IS both enabled. Scenarios assert:
- kernel + `show interface` secondary verdict (config-driven install, i.e. the no-self-echo local mirror),
- one connected route per subnet,
- z1's Router-LSA at `Number of Links: 2` (a counted secondary would make it 3) and IS-IS reachability deduped,
- z2 learns every z1 address from one packed TLV 132,
- learned routes go `via 10.0.1.1` and the secondary never appears as a nexthop,
- deleting the secondary keeps the connected route and the advertisements,
- deleting the primary promotes the configured sibling: kernel flags settle, and z2 re-pins its nexthop to `via 10.0.1.2`,
- explicit teardown scenario.

**The primary-delete scenario failed against the daemon** and flushed out five real OSPFv2 defects, fixed here:

1. **Multicast TX source unpinned** — `Message::Send` carried no source; `write_packet` sent with `ipi_spec_dst=0`, so the kernel free-picked the device's first primary, which on a multi-subnet interface can be an address outside the OSPF network. Peers keyed a phantom neighbor on the bogus source. Hellos/delayed Acks now pin the interface's OSPF identity; unicast keeps kernel (route-based, subnet-correct) selection.
2. **No Router-LSA re-origination on `addr_add`/`addr_del`** — a new subnet or a promoted primary's Link Data only reached peers at the next unrelated refresh; peers' SPF kept resolving nexthops from stale Link Data. The OSPF twin of the IS-IS `LspOriginate` gap fixed in #2185. Both handlers now call the (MinLSInterval-throttled) `router_lsa_originate()`.
3. **Missing RFC 2328 §10.5 same-network ingress check** — a Hello sourced from another subnet was accepted on broadcast interfaces and created a neighbor wedged in ExStart forever (its unicast replies come from the on-link address). P2P/virtual links keep their address-agnostic behavior.
4. **No dead-man timer on Full neighbors** — `ospf_nfsm_timer_set` runs after *every* NFSM event and cleared the inactivity timer for Full (and Init/TwoWay), immediately dropping the arm from HelloReceived. A neighbor whose Hellos stopped — or moved to a new source address — survived as a routing zombie forever (`Dead Time -` in `show ospf neighbor`). FRR's `nsm_timer_set` clears `t_inactivity` only for Down/Deleted; matched. The timer also hardcoded 40s and now honors the configured dead-interval.
5. **Multi-subnet Router-LSA modeling** — with a transit adjacency, *every* non-secondary address was emitted as a Transit link; an additional subnet's transit edge pointed at a DR not on that network and the subnet vanished from SPF. Only the DR's subnet is transit; other subnets now emit Stub links (Cisco secondary-subnet model).

## Testing

- New feature passes: 5 scenarios, 55 steps, environment clean after teardown.
- Manual two-router repro: primary flip reconverges in ~36s (bounded by the old neighbor's dead-interval) with the route re-pinned `via 10.0.1.2`, exactly one Full neighbor with a live dead timer, and the LSA at transit(10.0.1.2)+stub.
- Full BDD suite at c=16: **274 features, 272 passed**; the two failures (`ospfv2_redist_table`, `bgp_lu_route_map`) are prior load-margin repeaters and both pass solo at c=1. No leaked namespaces or daemons.
- `cargo test --workspace --exclude bdd`: 2702 passed, 0 failed; workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)