### PR TITLE
bgp: address-registry hygiene; re-broadcast kernel flag changes

### DIFF
--- a/zebra-rs/src/bgp/connected.rs
+++ b/zebra-rs/src/bgp/connected.rs
@@ -16,24 +16,33 @@
 //! addresses) makes the check **fail open**, matching FRR's behaviour
 //! when it has no RIB connectivity information.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 
 use ipnet::IpNet;
 
 use crate::rib::link::LinkAddr;
 
-/// One reference-counted connected network and the interface it lives on.
-#[derive(Debug)]
+/// One connected network, its contributing addresses, and the interface
+/// it lives on.
+#[derive(Debug, Default)]
 struct SubnetRef {
-    count: usize,
+    /// The interface addresses (with host bits, plus owning ifindex)
+    /// that contribute this network. A set, not a counter: the RIB
+    /// re-broadcasts an address it already announced whenever its
+    /// *state* changes (kernel secondary flip today, address-flag
+    /// updates when those start re-broadcasting), so counting events
+    /// would inflate on every re-delivery and one AddrDel could never
+    /// drain the subnet again.
+    addrs: BTreeSet<(IpNet, u32)>,
     /// The recording address's ifindex. With several addresses in one subnet
     /// the last writer wins — a subnet spanning *different* interfaces is a
     /// pathological config we don't try to disambiguate.
     ifindex: u32,
 }
 
