### PR TITLE
ospfv3: stable link-local selection + neighbor source refresh

### DIFF
--- a/zebra-rs/src/ospf/addr.rs
+++ b/zebra-rs/src/ospf/addr.rs
@@ -35,6 +35,29 @@ where
     }
 }
 
+/// The interface's IPv6 link-local source address (RFC 5340 §A.1:
+/// every v3 control packet sources from it, and the Link-LSA
+/// advertises it).
+///
+/// Selection must be STABLE against address-list reordering — the
+/// list order is netlink delivery order, which a re-notify or a
+/// delete/re-add can permute — because every consumer must keep
+/// agreeing on one address: the Hello source, the pseudo-header
+/// checksum + `IPV6_PKTINFO` pin, the Link-LSA, and the BFD session
+/// local endpoint. Pick the numerically lowest link-local instead of
+/// the first in list order. Adding a lower link-local moves the
+/// source; peers absorb that via the same-Router-ID source refresh
+/// in `ospfv3_hello_recv`.
+pub fn stable_link_local(
+    addrs: &[OspfAddr<crate::ospf::version::Ospfv3>],
+) -> Option<std::net::Ipv6Addr> {
+    addrs
+        .iter()
+        .map(|a| a.prefix.addr())
+        .filter(|a| a.is_unicast_link_local())
+        .min()
+}
+
 /// First address passing `pred` that is not kernel-secondary, falling
 /// back to the first passing one at all. Selection sites (identity,
 /// Hello netmask, Network-LSA ls_id, BFD, SR host prefix) go through
@@ -179,6 +202,27 @@ mod tests {
                 secondary: false
             }
         ));
+    }
+
+    #[test]
+    fn stable_link_local_is_order_independent() {
+        let ll_low: ipnet::Ipv6Net = "fe80::1/64".parse().unwrap();
+        let ll_high: ipnet::Ipv6Net = "fe80::5054:ff:fe00:1/64".parse().unwrap();
+        let global: ipnet::Ipv6Net = "2001:db8::1/64".parse().unwrap();
+        let mk = |p: ipnet::Ipv6Net| OspfAddr::<Ospfv3> {
+            prefix: p,
+            secondary: false,
+        };
+
+        // Same set, both delivery orders → same pick (the lowest).
+        let fwd = vec![mk(global), mk(ll_low), mk(ll_high)];
+        let rev = vec![mk(ll_high), mk(ll_low), mk(global)];
+        assert_eq!(stable_link_local(&fwd), Some("fe80::1".parse().unwrap()));
+        assert_eq!(stable_link_local(&fwd), stable_link_local(&rev));
+
+        // No link-local → None; globals never qualify.
+        assert_eq!(stable_link_local(&[mk(global)]), None);
+        assert_eq!(stable_link_local(&[]), None);
     }
 
     #[test]

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -6032,6 +6032,11 @@ impl Ospf<Ospfv2> {
             // (no-op on links without SR + a configured prefix-sid).
             // Mirrors the v3 `addr_add` fix.
             self.ext_prefix_lsa_originate(addr.ifindex);
+
+            // A kernel promotion may have moved the primary — the BFD
+            // sessions on this link key on it as the local endpoint,
+            // so re-key them. No-op when the pick didn't change.
+            self.bfd_reconcile_link(addr.ifindex);
         }
     }
 
@@ -6066,6 +6071,9 @@ impl Ospf<Ospfv2> {
             // a different remaining address now wins.
             self.router_lsa_originate();
             self.ext_prefix_lsa_originate(addr.ifindex);
+            // See `addr_add`: the deleted address may have been the
+            // primary — BFD must re-key onto the promoted survivor.
+            self.bfd_reconcile_link(addr.ifindex);
         }
     }
 
