### PR TITLE
docs: bring the EVPN support-status doc up to the closed E-Line arcs

### DIFF
--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -12,28 +12,34 @@ Each side advertises a **per-EVI Ethernet A-D route (Type-1)** whose
 Ethernet Tag is its *local* VPWS service instance id, carrying its
 service binding per the afi-safi `encapsulation`: an **SRv6 End.DX2
 L2-Service Prefix-SID** (RFC 9252 §6.3) carved from the BGP SRv6
-locator, or — under the default `vxlan` — the **service VNI in the
-label field** with the VXLAN Encapsulation extended community and the
-VTEP as next hop (RFC 8365 §6). Importing the remote's Type-1 — matched
-by Ethernet Tag == `remote-service-id` within the shared EVI — binds
-the remote endpoint *as the remote signalled it* as the AC's
-cross-connect target. Forwarding runs in the
+locator, the **service VNI in the label field** with the VXLAN
+Encapsulation extended community and the VTEP as next hop under the
+default `vxlan` (RFC 8365 §6), or a **per-service MPLS label** with no
+Encapsulation EC under `mpls` (RFC 8365 §5.1.3). Importing the remote's
+Type-1 — matched by Ethernet Tag == `remote-service-id` within the
+shared EVI — binds the remote endpoint *as the remote signalled it* as
+the AC's cross-connect target. Forwarding runs in the
 [eBPF data plane](ch-16-00-ebpf.md): the AC's ingress encapsulates every
-frame (any EtherType)
-MAC-in-SRv6 toward the remote SID, and the local End.DX2 decap emits
-received frames raw on the same AC.
+frame (any EtherType) toward the remote endpoint, and the local decap —
+End.DX2 SID, E-Line VNI, or pop-to-AC label — emits received frames raw
+on the same AC.
 
 The RD is auto-derived as `router-id:evi`, the route-target as
-`AS:evi`; the ESI is all-zero (single-homed) in this phase.
+`AS:evi`; the ESI is all-zero unless the AC sits on a multihomed
+Ethernet Segment (see below).
 
 ## Configuration
 
-A VPWS service lives under the EVPN address family:
+A VPWS service lives under the EVPN address family, and its wire format
+follows the afi-safi `encapsulation` (`vxlan` — the default — `srv6` or
+`mpls`; per-encapsulation specifics in the sections below). Under
+`encapsulation srv6`:
 
 ```
 set router bgp global as 65001
 set router bgp global router-id 10.0.0.1
 set router bgp segment-routing srv6 locator LOC1
+set router bgp afi-safi evpn encapsulation srv6
 set router bgp afi-safi evpn vpws eline1 evi 100
 set router bgp afi-safi evpn vpws eline1 local-service-id 101
 set router bgp afi-safi evpn vpws eline1 remote-service-id 102
@@ -75,11 +81,13 @@ set router bgp afi-safi evpn vpws eline2 vlan 30
 
 `vlan` scopes the AC to one 802.1Q VID (RFC 8214 VLAN-based E-Line):
 only tagged frames with that VID enter the cross-connect — the tag
-crosses the service transparently — and the local SID becomes
-**End.DX2V** (RFC 8986 §4.10), demuxing return traffic by inner VID
-over the EVI's VLAN table. Tagged and untagged services can share the
+crosses the service transparently — and return traffic is demuxed by
+inner VID over the EVI's VLAN table (the local SID becomes **End.DX2V**,
+RFC 8986 §4.10, under SRv6; the E-Line VNI or pop label demuxes over the
+same table under VXLAN/MPLS). Tagged and untagged services can share the
 same AC port: VID-scoped entries match first, everything else rides
-the whole-port service.
+the whole-port service. Works identically under all three
+encapsulations.
 
 > **Operational note:** VLAN offloads must be **off** on the CE side of
 > the AC (`ethtool -K <if> txvlan off rxvlan off`). An offloaded tag
@@ -378,19 +386,25 @@ a deliberately single-homed service:
 ```
 
 `json` is supported. The state progresses `partial-config` (mandatory
-leaves missing) → `pending` (config complete, no router-id / locator
-yet) → `advertised` (Type-1 originated, remote not matched) →
-`up` (remote endpoint bound to the AC), with `mtu-mismatch` reported
-when a matching remote is rejected by the MTU check and `vni-conflict`
-when the service's VNI is already claimed on this PE.
+leaves missing) → `pending` (config complete, no router-id yet — or,
+under srv6, no locator) → `advertised` (Type-1 originated, remote not
+matched) → `up` (remote endpoint bound to the AC), with `mtu-mismatch`
+reported when a matching remote is rejected by the MTU check and
+`vni-conflict` when the service's VNI is already claimed on this PE. An
+MPLS service configured before the dynamic label block arrives shows
+`advertised` with no `Local Label:` line — its Type-1 carries label 0,
+which no remote binds — and re-originates by itself on the grant.
 
 ## Reconciliation
 
 The service re-syncs — withdraw + re-originate + re-derive the AC
 binding from the EVPN Loc-RIB — on any leaf change, router-id rebind,
