### PR TITLE
fib: tee the VPWS VXLAN cross-connect to cradle

### DIFF
--- a/docs/design/bgp-evpn-support-status.md
+++ b/docs/design/bgp-evpn-support-status.md
@@ -1,6 +1,6 @@
 # EVPN Support Status by Encapsulation
 
-Status as of 2026-07-31.
+Status as of 2026-08-01.
 
 A framing fact that applies to all three encapsulations: the EVPN control
 plane (route types 1–6 and 9–11, ESI multihoming with DF election, MAC
@@ -19,7 +19,7 @@ datapath, driven from zebra-rs via the FibHandle tee.
 | **L3 / Type-5 IP Prefix (RFC 9136)** | ✅ Symmetric IRB, L3VNI + Router's-MAC EC (zebra #1913 + cradle #119) | ✅ End.DT46/DT4/DT6 per RFC 9252 (no RMAC by design) | ✅ Reuses VPNv4/v6 L3VPN data plane (#1035–#1039) |
 | **Multihoming ESI (Type-1/4, DF election)** | ✅ Control plane (shared) | ✅ Full signal set incl. Type-2 ESI (#2148/#2150/#2152) | ✅ Control plane (shared) |
 | **MAC aliasing / mass-withdraw consumers** | ❌ Open (receive side) | ❌ Open — exists for VPWS only | ❌ Open |
-| **E-Line / VPWS (RFC 8214)** | 🟡 Signaling ✅ (Type-1 VNI + Encapsulation EC + VTEP next hop); cradle xconnect datapath open | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | ❌ SRv6-only today |
+| **E-Line / VPWS (RFC 8214)** | ✅ Type-1 VNI + Encapsulation EC + VTEP next hop; cradle eBPF xconnect (VTEP+VNI encap, E-Line-VNI decap) | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | ❌ SRv6-only today |
 | **IPv6 underlay transport** | ✅ Zero code changes (#1850) | ✅ (native) | — (IS-IS SR-MPLS underlay) |
 | **IGMP/MLD proxy / SMET (RFC 9251)** | ✅ Incl. per-VTEP selective MDB | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **Assisted Replication (RFC 9574)** | ✅ Control plane; AR-LEAF/RNVE forward natively. ❌ AR-REPLICATOR data plane deferred | ✅ Control plane (shared) | ✅ Control plane (shared) |
@@ -50,7 +50,7 @@ datapath via SRv6 End.DX2 / End.DX2V cross-connects.
 | All-active load balancing | ❌ Open | Needs a cradle xconnect holding more than one remote SID |
 | Control word | ❌ | C flag always 0 |
 | MPLS encapsulation | ❌ | `evpn_vpws_sid` reads only End.DX2/DX2V — SRv6-only |
-| VXLAN encapsulation | 🟡 | Signaling complete: `encapsulation vxlan` puts the service VNI (`vni` leaf, default the EVI) in the Type-1 label field with the VXLAN Encapsulation EC and VTEP next hop (RFC 8365 §6); import binds whatever encap the remote signalled. Cradle xconnect datapath open |
+| VXLAN encapsulation | ✅ | `encapsulation vxlan` puts the service VNI (`vni` leaf, default the EVI) in the Type-1 label field with the VXLAN Encapsulation EC and VTEP next hop (RFC 8365 §6); import binds whatever encap the remote signalled; the tee drives the cradle VXLAN xconnect (VTEP+VNI encap, E-Line-VNI decap, `SetVtepSource` from the advertised next hop) |
 | Datapath BDD | ✅ | `cradle_vpws_zebra` (untagged + VLAN-30 E-Line, CE-to-CE), `cradle_evpn_vpws` (static) |
 
 ### E-Line by Encapsulation
@@ -60,22 +60,22 @@ Type-1 carries the service VNI in its label field with the VXLAN
 Encapsulation EC and the VTEP next hop (RFC 8365 §6), and the import side
 classifies each remote by what *it* signalled (SRv6 L2 Service TLV first,
 else VXLAN EC + label), so a fabric can migrate one PE at a time. The
-cradle cross-connect data plane is still SRv6-only — the VXLAN xconnect
-tee (remote VTEP+VNI encap, VNI-to-AC decap) is the open half. MPLS VPWS
-originates/consumes nothing yet (under `encapsulation mpls` a VPWS still
-signals SRv6).
+cradle cross-connect data plane runs both flavors: the tee programs the
+remote VTEP+VNI encap, the E-Line-VNI-to-AC decap and the fabric VTEP
+source in one `AddXconnect`. MPLS VPWS originates/consumes nothing yet
+(under `encapsulation mpls` a VPWS still signals SRv6).
 
 | E-Line capability | E-Line/VXLAN | E-Line/SRv6 | E-Line/MPLS |
 |---|---|---|---|
 | **Per-EVI Ethernet A-D signaling (Type-1)** | ✅ VNI in the label field + VXLAN Encapsulation EC + VTEP next hop | ✅ SRv6 L2 Service TLV → End.DX2 SID | ❌ Type-1 MPLS label field not originated/consumed |
-| **P2P cross-connect data plane** | ❌ Cradle `Xconnect` has no VXLAN flavor yet | ✅ cradle eBPF xconnect (cradle #45) | ❌ Not built (cradle MPLS L2 covers E-LAN, not xconnect) |
-| **VLAN-scoped E-Line** | 🟡 Signaling (`vlan` scoping is a local AC property); datapath open | ✅ End.DX2V, VLAN table = EVI (zebra #1782, cradle #48) | ❌ |
+| **P2P cross-connect data plane** | ✅ cradle eBPF xconnect (`ReplTarget`-shaped maps + `VNI_F_ELINE` decap, cradle #163) | ✅ cradle eBPF xconnect (cradle #45) | ❌ Not built (cradle MPLS L2 covers E-LAN, not xconnect) |
+| **VLAN-scoped E-Line** | ✅ Inner-VID demux from the DX2V table (`VNI_F_ELINE_VLAN`) | ✅ End.DX2V, VLAN table = EVI (zebra #1782, cradle #48) | ❌ |
 | **L2-Attributes EC (P/B/C flags + MTU)** | ✅ On every VPWS Type-1 | ✅ On every VPWS Type-1 (#1779) | ❌ No service to attach to |
 | **Multihoming origination (ESI, P/B roles)** | ✅ Encap-agnostic (#2116) | ✅ DF per `<ESI, service instance>` (#2116) | ❌ |
 | **Remote P/B selection + per-ES fast failover** | ✅ Encap-agnostic | ✅ | ❌ |
 | **All-active load balancing** | ❌ | ❌ Open (needs multi-SID xconnect) | ❌ |
 | **Control word** | — (no control word in VXLAN) | — (no control word in SRv6) | ❌ C flag always 0 |
-| **Datapath BDD** | ❌ (signaling BDD: `bgp_evpn_vpws_vxlan`) | ✅ `cradle_vpws_zebra`, `cradle_evpn_vpws` | ❌ |
+| **Datapath BDD** | ✅ `cradle_vpws_vxlan_zebra`, `cradle_evpn_vpws_vxlan` (+ signaling `bgp_evpn_vpws_vxlan`) | ✅ `cradle_vpws_zebra`, `cradle_evpn_vpws` | ❌ |
 
 ## Per-Encapsulation Summary
 

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -191,10 +191,17 @@ message Xconnect {
   string local_sid  = 4;
   // Non-zero = VLAN-scoped E-Line (RFC 8214 VLAN-based service): only
   // 802.1Q frames with this VID on the AC enter the cross-connect (the
-  // tag rides inside the encapsulation), and local_sid's End.DX2V demuxes
-  // the return direction from its (dx2v_table, vid) entry onto the AC.
+  // tag rides inside the encapsulation), and the return direction —
+  // local_sid's End.DX2V, or local_vni's E-Line VNI — demuxes on the
+  // inner VID from its (dx2v_table, vid) entry onto the AC.
   uint32 vid        = 5;
-  uint32 dx2v_table = 6; // End.DX2V VLAN-table id (only with vid != 0)
+  uint32 dx2v_table = 6; // VLAN-table id (only with vid != 0)
+  string remote_vtep = 7; // VXLAN: remote VTEP IPv4
+  uint32 remote_vni  = 8; // VXLAN: VNI the remote advertised (with remote_vtep)
+  // When non-zero, also bind this VNI as the E-Line's local decap
+  // identity (the VNI our own Type-1 advertised) — the VXLAN analog of
+  // local_sid, at most one of the two.
+  uint32 local_vni   = 9;
 }
 
 message XconnectDel {
@@ -203,6 +210,7 @@ message XconnectDel {
   string local_sid  = 3; // when non-empty, also remove this End.DX2/DX2V LocalSid
   uint32 vid        = 4; // non-zero = remove the VLAN-scoped binding
   uint32 dx2v_table = 5;
+  uint32 local_vni  = 6; // when non-zero, also remove this E-Line VNI binding
 }
 
 // A BUM ingress-replication slot: one remote PE in bridge domain `bd`,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7337,6 +7337,7 @@ fn vpws_rebind(local_rib: &mut LocalRib, rib_client: &crate::rib::client::RibCli
     let (vid, table) = svc.vid_table();
     let local_mtu = svc.mtu;
     let local_vni = svc.local_vni;
+    let local_vtep = svc.local_vtep;
     let selection = match svc.params() {
         Some((evi, _, remote_id, _)) => {
             super::vpws::select_remote(vpws_gather_remotes(local_rib, evi, remote_id), local_mtu)
@@ -7365,6 +7366,7 @@ fn vpws_rebind(local_rib: &mut LocalRib, rib_client: &crate::rib::client::RibCli
                     remote,
                     local_sid,
                     local_vni,
+                    local_vtep,
                     vid,
                     table,
                 });
@@ -16563,10 +16565,11 @@ impl Bgp {
         }
         attr.ecom = Some(ecom);
         attr.prefix_sid = prefix_sid;
-        attr.nexthop = Some(BgpNexthop::Evpn(match local_vni {
+        let nexthop = match local_vni {
             Some(vni) => self.evpn_nexthop_for_vni(vni),
             None => IpAddr::V4(self.router_id),
-        }));
+        };
+        attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
         let rib = BgpRib::new(
             ORIGINATED_PEER,
             Ipv4Addr::UNSPECIFIED,
@@ -16585,6 +16588,12 @@ impl Bgp {
         if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
             svc.originated = Some((evi, local_id, esi));
             svc.local_vni = local_vni;
+            // The advertised next hop is what the remote encapsulates
+            // toward — the tee programs it as the VXLAN decap source.
+            svc.local_vtep = match (local_vni, nexthop) {
+                (Some(_), IpAddr::V4(vtep)) => Some(vtep),
+                _ => None,
+            };
         }
         self.evpn_originate_synch(rd, prefix, rib);
     }

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -88,6 +88,12 @@ pub struct VpwsService {
     /// `End.DX2` entry in `VpwsState::sids`. `None` when the service
     /// originated under SRv6 (or not at all).
     pub local_vni: Option<u32>,
+    /// The IPv4 VTEP our Type-1 went out with as its next hop — what the
+    /// remote encapsulates toward, so the tee programs it as cradle's
+    /// fabric-wide VXLAN source (`SetVtepSource`, the decap match). Set
+    /// alongside `local_vni`; `None` under SRv6 or when the advertised
+    /// next hop is not IPv4.
+    pub local_vtep: Option<Ipv4Addr>,
     /// The remote's L2 MTU when a matching Type-1 was **rejected** for an
     /// MTU mismatch — the service shows `mtu-mismatch` instead of `up`.
     pub remote_mtu_mismatch: Option<u16>,

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -115,8 +115,10 @@ struct CradleMirror {
     /// L3VNI ↔ VRF bindings (symmetric IRB): vni → (vrf_table_id, rmac).
     vnis_l3: HashMap<u32, (u32, [u8; 6])>,
     vtep_source: Option<Ipv4Addr>,
-    /// (AC port, vid, dx2v table) → (remote SID, local decap SID).
-    xconnects: HashMap<(String, u16, u32), (Ipv6Addr, Option<Ipv6Addr>)>,
+    /// (AC port, vid, dx2v table) → (remote endpoint — SID or VTEP+VNI,
+    /// local decap SID, local decap VNI).
+    xconnects:
+        HashMap<(String, u16, u32), (crate::rib::XconnectRemote, Option<Ipv6Addr>, Option<u32>)>,
     /// (mirror context, protected prefix) → reproduction VRF table.
     mirror_routes: HashMap<(u32, Ipv6Net), u32>,
     /// (neighbor ip, oif) → mac. Grow-only, like the upstream tee (no
@@ -558,8 +560,9 @@ impl CradleFib {
         for (vni, vtep) in &m.repl_slots_vxlan {
             self.repl_slot_add_vxlan(*vni, *vtep).await;
         }
-        for ((port, vid, table), (remote, local)) in &m.xconnects {
-            self.xconnect_add(port, *remote, *local, *vid, *table).await;
+        for ((port, vid, table), (remote, local_sid, local_vni)) in &m.xconnects {
+            self.xconnect_add(port, *remote, *local_sid, *local_vni, *vid, *table)
+                .await;
         }
         for ((dst, teid), table) in &m.gtp_pdrs {
             self.gtp_pdr_add(*dst, *teid, *table).await;
@@ -1754,33 +1757,43 @@ impl CradleFib {
         }
     }
 
-    /// EVPN VPWS cross-connect (RFC 8214 / RFC 9252 §6.3): bind AC `port`
-    /// to the remote PE's End.DX2/DX2V service SID. `local_sid`, when
-    /// present, rides in the same RPC so cradle also installs the local
-    /// decap bound to the AC — one message programs the E-Line both ways.
-    /// A non-zero `vid` makes the binding VLAN-scoped (End.DX2V over VLAN
-    /// table `table`).
+    /// EVPN VPWS cross-connect (RFC 8214): bind AC `port` to the remote
+    /// PE's service endpoint — an End.DX2/DX2V SID (RFC 9252 §6.3) or a
+    /// VXLAN VTEP with the VNI the remote advertised (RFC 8365 §6). The
+    /// local decap identity (`local_sid` LocalSid, or `local_vni` E-Line
+    /// VNI — at most one) rides in the same RPC so cradle programs the
+    /// E-Line both ways in one message. A non-zero `vid` makes the binding
+    /// VLAN-scoped (demuxed over VLAN table `table`).
     pub async fn xconnect_add(
         &self,
         port: &str,
-        remote_sid: std::net::Ipv6Addr,
+        remote: crate::rib::XconnectRemote,
         local_sid: Option<std::net::Ipv6Addr>,
+        local_vni: Option<u32>,
         vid: u16,
         table: u32,
     ) {
-        self.mirror
-            .lock()
-            .await
-            .xconnects
-            .insert((port.to_string(), vid, table), (remote_sid, local_sid));
+        self.mirror.lock().await.xconnects.insert(
+            (port.to_string(), vid, table),
+            (remote, local_sid, local_vni),
+        );
+        let (remote_sid, remote_vtep, remote_vni) = match remote {
+            crate::rib::XconnectRemote::Srv6(sid) => (sid.to_string(), String::new(), 0),
+            crate::rib::XconnectRemote::Vxlan { vtep, vni } => {
+                (String::new(), vtep.to_string(), vni)
+            }
+        };
         let result = async {
             self.client()
                 .await?
                 .add_xconnect(pb::Xconnect {
                     port: port.to_string(),
                     port_index: 0,
-                    remote_sid: remote_sid.to_string(),
+                    remote_sid,
+                    remote_vtep,
+                    remote_vni,
                     local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
+                    local_vni: local_vni.unwrap_or(0),
                     vid: vid as u32,
                     dx2v_table: table,
                 })
@@ -1789,16 +1802,17 @@ impl CradleFib {
         }
         .await;
         if let Err(e) = result {
-            tracing::warn!("fib: cradle xconnect_add {port} -> {remote_sid} failed: {e}");
+            tracing::warn!("fib: cradle xconnect_add {port} -> {remote:?} failed: {e}");
         }
     }
 
-    /// Remove a VPWS cross-connect (and its local End.DX2/DX2V decap, when
-    /// `local_sid` is present).
+    /// Remove a VPWS cross-connect (and its local decap — the
+    /// End.DX2/DX2V LocalSid or the E-Line VNI binding — when present).
     pub async fn xconnect_del(
         &self,
         port: &str,
         local_sid: Option<std::net::Ipv6Addr>,
+        local_vni: Option<u32>,
         vid: u16,
         table: u32,
     ) {
@@ -1814,6 +1828,7 @@ impl CradleFib {
                     port: port.to_string(),
                     port_index: 0,
                     local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
+                    local_vni: local_vni.unwrap_or(0),
                     vid: vid as u32,
                     dx2v_table: table,
                 })

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -735,37 +735,33 @@ impl FibHandle {
     }
 
     /// Tee an EVPN VPWS cross-connect to cradle (RFC 8214 Type-1 with an
-    /// SRv6 End.DX2/DX2V SID): bind AC `port` to the remote service SID,
-    /// and — when `local_sid` is present — install the local decap on the
-    /// same AC. A non-zero `vid` scopes the binding to that 802.1Q VID
-    /// (End.DX2V over VLAN table `table`). No kernel counterpart — cradle
-    /// is the L2 data plane.
+    /// SRv6 End.DX2/DX2V SID or a VXLAN VTEP+VNI): bind AC `port` to the
+    /// remote service endpoint, and install the local decap for the return
+    /// direction — the `local_sid` LocalSid on the same AC (SRv6), or the
+    /// `local_vni` E-Line VNI binding (VXLAN). A non-zero `vid` scopes the
+    /// binding to that 802.1Q VID (demuxed over VLAN table `table`). No
+    /// kernel counterpart — cradle is the L2 data plane.
+    #[allow(clippy::too_many_arguments)]
     pub async fn cradle_xconnect_add(
         &self,
         port: &str,
         remote: crate::rib::XconnectRemote,
         local_sid: Option<std::net::Ipv6Addr>,
         local_vni: Option<u32>,
+        local_vtep: Option<std::net::Ipv4Addr>,
         vid: u16,
         table: u32,
     ) {
         if let Some(cradle) = &self.cradle {
-            match remote {
-                crate::rib::XconnectRemote::Srv6(remote_sid) => {
-                    cradle
-                        .xconnect_add(port, remote_sid, local_sid, vid, table)
-                        .await;
-                }
-                crate::rib::XconnectRemote::Vxlan { vtep, vni } => {
-                    // The cradle Xconnect RPC has no VXLAN flavor yet — the
-                    // control plane binds and shows `up`, the datapath tee
-                    // lands with the cradle-side E-Line/VXLAN support.
-                    tracing::info!(
-                        "fib: cradle xconnect {port} -> vtep {vtep} vni {vni} \
-                         (local vni {local_vni:?}): VXLAN tee not yet implemented"
-                    );
-                }
+            if let (crate::rib::XconnectRemote::Vxlan { .. }, Some(local)) = (&remote, local_vtep) {
+                // The fabric-wide VXLAN source — decap match and outer
+                // source — must be the address our Type-1 told the remote
+                // to send to. Idempotent; one VTEP per PE.
+                cradle.set_vtep_source(local).await;
             }
+            cradle
+                .xconnect_add(port, remote, local_sid, local_vni, vid, table)
+                .await;
         }
     }
 
@@ -778,12 +774,9 @@ impl FibHandle {
         table: u32,
     ) {
         if let Some(cradle) = &self.cradle {
-            if local_vni.is_some() {
-                // VXLAN-flavored binding: nothing was teed (see
-                // `cradle_xconnect_add`), so nothing to remove.
-                return;
-            }
-            cradle.xconnect_del(port, local_sid, vid, table).await;
+            cradle
+                .xconnect_del(port, local_sid, local_vni, vid, table)
+                .await;
         }
     }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -431,6 +431,10 @@ pub enum Message {
         remote: XconnectRemote,
         local_sid: Option<std::net::Ipv6Addr>,
         local_vni: Option<u32>,
+        /// The IPv4 VTEP this PE advertised as the service's next hop —
+        /// teed as cradle's fabric-wide `SetVtepSource` (the VXLAN decap
+        /// match and outer source) before the VXLAN xconnect lands.
+        local_vtep: Option<Ipv4Addr>,
         vid: u16,
         table: u32,
     },
@@ -3770,11 +3774,14 @@ impl Rib {
                 remote,
                 local_sid,
                 local_vni,
+                local_vtep,
                 vid,
                 table,
             } => {
                 self.fib_handle
-                    .cradle_xconnect_add(&ifname, remote, local_sid, local_vni, vid, table)
+                    .cradle_xconnect_add(
+                        &ifname, remote, local_sid, local_vni, local_vtep, vid, table,
+                    )
                     .await;
             }
             Message::XconnectDel {


### PR DESCRIPTION
## Summary

PR 3a of the E-LINE/VXLAN series (after #2190 and cradle-rs/cradle-rs#163): the FibHandle stub becomes the real tee.

- **Vendored proto sync** — `Xconnect` gains `remote_vtep`/`remote_vni`/`local_vni`, `XconnectDel` gains `local_vni` (matching cradle-rs main after #163).
- **`CradleFib::xconnect_add`** takes the `XconnectRemote` endpoint enum plus both local decap identities (`local_sid` / `local_vni`), mirrors them, and replays them after an engine restart — the replay snapshot already orders `vtep_source` and `vnis` first.
- **Fabric VTEP source** — origination records the IPv4 next hop the Type-1 went out with (`svc.local_vtep`, what the remote encapsulates toward), the rebind threads it through `XconnectAdd.local_vtep`, and the FibHandle tees `SetVtepSource` before the VXLAN xconnect lands. A pure-VPWS PE therefore needs no vxlan device for its decap match, and the advertised next hop and the decap match can never disagree.
- Support-status doc rows flip to done (datapath now proven).

## Testing

- **End-to-end proven** by cradle-rs's `cradle_vpws_vxlan_zebra` BDD (paired PR cradle-rs/cradle-rs#164): two zebra+cradle PEs, BGP over loopback VTEPs, an untagged E-Line with **asymmetric VNIs per direction** (pe1 advertises 5001, pe2 defaults to the EVI) plus a VID-30 E-Line sharing the same AC — CE-to-CE ARP+ICMP both ways on the first run, `vxlan_encap`/`vxlan_dx2` moving on both PEs, SRv6 counters asserted zero.
- `bgp_evpn_vpws_vxlan` (signaling) still passes on this branch.
- Full zebra-rs unit suite green (1875), workspace clippy clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)