-/// Reference-counted set of directly-connected networks.
+/// Set of directly-connected networks, keyed by network with the exact
+/// contributing addresses tracked per entry.
 #[derive(Debug, Default)]
 pub struct ConnectedSubnets {
     nets: BTreeMap<IpNet, SubnetRef>,
@@ -45,29 +54,45 @@ impl ConnectedSubnets {
     }
 
     /// Record an interface address. The stored key is its network
-    /// (`addr.trunc()`, host bits cleared), reference-counted so several
-    /// addresses sharing one subnet coexist. A /32 or /128 host address
+    /// (`addr.trunc()`, host bits cleared); the exact address is tracked
+    /// so several addresses sharing one subnet coexist and re-delivery
+    /// of a known address is a no-op. A /32 or /128 host address
     /// contributes only itself, which is exactly what we want — it does
     /// not make a different peer "connected".
     pub fn record(&mut self, addr: &LinkAddr) {
-        let entry = self.nets.entry(addr.addr.trunc()).or_insert(SubnetRef {
-            count: 0,
-            ifindex: addr.ifindex,
-        });
-        entry.count += 1;
+        let entry = self.nets.entry(addr.addr.trunc()).or_default();
+        entry.addrs.insert((addr.addr, addr.ifindex));
         entry.ifindex = addr.ifindex;
     }
 
     /// Forget an interface address previously passed to [`Self::record`].
-    /// The subnet is dropped only when its last contributing address goes.
+    /// The subnet is dropped only when its last contributing address goes;
+    /// forgetting an address never recorded (or already forgotten) changes
+    /// nothing.
     pub fn forget(&mut self, addr: &LinkAddr) {
         let net = addr.addr.trunc();
         if let Some(entry) = self.nets.get_mut(&net) {
-            entry.count -= 1;
-            if entry.count == 0 {
+            entry.addrs.remove(&(addr.addr, addr.ifindex));
+            if entry.addrs.is_empty() {
                 self.nets.remove(&net);
             }
         }
+    }
+
+    /// Drop every contribution made by addresses on `ifindex`. A deleted
+    /// link's addresses are not reliably withdrawn one by one — a veth
+    /// moved into another netns emits only RTM_DELLINK — so the LinkDel
+    /// handler sweeps them here wholesale.
+    pub fn purge_ifindex(&mut self, ifindex: u32) {
+        self.nets.retain(|_, entry| {
+            entry.addrs.retain(|(_, ifi)| *ifi != ifindex);
+            if let Some((_, survivor)) = entry.addrs.iter().next()
+                && entry.ifindex == ifindex
+            {
+                entry.ifindex = *survivor;
+            }
+            !entry.addrs.is_empty()
+        });
     }
 
     /// True while no interface address is known. The connected check
@@ -132,6 +157,48 @@ mod tests {
 
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    #[test]
+    fn record_is_idempotent_per_address() {
+        let mut t = ConnectedSubnets::new();
+        // The RIB re-broadcasts a known address on state changes
+        // (secondary flip, flag updates) — the re-delivery must not
+        // create a second reference one AddrDel can't drain.
+        t.record(&v4("10.0.0.1", 24));
+        t.record(&v4("10.0.0.1", 24));
+        assert!(t.covers(ip("10.0.0.2")));
+        t.forget(&v4("10.0.0.1", 24));
+        assert!(!t.covers(ip("10.0.0.2")));
+
+        // Two DISTINCT addresses in one subnet still keep it alive
+        // until the last one goes.
+        t.record(&v4("10.0.0.1", 24));
+        t.record(&v4("10.0.0.9", 24));
+        t.forget(&v4("10.0.0.1", 24));
+        assert!(t.covers(ip("10.0.0.2")));
+        t.forget(&v4("10.0.0.9", 24));
+        assert!(!t.covers(ip("10.0.0.2")));
+    }
+
+    #[test]
+    fn purge_ifindex_sweeps_only_that_link() {
+        let mut t = ConnectedSubnets::new();
+        t.record(&v4_on("10.0.0.1", 24, 3));
+        t.record(&v4_on("10.1.0.1", 24, 5));
+        // A subnet spanning both links survives the purge via the
+        // other link's contribution, and its ifindex re-points.
+        t.record(&v4_on("10.2.0.1", 24, 3));
+        t.record(&v4_on("10.2.0.2", 24, 5));
+
+        t.purge_ifindex(3);
+        assert!(!t.covers(ip("10.0.0.2")), "purged link's subnet gone");
+        assert!(t.covers(ip("10.1.0.2")), "other link untouched");
+        assert!(t.covers(ip("10.2.0.9")), "shared subnet survives");
+        assert_eq!(t.ifindex_for(ip("10.2.0.9")), Some(5));
+
+        t.purge_ifindex(5);
+        assert!(t.is_empty());
     }
 
     #[test]

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4146,8 +4146,24 @@ impl Bgp {
             // sessions riding it, instead of leaving them to hold-timer
             // expiry. LinkUp re-kicks parked peers for fast
             // reconvergence.
-            RibRx::LinkDown(ifindex) | RibRx::LinkDel(ifindex) => {
+            RibRx::LinkDown(ifindex) => {
                 self.link_down_failover(ifindex);
+            }
+            RibRx::LinkDel(ifindex) => {
+                self.link_down_failover(ifindex);
+                // A deleted link's addresses are not reliably withdrawn
+                // one by one (a veth moved into another netns emits only
+                // RTM_DELLINK), so sweep its contributions out of the
+                // address registries — otherwise `covers()` keeps
+                // passing the connected check against a subnet that no
+                // longer exists and the next-hop sources go stale. Not
+                // done for LinkDown: v4 addresses persist across admin
+                // down/up, and the kernel's v6 flush arrives as
+                // explicit AddrDel events.
+                self.interface_addrs.purge_ifindex(ifindex);
+                self.connected_subnets.purge_ifindex(ifindex);
+                self.refresh_connected();
+                super::config::bfd_reconcile_all(self);
             }
             RibRx::LinkUp(ifindex) => {
                 self.link_up_kick(ifindex);

--- a/zebra-rs/src/bgp/interface_addrs.rs
+++ b/zebra-rs/src/bgp/interface_addrs.rs
@@ -83,6 +83,17 @@ impl InterfaceAddrs {
         }
     }
 
+    /// Drop everything recorded against `ifindex`. A deleted link's
+    /// addresses are not reliably withdrawn one by one — a veth moved
+    /// into another netns emits only RTM_DELLINK — so the LinkDel
+    /// handler sweeps them here wholesale. Without it, a dead
+    /// interface keeps serving next-hop sources forever.
+    pub fn purge_ifindex(&mut self, ifindex: u32) {
+        self.link_local.remove(&ifindex);
+        self.global.remove(&ifindex);
+        self.v4_owner.retain(|_, owner| *owner != ifindex);
+    }
+
     /// Which interface owns this local IPv4 address, if any. Used to
     /// map a v4-addressed BGP session's local end back to its
     /// interface so [`Self::global_for`] can supply the v6 next-hop
@@ -190,6 +201,22 @@ mod tests {
         assert_eq!(t.link_local_for(7), Some("fe80::1".parse().unwrap()));
         t.forget(&a);
         assert_eq!(t.link_local_for(7), None);
+    }
+
+    #[test]
+    fn purge_ifindex_drops_all_kinds() {
+        let mut t = InterfaceAddrs::new();
+        t.record(&v6("fe80::1", 64, 7));
+        t.record(&v6("2001:db8::1", 64, 7));
+        t.record(&v4("10.0.0.1", 24, 7));
+        t.record(&v6("fe80::2", 64, 9));
+
+        t.purge_ifindex(7);
+        assert_eq!(t.link_local_for(7), None);
+        assert_eq!(t.global_for(7), None);
+        assert_eq!(t.ifindex_for_v4("10.0.0.1".parse().unwrap()), None);
+        // The other interface is untouched.
+        assert_eq!(t.link_local_for(9), Some("fe80::2".parse().unwrap()));
     }
 
     #[test]

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -119,13 +119,29 @@ fn materialize(
     let cfg = bgp.interface_neighbors.get(name)?.clone();
     let resolved = resolve_remote_as_with_source(bgp, &cfg)?;
 
-    // Already materialized? Refresh address (the peer's link-local
-    // can change if the kernel reassigns it) but otherwise leave the
-    // FSM alone — except a dormant peer (materialized at config time,
-    // address still unspecified), which gets its first kick here.
+    // Already materialized? Possibly refresh the address, but leave
+    // the FSM alone — except a dormant peer (materialized at config
+    // time, address still unspecified), which gets its first kick here.
     if let Some(existing) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex)) {
         if let Some(link_local) = link_local {
-            existing.address = link_local.into();
+            let incoming: std::net::IpAddr = link_local.into();
+            let unspecified =
+                matches!(existing.address, std::net::IpAddr::V6(a) if a.is_unspecified());
+            // RA stickiness: adopt the RA's source address only when
+            // the peer has no address yet (dormant) or no session is
+            // riding the current one. A peer holding several
+            // link-locals can alternate its RA source between them —
+            // rewriting a live session's identity on every RA
+            // desynchronizes it from the TCP session underneath and
+            // from show/clear lookups. If the peer genuinely
+            // renumbered, the dead session clears via hold-timer /
+            // TCP reset and the next RA re-points us then.
+            if unspecified
+                || (existing.address != incoming
+                    && existing.state != super::peer::State::Established)
+            {
+                existing.address = incoming;
+            }
             nd_mark_refreshed(existing, Instant::now());
             // No-op on a running peer (`start()` gates on `!active`);
             // a dormant one leaves Idle now that it can dial.

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -660,16 +660,18 @@ pub enum AddrUpdate {
     /// address, or the kernel confirming a config-driven (re-)install —
     /// or its secondary verdict moved (promotion/demotion).
     Merged,
-    /// The address was present and only its kernel metadata moved —
-    /// `IFA_FLAGS` (DAD completing clears tentative), scope, or the
-    /// `IFA_CACHEINFO` lifetimes an RA renewal refreshes. The stored
-    /// entry was updated but nothing is re-broadcast to protocol
-    /// clients yet: today no protocol consumes the flags, and the BGP
-    /// connected-subnet registry counts AddrAdd events non-idempotently,
-    /// so re-notifying on every DAD completion would inflate it. The
-    /// re-broadcast comes with the BGP registry-hygiene PR.
+    /// The address was present and its kernel address state moved —
+    /// `IFA_FLAGS` (DAD completing clears tentative, deprecation) or
+    /// scope. Re-broadcast to protocol clients: address-state-aware
+    /// consumers (BGP next-hop selection) need the transition, and
+    /// every registry fed by AddrAdd is idempotent against
+    /// re-delivery of a known address.
     Refreshed,
-    /// The address was present and nothing changed (kernel re-notify).
+    /// The address was present and nothing broadcast-worthy changed —
+    /// a kernel re-notify, or an `IFA_CACHEINFO` lifetime renewal
+    /// (adopted into the stored entry silently: every RA refreshes
+    /// the lifetimes, and re-broadcasting each one would have IS-IS
+    /// re-originating LSPs on the RA interval).
     Unchanged,
 }
 
@@ -714,12 +716,11 @@ pub fn link_addr_update(link: &mut Link, addr: LinkAddr) -> AddrUpdate {
         // kernel resends RTM_NEWADDR whenever this state moves (DAD
         // completion flips tentative off, each RA renews the
         // lifetimes), so a kernel event is always the fresher truth.
+        // Flag / scope movement is broadcast-worthy (Refreshed);
+        // lifetime renewal is adopted silently — see [`AddrUpdate`].
         let mut refreshed = false;
         if !addr.config {
-            refreshed = existing.scope != addr.scope
-                || existing.flags != addr.flags
-                || existing.valid_lft != addr.valid_lft
-                || existing.preferred_lft != addr.preferred_lft;
+            refreshed = existing.scope != addr.scope || existing.flags != addr.flags;
             existing.scope = addr.scope;
             existing.flags = addr.flags;
             existing.valid_lft = addr.valid_lft;
@@ -1421,10 +1422,14 @@ impl Rib {
                 }
             }
             // Don't re-broadcast a notification that changed nothing (the
-            // kernel echoing an address we already hold) — consumers that
-            // count events rather than addresses would drift. Refreshed
-            // (kernel metadata moved) stays silent too; see [`AddrUpdate`].
-            if matches!(update, AddrUpdate::Added | AddrUpdate::Merged) {
+            // kernel echoing an address we already hold, a lifetime-only
+            // renewal). Added / Merged / Refreshed all carry state a
+            // subscriber can act on; every AddrAdd-fed registry is
+            // idempotent against re-delivery of a known address.
+            if matches!(
+                update,
+                AddrUpdate::Added | AddrUpdate::Merged | AddrUpdate::Refreshed
+            ) {
                 // Broadcast the merged entry, not the raw incoming addr —
                 // a config push landing on a kernel-known address must
                 // not advertise default kernel metadata over the state
@@ -2076,19 +2081,20 @@ mod tests {
     }
 
     #[test]
-    fn test_link_addr_update_lifetime_renewal_is_refreshed() {
+    fn test_link_addr_update_lifetime_renewal_is_silent() {
         let mut link = test_link();
         let mut slaac = test_addr_v6("2001:db8::5054:ff:fe00:1/64", false, true);
         slaac.valid_lft = Some(86400);
         slaac.preferred_lft = Some(14400);
         assert_eq!(link_addr_update(&mut link, slaac), AddrUpdate::Added);
 
-        // Each RA renews the lifetimes; the stored entry follows without
-        // notifying protocol clients.
+        // Each RA renews the lifetimes; the stored entry follows but
+        // protocol clients are NOT re-notified — Unchanged, not
+        // Refreshed, or IS-IS would re-originate LSPs per RA interval.
         let mut renewed = test_addr_v6("2001:db8::5054:ff:fe00:1/64", false, true);
         renewed.valid_lft = Some(86400);
         renewed.preferred_lft = Some(13000);
-        assert_eq!(link_addr_update(&mut link, renewed), AddrUpdate::Refreshed);
+        assert_eq!(link_addr_update(&mut link, renewed), AddrUpdate::Unchanged);
         assert_eq!(link.addr6[0].preferred_lft, Some(13000));
     }
 


### PR DESCRIPTION
## Summary

PR 8 of the multiple-IPv6-address-per-interface series: make every AddrAdd-fed BGP registry safe against re-delivery, purge them on link deletion, stop the interface-peer RA flip-flop — and lift the `AddrUpdate::Refreshed` broadcast deferral from PR 3 (#2184) now that it's safe.

- **`ConnectedSubnets` idempotency**: it counted AddrAdd *events*; state-change re-broadcasts (secondary flips, now flag updates) inflated the count so one AddrDel could never drain the subnet — the eBGP connected check kept passing against a dead subnet. Entries now track exact contributing `(address, ifindex)` pairs.
- **LinkDel purge**: a deleted link's addresses aren't reliably withdrawn one by one (a veth moved to another netns emits only `RTM_DELLINK`); both registries now purge by ifindex on `LinkDel` (split from `LinkDown`, where v4 addresses legitimately persist), followed by connected-gate refresh and BFD re-reconcile.
- **RA stickiness**: every RA overwrote the materialized interface-peer's address, flipping a live session's identity when the peer holds two link-locals. Sticky while Established; adopted freely when dormant/down; ND freshness still updates on every RA.
- **Broadcast flip**: kernel flag/scope movement (DAD completion, deprecation) now re-broadcasts `AddrAdd` to protocol clients — PR 9's address-state-aware selection consumes it. Lifetime-only renewals stay silent (every RA refreshes them; broadcasting would re-originate IS-IS LSPs on the RA interval).

## Testing

- Unit: idempotent record/forget round-trips, per-address draining, ifindex purge sweeping only the target link (with shared-subnet ifindex re-pointing), lifetime-renewal silence. Workspace suite 2,719 passed / 0 failed; clippy clean; fmt clean.
- BDD: `bgp_unnumbered_neighbor` / `_incremental` / `_afi_safi` / `_summary` (the RA/interface-peer machinery), `bgp_disable_connected_check` (the rewritten registry), `ipv4_address_secondary` (Merged re-broadcast against the idempotent record), `isis_bfd_ipv6_p2p` (Refreshed broadcast flip does no harm) — 7/7 pass.

Series: PR 1 #2169, PR 2 #2174, PR 3 #2184, PR 4 #2186, PR 5 #2189, PR 6 #2191 (PR 7 was absorbed by #2185).

🤖 Generated with [Claude Code](https://claude.com/claude-code)