### PR TITLE
fib: tee the VPWS MPLS cross-connect to cradle

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -52,7 +52,7 @@
   - [EVPN IGMP/MLD Proxy (Selective Multicast)](ch-02-32-bgp-evpn-igmp-mld-proxy.md)
   - [EVPN BUM & Assisted Replication](ch-02-33-bgp-evpn-assisted-replication.md)
   - [EVPN BUM Tunnel Segmentation (RFC 9572)](ch-02-34-bgp-evpn-segmentation.md)
-  - [EVPN VPWS (E-Line over SRv6 or VXLAN)](ch-02-38-bgp-evpn-vpws.md)
+  - [EVPN VPWS (E-Line over SRv6, VXLAN or MPLS)](ch-02-38-bgp-evpn-vpws.md)
   - [EVPN over MPLS](ch-02-40-bgp-evpn-mpls.md)
   - [Mobile User Plane (MUP) & the MUP Controller](ch-02-35-bgp-mup.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -1,7 +1,8 @@
-# EVPN VPWS (E-Line over SRv6 or VXLAN)
+# EVPN VPWS (E-Line over SRv6, VXLAN or MPLS)
 
 zebra-rs implements **EVPN VPWS** (Virtual Private Wire Service, RFC
-8214) over an SRv6 or VXLAN data plane: a point-to-point **E-Line** that
+8214) over an SRv6, VXLAN or MPLS data plane: a point-to-point **E-Line**
+that
 cross-connects one local attachment circuit (AC) to one remote PE's AC
 as a transparent wire — no MAC learning, no FDB, no flooding. The two
 CEs behave as if joined by a cable: they share subnets and resolve each
@@ -121,13 +122,43 @@ set router bgp afi-safi evpn vpws eline1 vni 5001
 The receive side is **not** gated by the local knob: each direction of
 an E-Line uses the encapsulation its originator signalled (SRv6 SID
 first; else Encapsulation EC = VXLAN with a non-zero label; a label
-with no EC means MPLS per RFC 8365 §5.1.3 and is not bound). A fabric
+with no EC — RFC 8365 §5.1.3's default — binds as an MPLS PE+label
+endpoint). A fabric
 therefore migrates between encapsulations one PE at a time, the service
 staying up asymmetrically in between. VLAN-scoped services, the MTU
-check and multihoming below all work identically under VXLAN — the
-election, selection and mass-withdraw machinery is
+check and multihoming below all work identically under every
+encapsulation — the election, selection and mass-withdraw machinery is
 encapsulation-agnostic, and a failover to the other PE of a multihomed
-pair re-binds both the VTEP and that PE's own VNI.
+pair re-binds the whole endpoint (VTEP *and* VNI, or PE *and* label —
+each PE assigns its own).
+
+### MPLS encapsulation (RFC 8365 §5.1.3)
+
+Under `encapsulation mpls` a VPWS needs no locator and no VNI — and no
+configuration beyond the service itself:
+
+```
+set router bgp afi-safi evpn encapsulation mpls
+set router bgp afi-safi evpn vpws eline1 evi 100
+set router bgp afi-safi evpn vpws eline1 local-service-id 101
+set router bgp afi-safi evpn vpws eline1 remote-service-id 102
+set router bgp afi-safi evpn vpws eline1 interface ce1
+```
+
+* The Type-1 carries a **per-service MPLS label**, allocated dynamically
+  from the same block VRF and EVI labels come from, with **no
+  Encapsulation extended community** — its absence is what says MPLS. A
+  service configured before the block grant advertises label 0 (which no
+  remote binds) and is re-originated the moment the grant lands.
+* The next hop is the router-id — the address the transport LSP resolves
+  on. Make it a routable loopback carried by the IGP (IS-IS/OSPF
+  SR-MPLS) and peer BGP over it, the classic MPLS-VPN shape; the ingress
+  imposes `[transport…][service label]` with the transport stack coming
+  from the FIB toward the PE.
+* The egress pops its own service label and emits the frame **raw on the
+  AC** (for a VLAN-scoped service, demuxed on the inner VID) — a
+  disposition the kernel does not have, so MPLS E-Lines require the
+  [eBPF data plane](ch-16-00-ebpf.md).
 
 ### Multihoming (RFC 8214 §5)
 
@@ -314,11 +345,17 @@ VPWS service: eline1
 ```
 
 A VXLAN service shows its VNI and the bound remote endpoint instead of
-SIDs (and `VNI conflict: in use by …` when parked):
+SIDs (and `VNI conflict: in use by …` when parked); an MPLS service its
+labels:
 
 ```
   Local VNI: 5001
   Remote VTEP: 192.0.2.2 (VNI 100) (via 192.0.2.2)