@@ -7081,6 +7089,13 @@ impl Ospf<Ospfv3> {
             self.router_intra_area_prefix_lsa_originate(area_id);
             self.network_intra_area_prefix_lsa_originate(addr.ifindex);
 
+            // Our own stable link-local pick may have moved (a lower
+            // fe80 was added) — the BFD sessions on this link key on
+            // it as the local endpoint, so re-key them. Peers absorb
+            // the moved Hello source via their `NbrSourceChanged`
+            // refresh. No-op when the pick didn't change.
+            self.bfd_reconcile_link(addr.ifindex);
+
             // The Prefix-SID's E-Intra-Area-Prefix-LSA advertises this
             // link's first routable global as a /128 host prefix. The
             // config handler originates it at commit time, but the
@@ -7247,6 +7262,9 @@ impl Ospf<Ospfv3> {
             self.router_intra_area_prefix_lsa_originate(area_id);
             self.network_intra_area_prefix_lsa_originate(addr.ifindex);
             self.ext_intra_area_prefix_v3_lsa_originate(addr.ifindex);
+            // See `addr_add`: the deleted address may have been the
+            // stable link-local — BFD must re-key onto the survivor.
+            self.bfd_reconcile_link(addr.ifindex);
         }
     }
 
@@ -7334,7 +7352,7 @@ impl Ospf<Ospfv3> {
                 // Skip link-local addresses — those are
                 // advertised by Link-LSAs (RFC 5340 §A.4.9), not
                 // by Intra-Area-Prefix-LSAs (§A.4.10).
-                if a.prefix.addr().segments()[0] == 0xfe80 {
+                if a.prefix.addr().is_unicast_link_local() {
                     continue;
                 }
                 let prefix_length = a.prefix.prefix_len();
@@ -7435,15 +7453,12 @@ impl Ospf<Ospfv3> {
             return None;
         }
 
-        // Pick a link-local. v3 hellos source from the link-local
-        // and v3 Link-LSAs advertise it (RFC 5340 §A.4.9). Until
-        // netlink reports one we publish `::` as a placeholder.
-        let link_local_address: Ipv6Addr = link
-            .addr
-            .iter()
-            .map(|a| a.prefix.addr())
-            .find(|a| a.segments()[0] == 0xfe80)
-            .unwrap_or(Ipv6Addr::UNSPECIFIED);
+        // The stable link-local — the same pick every v3 source-address
+        // site uses, so the Link-LSA advertises exactly the address our
+        // hellos come from (RFC 5340 §A.4.9). Until netlink reports one
+        // we publish `::` as a placeholder.
+        let link_local_address: Ipv6Addr =
+            super::addr::stable_link_local(&link.addr).unwrap_or(Ipv6Addr::UNSPECIFIED);
 
         // Every non-link-local prefix configured on the interface
         // gets advertised, host bits masked (see
@@ -7455,7 +7470,7 @@ impl Ospf<Ospfv3> {
         for a in link
             .addr
             .iter()
-            .filter(|a| a.prefix.addr().segments()[0] != 0xfe80)
+            .filter(|a| !a.prefix.addr().is_unicast_link_local())
         {
             let prefix_length = a.prefix.prefix_len();
             let address_prefix =
@@ -7481,7 +7496,7 @@ impl Ospf<Ospfv3> {
             link.addr
                 .iter()
                 .map(|a| a.prefix.addr())
-                .filter(|a| a.segments()[0] != 0xfe80)
+                .filter(|a| !a.is_unicast_link_local())
                 .map(|addr| {
                     let mut options = Ospfv3PrefixOptions::default();
                     options.set_la(true);
@@ -8209,7 +8224,7 @@ impl Ospf<Ospfv3> {
             l.addr
                 .iter()
                 .map(|a| a.prefix.addr())
-                .find(|a| !a.is_loopback() && (a.segments()[0] & 0xffc0) != 0xfe80)
+                .find(|a| !a.is_loopback() && !a.is_unicast_link_local())
         })
     }
 
@@ -9664,10 +9679,7 @@ impl Ospf<Ospfv3> {
             let Some(link) = self.links.get_mut(&ifindex) else {
                 continue;
             };
-            let Some(src) = link.addr.iter().find_map(|a| {
-                let addr = a.prefix.addr();
-                addr.is_unicast_link_local().then_some(addr)
-            }) else {
+            let Some(src) = super::addr::stable_link_local(&link.addr) else {
                 continue;
             };
             let retransmit_interval = link.retransmit_interval();
@@ -9770,10 +9782,7 @@ impl Ospf<Ospfv3> {
         let area_id = link.area;
         let v3_instance_id = link.v3_instance_id();
         let retransmit_interval = link.retransmit_interval();
-        let Some(src) = link.addr.iter().find_map(|a| {
-            let addr = a.prefix.addr();
-            addr.is_unicast_link_local().then_some(addr)
-        }) else {
+        let Some(src) = super::addr::stable_link_local(&link.addr) else {
             return;
         };
         // Auth send state captured before the neighbor borrow (see
@@ -10162,6 +10171,17 @@ impl Ospf<Ospfv3> {
                 // or no-ops when we aren't DR.
                 self.network_intra_area_prefix_lsa_originate(ifindex);
             }
+            Message::NbrSourceChanged(ifindex, nbr_router_id) => {
+                // The neighbor renumbered its link-local; its
+                // `ident.prefix` was already updated on the receive
+                // path. Re-key the consumers that cached the old
+                // address: the BFD session (remote endpoint) and the
+                // SRv6 End.X nexthop. Both reconciles read the
+                // current neighbor state and no-op when nothing is
+                // configured.
+                self.bfd_reconcile_nbr(ifindex, nbr_router_id);
+                self.reconcile_endx_sid(ifindex, nbr_router_id);
+            }
             Message::DdRetransmit(ifindex, router_id) => {
                 self.process_dd_retransmit(ifindex, router_id);
             }
@@ -10443,10 +10463,7 @@ impl Ospf<Ospfv3> {
             return;
         };
         let area_id = link.area;
-        let Some(src) = link.addr.iter().find_map(|a| {
-            let addr = a.prefix.addr();
-            addr.is_unicast_link_local().then_some(addr)
-        }) else {
+        let Some(src) = super::addr::stable_link_local(&link.addr) else {
             return;
         };
         let retransmit_interval = link.retransmit_interval();
@@ -10602,7 +10619,7 @@ impl Ospf<Ospfv3> {
                 // remote SIDs onto their own ::1/128 route (last
                 // writer wins) instead of the advertised loopbacks.
                 let a = a.prefix.addr();
-                a.segments()[0] != 0xfe80 && !a.is_loopback() && !a.is_unspecified()
+                !a.is_unicast_link_local() && !a.is_loopback() && !a.is_unspecified()
             }) {
             let host = Ipv6Net::new(addr.prefix.addr(), 128).unwrap_or(addr.prefix);
             // Loopback parity with v2 / FRR / Junos: stamp 0 instead
@@ -11144,7 +11161,7 @@ impl Ospf<Ospfv3> {
             let mut octets = [0u8; 16];
             octets.copy_from_slice(&p.address_prefix[..16]);
             let addr = Ipv6Addr::from(octets);
-            (addr.segments()[0] != 0xfe80).then_some(addr)
+            (!addr.is_unicast_link_local()).then_some(addr)
         })
     }
 
@@ -11677,7 +11694,7 @@ impl Ospf<Ospfv3> {
         let mut seen: std::collections::BTreeSet<(u8, Vec<u8>)> = std::collections::BTreeSet::new();
         let mut prefixes: Vec<Ospfv3IntraAreaPrefix> = Vec::new();
         for a in link.addr.iter() {
-            if a.prefix.addr().segments()[0] == 0xfe80 {
+            if a.prefix.addr().is_unicast_link_local() {
                 continue;
             }
             let prefix_length = a.prefix.prefix_len();
@@ -12170,6 +12187,17 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     ///
     /// v3-only; the v2 handler ignores it.
     LinkLsaInstalled(u32),
+    /// A known neighbor's link-local source address moved — a Hello
+    /// arrived with the same Router-ID from a new source (the peer
+    /// renumbered its link-local). `ospfv3_hello_recv` already
+    /// updated `nbr.ident.prefix`, which redirects every unicast
+    /// exchange (DBD / LSR / LSU retransmit / LSAck); this message
+    /// lets the instance re-key the consumers that cached the old
+    /// address: the BFD session (its remote endpoint is the
+    /// link-local pair) and the SRv6 End.X nexthop.
+    ///
+    /// (ifindex, nbr_router_id). v3-only; the v2 handler ignores it.
+    NbrSourceChanged(u32, Ipv4Addr),
     /// Retransmit LSAs to a specific neighbor.
     /// (ifindex, nbr_addr)
     Retransmit(u32, Ipv4Addr),
@@ -16175,7 +16203,7 @@ fn add_self_prefix_sids_to_ilm_v3(top: &Ospf<Ospfv3>, ilm: &mut BTreeMap<u32, Sp
                 let Some(our_addr) = link
                     .addr
                     .iter()
-                    .find(|a| a.prefix.addr().segments()[0] != 0xfe80)
+                    .find(|a| !a.prefix.addr().is_unicast_link_local())
                     .map(|a| a.prefix.addr())
                 else {
                     continue;

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -228,15 +228,14 @@ pub(super) fn verify_v3_auth_trailer(
     Some(seq)
 }
 
-/// First link-local address on this interface, or `None` if none has
+/// The interface's stable link-local address, or `None` if none has
 /// been picked up from `rib::Link` yet. The v3 send loop folds this
 /// into the IPv6 pseudo-header checksum and pins it via
 /// `IPV6_PKTINFO` so the kernel emits from the matching source.
+/// Selection is [`super::addr::stable_link_local`] — every source
+/// pick in the v3 path must agree on the same address.
 fn link_local_src(link: &OspfLink<Ospfv3>) -> Option<Ipv6Addr> {
-    link.addr.iter().find_map(|a| {
-        let addr = a.prefix.addr();
-        addr.is_unicast_link_local().then_some(addr)
-    })
+    super::addr::stable_link_local(&link.addr)
 }
 
 /// Build the next Ospfv3 Hello to emit on `link`. Mirrors v2's
@@ -449,6 +448,28 @@ pub fn ospfv3_hello_recv(
     // PointToPoint link records.
     nbr.interface_id = hello.interface_id;
 
+    // Same Router-ID, new link-local source: the peer renumbered its
+    // link-local (deleted / replaced, or its own stable pick moved).
+    // The recorded address was set once at neighbor creation and is
+    // the destination of every unicast exchange (DBD / LSR / LSU
+    // retransmit / LSAck) — left stale, those all go to a dead
+    // address and the adjacency wedges on retransmits while
+    // multicast Hellos keep it looking alive. Follow the source and
+    // tell the instance so BFD / End.X re-key too.
+    if !init && nbr.ident.prefix != prefix {
+        ospf_pdu_trace!(
+            tracing,
+            "[v3 Hello:Recv] neighbor {} link-local moved {} -> {}",
+            nbr_router_id,
+            nbr.ident.prefix.addr(),
+            src,
+        );
+        nbr.ident.prefix = prefix;
+        oi.tx
+            .send(Message::NbrSourceChanged(oi.index, nbr_router_id))
+            .unwrap();
+    }
+
     oi.tx
         .send(Message::Nfsm(
             oi.index,
@@ -504,14 +525,11 @@ pub fn ospfv3_hello_recv(
     }
 }
 
-/// First link-local v6 address among the interface's configured
-/// addresses. Same helper as `link_local_src` but on the
+/// The stable link-local among the interface's configured addresses.
+/// Same helper as `link_local_src` but on the
 /// `OspfInterface<Ospfv3>` borrow used by NFSM-side packet senders.
 fn interface_link_local_src(oi: &OspfInterface<Ospfv3>) -> Option<Ipv6Addr> {
-    oi.addr.iter().find_map(|a| {
-        let addr = a.prefix.addr();
-        addr.is_unicast_link_local().then_some(addr)
-    })
+    super::addr::stable_link_local(oi.addr)
 }
 
 /// Pack the LSAs currently queued on `nbr.db_sum` into `dd.lsa_headers`.

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -594,12 +594,9 @@ impl OspfVersion for Ospfv3 {
         // as a /128 in `ident.prefix`. BFD mirrors that — both
         // endpoints are link-local, demuxed per-ifindex (the
         // `SessionKey.ifindex` is set by the reconcile, and v6 egress
-        // is pinned to it via `IPV6_PKTINFO`). Mirrors
+        // is pinned to it via `IPV6_PKTINFO`). Same stable pick as
         // `packet_v3::link_local_src`.
-        let local = addrs.iter().find_map(|a| {
-            let addr = a.prefix.addr();
-            addr.is_unicast_link_local().then_some(addr)
-        })?;
+        let local = crate::ospf::addr::stable_link_local(addrs)?;
         let remote = nbr.ident.prefix.addr();
         Some((std::net::IpAddr::V6(local), std::net::IpAddr::V6(remote)))
     }


### PR DESCRIPTION
## Summary

PR 5 of the multiple-IPv6-address-per-interface series: make the v3 link-local source address deterministic and survivable when it changes.

- **Stable selection**: six sites (Hello build, NFSM-side senders, both flood paths, Link-LSA advertisement, BFD local endpoint) each independently picked the *first* fe80 in `link.addr` — netlink delivery order, permutable by re-notify or delete/re-add — so the Hello source, Link-LSA, and BFD could disagree and flip between runs. All now share `addr::stable_link_local`: numerically lowest link-local, order-independent.
- **Neighbor source refresh**: a peer's link-local was recorded once at neighbor creation. On renumber (same Router-ID, new source), all unicast exchanges (DBD/LSR/LSU retransmit/LSAck) went to the dead address while multicast Hellos kept the adjacency looking alive — a silent permanent wedge, with BFD stuck on the stale remote. `ospfv3_hello_recv` now follows the source (complementing the existing same-source-new-Router-ID sweep), and a new `Message::NbrSourceChanged` re-keys the cached consumers (BFD session, SRv6 End.X nexthop).
- **Local re-key**: when an address event moves our own pick (lower LL added / current LL deleted in v3; kernel promotion moving the v4 primary), `addr_add`/`addr_del` now call `bfd_reconcile_link` so the local BFD endpoint follows.
- **Predicate sweep**: eight `segments()[0] == 0xfe80` (fe80::/16) sites unified onto `is_unicast_link_local()` (fe80::/10, RFC 4291).

## Testing

- Unit: `stable_link_local` order-independence (same set, reversed order → same pick), lowest-wins, non-LL exclusion, empty. Full workspace suite: 2,706 passed, 0 failed; clippy clean; fmt clean.
- **Live two-node segment with OSPFv3 + BFD**: adding `fe80::1:1` moved the Hello source; the peer re-keyed BFD onto the new pair (Up ~12s) and re-pinned routes `via fe80::1:1`; adjacency re-formed ~2s; a subnet added *after* the renumber flooded in ~1s; deleting the address fell everything back to the EUI-64 LL in ~8s. Each of those was previously a permanent wedge.
- BDD: `ospfv3_bfd_frr`, `ospfv2_bfd_frr`, `ospfv3_adjacency`, `ipv4_address_secondary` — 4/4 pass.

Series: PR 1 #2169, PR 2 #2174, PR 3 #2184, PR 4 #2186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)