### PR TITLE
playset: eBPF-engine twins of the EVPN/VXLAN IPv4 labs

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -108,6 +108,14 @@ endpoints, next hops, PMSI, and FDB `dst`, while the RD stays IPv4), and move
 down to add a **second isolated VNI** (three VTEPs, one serving both; per-VNI
 RD/RT — hosts in different VNIs share a subnet yet cannot reach each other).
 
+The IPv4 column also exists on the **eBPF engine** —
+[bgp-evpn-vxlan4-ebpf](bgp-evpn-vxlan4-ebpf/README.md) and
+[bgp-evpn-vxlan4-multi-ebpf](bgp-evpn-vxlan4-multi-ebpf/README.md): the same
+labs with the forwarding moved into XDP (`system ebpf enabled`), loopback
+VTEPs (the engine has one fabric-wide VTEP source), and kernel forwarding
+off. There is no eBPF IPv6 pair: the engine's VXLAN underlay is IPv4-only,
+so the IPv6-underlay story stays with the kernel labs.
+
 The four EVPN labs reuse the same namespace names (`vtep1`..`vtep3`,
 `h1`..`h4`), so bring up only one at a time — `up.sh` sweeps leftovers of
 the same names first.

--- a/playset/bgp-evpn-vxlan4-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-ebpf/README.md
@@ -1,0 +1,162 @@
+# BGP EVPN VXLAN, eBPF data plane
+
+The same demo as [bgp-evpn-vxlan4](../bgp-evpn-vxlan4/README.md) — one L2
+segment stretched between two hosts over an EVPN/VXLAN fabric — with the
+forwarding moved from the kernel's single-VXLAN-device data path onto the
+**eBPF engine**: `system ebpf enabled` makes zebra-rs spawn cradle, the
+host ports become its L2 ports, and every MAC learn, flood copy, VXLAN
+encap and decap runs in XDP. The kernel VXLAN device stays configured (it
+is the VNI declaration) but never sees a frame.
+
+Two deliberate differences from the kernel twin:
+
+* **The VTEP is a loopback.** The engine has one fabric-wide VTEP source,
+  so `192.0.2.x/32` loopbacks carry the vxlan `local-address`, the BGP
+  sessions (`update-source`), and the advertised routes' next hops — the
+  classic EVPN shape. A static /32 toward the peer's loopback resolves
+  the encapsulation via the teed FIB.
+* **Kernel forwarding is off** on both VTEPs, so the ping proves the
+  engine did the work.
+
+```
+ h1 ── vtep1 ══════════ vtep2 ── h2     h1/h2: 172.16.10.1/24, .2/24
+         192.168.0.0/24                 vtep1: lo/VTEP 192.0.2.1
+         IPv4 underlay                  vtep2: lo/VTEP 192.0.2.2
+             VNI 10 / bridge domain 10 stretched across
+```
+
+> **Why is there no `bgp-evpn-vxlan6-ebpf`?** The engine's VXLAN underlay
+> is IPv4-only (VTEPs ride v4-mapped in its tables, the outer header is
+> IPv4) — a v6-VTEP MAC is deliberately handed to the kernel data path
+> instead. The IPv6-underlay story is the kernel labs'
+> ([bgp-evpn-vxlan6](../bgp-evpn-vxlan6/README.md)).
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h2
+applied
+```
+
+## Take a look at the YAML configuration
+
+`vtep1.yaml` in full — diff it against the kernel twin's: the additions
+are `system ebpf enabled`, the per-port `ebpf enabled` leaves, and the
+loopback-VTEP addressing:
+
+```yaml
+system:
+  hostname: vtep1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.1/32
+- if-name: vtep1-vtep2
+  ipv4:
+    address: 192.168.0.1/24
+  ebpf:
+    enabled: true
+- if-name: vtep1-h1
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.0.2.1
+  bridge: br10
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.2/32
+        nexthop:
+        - address: 192.168.0.2
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.0.2.2
+      remote-as: 65001
+      update-source: 192.0.2.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+```
+
+## Ping, then look at what the engine built
+
+Fully dynamic — h1's first ARP floods over the ingress-replication
+tunnel, the engine learns both hosts' MACs in XDP and streams them to
+zebra-rs, each becoming a Type-2:
+
+```shell
+$ sudo ip netns exec h1 ping -c 3 172.16.10.2
+...
+3 packets transmitted, 3 received, 0% packet loss, time 607ms
+```
+
+```shell
+$ sudo ip netns exec vtep1 vty
+vtep1>show bgp evpn
+Route Distinguisher: 192.0.2.1:10
+ *>  [2]:[0]:[48]:[5e:e6:e4:61:da:cd]
+                    192.0.2.1                  0         32768 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [3]:[0]:[32]:[192.0.2.1]
+                    192.0.2.1                  0         32768 i
+                    Extended community: RT:65001:10 ET:8
+                    PMSI: ingress-replication endpoint:192.0.2.1 vni:10
+Route Distinguisher: 192.0.2.2:10
+ *>  [2]:[0]:[48]:[06:9c:54:9f:22:52]
+                    192.0.2.2                  0    100      0 i
+                    Extended community: RT:65001:10 ET:8
+```
+
+The engine's FDB is where this lab differs visibly from the kernel one:
+instead of `bridge fdb show`, the MACs live in the eBPF map — locally
+learned ones with an age, remote ones bound to the peer's VTEP,
+**v4-mapped** (`::ffff:…`) in the engine's 16-byte address slot:
+
+```shell
+vtep1>show ebpf l2
+mac                 vlan      oif flags       age_ms remote_sid
+0e:02:37:98:bd:95     10        0 remote           0 ::ffff:192.0.2.2
+5e:e6:e4:61:da:cd     10        3 learned       4460
+```
+
+```shell
+vtep1>show ebpf stats
+...
+l2_forward     5
+l2_flood       10
+vxlan_encap    1
+vxlan_decap    11
+vxlan_flood    10
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host | `h1-vtep1` 172.16.10.1/24 |
+| vtep1 | VTEP | `lo` 192.0.2.1/32, `vtep1-vtep2` 192.168.0.1/24, VNI 10 |
+| vtep2 | VTEP | `lo` 192.0.2.2/32, `vtep2-vtep1` 192.168.0.2/24, VNI 10 |
+| h2 | tenant host | `h2-vtep2` 172.16.10.2/24 |

