### PR TITLE
playset: EVPN VPWS E-Line labs — SRv6, VXLAN and MPLS

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -112,6 +112,26 @@ The four EVPN labs reuse the same namespace names (`vtep1`..`vtep3`,
 `h1`..`h4`), so bring up only one at a time — `up.sh` sweeps leftovers of
 the same names first.
 
+## BGP EVPN VPWS (E-Line)
+
+Three labs, one service — a point-to-point **E-Line** (EVPN VPWS,
+RFC 8214) cross-connecting two CEs as a transparent wire, once per
+encapsulation. The signaling is the same Type-1 per-EVI Ethernet A-D route
+throughout; what changes is the service binding it carries and the wire
+format underneath. All three forward on the eBPF data plane —
+`system ebpf enabled` makes zebra-rs spawn the cradle engine
+(`/usr/bin/cradle`, from the co-distributed cradle-rs package) — since the
+kernel has no E-Line disposition for any of them.
+
+| playset | wire format |
+|:--|:--|
+| [bgp-evpn-vpws-srv6](bgp-evpn-vpws-srv6/README.md) | End.DX2 L2-Service SID carved from the SRv6 locator, IS-IS SRv6 underlay |
+| [bgp-evpn-vpws-vxlan](bgp-evpn-vpws-vxlan/README.md) | Service VNI in the Type-1 label field + VXLAN Encapsulation EC, loopback VTEPs — with deliberately asymmetric VNIs per direction |
+| [bgp-evpn-vpws-mpls](bgp-evpn-vpws-mpls/README.md) | Dynamic per-service MPLS label, no Encapsulation EC (RFC 8365 §5.1.3), IS-IS SR-MPLS transport through a pure-transit P router |
+
+The labs share namespace names (`c1`, `c2`, `pe1`, `pe2`, plus `p` in the
+MPLS variant), so bring up only one at a time.
+
 ## BGP Inter-AS L3VPN
 
 Two providers, one VPN — the RFC 4364 §10 options (plus Cisco's AB

--- a/playset/bgp-evpn-vpws-mpls/README.md
+++ b/playset/bgp-evpn-vpws-mpls/README.md
@@ -1,0 +1,199 @@
+# EVPN VPWS: E-Line over MPLS
+
+This demo runs a point-to-point **E-Line** (EVPN VPWS, RFC 8214) over
+RFC 7432's original encapsulation — MPLS — with a pure-transit **P router**
+between the PEs. It is the encapsulation the Linux kernel cannot forward at
+all: no kernel action pops an MPLS label and emits the exposed Ethernet
+frame raw on a port, so the eBPF data plane is the E-Line end to end.
+
+Three layers compose, each from a different protocol:
+
+* **IS-IS SR-MPLS** distributes the transport labels to the PE loopbacks;
+* **iBGP L2VPN-EVPN** under `encapsulation mpls` advertises a
+  **per-service label** on each vpws Type-1 — allocated dynamically from
+  the same block VRF and EVI labels come from, with **no Encapsulation
+  extended community** (its absence is the MPLS signal, RFC 8365 §5.1.3);
+* the FibHandle tee programs the eBPF cross-connect: label imposition
+  under the FIB-resolved transport LSP at the ingress AC, and a pop-to-AC
+  disposition at the label this PE advertised.
+
+The P router carries **no EVPN state whatsoever** — no BGP, no vpws. It
+label-switches the transport label and, as penultimate hop for both
+loopbacks, pops it, exposing the service label to the egress PE. That
+layering is the demo: BGP advertises a PE, IS-IS supplies the label to
+reach it, and the data plane composes the two.
+
+```
+ c1 ── pe1 ═══════ p ═══════ pe2 ── c2     c1/c2: 10.0.0.1/24, 10.0.0.2/24
+     10.250.0.0/30   10.250.0.4/30         pe1: lo 1.1.1.1, SID index 1
+        IS-IS SR-MPLS underlay             p:   lo 3.3.3.3, SID index 3
+                                           pe2: lo 2.2.2.2, SID index 2
+   vpws eline1: evi 100, pe1 svc-id 101 ⇄ pe2 svc-id 102
+```
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: c2
+applied
+```
+
+(`up.sh` also turns kernel forwarding off on pe1/p/pe2 and computes TCP
+checksums in software on the PEs' core veths — router-originated TCP
+entering an XDP-forwarded core carries deferred checksums that an XDP
+redirect never resolves, which would stall the BGP session while ICMP
+flows fine.)
+
+## Take a look at the YAML configuration
+
+`pe1.yaml` in full — `pe2.yaml` mirrors it, `p.yaml` is IS-IS only:
+
+```yaml
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: pe1-p
+  ipv4:
+    address: 10.250.0.1/30
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1
+    - if-name: pe1-p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      encapsulation: mpls
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+    neighbor:
+    - remote-address: 2.2.2.2
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+```
+
+* `encapsulation mpls` — the vpws needs no locator and no VNI; its service
+  label is allocated dynamically.
+* The next hop is the router-id: the loopback the transport LSP resolves
+  on, carried by IS-IS SR-MPLS (`prefix-sid index 1`), with BGP peering
+  over it — the classic MPLS-VPN shape.
+
+## The E-Line comes up
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn vpws
+VPWS service: eline1
+  EVI: 100
+  Service ID: local 101, remote 102
+  Interface: pe1-c1
+  Local Label: 16
+  Remote PE: 2.2.2.2 (label 16) (via 2.2.2.2)
+  State: up
+```
+
+Both labels came from each PE's dynamic block (both happen to draw 16 —
+per-PE label spaces are independent). On the wire the Type-1s carry **no**
+Encapsulation extended community — compare the VXLAN playset's `ET:8` —
+which is exactly RFC 8365 §5.1.3's "absent means MPLS":
+
+```shell
+pe1>show bgp evpn
+   Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 1.1.1.1:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[101]
+                    1.1.1.1                    0         32768 i
+                    Extended community: RT:65000:100 l2-attr:P:mtu0
+Route Distinguisher: 2.2.2.2:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[102]
+                    2.2.2.2                    0    100      0 i
+                    Extended community: RT:65000:100 l2-attr:P:mtu0
+```
+
+## Ping across the wire
+
+Kernel forwarding is off on all three core nodes, so this — ARP included —
+rides `[transport label][service label]` through the P router end to end:
+
+```shell
+$ sudo ip netns exec c1 ping -c 3 10.0.0.2
+...
+3 packets transmitted, 3 received, 0% packet loss, time 611ms
+```
+
+The PE counters show the imposition and the pop-to-AC disposition — and an
+E-Line never floods (`mpls_l2_bum 0`) and never bridges (`mpls_l2_decap
+0`, the EVI path):
+
+```shell
+pe1>show ebpf stats
+...
+mpls_l2_encap  4
+mpls_l2_decap  0
+mpls_l2_bum    0
+mpls_dx2       4
+```
+
+The P router did all its work with zero EVPN state — pure label switching,
+popping the transport label as penultimate hop:
+
+```shell
+p>show ebpf stats
+...
+mpls_pop       29
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| c1 | CE | `c1-pe1` 10.0.0.1/24 |
+| pe1 | PE | `lo` 1.1.1.1/32, `pe1-p` 10.250.0.1/30, SID index 1 |
+| p | transit LSR | `lo` 3.3.3.3/32, `p-pe1` 10.250.0.2/30, `p-pe2` 10.250.0.5/30, SID index 3 |
+| pe2 | PE | `lo` 2.2.2.2/32, `pe2-p` 10.250.0.6/30, SID index 2 |
+| c2 | CE | `c2-pe2` 10.0.0.2/24 |

--- a/playset/bgp-evpn-vpws-mpls/c1.yaml
+++ b/playset/bgp-evpn-vpws-mpls/c1.yaml
@@ -1,0 +1,9 @@
+# CE 1 — a plain host on the E-Line. It shares 10.0.0.0/24 with c2 and
+# resolves it by ARP straight through the service: no routing, no
+# gateway, nothing E-Line-aware.
+interface:
+- if-name: c1-pe1
+  ipv4:
+    address: 10.0.0.1/24
+system:
+  hostname: c1

--- a/playset/bgp-evpn-vpws-mpls/c2.yaml
+++ b/playset/bgp-evpn-vpws-mpls/c2.yaml
@@ -1,0 +1,7 @@
+# CE 2 — the other end of the wire.
+interface:
+- if-name: c2-pe2
+  ipv4:
+    address: 10.0.0.2/24
+system:
+  hostname: c2

--- a/playset/bgp-evpn-vpws-mpls/down.sh
+++ b/playset/bgp-evpn-vpws-mpls/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vpws-mpls/p.yaml
+++ b/playset/bgp-evpn-vpws-mpls/p.yaml
@@ -1,0 +1,47 @@
+# P — the transit LSR. No BGP and no EVPN state at all: it only
+# label-switches the transport label toward the egress PE's loopback,
+# and — being the penultimate hop for both loopbacks — pops it, exposing
+# the service label to the egress PE. That layering is the demo: BGP
+# advertises a PE, IS-IS supplies the label to reach it, and the eBPF
+# data plane composes the two.
+system:
+  hostname: p
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 3.3.3.3/32
+- if-name: p-pe1
+  ipv4:
+    address: 10.250.0.2/30
+  ebpf:
+    enabled: true
+- if-name: p-pe2
+  ipv4:
+    address: 10.250.0.5/30
+  ebpf:
+    enabled: true
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 3.3.3.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 3
+    - if-name: p-pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p-pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true

--- a/playset/bgp-evpn-vpws-mpls/pe1.yaml
+++ b/playset/bgp-evpn-vpws-mpls/pe1.yaml
@@ -1,0 +1,64 @@
+# PE1 — EVPN VPWS provider edge over MPLS (RFC 8365 §5.1.3). IS-IS
+# SR-MPLS supplies the transport LSP to PE2's loopback; under
+# `encapsulation mpls` the vpws Type-1 carries a per-service label from
+# the dynamic block with NO Encapsulation extended community — its
+# absence is the MPLS signal. No locator, no VNI. cradle is the E-Line
+# data plane: the kernel has no action that pops a label onto a port.
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: pe1-p
+  ipv4:
+    address: 10.250.0.1/30
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1
+    - if-name: pe1-p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      encapsulation: mpls
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+    neighbor:
+    - remote-address: 2.2.2.2
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-mpls/pe2.yaml
+++ b/playset/bgp-evpn-vpws-mpls/pe2.yaml
@@ -1,0 +1,59 @@
+# PE2 — the mirror of PE1.
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: pe2-p
+  ipv4:
+    address: 10.250.0.6/30
+  ebpf:
+    enabled: true
+- if-name: pe2-c2
+  ebpf:
+    enabled: true
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 2
+    - if-name: pe2-p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 2.2.2.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      encapsulation: mpls
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: pe2-c2
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      update-source: 2.2.2.2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-mpls/topology.sh
+++ b/playset/bgp-evpn-vpws-mpls/topology.sh
@@ -1,0 +1,18 @@
+# EVPN VPWS (E-Line over MPLS) demo topology, with a pure-transit P
+# router between the PEs.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(c1 pe1 p pe2 c2)
+
+PLAYSET_LINKS=(
+    c1:c1-pe1:pe1:pe1-c1
+    pe1:pe1-p:p:p-pe1
+    p:p-pe2:pe2:pe2-p
+    pe2:pe2-c2:c2:c2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(c1 pe1 p pe2 c2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(c1 pe1 p pe2 c2)

--- a/playset/bgp-evpn-vpws-mpls/up.sh
+++ b/playset/bgp-evpn-vpws-mpls/up.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Bring up the EVPN VPWS (E-Line over MPLS) namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the PEs and the P router: the eBPF data plane
+# does the label work, and a successful CE-to-CE ping must prove it (the
+# kernel has no pop-to-port MPLS disposition at all).
+for ns in pe1 p pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+done
+
+# The PEs' own iBGP session is router-originated TCP entering an
+# XDP-forwarded core: it leaves the stack with deferred (partial)
+# checksums that an XDP redirect never resolves, so the far end would
+# drop the segments while ICMP and transit traffic flow fine. Compute
+# checksums in software on the core-facing veths instead.
+run_in_netns pe1 ethtool -K pe1-p tx off
+run_in_netns pe2 ethtool -K pe2-p tx off

--- a/playset/bgp-evpn-vpws-srv6/README.md
+++ b/playset/bgp-evpn-vpws-srv6/README.md
@@ -1,0 +1,184 @@
+# EVPN VPWS: E-Line over SRv6
+
+This demo runs a point-to-point **E-Line** (EVPN VPWS, RFC 8214) over an
+SRv6 data plane. Two CEs are cross-connected as a transparent wire: no MAC
+learning, no FDB, no flooding — they share a subnet and resolve each other
+by ARP straight through the service.
+
+Each PE advertises a per-EVI Ethernet A-D route (Type-1) whose Ethernet Tag
+is its local service instance id, carrying an **End.DX2 L2-Service
+Prefix-SID** (RFC 9252 §6.3) carved from its SRv6 locator. Importing the
+peer's Type-1 binds the remote SID as the attachment circuit's
+cross-connect target. Forwarding runs on the eBPF data plane —
+`system ebpf enabled` makes zebra-rs spawn and supervise the cradle engine
+(`/usr/bin/cradle`, from the co-distributed cradle-rs package) — because
+the kernel has no End.DX2 action.
+
+```
+ c1 ── pe1 ══════════ pe2 ── c2      c1/c2: 10.0.0.1/24, 10.0.0.2/24
+       2001:db8:0:12::/64            pe1: lo 2001:db8::1, LOC1 fcbb:bbbb:1::/48
+       IS-IS SRv6 underlay           pe2: lo 2001:db8::2, LOC2 fcbb:bbbb:2::/48
+   vpws eline1: evi 100, pe1 svc-id 101 ⇄ pe2 svc-id 102
+```
+
+IS-IS carries the loopbacks and locators; the iBGP L2VPN-EVPN session runs
+between the loopbacks. The CE-facing ports (`pe1-c1`, `pe2-c2`) carry no
+address and no bridge — they are pure attachment circuits.
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: c2
+applied
+```
+
+## Take a look at the YAML configuration
+
+`pe1.yaml` in full — `pe2.yaml` mirrors it, and the CEs are plain hosts
+with one address each:
+
+```yaml
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: pe1-pe2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: pe1-pe2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+```
+
+* `system ebpf enabled` spawns the cradle engine and implies the FIB tee;
+  the two `ebpf enabled` interface leaves attach the underlay port and the
+  attachment circuit to it.
+* `encapsulation srv6` makes the vpws Type-1 carry an End.DX2 SID carved
+  dynamically from `LOC1` — no manual SID configuration.
+* The service ids cross: pe1's `local-service-id 101` is pe2's
+  `remote-service-id`, and vice versa.
+
+## The E-Line comes up
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn vpws
+VPWS service: eline1
+  EVI: 100
+  Service ID: local 101, remote 102
+  Interface: pe1-c1
+  Local SID (End.DX2): fcbb:bbbb:1:40::
+  Remote SID: fcbb:bbbb:2:40:: (via 2001:db8::2)
+  State: up
+```
+
+Both Type-1 routes are in the EVPN table, each carrying its End.DX2 SID
+and the RFC 8214 §3.1 Layer-2 Attributes extended community:
+
+```shell
+pe1>show bgp evpn
+   Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 10.0.0.1:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[101]
+                    10.0.0.1                   0         32768 i
+                    Local SID: fcbb:bbbb:1:40:: (End.DX2)
+                    Extended community: RT:65001:100 l2-attr:P:mtu0
+Route Distinguisher: 10.0.0.2:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[102]
+                    2001:db8::2                0    100      0 i
+                    Remote SID: fcbb:bbbb:2:40:: (End.DX2)
+                    Extended community: RT:65001:100 l2-attr:P:mtu0
+```
+
+## Ping across the wire
+
+Kernel forwarding is off on both PEs, so this ping — ARP included — rides
+the eBPF cross-connect end to end:
+
+```shell
+$ sudo ip netns exec c1 ping -c 3 10.0.0.2
+...
+3 packets transmitted, 3 received, 0% packet loss, time 609ms
+```
+
+The engine counters show both legs: MAC-in-SRv6 encapsulation at the AC
+ingress, and the End.DX2 raw emit at the egress:
+
+```shell
+pe1>show ebpf stats
+...
+srv6_l2_encap  5
+srv6_dx2       5
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| c1 | CE | `c1-pe1` 10.0.0.1/24 |
+| pe1 | PE | `lo` 2001:db8::1/128, `pe1-pe2` 2001:db8:0:12::1/64, LOC1 `fcbb:bbbb:1::/48` |
+| pe2 | PE | `lo` 2001:db8::2/128, `pe2-pe1` 2001:db8:0:12::2/64, LOC2 `fcbb:bbbb:2::/48` |
+| c2 | CE | `c2-pe2` 10.0.0.2/24 |