-and locator (re)resolution. The Loc-RIB rescan means ordering does not
-matter: a remote Type-1 that arrived *before* the service was
-configured (or re-pointed) is found without waiting for a route churn.
+locator (re)resolution, label-block grant, and `encapsulation` change
+(which also releases the old flavor's SID or label and unbinds the live
+cross-connect under its old decap identity first). The Loc-RIB rescan
+means ordering does not matter: a remote Type-1 that arrived *before*
+the service was configured (or re-pointed) is found without waiting for
+a route churn.
 
 ## Scope
 

--- a/docs/design/bgp-evpn-support-status.md
+++ b/docs/design/bgp-evpn-support-status.md
@@ -26,7 +26,7 @@ datapath, driven from zebra-rs via the FibHandle tee.
 | **BUM segmentation (RFC 9572, Types 9/10/11)** | ✅ Control plane complete (RBR/ASBR, DF, S-PMSI) | ✅ + SR-P2MP tree offload wiring | ✅ Control plane (shared) |
 | **P2MP replication tree** | — (head-end IR model) | ✅ RFC 9524 End.Replicate incl. Bud (zebra #1923 + cradle #131) | ❌ MPLS-P2MP forwarder not built |
 | **ARP suppression** | ❌ Open | ❌ Open | ❌ Open |
-| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit) |
+| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit) |
 
 **Legend**: ✅ supported · ❌ not yet · — not applicable. "Control plane
 (shared)" = the feature is encapsulation-agnostic in zebra-rs; the per-encap
@@ -37,7 +37,8 @@ column difference is only the forwarding plane.
 E-Line service is implemented as EVPN VPWS: a `vpws` list under
 `router bgp afi-safi evpn` (RD `router-id:evi`, RT `AS:evi`), signaled with
 per-EVI Ethernet A-D (Type-1) routes and forwarded by the cradle eBPF
-datapath via SRv6 End.DX2 / End.DX2V cross-connects.
+cross-connect datapath under all three encapsulations — SRv6 End.DX2/DX2V,
+VXLAN VTEP+VNI, or an MPLS service label under the transport LSP.
 
 | E-Line capability | Status | Notes |
 |---|---|---|
@@ -48,19 +49,22 @@ datapath via SRv6 End.DX2 / End.DX2V cross-connects.
 | Multihoming origination (ESI, Primary/Backup roles) | ✅ | #2116 — `vpws` references an `ethernet-segment`; DF election per `<ESI, service instance>`; all-active ⇒ all Primary, single-active ⇒ DF Primary + Backup |
 | VNI-conflict guard (VXLAN) | ✅ | A VNI already claimed on the PE — another VPWS service, an L2VNI vxlan device, a VRF's L3VNI — parks the service in `vni-conflict` (owner named in show) instead of originating; retry hooks un-park it when the owner releases the VNI |
 | Remote Primary/Backup selection + per-ES A-D fast failover | ✅ | `select_remote` ranks P over B with the per-ES A-D mass-withdraw gate; failover scenarios in `bgp_evpn_vpws_multihoming.feature` |
-| All-active load balancing | ❌ Open | Needs a cradle xconnect holding more than one remote SID |
+| All-active load balancing | ❌ Open | Needs a cradle xconnect holding more than one remote endpoint |
 | Control word | ❌ | C flag always 0 |
 | MPLS encapsulation | ✅ | `encapsulation mpls` puts a per-service label (same dynamic block as VRF/EVI labels) in the Type-1 label field with no Encapsulation EC (RFC 8365 §5.1.3); import binds PE+label remotes; the tee drives the cradle MPLS xconnect (label imposed under the FIB-resolved transport LSP, `MPLS_OP_POP_XC` pop-to-AC decap) |
 | VXLAN encapsulation | ✅ | `encapsulation vxlan` puts the service VNI (`vni` leaf, default the EVI) in the Type-1 label field with the VXLAN Encapsulation EC and VTEP next hop (RFC 8365 §6); import binds whatever encap the remote signalled; the tee drives the cradle VXLAN xconnect (VTEP+VNI encap, E-Line-VNI decap, `SetVtepSource` from the advertised next hop) |