--- a/playset/bgp-evpn-vxlan4-ebpf/down.sh
+++ b/playset/bgp-evpn-vxlan4-ebpf/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vxlan4-ebpf/h1.yaml
+++ b/playset/bgp-evpn-vxlan4-ebpf/h1.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h1-vtep1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-vxlan4-ebpf/h2.yaml
+++ b/playset/bgp-evpn-vxlan4-ebpf/h2.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h2-vtep2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-vxlan4-ebpf/topology.sh
+++ b/playset/bgp-evpn-vxlan4-ebpf/topology.sh
@@ -1,0 +1,16 @@
+# BGP EVPN VXLAN (eBPF data plane) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(vtep1 vtep2 h1 h2)
+
+PLAYSET_LINKS=(
+    vtep1:vtep1-vtep2:vtep2:vtep2-vtep1
+    h1:h1-vtep1:vtep1:vtep1-h1
+    h2:h2-vtep2:vtep2:vtep2-h2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(vtep1 vtep2 h1 h2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(vtep1 vtep2 h1 h2)

--- a/playset/bgp-evpn-vxlan4-ebpf/up.sh
+++ b/playset/bgp-evpn-vxlan4-ebpf/up.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Bring up the BGP EVPN VXLAN (eBPF data plane) demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the VTEPs: the eBPF engine encapsulates,
+# floods and decapsulates, and a successful host-to-host ping must prove
+# it — the kernel VXLAN path stays configured but never sees a frame.
+for ns in vtep1 vtep2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+done

--- a/playset/bgp-evpn-vxlan4-ebpf/vtep1.yaml
+++ b/playset/bgp-evpn-vxlan4-ebpf/vtep1.yaml
@@ -1,0 +1,57 @@
+# VTEP 1 — the same EVPN/VXLAN VTEP as bgp-evpn-vxlan4, moved onto the
+# eBPF data plane: `system ebpf enabled` spawns the cradle engine, the
+# host port becomes its L2 port in bridge domain 10, and every MAC,
+# flood copy, encap and decap runs in XDP — the kernel VXLAN device
+# stays configured but never sees a frame.
+#
+# One engine-side difference from the kernel twin: the engine has ONE
+# fabric-wide VTEP source, so the VTEP is a loopback (192.0.2.1), the
+# vxlan device's local-address and the BGP session both ride it, and a
+# static /32 toward the peer's loopback resolves the encapsulation via
+# the teed FIB.
+system:
+  hostname: vtep1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.1/32
+- if-name: vtep1-vtep2
+  ipv4:
+    address: 192.168.0.1/24
+  ebpf:
+    enabled: true
+- if-name: vtep1-h1
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.0.2.1
+  bridge: br10
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.2/32
+        nexthop:
+        - address: 192.168.0.2
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.0.2.2
+      remote-as: 65001
+      update-source: 192.0.2.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan4-ebpf/vtep2.yaml
+++ b/playset/bgp-evpn-vxlan4-ebpf/vtep2.yaml
@@ -1,0 +1,57 @@
+# VTEP 2 — the same EVPN/VXLAN VTEP as bgp-evpn-vxlan4, moved onto the
+# eBPF data plane: `system ebpf enabled` spawns the cradle engine, the
+# host port becomes its L2 port in bridge domain 10, and every MAC,
+# flood copy, encap and decap runs in XDP — the kernel VXLAN device
+# stays configured but never sees a frame.
+#
+# One engine-side difference from the kernel twin: the engine has ONE
+# fabric-wide VTEP source, so the VTEP is a loopback (192.0.2.2), the
+# vxlan device's local-address and the BGP session both ride it, and a
+# static /32 toward the peer's loopback resolves the encapsulation via
+# the teed FIB.
+system:
+  hostname: vtep2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.2/32
+- if-name: vtep2-vtep1
+  ipv4:
+    address: 192.168.0.2/24
+  ebpf:
+    enabled: true
+- if-name: vtep2-h2
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.0.2.2
+  bridge: br10
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.1/32
+        nexthop:
+        - address: 192.168.0.1
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.0.2.1
+      remote-as: 65001
+      update-source: 192.0.2.2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/README.md
@@ -1,0 +1,106 @@
+# BGP EVPN VXLAN multi-tenant, eBPF data plane
+
+The multi-tenant demo of
+[bgp-evpn-vxlan4-multi](../bgp-evpn-vxlan4-multi/README.md) on the eBPF
+engine: three VTEPs, two isolated tenants — VNI 10 stretches h1↔h2 across
+vtep1/vtep2, VNI 20 stretches h3↔h4 across vtep3/vtep1 — and **vtep1
+serves both** from one engine, its single eBPF FDB cleanly split by
+bridge domain. All four hosts share `172.16.10.0/24`; the two tenants
+still cannot reach each other, which is the isolation proof.
+
+One deliberate difference from the kernel twin: there, vtep1 gives each
+VNI its own per-underlay VTEP address. The engine has **one fabric-wide
+VTEP source**, so both of vtep1's vxlan devices ride the same loopback
+(`192.0.2.1`), both BGP sessions ride it too, and static /32s toward the
+peers' loopbacks resolve the encapsulation. Per-VNI RD/RT
+(`192.0.2.1:10` / `192.0.2.1:20`) keeps the tenants apart in BGP exactly
+as before.
+
+```
+        h1(10)   h4(20)
+           \      /
+ h2 ── vtep2 ── vtep1 ── vtep3 ── h3      VNI 10: h1, h2
+ (10)   192.168.0.0/24  192.168.1.0/24    VNI 20: h3, h4
+        lo .2.2   lo .2.1   lo .2.3       all hosts: 172.16.10.0/24
+```
+
+vtep2 and vtep3 never peer with each other — each tenant is stretched
+only where it exists, so neither VTEP ever learns the other's routes.
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h4
+applied
+```
+
+## Both tenants forward, and never into each other
+
+```shell
+$ sudo ip netns exec h1 ping -c 2 172.16.10.2      # VNI 10, vtep1 ↔ vtep2
+2 packets transmitted, 2 received, 0% packet loss
+$ sudo ip netns exec h3 ping -c 2 172.16.10.4      # VNI 20, vtep3 ↔ vtep1
+2 packets transmitted, 2 received, 0% packet loss
+$ sudo ip netns exec h1 ping -c 2 172.16.10.4      # cross-tenant
+2 packets transmitted, 0 received, 100% packet loss
+```
+
+The cross-tenant ping dies at ARP — h1 and h4 sit behind the *same*
+engine on vtep1, one bridge domain apart, and the broadcast never
+crosses:
+
+```shell
+$ sudo ip netns exec h1 ip neigh show 172.16.10.4
+172.16.10.4 dev h1-vtep1 FAILED
+```
+
+## One engine, two tenants
+
+vtep1's eBPF FDB carries both bridge domains side by side — locally
+learned MACs with an age, remote ones bound to the right peer's VTEP
+(v4-mapped in the engine's address slot):
+
+```shell
+$ sudo ip netns exec vtep1 vty
+vtep1>show ebpf l2
+mac                 vlan      oif flags       age_ms remote_sid
+7e:96:2e:a8:36:80     20        0 remote           0 ::ffff:192.0.2.3
+82:09:aa:f2:41:a3     20        5 learned       7922
+f6:12:8c:56:c7:86     10        0 remote           0 ::ffff:192.0.2.2
+3e:7a:72:53:89:fc     10        4 learned       7922
+```
+
+And in BGP each tenant keeps its own RD and its own ingress-replication
+tunnel:
+
+```shell
+vtep1>show bgp evpn
+Route Distinguisher: 192.0.2.1:10
+                    PMSI: ingress-replication endpoint:192.0.2.1 vni:10
+Route Distinguisher: 192.0.2.1:20
+                    PMSI: ingress-replication endpoint:192.0.2.1 vni:20
+Route Distinguisher: 192.0.2.2:10
+                    PMSI: ingress-replication endpoint:192.0.2.2 vni:10
+Route Distinguisher: 192.0.2.3:20
+                    PMSI: ingress-replication endpoint:192.0.2.3 vni:20
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host, VNI 10 | `h1-vtep1` 172.16.10.1/24 |
+| h2 | tenant host, VNI 10 | `h2-vtep2` 172.16.10.2/24 |
+| h3 | tenant host, VNI 20 | `h3-vtep3` 172.16.10.3/24 |
+| h4 | tenant host, VNI 20 | `h4-vtep1` 172.16.10.4/24 |
+| vtep1 | VTEP, VNIs 10+20 | `lo` 192.0.2.1/32, `vtep1-vtep2` 192.168.0.1/24, `vtep1-vtep3` 192.168.1.1/24 |
+| vtep2 | VTEP, VNI 10 | `lo` 192.0.2.2/32, `vtep2-vtep1` 192.168.0.2/24 |
+| vtep3 | VTEP, VNI 20 | `lo` 192.0.2.3/32, `vtep3-vtep1` 192.168.1.2/24 |

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/down.sh
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/h1.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/h1.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h1-vtep1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/h2.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/h2.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h2-vtep2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/h3.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/h3.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h3-vtep3
+  ipv4:
+    address: 172.16.10.3/24
+system:
+  hostname: h3

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/h4.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/h4.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h4-vtep1
+  ipv4:
+    address: 172.16.10.4/24
+system:
+  hostname: h4

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/topology.sh
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/topology.sh
@@ -1,0 +1,19 @@
+# BGP EVPN VXLAN multi-tenant (eBPF data plane) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(vtep1 vtep2 vtep3 h1 h2 h3 h4)
+
+PLAYSET_LINKS=(
+    vtep1:vtep1-vtep2:vtep2:vtep2-vtep1
+    vtep1:vtep1-vtep3:vtep3:vtep3-vtep1
+    h1:h1-vtep1:vtep1:vtep1-h1
+    h2:h2-vtep2:vtep2:vtep2-h2
+    h3:h3-vtep3:vtep3:vtep3-h3
+    h4:h4-vtep1:vtep1:vtep1-h4
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(vtep1 vtep2 vtep3 h1 h2 h3 h4)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(vtep1 vtep2 vtep3 h1 h2 h3 h4)

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/up.sh
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Bring up the BGP EVPN VXLAN multi-tenant (eBPF data plane) demo from
+# scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF on the VTEPs: the eBPF engine encapsulates,
+# floods and decapsulates, and a successful host-to-host ping must prove
+# it — the kernel VXLAN path stays configured but never sees a frame.
+for ns in vtep1 vtep2 vtep3; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+done

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/vtep1.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/vtep1.yaml
@@ -1,0 +1,77 @@
+# VTEP 1 — serves BOTH tenants on the eBPF data plane: bridge domain 10
+# (h1, stretched to vtep2) and bridge domain 20 (h4, stretched to
+# vtep3). Where the kernel twin gives each VNI its own per-underlay VTEP
+# address, the engine has ONE fabric-wide VTEP source — so both vxlan
+# devices ride the same loopback (192.0.2.1), the BGP sessions ride it
+# too, and static /32s toward the peers' loopbacks resolve the
+# encapsulation via the teed FIB.
+system:
+  hostname: vtep1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.1/32
+- if-name: vtep1-vtep2
+  ipv4:
+    address: 192.168.0.1/24
+  ebpf:
+    enabled: true
+- if-name: vtep1-vtep3
+  ipv4:
+    address: 192.168.1.1/24
+  ebpf:
+    enabled: true
+- if-name: vtep1-h1
+  bridge: br10
+  ebpf:
+    enabled: true
+- if-name: vtep1-h4
+  bridge: br20
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+- name: br20
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.0.2.1
+  bridge: br10
+- name: vxlan20
+  vni: 20
+  local-address: 192.0.2.1
+  bridge: br20
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.2/32
+        nexthop:
+        - address: 192.168.0.2
+      - prefix: 192.0.2.3/32
+        nexthop:
+        - address: 192.168.1.2
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.0.2.2
+      remote-as: 65001
+      update-source: 192.0.2.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+    - remote-address: 192.0.2.3
+      remote-as: 65001
+      update-source: 192.0.2.1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/vtep2.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/vtep2.yaml
@@ -1,0 +1,48 @@
+# VTEP 2 — tenant VNI 10 only (h2). Loopback VTEP 192.0.2.2; it peers
+# with vtep1 alone: its tenant is stretched to vtep1, never to vtep3.
+system:
+  hostname: vtep2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.2/32
+- if-name: vtep2-vtep1
+  ipv4:
+    address: 192.168.0.2/24
+  ebpf:
+    enabled: true
+- if-name: vtep2-h2
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.0.2.2
+  bridge: br10
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.1/32
+        nexthop:
+        - address: 192.168.0.1
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.0.2.1
+      remote-as: 65001
+      update-source: 192.0.2.2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/vtep3.yaml
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/vtep3.yaml
@@ -1,0 +1,48 @@
+# VTEP 3 — tenant VNI 20 only (h3). Loopback VTEP 192.0.2.3; it peers
+# with vtep1 alone: its tenant is stretched to vtep1, never to vtep3.
+system:
+  hostname: vtep3
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.0.2.3/32
+- if-name: vtep3-vtep1
+  ipv4:
+    address: 192.168.1.2/24
+  ebpf:
+    enabled: true
+- if-name: vtep3-h3
+  bridge: br20
+  ebpf:
+    enabled: true
+bridge:
+- name: br20
+vxlan:
+- name: vxlan20
+  vni: 20
+  local-address: 192.0.2.3
+  bridge: br20
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.0.2.1/32
+        nexthop:
+        - address: 192.168.1.1
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.3
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.0.2.1
+      remote-as: 65001
+      update-source: 192.0.2.3
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true


### PR DESCRIPTION
## Summary

`bgp-evpn-vxlan4-ebpf` and `bgp-evpn-vxlan4-multi-ebpf` — the kernel VXLAN labs re-run on the eBPF data plane, completing the engine-side playset matrix (E-LAN now demoed on all three encapsulations, E-Line likewise):

- Same tenants, same story: `system ebpf enabled` spawns the engine, host ports become its L2 ports, and every MAC learn, flood copy, VXLAN encap and decap runs in XDP. The kernel VXLAN device stays configured (it is the VNI declaration) but never sees a frame; kernel forwarding is off so the pings prove the engine did the work.
- **Two documented divergences from the kernel twins.** The VTEPs are loopbacks (static /32s, BGP over them): the engine has *one fabric-wide VTEP source*, so the kernel multi lab's per-VNI VTEP addresses cannot be expressed — both of vtep1's VNIs ride `192.0.2.1`, kept apart by per-VNI RD/RT. And **there is no IPv6 pair**: the engine's VXLAN underlay is IPv4-only (VTEPs ride v4-mapped; v6-VTEP MACs are deliberately handed to the kernel path), so `bgp-evpn-vxlan6{,-multi}-ebpf` cannot genuinely exist today — called out in the READMEs and the series index rather than silently skipped.

## Testing

Both labs brought up live on this branch. `vxlan4-ebpf`: ping 0% loss on the first attempt, dynamic Type-2s, and the signature capture — remote MACs bound to the **v4-mapped** VTEP (`::ffff:192.0.2.2`) in `show ebpf l2`, with `vxlan_encap/decap/flood` moving. `vxlan4-multi-ebpf`: both tenants forward (h1↔h2 on VNI 10, h3↔h4 on VNI 20, vtep1 serving both from one engine FDB split by bridge domain), and the cross-tenant ping fails at ARP (`ip neigh` shows `FAILED`) — the isolation proof. All README output captured verbatim. `make -C packaging playset` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)