--- a/playset/bgp-evpn-vpws-srv6/c1.yaml
+++ b/playset/bgp-evpn-vpws-srv6/c1.yaml
@@ -1,0 +1,9 @@
+# CE 1 — a plain host on the E-Line. It shares 10.0.0.0/24 with c2 and
+# resolves it by ARP straight through the service: no routing, no
+# gateway, nothing E-Line-aware.
+interface:
+- if-name: c1-pe1
+  ipv4:
+    address: 10.0.0.1/24
+system:
+  hostname: c1

--- a/playset/bgp-evpn-vpws-srv6/c2.yaml
+++ b/playset/bgp-evpn-vpws-srv6/c2.yaml
@@ -1,0 +1,7 @@
+# CE 2 — the other end of the wire.
+interface:
+- if-name: c2-pe2
+  ipv4:
+    address: 10.0.0.2/24
+system:
+  hostname: c2

--- a/playset/bgp-evpn-vpws-srv6/down.sh
+++ b/playset/bgp-evpn-vpws-srv6/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vpws-srv6/pe1.yaml
+++ b/playset/bgp-evpn-vpws-srv6/pe1.yaml
@@ -1,0 +1,69 @@
+# PE1 — EVPN VPWS provider edge over SRv6. IS-IS SRv6 distributes the
+# locators; the vpws Type-1 carries an End.DX2 L2-Service SID carved from
+# LOC1; `system ebpf enabled` spawns the cradle engine and tees the
+# cross-connect into it (the kernel has no End.DX2 action).
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: pe1-pe2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: pe1-pe2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-srv6/pe2.yaml
+++ b/playset/bgp-evpn-vpws-srv6/pe2.yaml
@@ -1,0 +1,66 @@
+# PE2 — the mirror of PE1 (LOC2, service instance 102).
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe2-pe1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+  ebpf:
+    enabled: true
+- if-name: pe2-c2
+  ebpf:
+    enabled: true
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: pe2-pe1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: pe2-c2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65001
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-srv6/topology.sh
+++ b/playset/bgp-evpn-vpws-srv6/topology.sh
@@ -1,0 +1,16 @@
+# EVPN VPWS (E-Line over SRv6) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(c1 pe1 pe2 c2)
+
+PLAYSET_LINKS=(
+    c1:c1-pe1:pe1:pe1-c1
+    pe1:pe1-pe2:pe2:pe2-pe1
+    pe2:pe2-c2:c2:c2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(c1 pe1 pe2 c2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(c1 pe1 pe2 c2)

--- a/playset/bgp-evpn-vpws-srv6/up.sh
+++ b/playset/bgp-evpn-vpws-srv6/up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Bring up the EVPN VPWS (E-Line over SRv6) namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the PEs: the eBPF data plane does the label
+# work, and a successful CE-to-CE ping must prove it (the kernel has no
+# End.DX2 action anyway).
+for ns in pe1 pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done

--- a/playset/bgp-evpn-vpws-vxlan/README.md
+++ b/playset/bgp-evpn-vpws-vxlan/README.md
@@ -1,0 +1,183 @@
+# EVPN VPWS: E-Line over VXLAN
+
+This demo runs a point-to-point **E-Line** (EVPN VPWS, RFC 8214) over a
+plain VXLAN fabric (RFC 8365 §6) — no SRv6 locator, no MPLS, and under the
+**default** `encapsulation vxlan`, so the whole configuration is the
+service itself. Two CEs are cross-connected as a transparent wire: no MAC
+learning, no FDB, no flooding.
+
+Each PE advertises a per-EVI Ethernet A-D route (Type-1) with its **service
+VNI in the label field**, the VXLAN Encapsulation extended community, and
+its loopback VTEP as next hop. The VNIs are deliberately **asymmetric**:
+pe1 pins `vni 5001`, pe2 lets its VNI default to the EVI (100) — the label
+field is downstream-assigned, so each PE simply encapsulates with what its
+peer advertised. Forwarding runs on the eBPF data plane
+(`system ebpf enabled` spawns the cradle engine) — the kernel has no
+VNI-to-port E-Line disposition.
+
+```
+ c1 ── pe1 ══════════ pe2 ── c2      c1/c2: 10.0.0.1/24, 10.0.0.2/24
+        10.0.12.0/24                 pe1: lo/VTEP 192.0.2.1, vni 5001
+       IPv4 underlay                 pe2: lo/VTEP 192.0.2.2, vni = evi = 100
+   vpws eline1: evi 100, pe1 svc-id 101 ⇄ pe2 svc-id 102
+```
+
+The VTEPs are the loopbacks and BGP peers over them, so the advertised
+Type-1 next hop *is* the VTEP; a static /32 toward the peer's VTEP resolves
+the datapath encapsulation, and the underlay ARP the BGP session performs
+seeds the engine's neighbor table — everything the datapath needs arrives
+over the tee.
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: c2
+applied
+```
+
+## Take a look at the YAML configuration
+
+`pe1.yaml` in full — `pe2.yaml` mirrors it without the `vni` leaf:
+
+```yaml
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.1/32
+- if-name: pe1-pe2
+  ipv4:
+    address: 10.0.12.1/24
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.2/32
+        nexthop:
+        - address: 10.0.12.2
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+        vni: 5001
+    neighbor:
+    - remote-address: 192.0.2.2
+      remote-as: 65001
+      update-source: 192.0.2.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+```
+
+* No `encapsulation` leaf: `vxlan` is the default.
+* `vni 5001` is what pe1 advertises — the VNI the *remote* encapsulates
+  toward pe1 with, and pe1's decap identity. Unset (as on pe2) it defaults
+  to the EVI.
+* The router-id is the loopback VTEP and the session runs over it
+  (`update-source`), so the address the peer sends VXLAN to and the
+  address this PE accepts can never disagree.
+
+## The E-Line comes up — with a different VNI per direction
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn vpws
+VPWS service: eline1
+  EVI: 100
+  Service ID: local 101, remote 102
+  Interface: pe1-c1
+  Local VNI: 5001
+  Remote VTEP: 192.0.2.2 (VNI 100) (via 192.0.2.2)
+  State: up
+```
+
+pe2 shows the mirror image — it advertised the EVI default and bound pe1's
+explicit 5001:
+
+```shell
+pe2>show bgp evpn vpws
+VPWS service: eline1
+  EVI: 100
+  Service ID: local 102, remote 101
+  Interface: pe2-c2
+  Local VNI: 100
+  Remote VTEP: 192.0.2.1 (VNI 5001) (via 192.0.2.1)
+  State: up
+```
+
+On the wire the Type-1s carry the VXLAN Encapsulation extended community
+(`ET:8`, RFC 9012 tunnel type 8) — the marker that distinguishes this
+E-Line from the MPLS form, which signals by the EC's *absence*:
+
+```shell
+pe1>show bgp evpn
+   Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 192.0.2.1:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[101]
+                    192.0.2.1                  0         32768 i
+                    Extended community: RT:65001:100 ET:8 l2-attr:P:mtu0
+Route Distinguisher: 192.0.2.2:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[102]
+                    192.0.2.2                  0    100      0 i
+                    Extended community: RT:65001:100 ET:8 l2-attr:P:mtu0
+```
+
+## Ping across the wire
+
+Kernel forwarding is off on both PEs, so this — ARP included — rides the
+eBPF cross-connect as VXLAN end to end:
+
+```shell
+$ sudo ip netns exec c1 ping -c 3 10.0.0.2
+...
+3 packets transmitted, 3 received, 0% packet loss, time 612ms
+```
+
+The counters show the two E-Line legs and, just as telling, what stayed at
+zero: an E-Line never floods and never touches the bridged-VXLAN path:
+
+```shell
+pe1>show ebpf stats
+...
+vxlan_encap    4
+vxlan_decap    0
+vxlan_flood    0
+vxlan_dx2      4
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| c1 | CE | `c1-pe1` 10.0.0.1/24 |
+| pe1 | PE / VTEP | `lo` 192.0.2.1/32, `pe1-pe2` 10.0.12.1/24, VNI 5001 |
+| pe2 | PE / VTEP | `lo` 192.0.2.2/32, `pe2-pe1` 10.0.12.2/24, VNI 100 (= EVI) |
+| c2 | CE | `c2-pe2` 10.0.0.2/24 |

--- a/playset/bgp-evpn-vpws-vxlan/c1.yaml
+++ b/playset/bgp-evpn-vpws-vxlan/c1.yaml
@@ -1,0 +1,9 @@
+# CE 1 — a plain host on the E-Line. It shares 10.0.0.0/24 with c2 and
+# resolves it by ARP straight through the service: no routing, no
+# gateway, nothing E-Line-aware.
+interface:
+- if-name: c1-pe1
+  ipv4:
+    address: 10.0.0.1/24
+system:
+  hostname: c1

--- a/playset/bgp-evpn-vpws-vxlan/c2.yaml
+++ b/playset/bgp-evpn-vpws-vxlan/c2.yaml
@@ -1,0 +1,7 @@
+# CE 2 — the other end of the wire.
+interface:
+- if-name: c2-pe2
+  ipv4:
+    address: 10.0.0.2/24
+system:
+  hostname: c2

--- a/playset/bgp-evpn-vpws-vxlan/down.sh
+++ b/playset/bgp-evpn-vpws-vxlan/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vpws-vxlan/pe1.yaml
+++ b/playset/bgp-evpn-vpws-vxlan/pe1.yaml
@@ -1,0 +1,53 @@
+# PE1 — EVPN VPWS provider edge over VXLAN (RFC 8365 §6), under the
+# DEFAULT `encapsulation vxlan`: no SRv6 locator anywhere. The vpws
+# Type-1 carries VNI 5001 (explicit leaf) in its label field plus the
+# VXLAN Encapsulation extended community, next hop = the router-id =
+# this loopback VTEP the BGP session runs over. The static /32 toward
+# PE2's VTEP resolves the datapath encapsulation via the teed FIB.
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.1/32
+- if-name: pe1-pe2
+  ipv4:
+    address: 10.0.12.1/24
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.2/32
+        nexthop:
+        - address: 10.0.12.2
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+        vni: 5001
+    neighbor:
+    - remote-address: 192.0.2.2
+      remote-as: 65001
+      update-source: 192.0.2.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-vxlan/pe2.yaml
+++ b/playset/bgp-evpn-vpws-vxlan/pe2.yaml
@@ -1,0 +1,50 @@
+# PE2 — the mirror of PE1. eline1 leaves the `vni` leaf unset, so its
+# VNI defaults to the EVI (100): the two directions of the E-Line
+# deliberately carry DIFFERENT VNIs — each PE encapsulates with what its
+# peer advertised (the downstream-assigned Type-1 label-field semantic).
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.2/32
+- if-name: pe2-pe1
+  ipv4:
+    address: 10.0.12.2/24
+  ebpf:
+    enabled: true
+- if-name: pe2-c2
+  ebpf:
+    enabled: true
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.1/32
+        nexthop:
+        - address: 10.0.12.1
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: pe2-c2
+    neighbor:
+    - remote-address: 192.0.2.1
+      remote-as: 65001
+      update-source: 192.0.2.2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-vxlan/topology.sh
+++ b/playset/bgp-evpn-vpws-vxlan/topology.sh
@@ -1,0 +1,16 @@
+# EVPN VPWS (E-Line over VXLAN) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(c1 pe1 pe2 c2)
+
+PLAYSET_LINKS=(
+    c1:c1-pe1:pe1:pe1-c1
+    pe1:pe1-pe2:pe2:pe2-pe1
+    pe2:pe2-c2:c2:c2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(c1 pe1 pe2 c2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(c1 pe1 pe2 c2)

--- a/playset/bgp-evpn-vpws-vxlan/up.sh
+++ b/playset/bgp-evpn-vpws-vxlan/up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Bring up the EVPN VPWS (E-Line over VXLAN) namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the PEs: the eBPF data plane does the VXLAN
+# work, and a successful CE-to-CE ping must prove it (the kernel has no
+# VNI-to-port E-Line disposition).
+for ns in pe1 pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done


### PR DESCRIPTION
## Summary

Three new playsets, one per E-Line encapsulation — the demo counterpart of the just-closed VPWS arcs, and the **first playsets on the eBPF data plane**:

- **`bgp-evpn-vpws-srv6`** — End.DX2 L2-Service SID carved from the SRv6 locator, IS-IS SRv6 underlay, iBGP over loopbacks.
- **`bgp-evpn-vpws-vxlan`** — the default `encapsulation vxlan`, loopback VTEPs, and deliberately **asymmetric VNIs per direction** (pe1 pins `vni 5001`, pe2 defaults to the EVI) so the downstream-assigned label-field semantic is visible in `show bgp evpn vpws` on both ends.
- **`bgp-evpn-vpws-mpls`** — dynamic per-service label with **no** Encapsulation EC (RFC 8365 §5.1.3), IS-IS SR-MPLS transport through a pure-transit **P router** with zero EVPN state; `up.sh` handles the two operational traps (kernel forwarding off; software TCP checksums on the core veths so the iBGP session survives the XDP-forwarded core).

The engine needs no harness support: `system ebpf enabled` in the node YAML makes zebra-rs spawn and supervise cradle (`/usr/bin/cradle` — the co-distributed cradle-rs package pinned at v0.9.9 in #2200), and per-interface `ebpf enabled` leaves attach the ACs and underlay ports. No new file kinds, so the `playset packaging assets` gate passes unchanged. `playset/README.md` gains the series index.

## Testing

Each playset was brought up live on this branch: BGP Established, `show bgp evpn vpws` reaching `State: up` (SRv6 SIDs / asymmetric VNIs / dynamic label 16 visible per flavor), CE-to-CE `ping` 0% loss with kernel forwarding off (ARP + ICMP through the eBPF cross-connect), and the engine counters moving with the isolation counters at zero (`vxlan_flood`/`mpls_l2_bum`/`mpls_l2_decap` = 0; `mpls_pop` on the P node). Every README's output block is captured verbatim from those runs. `make -C packaging playset` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)