-| Datapath BDD | ✅ | `cradle_vpws_zebra` (untagged + VLAN-30 E-Line, CE-to-CE), `cradle_evpn_vpws` (static) |
+| Datapath BDD | ✅ | Zebra-driven CE-to-CE per encap: `cradle_vpws_zebra` (SRv6), `cradle_vpws_vxlan_zebra` (VXLAN), `cradle_vpws_mpls_zebra` (MPLS, IS-IS SR-MPLS + P transit) — each untagged + VLAN-30; static twins `cradle_evpn_vpws{,_vxlan,_mpls}` |
 
 ### E-Line by Encapsulation
 
-E-Line signaling honors the afi-safi `encapsulation`: under `vxlan` the
-Type-1 carries the service VNI in its label field with the VXLAN
-Encapsulation EC and the VTEP next hop (RFC 8365 §6), and the import side
-classifies each remote by what *it* signalled (SRv6 L2 Service TLV first,
-else VXLAN EC + label), so a fabric can migrate one PE at a time. The
+E-Line signaling honors the afi-safi `encapsulation`: the Type-1 carries
+an End.DX2/DX2V L2-Service Prefix-SID under `srv6`, the service VNI plus
+the VXLAN Encapsulation EC and VTEP next hop under `vxlan` (RFC 8365 §6),
+or a per-service MPLS label with no Encapsulation EC under `mpls` (RFC
+8365 §5.1.3's default). The import side classifies each remote by what
+*it* signalled (SRv6 L2 Service TLV first, else VXLAN EC + label, else
+no-EC label = MPLS PE+label), so a fabric can migrate between any pair of
+encapsulations one PE at a time. The
 cradle cross-connect data plane runs all three flavors: the tee
 programs the remote endpoint encap, the local decap identity (LocalSid,
 E-Line VNI, or pop-to-AC ILM) and, for VXLAN, the fabric VTEP source in
@@ -83,11 +87,20 @@ except all-active load balancing and the control word.
 
 - **VXLAN**: mature, with both kernel-native and eBPF data planes; the only
   encapsulation with kernel forwarding and the full multicast-optimization
-  stack (SMET per-VTEP delivery, AR leaf/RNVE).
+  stack (SMET per-VTEP delivery, AR leaf/RNVE). VPWS complete
+  (#2190/#2192/#2193 + cradle #163/#164) with the VNI-conflict guard and
+  multihoming failover proofs.
 - **SRv6**: complete L2 + L3 + VPWS + P2MP replication on the eBPF data
   plane, with the deepest BDD coverage (coverage plan phases 0–3 closed
   2026-07-28).
-- **MPLS**: L3 (Type-5) complete for a long time via L3VPN reuse; L2
-  recently made real by the cradle eBPF data plane (`cradle_evpn_mpls_zebra`
-  proves IS-IS SR-MPLS transport + BGP EVPN service labels end to end);
-  VPWS and P2MP replication remain the gaps.
+- **MPLS**: L3 (Type-5) complete for a long time via L3VPN reuse; L2 made
+  real by the cradle eBPF data plane (`cradle_evpn_mpls_zebra` proves
+  IS-IS SR-MPLS transport + BGP EVPN service labels end to end); VPWS
+  complete (#2196/#2198 + cradle #165/#166 — dynamic per-service labels,
+  pop-to-AC ILM, `cradle_vpws_mpls_zebra` e2e). P2MP replication remains
+  the gap.
+
+With the E-LINE arcs closed 2026-08-02, VPWS is the first EVPN service
+running end to end over all three encapsulations, mixed per direction; the
+per-service E-Line gaps left open everywhere are all-active load balancing
+and the (MPLS-only) control word.


### PR DESCRIPTION
## Summary

Docs-only sweep of `docs/design/bgp-evpn-support-status.md` after the E-LINE/VXLAN and E-LINE/MPLS arcs fully merged:

- Top-matrix and detail **Datapath BDD** rows now list the zebra-driven VPWS suites for all three encapsulations (`cradle_vpws_zebra` / `cradle_vpws_vxlan_zebra` / `cradle_vpws_mpls_zebra` + their static twins).
- The VPWS intro no longer describes the forwarding plane as "SRv6 End.DX2/DX2V cross-connects" only.
- The receive-side classification prose gains the MPLS no-EC default arm (RFC 8365 §5.1.3) and the any-pair migration statement.
- The per-encapsulation summary records VPWS complete for VXLAN (#2190/#2192/#2193 + cradle #163/#164) and MPLS (#2196/#2198 + cradle #165/#166); MPLS's remaining gap is P2MP replication, and the only open E-Line rows anywhere are all-active load balancing and the (MPLS-only) control word.

## Testing

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)