### PR TITLE
playset: EVPN over SRv6 and MPLS E-LAN labs in eBPF

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -112,6 +112,22 @@ The four EVPN labs reuse the same namespace names (`vtep1`..`vtep3`,
 `h1`..`h4`), so bring up only one at a time — `up.sh` sweeps leftovers of
 the same names first.
 
+## BGP EVPN over SRv6 and MPLS (E-LAN in eBPF)
+
+The stretched-segment story of the VXLAN labs, re-run on the other two
+encapsulations — the ones the kernel cannot forward, so `system ebpf
+enabled` makes zebra-rs spawn the cradle engine and the whole L2 service
+(XDP MAC learning → WatchFdb → Type-2, ingress-replication flood, decap)
+runs in eBPF:
+
+| playset | wire format |
+|:--|:--|
+| [bgp-evpn-srv6](bgp-evpn-srv6/README.md) | MAC-in-SRv6 (RFC 9252): per-VNI End.DT2U on the Type-2, End.DT2M on the Type-3, SIDs carved from each PE's locator; IS-IS SRv6 underlay |
+| [bgp-evpn-mpls](bgp-evpn-mpls/README.md) | RFC 7432's original encapsulation: a dynamic per-EVI service label (no Encapsulation EC — absent means MPLS), IS-IS SR-MPLS transport through a pure-transit P router |
+
+Both share namespace names (`h1`, `h2`, `pe1`, `pe2`, plus `p` in the
+MPLS variant) — one at a time.
+
 ## BGP EVPN VPWS (E-Line)
 
 Three labs, one service — a point-to-point **E-Line** (EVPN VPWS,

--- a/playset/bgp-evpn-mpls/README.md
+++ b/playset/bgp-evpn-mpls/README.md
@@ -1,0 +1,198 @@
+# EVPN over MPLS: a stretched segment in eBPF
+
+This demo stretches one L2 segment (E-LAN) between two hosts over
+**MPLS** — RFC 7432's original encapsulation, and the one the Linux
+kernel cannot forward at all: no kernel action pops an MPLS label and
+hands the exposed Ethernet frame to a bridge. The eBPF data plane is the
+service end to end, with a pure-transit **P router** between the PEs.
+
+Three layers compose, each from a different protocol:
+
+* **IS-IS SR-MPLS** distributes the transport labels to the PE loopbacks;
+* **iBGP L2VPN-EVPN** under `encapsulation mpls` gives the `evi 100`
+  instance a dynamic **per-EVI service label**, advertised on its Type-2
+  and Type-3 routes (in the PMSI for the BUM tunnel) instead of a VNI,
+  and installs the bridge-domain decap ILM at it;
+* the FibHandle tee programs the engine: remote MACs impose the far PE's
+  service label under the transport LSP, the Type-3 becomes a
+  replication slot, and the ILM pops arriving service labels into bridge
+  domain 100.
+
+The P router carries no EVPN state whatsoever — no BGP, no EVI. It
+label-switches the transport label and, as penultimate hop for both
+loopbacks, pops it, exposing the service label to the egress PE.
+
+```
+ h1 ── pe1 ═══════ p ═══════ pe2 ── h2     h1/h2: 172.16.10.1/24, .2/24
+     10.250.0.0/30   10.250.0.4/30         pe1: lo 1.1.1.1, SID index 1
+        IS-IS SR-MPLS underlay             p:   lo 3.3.3.3, SID index 3
+                                           pe2: lo 2.2.2.2, SID index 2
+             EVI 100 / bridge domain 100 stretched across
+```
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h2
+applied
+```
+
+(`up.sh` also turns kernel forwarding off on pe1/p/pe2 and computes TCP
+checksums in software on the PEs' core veths — router-originated TCP
+entering an XDP-forwarded core carries deferred checksums that an XDP
+redirect never resolves, which would stall the BGP session while ICMP
+flows fine.)
+
+## Take a look at the YAML configuration
+
+`pe1.yaml` in full — `pe2.yaml` mirrors it, `p.yaml` is IS-IS only, and
+the hosts are plain tenants:
+
+```yaml
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: pe1-p
+  ipv4:
+    address: 10.250.0.1/30
+  ebpf:
+    enabled: true
+- if-name: pe1-h1
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1
+    - if-name: pe1-p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      evi:
+      - id: 100
+        bridge: br100
+    neighbor:
+    - remote-address: 2.2.2.2
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+```
+
+* `encapsulation mpls` + the `evi` list: there is no VXLAN device to read
+  a VNI from, so an MPLS bridge domain is declared explicitly — `id 100`
+  is the RD/RT number *and* the bridge domain, pinned to `br100`.
+* The service label is dynamic (drawn from the same block VRF labels come
+  from); nothing about labels appears in the configuration.
+
+## Ping, then look at what it built
+
+Fully dynamic — no static ARP, labels, or FDB anywhere. h1's first ARP
+floods over the ingress-replication slot toward pe2's BUM label; the
+learned MACs come back as Type-2s carrying the EVI service label:
+
+```shell
+$ sudo ip netns exec h1 ping -c 3 172.16.10.2
+...
+3 packets transmitted, 3 received, 0% packet loss, time 614ms
+```
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn
+   Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 1.1.1.1:100
+ *>  [2]:[0]:[48]:[92:bb:f8:55:7b:35]
+                    1.1.1.1                    0         32768 i
+                    Extended community: RT:65000:100
+ *>  [3]:[0]:[32]:[1.1.1.1]
+                    1.1.1.1                    0         32768 i
+                    Extended community: RT:65000:100
+                    PMSI: ingress-replication endpoint:1.1.1.1 label:16
+Route Distinguisher: 2.2.2.2:100
+ *>  [2]:[0]:[48]:[5e:22:85:78:70:06]
+                    2.2.2.2                    0    100      0 i
+                    Extended community: RT:65000:100
+ *>  [3]:[0]:[32]:[2.2.2.2]
+                    2.2.2.2                    0    100      0 i
+                    Extended community: RT:65000:100
+                    PMSI: ingress-replication endpoint:2.2.2.2 label:16
+```
+
+Note what is **absent**: no Encapsulation extended community — RFC 8365
+§5.1.3 makes MPLS the default, signalled by omission (compare the
+`ET:8` in the [VXLAN](../bgp-evpn-vxlan4/README.md) and
+[SRv6](../bgp-evpn-srv6/README.md) labs) — and the PMSI's 24-bit field
+reads `label:`, not `vni:`. The decap side is the EVI's ILM:
+
+```shell
+pe1>show mpls ilm
+*> B 20   16     Pop         EVPN Decap (bd 100 ) -
+```
+
+The counters on pe1 show the service legs, and the P router did all its
+work with zero EVPN state — pure label switching, popping the transport
+label as penultimate hop:
+
+```shell
+pe1>show ebpf stats
+...
+mpls_l2_encap  1
+mpls_l2_decap  11
+mpls_l2_bum    10
+```
+
+```shell
+p>show ebpf stats
+...
+mpls_pop       52
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host | `h1-pe1` 172.16.10.1/24 |
+| pe1 | PE | `lo` 1.1.1.1/32, `pe1-p` 10.250.0.1/30, SID index 1 |
+| p | transit LSR | `lo` 3.3.3.3/32, `p-pe1` 10.250.0.2/30, `p-pe2` 10.250.0.5/30, SID index 3 |
+| pe2 | PE | `lo` 2.2.2.2/32, `pe2-p` 10.250.0.6/30, SID index 2 |
+| h2 | tenant host | `h2-pe2` 172.16.10.2/24 |

--- a/playset/bgp-evpn-mpls/down.sh
+++ b/playset/bgp-evpn-mpls/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-mpls/h1.yaml
+++ b/playset/bgp-evpn-mpls/h1.yaml
@@ -1,0 +1,7 @@
+# Host 1 — a plain tenant host on the stretched segment.
+interface:
+- if-name: h1-pe1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-mpls/h2.yaml
+++ b/playset/bgp-evpn-mpls/h2.yaml
@@ -1,0 +1,7 @@
+# Host 2 — the other tenant host.
+interface:
+- if-name: h2-pe2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-mpls/p.yaml
+++ b/playset/bgp-evpn-mpls/p.yaml
@@ -1,0 +1,47 @@
+# P — the transit LSR. No BGP and no EVPN state at all: it only
+# label-switches the transport label toward the egress PE's loopback,
+# and — being the penultimate hop for both loopbacks — pops it, exposing
+# the service label to the egress PE. That layering is the demo: BGP
+# advertises a PE, IS-IS supplies the label to reach it, and the eBPF
+# data plane composes the two.
+system:
+  hostname: p
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 3.3.3.3/32
+- if-name: p-pe1
+  ipv4:
+    address: 10.250.0.2/30
+  ebpf:
+    enabled: true
+- if-name: p-pe2
+  ipv4:
+    address: 10.250.0.5/30
+  ebpf:
+    enabled: true
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 3.3.3.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 3
+    - if-name: p-pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p-pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true

--- a/playset/bgp-evpn-mpls/pe1.yaml
+++ b/playset/bgp-evpn-mpls/pe1.yaml
@@ -1,0 +1,68 @@
+# PE1 — an EVPN-over-MPLS provider edge, RFC 7432's original
+# encapsulation. IS-IS SR-MPLS supplies the transport LSP to PE2's
+# loopback; under `encapsulation mpls` the `evi 100` instance takes a
+# dynamic per-EVI service label — advertised on the Type-2/Type-3 routes
+# instead of a VNI — and installs its bridge-domain decap ILM. The `evi`
+# list pins bridge br100 as the instance's bridge domain; the host port
+# (enslaved to br100, `ebpf enabled`) becomes the cradle engine's L2
+# port in it. Everything forwards in eBPF — no kernel action pops an
+# MPLS label into a bridge.
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: pe1-p
+  ipv4:
+    address: 10.250.0.1/30
+  ebpf:
+    enabled: true
+- if-name: pe1-h1
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1
+    - if-name: pe1-p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      evi:
+      - id: 100
+        bridge: br100
+    neighbor:
+    - remote-address: 2.2.2.2
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-mpls/pe2.yaml
+++ b/playset/bgp-evpn-mpls/pe2.yaml
@@ -1,0 +1,68 @@
+# PE2 — an EVPN-over-MPLS provider edge, RFC 7432's original
+# encapsulation. IS-IS SR-MPLS supplies the transport LSP to PE2's
+# loopback; under `encapsulation mpls` the `evi 100` instance takes a
+# dynamic per-EVI service label — advertised on the Type-2/Type-3 routes
+# instead of a VNI — and installs its bridge-domain decap ILM. The `evi`
+# list pins bridge br100 as the instance's bridge domain; the host port
+# (enslaved to br100, `ebpf enabled`) becomes the cradle engine's L2
+# port in it. Everything forwards in eBPF — no kernel action pops an
+# MPLS label into a bridge.
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: pe2-p
+  ipv4:
+    address: 10.250.0.6/30
+  ebpf:
+    enabled: true
+- if-name: pe2-h2
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 2
+    - if-name: pe2-p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 2.2.2.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      evi:
+      - id: 100
+        bridge: br100
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      update-source: 2.2.2.2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-mpls/topology.sh
+++ b/playset/bgp-evpn-mpls/topology.sh
@@ -1,0 +1,18 @@
+# EVPN over MPLS (E-LAN in eBPF) demo topology, with a pure-transit P
+# router between the PEs.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(h1 pe1 p pe2 h2)
+
+PLAYSET_LINKS=(
+    h1:h1-pe1:pe1:pe1-h1
+    pe1:pe1-p:p:p-pe1
+    p:p-pe2:pe2:pe2-p
+    pe2:pe2-h2:h2:h2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(h1 pe1 p pe2 h2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(h1 pe1 p pe2 h2)

--- a/playset/bgp-evpn-mpls/up.sh
+++ b/playset/bgp-evpn-mpls/up.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Bring up the EVPN over MPLS (E-LAN in eBPF) namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the PEs and the P router: the eBPF data plane
+# does the label work, and a successful host-to-host ping must prove it
+# (the kernel has no action that pops an MPLS label into a bridge).
+for ns in pe1 p pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+done
+
+# The PEs' own iBGP session is router-originated TCP entering an
+# XDP-forwarded core: it leaves the stack with deferred (partial)
+# checksums that an XDP redirect never resolves, so the far end would
+# drop the segments while ICMP and transit traffic flow fine. Compute
+# checksums in software on the core-facing veths instead.
+run_in_netns pe1 ethtool -K pe1-p tx off
+run_in_netns pe2 ethtool -K pe2-p tx off

--- a/playset/bgp-evpn-srv6/README.md
+++ b/playset/bgp-evpn-srv6/README.md
@@ -1,0 +1,193 @@
+# EVPN over SRv6: a stretched segment in eBPF
+
+This demo stretches one L2 segment (E-LAN) between two hosts over an
+**SRv6** data plane — the eBPF counterpart of
+[bgp-evpn-vxlan4](../bgp-evpn-vxlan4/README.md). The EVPN control plane is
+the same (Type-2 MAC/IP + Type-3 IMET, ingress replication); what changes
+is the service binding: under `encapsulation srv6` the routes carry **SRv6
+L2 Service SIDs** (RFC 9252) carved from each PE's locator — a per-VNI
+**End.DT2U** on the Type-2 and an **End.DT2M** on the Type-3 — instead of
+the VXLAN encapsulation, and every frame rides MAC-in-SRv6.
+
+The kernel cannot forward this (no End.DT2U/DT2M action), so
+`system ebpf enabled` makes zebra-rs spawn the cradle engine: the host
+ports become its L2 ports in bridge domain 100, MACs are learned in XDP
+and streamed back over WatchFdb (each becoming a Type-2), and remote MACs
+install as eBPF FDB entries pointing at the peer's service SID. The
+`vxlan100` device enslaved to `br100` is only the VNI declaration — the
+kernel path stays inert.
+
+```
+ h1 ── pe1 ══════════ pe2 ── h2      h1/h2: 172.16.10.1/24, .2/24
+       2001:db8:0:12::/64            pe1: lo 2001:db8::1, LOC1 fcbb:bbbb:1::/48
+       IS-IS SRv6 underlay           pe2: lo 2001:db8::2, LOC2 fcbb:bbbb:2::/48
+             VNI 100 / bridge domain 100 stretched across
+```
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h2
+applied
+```
+
+## Take a look at the YAML configuration
+
+`pe1.yaml` in full — `pe2.yaml` mirrors it, and the hosts are plain
+tenants with one address each:
+
+```yaml
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: pe1-pe2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+  ebpf:
+    enabled: true
+- if-name: pe1-h1
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+vxlan:
+- name: vxlan100
+  vni: 100
+  local-address: 2001:db8::1
+  bridge: br100
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: pe1-pe2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: srv6
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+```
+
+* `encapsulation srv6` swaps the service binding: DT2U/DT2M SIDs from
+  `LOC1` instead of VNIs-with-VXLAN-EC. `advertise-all-vni` originates for
+  every declared VNI.
+* The host port is enslaved to `br100` and marked `ebpf enabled` — that is
+  what makes it the engine's L2 port in bridge domain 100 (the bd follows
+  the bridge's VXLAN slave VNI).
+
+## Ping, then look at what it built
+
+Everything is dynamic — no static ARP, no static FDB anywhere. h1's first
+ARP floods over the ingress-replication tunnel (End.DT2M), the engine
+learns both hosts' MACs in XDP, and each becomes a Type-2:
+
+```shell
+$ sudo ip netns exec h1 ping -c 3 172.16.10.2
+...
+3 packets transmitted, 3 received, 0% packet loss, time 618ms
+```
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn
+   Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 10.0.0.1:100
+ *>  [2]:[0]:[48]:[ce:c5:b5:8f:b5:e4]
+                    2001:db8::1                0         32768 i
+                    Local SID: fcbb:bbbb:1:41:: (End.DT2U)
+                    Extended community: RT:65001:100 ET:8
+ *>  [3]:[0]:[128]:[2001:db8::1]
+                    2001:db8::1                0         32768 i
+                    Local SID: fcbb:bbbb:1:40:: (End.DT2M)
+                    Extended community: RT:65001:100 ET:8
+                    PMSI: ingress-replication endpoint:2001:db8::1 vni:100
+Route Distinguisher: 10.0.0.2:100
+ *>  [2]:[0]:[48]:[ca:c4:f0:78:ef:a5]
+                    2001:db8::2                0    100      0 i
+                    Remote SID: fcbb:bbbb:2:41:: (End.DT2U)
+                    Extended community: RT:65001:100 ET:8
+ *>  [3]:[0]:[128]:[2001:db8::2]
+                    2001:db8::2                0    100      0 i
+                    Remote SID: fcbb:bbbb:2:40:: (End.DT2M)
+                    Extended community: RT:65001:100 ET:8
+```
+
+The engine's FDB shows the split: locally-learned MACs with an age, remote
+MACs bound to the peer's End.DT2U SID:
+
+```shell
+pe1>show ebpf l2
+mac                 vlan      oif flags       age_ms remote_sid
+ce:c5:b5:8f:b5:e4    100        2 learned       4418
+ca:c4:f0:78:ef:a5    100        0 remote           0 fcbb:bbbb:2:41::
+```
+
+And the counters carry the whole story — BUM flooded over the tunnel,
+unicast switched locally or MAC-in-SRv6 encapsulated, everything decapped
+on the way in:
+
+```shell
+pe1>show ebpf stats
+...
+l2_forward     5
+l2_flood       12
+srv6_l2_encap  1
+srv6_l2_decap  13
+srv6_l2_bum    12
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host | `h1-pe1` 172.16.10.1/24 |
+| pe1 | PE | `lo` 2001:db8::1/128, `pe1-pe2` 2001:db8:0:12::1/64, LOC1 `fcbb:bbbb:1::/48` |
+| pe2 | PE | `lo` 2001:db8::2/128, `pe2-pe1` 2001:db8:0:12::2/64, LOC2 `fcbb:bbbb:2::/48` |
+| h2 | tenant host | `h2-pe2` 172.16.10.2/24 |

--- a/playset/bgp-evpn-srv6/down.sh
+++ b/playset/bgp-evpn-srv6/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-srv6/h1.yaml
+++ b/playset/bgp-evpn-srv6/h1.yaml
@@ -1,0 +1,7 @@
+# Host 1 — a plain tenant host on the stretched segment.
+interface:
+- if-name: h1-pe1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-srv6/h2.yaml
+++ b/playset/bgp-evpn-srv6/h2.yaml
@@ -1,0 +1,7 @@
+# Host 2 — the other tenant host.
+interface:
+- if-name: h2-pe2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-srv6/pe1.yaml
+++ b/playset/bgp-evpn-srv6/pe1.yaml
@@ -1,0 +1,77 @@
+# PE1 — an EVPN-over-SRv6 VTEP (RFC 9252). `advertise-all-vni` originates
+# Type-2 (MAC/IP) and Type-3 (IMET) routes for VNI 100; `encapsulation
+# srv6` makes them carry SRv6 L2 Service SIDs carved from LOC1 — a
+# per-VNI End.DT2U on the Type-2 and an End.DT2M on the Type-3 — instead
+# of the VXLAN encapsulation extended community. The vxlan100 device
+# enslaved to br100 is the VNI declaration; the kernel path stays inert:
+# `system ebpf enabled` spawns the cradle engine, the host port (enslaved
+# to br100, `ebpf enabled`) becomes its L2 port in bridge domain 100, and
+# every learned MAC, flood copy and decap runs in eBPF.
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: pe1-pe2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+  ebpf:
+    enabled: true
+- if-name: pe1-h1
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+vxlan:
+- name: vxlan100
+  vni: 100
+  local-address: 2001:db8::1
+  bridge: br100
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: pe1-pe2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: srv6
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-srv6/pe2.yaml
+++ b/playset/bgp-evpn-srv6/pe2.yaml
@@ -1,0 +1,77 @@
+# PE2 — an EVPN-over-SRv6 VTEP (RFC 9252). `advertise-all-vni` originates
+# Type-2 (MAC/IP) and Type-3 (IMET) routes for VNI 100; `encapsulation
+# srv6` makes them carry SRv6 L2 Service SIDs carved from LOC2 — a
+# per-VNI End.DT2U on the Type-2 and an End.DT2M on the Type-3 — instead
+# of the VXLAN encapsulation extended community. The vxlan100 device
+# enslaved to br100 is the VNI declaration; the kernel path stays inert:
+# `system ebpf enabled` spawns the cradle engine, the host port (enslaved
+# to br100, `ebpf enabled`) becomes its L2 port in bridge domain 100, and
+# every learned MAC, flood copy and decap runs in eBPF.
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe2-pe1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+  ebpf:
+    enabled: true
+- if-name: pe2-h2
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+vxlan:
+- name: vxlan100
+  vni: 100
+  local-address: 2001:db8::2
+  bridge: br100
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: pe2-pe1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: srv6
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65001
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-srv6/topology.sh
+++ b/playset/bgp-evpn-srv6/topology.sh
@@ -1,0 +1,16 @@
+# EVPN over SRv6 (E-LAN in eBPF) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(h1 pe1 pe2 h2)
+
+PLAYSET_LINKS=(
+    h1:h1-pe1:pe1:pe1-h1
+    pe1:pe1-pe2:pe2:pe2-pe1
+    pe2:pe2-h2:h2:h2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(h1 pe1 pe2 h2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(h1 pe1 pe2 h2)

--- a/playset/bgp-evpn-srv6/up.sh
+++ b/playset/bgp-evpn-srv6/up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Bring up the EVPN over SRv6 (E-LAN in eBPF) namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the PEs: the eBPF data plane bridges and
+# encapsulates, and a successful host-to-host ping must prove it (the
+# kernel has no End.DT2U/DT2M action anyway).
+for ns in pe1 pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done


### PR DESCRIPTION
## Summary

Two more eBPF-data-plane playsets — the E-LAN (stretched segment) counterparts of the `bgp-evpn-vxlan*` kernel labs, on the encapsulations the kernel cannot forward:

- **`bgp-evpn-srv6`** — MAC-in-SRv6 (RFC 9252): dynamic Type-2s carrying per-VNI **End.DT2U** SIDs, IMET with **End.DT2M**, remote MACs bound to the peer's SID in the eBPF FDB (visible in `show ebpf l2`); IS-IS SRv6 underlay, iBGP over loopbacks. The `vxlan100`-in-`br100` device is only the VNI declaration — the engine's bridge domain follows the VXLAN slave's VNI, and the kernel path stays inert.
- **`bgp-evpn-mpls`** — RFC 7432's original encapsulation: the `evi 100` instance draws a **dynamic per-EVI service label** (the PMSI reads `label:16`, and there is **no** Encapsulation EC on the wire — RFC 8365 §5.1.3's absent-means-MPLS, contrasted in the README against the VXLAN/SRv6 labs' `ET:8`), pops arriving labels via its `EVPN Decap (bd 100)` ILM, and the transport runs IS-IS SR-MPLS through a **pure-transit P router** with zero EVPN state. `up.sh` carries the two operational traps (kernel forwarding off; software TCP checksums on the core veths).

Same managed-engine recipe as the E-Line playsets (#2201): `system ebpf enabled` spawns cradle, per-interface `ebpf enabled` attaches ports, and bridge enslavement supplies the L2 role — no harness changes, no new file kinds, `playset packaging assets` passes as-is. `playset/README.md` gains the series section.

## Testing

Both labs brought up live on this branch, fully dynamically (no static ARP/FDB/labels): BGP Established over loopbacks, host-to-host `ping` 0% loss on the first attempt with kernel forwarding off, Type-2s appearing from XDP-learned MACs, and the counters telling the story (`srv6_l2_bum/decap` moving on the SRv6 lab; `mpls_l2_bum/decap` on the PEs and `mpls_pop 52` on the EVPN-free P node for MPLS). Every README output block is captured verbatim from those runs. `make -C packaging playset` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)