+```
+
+```
+  Local Label: 16
+  Remote PE: 2.2.2.2 (label 16) (via 2.2.2.2)
 ```
 
 A multihomed service adds its segment and elected role. `(from ce1)` marks a
@@ -360,10 +397,9 @@ configured (or re-pointed) is found without waiting for a route churn.
 Multihoming covers both directions: the Type-1 carries the segment's ESI and
 DF-elected P/B bits, and remote selection honours them (prefer `P`, fail over
 to `B`, per-ES A-D mass withdraw). Not yet implemented — all-active load
-balancing across both remote endpoints, MPLS
-encapsulation (under `encapsulation mpls` a VPWS still signals SRv6),
-and the control word (`C` is always 0). Forwarding requires the
+balancing across both remote endpoints, and the control word (`C` is
+always 0). Forwarding requires the
 [eBPF data plane](ch-16-00-ebpf.md)
 (`system ebpf enabled` to run the engine, `system cradle enabled` to tee the
-service into it); the kernel has no End.DX2/DX2V seg6local action, so these
-SIDs are never installed via netlink.
+service into it); the kernel has no End.DX2/DX2V seg6local action and no
+pop-to-port MPLS disposition, so neither is ever installed via netlink.

--- a/book/src/ch-02-40-bgp-evpn-mpls.md
+++ b/book/src/ch-02-40-bgp-evpn-mpls.md
@@ -192,4 +192,6 @@ diagnosis rather than a quiet success.
 - **No control word.** RFC 7432 leaves it optional and both ends must agree.
   Its absence is only a hazard where a P router hashes deeply enough to
   mistake a customer frame beginning with nibble 4 or 6 for an IP packet.
-- **EVPN-VPWS** (RFC 8214) over MPLS is not implemented; VPWS is SRv6-only.
+- **EVPN-VPWS** (RFC 8214) over MPLS is implemented — a per-service label
+  in the Type-1 and a pop-to-AC disposition; see
+  [EVPN VPWS](ch-02-38-bgp-evpn-vpws.md).

--- a/docs/design/bgp-evpn-support-status.md
+++ b/docs/design/bgp-evpn-support-status.md
@@ -1,6 +1,6 @@
 # EVPN Support Status by Encapsulation
 
-Status as of 2026-08-01.
+Status as of 2026-08-02.
 
 A framing fact that applies to all three encapsulations: the EVPN control
 plane (route types 1–6 and 9–11, ESI multihoming with DF election, MAC
@@ -19,7 +19,7 @@ datapath, driven from zebra-rs via the FibHandle tee.
 | **L3 / Type-5 IP Prefix (RFC 9136)** | ✅ Symmetric IRB, L3VNI + Router's-MAC EC (zebra #1913 + cradle #119) | ✅ End.DT46/DT4/DT6 per RFC 9252 (no RMAC by design) | ✅ Reuses VPNv4/v6 L3VPN data plane (#1035–#1039) |
 | **Multihoming ESI (Type-1/4, DF election)** | ✅ Control plane (shared) | ✅ Full signal set incl. Type-2 ESI (#2148/#2150/#2152) | ✅ Control plane (shared) |
 | **MAC aliasing / mass-withdraw consumers** | ❌ Open (receive side) | ❌ Open — exists for VPWS only | ❌ Open |
-| **E-Line / VPWS (RFC 8214)** | ✅ Type-1 VNI + Encapsulation EC + VTEP next hop; cradle eBPF xconnect (VTEP+VNI encap, E-Line-VNI decap) | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | 🟡 Signaling ✅ (per-service label from the dynamic block, no Encapsulation EC); cradle pop-to-AC datapath open |
+| **E-Line / VPWS (RFC 8214)** | ✅ Type-1 VNI + Encapsulation EC + VTEP next hop; cradle eBPF xconnect (VTEP+VNI encap, E-Line-VNI decap) | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | ✅ Per-service label, no Encapsulation EC; cradle eBPF xconnect (label encap under the transport LSP, pop-to-AC decap) |
 | **IPv6 underlay transport** | ✅ Zero code changes (#1850) | ✅ (native) | — (IS-IS SR-MPLS underlay) |
 | **IGMP/MLD proxy / SMET (RFC 9251)** | ✅ Incl. per-VTEP selective MDB | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **Assisted Replication (RFC 9574)** | ✅ Control plane; AR-LEAF/RNVE forward natively. ❌ AR-REPLICATOR data plane deferred | ✅ Control plane (shared) | ✅ Control plane (shared) |
@@ -50,7 +50,7 @@ datapath via SRv6 End.DX2 / End.DX2V cross-connects.
 | Remote Primary/Backup selection + per-ES A-D fast failover | ✅ | `select_remote` ranks P over B with the per-ES A-D mass-withdraw gate; failover scenarios in `bgp_evpn_vpws_multihoming.feature` |
 | All-active load balancing | ❌ Open | Needs a cradle xconnect holding more than one remote SID |
 | Control word | ❌ | C flag always 0 |
-| MPLS encapsulation | 🟡 | Signaling complete: `encapsulation mpls` puts a per-service label (same dynamic block as VRF/EVI labels) in the Type-1 label field with no Encapsulation EC (RFC 8365 §5.1.3); import binds PE+label remotes. Cradle pop-to-AC xconnect datapath open |
+| MPLS encapsulation | ✅ | `encapsulation mpls` puts a per-service label (same dynamic block as VRF/EVI labels) in the Type-1 label field with no Encapsulation EC (RFC 8365 §5.1.3); import binds PE+label remotes; the tee drives the cradle MPLS xconnect (label imposed under the FIB-resolved transport LSP, `MPLS_OP_POP_XC` pop-to-AC decap) |
 | VXLAN encapsulation | ✅ | `encapsulation vxlan` puts the service VNI (`vni` leaf, default the EVI) in the Type-1 label field with the VXLAN Encapsulation EC and VTEP next hop (RFC 8365 §6); import binds whatever encap the remote signalled; the tee drives the cradle VXLAN xconnect (VTEP+VNI encap, E-Line-VNI decap, `SetVtepSource` from the advertised next hop) |
 | Datapath BDD | ✅ | `cradle_vpws_zebra` (untagged + VLAN-30 E-Line, CE-to-CE), `cradle_evpn_vpws` (static) |
 
@@ -61,24 +61,23 @@ Type-1 carries the service VNI in its label field with the VXLAN
 Encapsulation EC and the VTEP next hop (RFC 8365 §6), and the import side
 classifies each remote by what *it* signalled (SRv6 L2 Service TLV first,
 else VXLAN EC + label), so a fabric can migrate one PE at a time. The
-cradle cross-connect data plane runs the SRv6 and VXLAN flavors: the
-tee programs the remote endpoint encap, the local decap identity and
-(for VXLAN) the fabric VTEP source in one `AddXconnect`. MPLS VPWS
-signaling is complete — a per-service label from the shared dynamic
-block, bound per RFC 8365 §5.1.3 — with the cradle pop-to-AC datapath
-as the open half.
+cradle cross-connect data plane runs all three flavors: the tee
+programs the remote endpoint encap, the local decap identity (LocalSid,
+E-Line VNI, or pop-to-AC ILM) and, for VXLAN, the fabric VTEP source in
+one `AddXconnect`. Every E-Line row in the matrix below is closed
+except all-active load balancing and the control word.
 
 | E-Line capability | E-Line/VXLAN | E-Line/SRv6 | E-Line/MPLS |
 |---|---|---|---|
 | **Per-EVI Ethernet A-D signaling (Type-1)** | ✅ VNI in the label field + VXLAN Encapsulation EC + VTEP next hop | ✅ SRv6 L2 Service TLV → End.DX2 SID | ✅ Per-service label in the label field, no Encapsulation EC (RFC 8365 §5.1.3) |
-| **P2P cross-connect data plane** | ✅ cradle eBPF xconnect (`ReplTarget`-shaped maps + `VNI_F_ELINE` decap, cradle #163) | ✅ cradle eBPF xconnect (cradle #45) | ❌ Not built (cradle MPLS L2 covers E-LAN, not xconnect) |
-| **VLAN-scoped E-Line** | ✅ Inner-VID demux from the DX2V table (`VNI_F_ELINE_VLAN`) | ✅ End.DX2V, VLAN table = EVI (zebra #1782, cradle #48) | ❌ |
+| **P2P cross-connect data plane** | ✅ cradle eBPF xconnect (`ReplTarget`-shaped maps + `VNI_F_ELINE` decap, cradle #163) | ✅ cradle eBPF xconnect (cradle #45) | ✅ cradle eBPF xconnect (`REPL_KIND_MPLS` targets + `MPLS_OP_POP_XC` decap, cradle #165) |
+| **VLAN-scoped E-Line** | ✅ Inner-VID demux from the DX2V table (`VNI_F_ELINE_VLAN`) | ✅ End.DX2V, VLAN table = EVI (zebra #1782, cradle #48) | ✅ Inner-VID demux from the DX2V table (`MPLS_OP_POP_XC_VLAN`) |
 | **L2-Attributes EC (P/B/C flags + MTU)** | ✅ On every VPWS Type-1 | ✅ On every VPWS Type-1 (#1779) | ✅ On every VPWS Type-1 |
 | **Multihoming origination (ESI, P/B roles)** | ✅ Encap-agnostic (#2116; `bgp_evpn_vpws_vxlan_multihoming` proves failover re-binds VTEP *and* per-PE VNI) | ✅ DF per `<ESI, service instance>` (#2116) | ✅ Encap-agnostic |
 | **Remote P/B selection + per-ES fast failover** | ✅ Encap-agnostic | ✅ | ✅ Encap-agnostic |
 | **All-active load balancing** | ❌ | ❌ Open (needs multi-SID xconnect) | ❌ |
 | **Control word** | — (no control word in VXLAN) | — (no control word in SRv6) | ❌ C flag always 0 |
-| **Datapath BDD** | ✅ `cradle_vpws_vxlan_zebra`, `cradle_evpn_vpws_vxlan` (+ signaling `bgp_evpn_vpws_vxlan`) | ✅ `cradle_vpws_zebra`, `cradle_evpn_vpws` | ❌ |
+| **Datapath BDD** | ✅ `cradle_vpws_vxlan_zebra`, `cradle_evpn_vpws_vxlan` (+ signaling `bgp_evpn_vpws_vxlan`) | ✅ `cradle_vpws_zebra`, `cradle_evpn_vpws` | ✅ `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS + P transit), `cradle_evpn_vpws_mpls` (+ signaling `bgp_evpn_vpws_mpls`) |
 
 ## Per-Encapsulation Summary
 

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -200,8 +200,15 @@ message Xconnect {
   uint32 remote_vni  = 8; // VXLAN: VNI the remote advertised (with remote_vtep)
   // When non-zero, also bind this VNI as the E-Line's local decap
   // identity (the VNI our own Type-1 advertised) — the VXLAN analog of
-  // local_sid, at most one of the two.
+  // local_sid, at most one of local_sid / local_vni / local_label.
   uint32 local_vni   = 9;
+  string remote_pe    = 10; // MPLS: remote PE (IPv4 or IPv6)
+  uint32 remote_label = 11; // MPLS: service label the remote advertised (with remote_pe)
+  // When non-zero, also install this label as the E-Line's local decap
+  // identity (the label our own Type-1 advertised): an ILM entry pops it
+  // and emits the inner frame raw on the AC — the MPLS analog of
+  // local_sid, at most one of the three.
+  uint32 local_label  = 12;
 }
 
 message XconnectDel {
@@ -211,6 +218,7 @@ message XconnectDel {
   uint32 vid        = 4; // non-zero = remove the VLAN-scoped binding
   uint32 dx2v_table = 5;
   uint32 local_vni  = 6; // when non-zero, also remove this E-Line VNI binding
+  uint32 local_label = 7; // when non-zero, also remove this E-Line pop ILM
 }
 
 // A BUM ingress-replication slot: one remote PE in bridge domain `bd`,

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1797,19 +1797,15 @@ impl CradleFib {
         vid: u16,
         table: u32,
     ) {
-        let (remote_sid, remote_vtep, remote_vni) = match remote {
-            crate::rib::XconnectRemote::Srv6(sid) => (sid.to_string(), String::new(), 0),
+        let (remote_sid, remote_vtep, remote_vni, remote_pe, remote_label) = match remote {
+            crate::rib::XconnectRemote::Srv6(sid) => {
+                (sid.to_string(), String::new(), 0, String::new(), 0)
+            }
             crate::rib::XconnectRemote::Vxlan { vtep, vni } => {
-                (String::new(), vtep.to_string(), vni)
+                (String::new(), vtep.to_string(), vni, String::new(), 0)
             }
             crate::rib::XconnectRemote::Mpls { pe, label } => {
-                // Unreachable until the cradle proto grows its MPLS
-                // fields — `FibHandle::cradle_xconnect_add` filters the
-                // flavor out before this method.
-                tracing::warn!(
-                    "fib: cradle xconnect {port} -> pe {pe} label {label}: no MPLS RPC form"
-                );
-                return;
+                (String::new(), String::new(), 0, pe.to_string(), label)
             }
         };
         self.mirror.lock().await.xconnects.insert(
@@ -1825,8 +1821,11 @@ impl CradleFib {
                     remote_sid,
                     remote_vtep,
                     remote_vni,
+                    remote_pe,
+                    remote_label,
                     local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
                     local_vni: local_vni.unwrap_or(0),
+                    local_label: local_label.unwrap_or(0),
                     vid: vid as u32,
                     dx2v_table: table,
                 })
@@ -1846,6 +1845,7 @@ impl CradleFib {
         port: &str,
         local_sid: Option<std::net::Ipv6Addr>,
         local_vni: Option<u32>,
+        local_label: Option<u32>,
         vid: u16,
         table: u32,
     ) {
@@ -1862,6 +1862,7 @@ impl CradleFib {
                     port_index: 0,
                     local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
                     local_vni: local_vni.unwrap_or(0),
+                    local_label: local_label.unwrap_or(0),
                     vid: vid as u32,
                     dx2v_table: table,
                 })

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -765,18 +765,7 @@ impl FibHandle {
                         cradle.set_vtep_source(local).await;
                     }
                 }
-                crate::rib::XconnectRemote::Mpls { pe, label } => {
-                    // The cradle Xconnect RPC has no MPLS flavor yet —
-                    // the control plane binds and shows `up`, the
-                    // datapath tee lands with the cradle-side
-                    // E-Line/MPLS support.
-                    tracing::info!(
-                        "fib: cradle xconnect {port} -> pe {pe} label {label} \
-                         (local label {local_label:?}): MPLS tee not yet implemented"
-                    );
-                    return;
-                }
-                crate::rib::XconnectRemote::Srv6(_) => {}
+                crate::rib::XconnectRemote::Mpls { .. } | crate::rib::XconnectRemote::Srv6(_) => {}
             }
             cradle
                 .xconnect_add(port, remote, local_sid, local_vni, local_label, vid, table)
@@ -794,13 +783,8 @@ impl FibHandle {
         table: u32,
     ) {
         if let Some(cradle) = &self.cradle {
-            if local_label.is_some() {
-                // MPLS-flavored binding: nothing was teed (see
-                // `cradle_xconnect_add`), so nothing to remove.
-                return;
-            }
             cradle
-                .xconnect_del(port, local_sid, local_vni, vid, table)
+                .xconnect_del(port, local_sid, local_vni, local_label, vid, table)
                 .await;
         }
     }


### PR DESCRIPTION
## Summary

PR 3 of the E-LINE/MPLS series (after #2196 and cradle-rs/cradle-rs#165) — the tee, the proof, and the closing docs.

- **Vendored proto sync** — `Xconnect` gains `remote_pe`/`remote_label`/`local_label`, `XconnectDel` gains `local_label` (matching cradle-rs main after #165).
- **Real tee** — the FibHandle stub is gone: `CradleFib::xconnect_add` maps `XconnectRemote::Mpls` into the new fields and `xconnect_del` carries the local decap label, so one `AddXconnect` binds the E-Line both ways (ingress encap toward the remote PE with the label *it* advertised, local pop-to-AC ILM at the label *we* advertised).
- **Books** — ch-02-38 becomes "E-Line over SRv6, VXLAN or MPLS" with the MPLS configuration section (dynamic per-service labels, router-id as the LSP anchor, no-EC signaling) and a corrected receive-side classification (a label with no EC now *binds*); ch-02-40 retires its "EVPN-VPWS over MPLS is not implemented" note; the support-status E-Line/MPLS column flips to done.

## Testing

- **End-to-end proven** by cradle-rs's `cradle_vpws_mpls_zebra` BDD (paired PR cradle-rs/cradle-rs#166): two zebra+cradle PEs and a zebra+cradle **P transit node**, IS-IS SR-MPLS transport, iBGP over loopbacks. Passes on the first run: untagged + VID-30 E-Lines sharing one AC, CE-to-CE pings on attempt 1 both directions, `mpls_l2_encap`/`mpls_dx2` moving, `mpls_pop` on the EVPN-free P node, and `mpls_l2_bum`/`mpls_l2_decap`/`srv6_dx2`/`vxlan_dx2` all asserted **zero** — an E-Line never floods, never bridges, never leaks into another overlay.
- `bgp_evpn_vpws_mpls` (signaling) still passes on this branch; full unit suite green (1886); workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)