### PR TITLE
isis: IPv6 reachability mask+dedup and stable v6 address picks

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2124,7 +2124,7 @@ impl Isis {
         for (ifindex, link) in self.links.iter() {
             let enable = link.config.bfd.resolve(&self.config.bfd).enable;
             let local_v4 = super::link::v4_primary(&link.state.v4addr).map(|e| e.prefix.addr());
-            let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
+            let local_v6ll = super::link::v6ll_pick(&link.state.v6laddr);
             for level in [Level::L1, Level::L2] {
                 for nbr in link.state.nbrs.get(&level).values() {
                     if nbr.state != NfsmState::Up {
@@ -2133,7 +2133,7 @@ impl Isis {
                     // v4-preferred / v6-link-local fallback, same selection as
                     // the NFSM subscribe path (see packet::bfd_session_key).
                     let remote_v4 = super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
-                    let remote_v6ll = nbr.addr6l.first().copied();
+                    let remote_v6ll = super::link::nbr_v6ll_pick(&nbr.addr6l);
                     let Some((local, remote)) = super::packet::bfd_session_addrs(
                         local_v4,
                         remote_v4,
@@ -2209,7 +2209,7 @@ impl Isis {
         // scope is the link's ifindex.
         let desired = if link.config.te_metric_measurement.enabled() && link.is_p2p() {
             let local_v4 = super::link::v4_primary(&link.state.v4addr).map(|e| e.prefix.addr());
-            let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
+            let local_v6ll = super::link::v6ll_pick(&link.state.v6laddr);
             let nbr = [Level::L1, Level::L2].iter().find_map(|level| {
                 link.state
                     .nbrs
@@ -2219,7 +2219,7 @@ impl Isis {
             });
             let remote_v4 =
                 nbr.and_then(|n| super::link::nbr_v4_pick(&link.state.v4addr, &n.addr4));
-            let remote_v6ll = nbr.and_then(|n| n.addr6l.first().copied());
+            let remote_v6ll = nbr.and_then(|n| super::link::nbr_v6ll_pick(&n.addr6l));
             super::packet::bfd_session_addrs(local_v4, remote_v4, local_v6ll, remote_v6ll).map(
                 |(local, remote)| {
                     (

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -763,6 +763,43 @@ pub fn nbr_v4_pick(
         .copied()
 }
 
+/// The link's stable IPv6 link-local — the v6 sibling of
+/// [`v4_primary`]. IPv6 has no kernel-secondary, so the only
+/// instability is list order (`v6laddr` is netlink delivery order,
+/// which a re-notify or delete/re-add permutes); pick the numerically
+/// lowest link-local instead. Every local v6 endpoint consumer (BFD
+/// session key on both the subscribe and the NFSM-teardown side,
+/// STAMP) must agree on one address. Mirrors OSPFv3's
+/// `stable_link_local`.
+pub fn v6ll_pick(v6laddr: &[Ipv6Net]) -> Option<std::net::Ipv6Addr> {
+    v6laddr
+        .iter()
+        .map(|p| p.addr())
+        .filter(|a| a.is_unicast_link_local())
+        .min()
+}
+
+/// The link's stable global IPv6 address (the SRLG TLV 139 local
+/// endpoint disambiguator): lowest non-loopback global.
+pub fn v6_global_pick(v6addr: &[Ipv6Net]) -> Option<std::net::Ipv6Addr> {
+    v6addr
+        .iter()
+        .map(|p| p.addr())
+        .filter(|a| !a.is_loopback() && !a.is_unicast_link_local())
+        .min()
+}
+
+/// One stable link-local out of a neighbor's advertised set — the v6
+/// sibling of [`nbr_v4_pick`]. TLV 232 packs the peer's link-locals
+/// in the peer's own list order, so "first" can flip between hellos;
+/// any of them is a valid nexthop on this link, so take the lowest.
+/// SPF nexthop resolution, the BFD/STAMP session keys, TI-LFA repair
+/// nexthops, and `show isis topology` all route through here so they
+/// agree with each other.
+pub fn nbr_v6ll_pick(addr6l: &[std::net::Ipv6Addr]) -> Option<std::net::Ipv6Addr> {
+    addr6l.iter().copied().min()
+}
+
 // Mutable data during operation.
 #[derive(Default, Debug)]
 pub struct LinkState {
@@ -3031,5 +3068,47 @@ mod v4addr_tests {
         // Delete matches by prefix regardless of the event's flag.
         v4addr_list_update(&mut list, entry("10.0.0.1/24", false), false);
         assert_eq!(list, vec![entry("10.0.0.2/24", true)]);
+    }
+}
+
+#[cfg(test)]
+mod v6_pick_tests {
+    use super::*;
+
+    #[test]
+    fn v6ll_pick_is_order_independent() {
+        let low: Ipv6Net = "fe80::1/64".parse().unwrap();
+        let high: Ipv6Net = "fe80::5054:ff:fe00:1/64".parse().unwrap();
+        assert_eq!(
+            v6ll_pick(&[high, low]),
+            Some("fe80::1".parse().unwrap()),
+            "lowest wins regardless of list order"
+        );
+        assert_eq!(v6ll_pick(&[low, high]), v6ll_pick(&[high, low]));
+        assert_eq!(v6ll_pick(&[]), None);
+    }
+
+    #[test]
+    fn v6_global_pick_skips_ll_and_loopback() {
+        let ll: Ipv6Net = "fe80::1/64".parse().unwrap();
+        let lo: Ipv6Net = "::1/128".parse().unwrap();
+        let g1: Ipv6Net = "2001:db8::2/64".parse().unwrap();
+        let g2: Ipv6Net = "2001:db8::1/64".parse().unwrap();
+        assert_eq!(
+            v6_global_pick(&[ll, lo, g1, g2]),
+            Some("2001:db8::1".parse().unwrap())
+        );
+        assert_eq!(v6_global_pick(&[ll, lo]), None);
+    }
+
+    #[test]
+    fn nbr_v6ll_pick_is_stable_across_peer_order() {
+        let a: std::net::Ipv6Addr = "fe80::2".parse().unwrap();
+        let b: std::net::Ipv6Addr = "fe80::10".parse().unwrap();
+        // The peer may pack its TLV 232 in either order between
+        // hellos; the pick must not flip.
+        assert_eq!(nbr_v6ll_pick(&[b, a]), Some(a));
+        assert_eq!(nbr_v6ll_pick(&[a, b]), Some(a));
+        assert_eq!(nbr_v6ll_pick(&[]), None);
     }
 }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1190,14 +1190,13 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 // (peer v6 address known). Skipped on v4-only links
                 // even if the v4 TLV above was emitted; the two TLVs
                 // are independent per RFC 6119.
-                let local_v6 = link.state.v6addr.first().map(|p| p.addr());
+                let local_v6 = super::link::v6_global_pick(&link.state.v6addr);
                 let remote_v6 = link
                     .state
                     .nbrs
                     .get(&level)
                     .values()
-                    .flat_map(|nbr| nbr.addr6.iter().copied())
-                    .next();
+                    .find_map(|nbr| nbr.addr6.iter().copied().min());
                 if let (Some(local_v6), Some(remote_v6)) = (local_v6, remote_v6) {
                     for chunk in values.chunks(IsisTlvIpv6Srlg::MAX_VALUES_PER_TLV) {
                         let tlv = IsisTlvIpv6Srlg {
@@ -1398,6 +1397,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     // topology, so the plain interface metric leaf is the metric.
     let mt_v6 = top.config.mt_enabled && top.config.mt_topologies.contains(&MtId::Ipv6Unicast);
     let mut ipv6_reach = IsisTlvIpv6Reach::default();
+    // Mask + dedup, the TLV 135 discipline above: RFC 5308 prefixes
+    // carry no host bits (a /64 address advertised unmasked leaks
+    // them into receivers' RIBs), and two same-subnet addresses mask
+    // to one prefix — advertise it once.
+    let mut seen_v6: BTreeSet<Ipv6Net> = BTreeSet::new();
     for (_, link) in top.links.iter() {
         if link.config.enable.v6 && has_level(link.state.level(), level) {
             let metric = if mt_v6 {
@@ -1406,10 +1410,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 link.config.metric()
             };
             for v6addr in link.state.v6addr.iter() {
-                if !v6addr.addr().is_loopback() {
+                let prefix = v6addr.apply_mask();
+                if !prefix.addr().is_loopback() && seen_v6.insert(prefix) {
                     ipv6_reach
                         .entries
-                        .push(ipv6_reach_entry(*v6addr, metric, false));
+                        .push(ipv6_reach_entry(prefix, metric, false));
                 }
             }
         }

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -174,7 +174,7 @@ impl Neighbor {
         self.addr6
             .first()
             .copied()
-            .or_else(|| self.addr6l.first().copied())
+            .or_else(|| super::link::nbr_v6ll_pick(&self.addr6l))
     }
 
     /// Re-originate the self-LSP (both levels; the per-level guard in

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -86,7 +86,7 @@ pub fn nbr_hold_timer_expire(
     // subscribe path used (packet::bfd_session_key) or the Unsubscribe key
     // won't match the live session.
     let bfd_peer_v4 = super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
-    let bfd_peer_v6ll = nbr.addr6l.first().copied();
+    let bfd_peer_v6ll = super::link::nbr_v6ll_pick(&nbr.addr6l);
 
     // Originate Hello and LSP.
     if is_p2p {

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -51,7 +51,7 @@ pub(super) fn bfd_session_key(
     peer_v6ll: Option<Ipv6Addr>,
 ) -> Option<SessionKey> {
     let local_v4 = super::link::v4_primary(&link.state.v4addr).map(|e| e.prefix.addr());
-    let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
+    let local_v6ll = super::link::v6ll_pick(&link.state.v6laddr);
     let (local, remote) = bfd_session_addrs(local_v4, peer_v4, local_v6ll, peer_v6ll)?;
     Some(SessionKey {
         local,
@@ -504,7 +504,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     let bfd_peer_v4: Option<Ipv4Addr> = super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
     // IPv6-only adjacency: the single-hop BFD session is keyed on the
     // neighbour's link-local (learned via TLV 232) and our own link-local.
-    let bfd_peer_v6ll: Option<Ipv6Addr> = nbr.addr6l.first().copied();
+    let bfd_peer_v6ll: Option<Ipv6Addr> = super::link::nbr_v6ll_pick(&nbr.addr6l);
 
     if state == NfsmState::Down {
         // 8.4.2.5.1
@@ -753,7 +753,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // Snapshot before any mut-nbr work; see LAN handler comment.
         let bfd_peer_v4: Option<Ipv4Addr> =
             super::link::nbr_v4_pick(&link.state.v4addr, &nbr.addr4);
-        let bfd_peer_v6ll: Option<Ipv6Addr> = nbr.addr6l.first().copied();
+        let bfd_peer_v6ll: Option<Ipv6Addr> = super::link::nbr_v6ll_pick(&nbr.addr6l);
 
         // When it is three way handshake.
         if state == NfsmState::Down {

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -239,9 +239,11 @@ impl IsisRibFamily for V6 {
     }
 
     fn nhop_addrs(_link: &IsisLink, nbr: &Neighbor) -> Vec<Ipv6Addr> {
-        // Link-locals are on-link by definition; the first is the
-        // same one the BFD/STAMP session keys use.
-        nbr.addr6l.first().into_iter().copied().collect()
+        // Link-locals are on-link by definition; the stable pick is
+        // the same one the BFD/STAMP session keys use.
+        super::link::nbr_v6ll_pick(&nbr.addr6l)
+            .into_iter()
+            .collect()
     }
 
     fn reach_entries<'a>(
@@ -2102,9 +2104,9 @@ fn build_rib6_from_flex_algo(
                 let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
                     continue;
                 };
-                if let Some(addr) = nbr.addr6l.first() {
+                if let Some(addr) = super::link::nbr_v6ll_pick(&nbr.addr6l) {
                     spf_nhops.insert(
-                        *addr,
+                        addr,
                         SpfNexthop::<V6> {
                             ifindex: *link_id,
                             adjacency: *node == nhop_id,

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1591,7 +1591,7 @@ fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
                         .map(|a: &Ipv6Addr| a.to_string())
                         .unwrap_or_else(|| "-".to_string()),
                     action: behavior.to_string(),
-                    nh6: nbr.addr6l.first().copied(),
+                    nh6: super::link::nbr_v6ll_pick(&nbr.addr6l),
                 });
             }
         }

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -178,7 +178,7 @@ pub(super) fn build_repair_path_srv6(
             .nbrs
             .get(&level)
             .values()
-            .find_map(|nbr| nbr.addr6l.first().copied())?
+            .find_map(|nbr| super::link::nbr_v6ll_pick(&nbr.addr6l))?
     } else {
         let sys_id = lsp_map.resolve(rp.first_hop)?;
         link.state


### PR DESCRIPTION
## Summary

PR 6 of the multiple-IPv6-address-per-interface series — the IPv6 half of the multi-address discipline #2185 built for IPv4 (that PR's LspOriginate trigger and packed TLV 232/233/132 parse/emit already cover both families, which also delivers what was planned as PR 7).

- **TLV 236 mask + dedup**: IPv6 Reachability advertised each interface address raw — host bits leaked into the wire prefix (`2001:db8:66::5/64` instead of `2001:db8:66::/64`) and two same-subnet addresses advertised the subnet twice. Now masked and deduped, mirroring the TLV 135 shape from #2185.
- **Stable v6 picks**: every v6 endpoint selection was first-in-list (netlink delivery order locally; the peer's own list order for TLV 232), so BFD/STAMP session keys, the SPF nexthop, TI-LFA repair nexthops, SRLG endpoints, and show output could flip on a re-notify or disagree with each other. Three shared helpers in `isis::link` (`v6ll_pick`, `v6_global_pick`, `nbr_v6ll_pick`) now give every consumer the numerically lowest qualifying address — the IS-IS sibling of OSPFv3's `stable_link_local` (#2189). The NFSM-teardown BFD snapshot uses the same pick as the subscribe key, so Unsubscribe keys keep matching.

## Testing

- Unit: order-independence for all three pick helpers; workspace suite 2,709 passed / 0 failed; clippy clean; fmt clean.
- **Live two-router netns**: host-bit address arrives at the peer as the masked /64 in ~2s (LspOriginate immediacy); a same-subnet second address leaves exactly **one** IPv6 Reachability entry in the peer's LSDB; adding `fe80::1:1` beside the EUI-64 LL moves the peer's route nexthop to it deterministically (~2s), deleting it falls back (~8s); deleting both subnet addresses withdraws the prefix in ~2s.
- BDD: `isis_bfd_ipv6_p2p`, `isis_bfd_ipv6_lan`, `isis_endx_ipv6`, `isis_topology_output`, `ipv4_address_secondary` — 5/5 pass.

Series: PR 1 #2169, PR 2 #2174, PR 3 #2184, PR 4 #2186, PR 5 #2189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)