### PR TITLE
EVPN over IPv6-underlay VXLAN: un-gate the cradle tees, vtep-source leaf

### DIFF
--- a/docs/design/bgp-evpn-support-status.md
+++ b/docs/design/bgp-evpn-support-status.md
@@ -20,13 +20,13 @@ datapath, driven from zebra-rs via the FibHandle tee.
 | **Multihoming ESI (Type-1/4, DF election)** | ✅ Control plane (shared) | ✅ Full signal set incl. Type-2 ESI (#2148/#2150/#2152) | ✅ Control plane (shared) |
 | **MAC aliasing / mass-withdraw consumers** | ❌ Open (receive side) | ❌ Open — exists for VPWS only | ❌ Open |
 | **E-Line / VPWS (RFC 8214)** | ✅ Type-1 VNI + Encapsulation EC + VTEP next hop; cradle eBPF xconnect (VTEP+VNI encap, E-Line-VNI decap) | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | ✅ Per-service label, no Encapsulation EC; cradle eBPF xconnect (label encap under the transport LSP, pop-to-AC decap) |
-| **IPv6 underlay transport** | ✅ Zero code changes (#1850) | ✅ (native) | — (IS-IS SR-MPLS underlay) |
+| **IPv6 underlay transport** | ✅ Kernel: zero code changes (#1850); eBPF: native v6 VTEPs incl. E-Line + `vtep-source` origination knob (cradle #168) | ✅ (native) | — (IS-IS SR-MPLS underlay; MPLS-over-v6 PEs open) |
 | **IGMP/MLD proxy / SMET (RFC 9251)** | ✅ Incl. per-VTEP selective MDB | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **Assisted Replication (RFC 9574)** | ✅ Control plane; AR-LEAF/RNVE forward natively. ❌ AR-REPLICATOR data plane deferred | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **BUM segmentation (RFC 9572, Types 9/10/11)** | ✅ Control plane complete (RBR/ASBR, DF, S-PMSI) | ✅ + SR-P2MP tree offload wiring | ✅ Control plane (shared) |
 | **P2MP replication tree** | — (head-end IR model) | ✅ RFC 9524 End.Replicate incl. Bud (zebra #1923 + cradle #131) | ❌ MPLS-P2MP forwarder not built |
 | **ARP suppression** | ❌ Open | ❌ Open | ❌ Open |
-| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit) |
+| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra`, v6-underlay twins `cradle_evpn_vxlan6_zebra` + `cradle_vpws_vxlan6_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit) |
 
 **Legend**: ✅ supported · ❌ not yet · — not applicable. "Control plane
 (shared)" = the feature is encapsulation-agnostic in zebra-rs; the per-encap

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -51,6 +51,7 @@
 /router/bgp/afi-safi/vpws/remote-service-id
 /router/bgp/afi-safi/vpws/vlan
 /router/bgp/afi-safi/vpws/vni
+/router/bgp/afi-safi/vtep-source
 /router/bgp/as-sets-withdraw
 /router/bgp/bfd/detect-offload
 /router/bgp/bfd/echo-mode

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -23,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 327
-Handled: 312
+Total settable schema nodes: 328
+Handled: 313
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -52,6 +52,7 @@
 /router/bgp/afi-safi/vpws/remote-service-id	leaf
 /router/bgp/afi-safi/vpws/vlan	leaf
 /router/bgp/afi-safi/vpws/vni	leaf
+/router/bgp/afi-safi/vtep-source	leaf
 /router/bgp/as-sets-withdraw	leaf
 /router/bgp/bfd	container
 /router/bgp/bfd/detect-offload	leaf

--- a/playset/bgp-evpn-vxlan4-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-ebpf/README.md
@@ -25,11 +25,10 @@ Two deliberate differences from the kernel twin:
              VNI 10 / bridge domain 10 stretched across
 ```
 
-> **Why is there no `bgp-evpn-vxlan6-ebpf`?** The engine's VXLAN underlay
-> is IPv4-only (VTEPs ride v4-mapped in its tables, the outer header is
-> IPv4) — a v6-VTEP MAC is deliberately handed to the kernel data path
-> instead. The IPv6-underlay story is the kernel labs'
-> ([bgp-evpn-vxlan6](../bgp-evpn-vxlan6/README.md)).
+> The IPv6-underlay twin of this lab is
+> [bgp-evpn-vxlan6-ebpf](../bgp-evpn-vxlan6-ebpf/README.md) — same
+> engine, outer header Ethernet + IPv6 + UDP, VTEPs native v6 in the
+> engine's tables.
 
 ## Bring up all nodes
 

--- a/playset/bgp-evpn-vxlan6-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan6-ebpf/README.md
@@ -1,0 +1,107 @@
+# BGP EVPN VXLAN over IPv6 underlay, eBPF data plane
+
+The same demo as [bgp-evpn-vxlan6](../bgp-evpn-vxlan6/README.md) — one L2
+segment stretched between two hosts across an IPv6-only core — with the
+forwarding moved onto the **eBPF engine**: `system ebpf enabled` makes
+zebra-rs spawn cradle, the host ports become its L2 ports, and every MAC
+learn, flood copy, VXLAN encap and decap runs in XDP. The outer header is
+now **Ethernet + IPv6 + UDP** toward the peer's v6 VTEP; the tenant
+payload stays IPv4 (`172.16.10.0/24`), carried unchanged across the
+IPv6-only underlay. The kernel VXLAN device stays configured (it is the
+VNI declaration) but never sees a frame.
+
+Same two deliberate differences from the kernel twin as
+[bgp-evpn-vxlan4-ebpf](../bgp-evpn-vxlan4-ebpf/README.md):
+
+* **The VTEP is a loopback.** The engine has one fabric-wide VTEP source
+  per address family, so `2001:db8::x/128` loopbacks carry the vxlan
+  `local-address`, the BGP sessions (`update-source`), and the advertised
+  routes' next hops. A static /128 toward the peer's loopback resolves
+  the encapsulation via the teed FIB6.
+* **Kernel forwarding is off** (both families) on the VTEPs, so the ping
+  proves the engine did the work.
+
+```
+ h1 ── vtep1 ══════════ vtep2 ── h2     h1/h2: 172.16.10.1/24, .2/24
+        2001:db8:12::/64                vtep1: lo/VTEP 2001:db8::1
+         IPv6 underlay                  vtep2: lo/VTEP 2001:db8::2
+             VNI 10 / bridge domain 10 stretched across
+```
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h2
+applied
+```
+
+## Ping, then look at what the engine built
+
+Fully dynamic — h1's first ARP floods over the ingress-replication
+tunnel, the engine learns both hosts' MACs in XDP and streams them to
+zebra-rs, each becoming a Type-2 with the v6 VTEP as next hop:
+
+```shell
+$ sudo ip netns exec h1 ping -c 3 172.16.10.2
+...
+3 packets transmitted, 3 received, 0% packet loss
+```
+
+```shell
+$ sudo ip netns exec vtep1 vty
+vtep1>show bgp evpn
+Route Distinguisher: 10.0.0.1:10
+ *>  [2]:[0]:[48]:[6a:de:ad:2a:26:05]
+                    2001:db8::1                0         32768 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [3]:[0]:[128]:[2001:db8::1]
+                    2001:db8::1                0         32768 i
+                    Extended community: RT:65001:10 ET:8
+                    PMSI: ingress-replication endpoint:2001:db8::1 vni:10
+Route Distinguisher: 10.0.0.2:10
+ *>  [2]:[0]:[48]:[be:ae:83:fb:98:25]
+                    2001:db8::2                0    100      0 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [3]:[0]:[128]:[2001:db8::2]
+                    2001:db8::2                0    100      0 i
+                    Extended community: RT:65001:10 ET:8
+                    PMSI: ingress-replication endpoint:2001:db8::2 vni:10
+```
+
+The engine's FDB shows what makes this the v6 lab: the remote MAC's
+16-byte address slot carries the peer's VTEP **native** — `2001:db8::2`,
+not a `::ffff:…` v4-mapped value:
+
+```shell
+vtep1>show ebpf l2
+mac                 vlan      oif flags       age_ms remote_sid
+be:ae:83:fb:98:25     10        0 remote           0 2001:db8::2
+6a:de:ad:2a:26:05     10        3 learned       11465
+```
+
+```shell
+vtep1>show ebpf stats
+...
+l2_forward     7
+l2_flood       14
+vxlan_encap    1
+vxlan_decap    15
+vxlan_flood    14
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host | `h1-vtep1` 172.16.10.1/24 |
+| vtep1 | VTEP | `lo` 2001:db8::1/128, `vtep1-vtep2` 2001:db8:12::1/64, VNI 10 |
+| vtep2 | VTEP | `lo` 2001:db8::2/128, `vtep2-vtep1` 2001:db8:12::2/64, VNI 10 |
+| h2 | tenant host | `h2-vtep2` 172.16.10.2/24 |

--- a/playset/bgp-evpn-vxlan6-ebpf/down.sh
+++ b/playset/bgp-evpn-vxlan6-ebpf/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the BGP EVPN VXLAN over IPv6 underlay (eBPF) namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vxlan6-ebpf/h1.yaml
+++ b/playset/bgp-evpn-vxlan6-ebpf/h1.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h1-vtep1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-vxlan6-ebpf/h2.yaml
+++ b/playset/bgp-evpn-vxlan6-ebpf/h2.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h2-vtep2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-vxlan6-ebpf/topology.sh
+++ b/playset/bgp-evpn-vxlan6-ebpf/topology.sh
@@ -1,0 +1,16 @@
+# BGP EVPN VXLAN over an IPv6 underlay (eBPF data plane) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(vtep1 vtep2 h1 h2)
+
+PLAYSET_LINKS=(
+    vtep1:vtep1-vtep2:vtep2:vtep2-vtep1
+    h1:h1-vtep1:vtep1:vtep1-h1
+    h2:h2-vtep2:vtep2:vtep2-h2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(vtep1 vtep2 h1 h2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(vtep1 vtep2 h1 h2)

--- a/playset/bgp-evpn-vxlan6-ebpf/up.sh
+++ b/playset/bgp-evpn-vxlan6-ebpf/up.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Bring up the BGP EVPN VXLAN over IPv6 underlay (eBPF data plane) demo
+# from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF (both families — the underlay is IPv6) on the
+# VTEPs: the eBPF engine encapsulates, floods and decapsulates, and a
+# successful host-to-host ping must prove it — the kernel VXLAN path
+# stays configured but never sees a frame.
+for ns in vtep1 vtep2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done

--- a/playset/bgp-evpn-vxlan6-ebpf/vtep1.yaml
+++ b/playset/bgp-evpn-vxlan6-ebpf/vtep1.yaml
@@ -1,0 +1,58 @@
+# VTEP 1 — the same EVPN/VXLAN VTEP as bgp-evpn-vxlan6, moved onto the
+# eBPF data plane: `system ebpf enabled` spawns the cradle engine, the
+# host port becomes its L2 port in bridge domain 10, and every MAC,
+# flood copy, encap and decap runs in XDP — with the outer header now
+# Ethernet + IPv6 + UDP toward the peer's v6 VTEP. The kernel VXLAN
+# device stays configured but never sees a frame.
+#
+# Same engine-side shape as the v4 twin: one fabric-wide VTEP source per
+# family, so the VTEP is a v6 loopback (2001:db8::1), the vxlan device's
+# local-address and the BGP session both ride it, and a static /128
+# toward the peer's loopback resolves the encapsulation via the teed
+# FIB6.
+system:
+  hostname: vtep1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: vtep1-vtep2
+  ipv6:
+    address: 2001:db8:12::1/64
+  ebpf:
+    enabled: true
+- if-name: vtep1-h1
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 2001:db8::1
+  bridge: br10
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8::2/128
+        nexthop:
+        - address: 2001:db8:12::2
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan6-ebpf/vtep2.yaml
+++ b/playset/bgp-evpn-vxlan6-ebpf/vtep2.yaml
@@ -1,0 +1,48 @@
+# VTEP 2 — mirror of vtep1: v6 loopback VTEP 2001:db8::2, bridge domain
+# 10 toward h2, static /128 back to vtep1's loopback.
+system:
+  hostname: vtep2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: vtep2-vtep1
+  ipv6:
+    address: 2001:db8:12::2/64
+  ebpf:
+    enabled: true
+- if-name: vtep2-h2
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 2001:db8::2
+  bridge: br10
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8::1/128
+        nexthop:
+        - address: 2001:db8:12::1
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65001
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/README.md
@@ -1,0 +1,107 @@
+# BGP EVPN VXLAN multi-tenant over IPv6 underlay, eBPF data plane
+
+The multi-tenant demo of
+[bgp-evpn-vxlan4-multi-ebpf](../bgp-evpn-vxlan4-multi-ebpf/README.md)
+moved onto an **IPv6-only underlay**: three VTEPs, two isolated tenants —
+VNI 10 stretches h1↔h2 across vtep1/vtep2, VNI 20 stretches h3↔h4 across
+vtep3/vtep1 — and **vtep1 serves both** from one engine, its single eBPF
+FDB cleanly split by bridge domain. Every VXLAN frame rides an outer
+Ethernet + IPv6 + UDP header between v6 loopback VTEPs. All four hosts
+share `172.16.10.0/24`; the two tenants still cannot reach each other,
+which is the isolation proof.
+
+Engine shape as in the v4 twin: one fabric-wide VTEP source per address
+family, so vtep1's two vxlan devices ride the same v6 loopback
+(`2001:db8::1`), both BGP sessions ride it too, and static /128s toward
+the peers' loopbacks resolve the encapsulation via the teed FIB6.
+Per-VNI RD/RT (`10.0.0.1:10` / `10.0.0.1:20`) keeps the tenants apart in
+BGP exactly as before.
+
+```
+        h1(10)   h4(20)
+           \      /
+ h2 ── vtep2 ── vtep1 ── vtep3 ── h3      VNI 10: h1, h2
+ (10) 2001:db8:12::/64 2001:db8:13::/64   VNI 20: h3, h4
+   lo ::2      lo ::1      lo ::3         all hosts: 172.16.10.0/24
+```
+
+vtep2 and vtep3 never peer with each other — each tenant is stretched
+only where it exists, so neither VTEP ever learns the other's routes.
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h4
+applied
+```
+
+## Both tenants forward, and never into each other
+
+```shell
+$ sudo ip netns exec h1 ping -c 2 172.16.10.2      # VNI 10, vtep1 ↔ vtep2
+2 packets transmitted, 2 received, 0% packet loss
+$ sudo ip netns exec h3 ping -c 2 172.16.10.4      # VNI 20, vtep3 ↔ vtep1
+2 packets transmitted, 2 received, 0% packet loss
+$ sudo ip netns exec h1 ping -c 2 172.16.10.4      # cross-tenant
+2 packets transmitted, 0 received, 100% packet loss
+```
+
+The cross-tenant ping dies at ARP — h1 and h4 sit behind the *same*
+engine on vtep1, one bridge domain apart, and the broadcast never
+crosses:
+
+```shell
+$ sudo ip netns exec h1 ip neigh show 172.16.10.4
+172.16.10.4 dev h1-vtep1 INCOMPLETE
+```
+
+## One engine, two tenants, native v6 VTEPs
+
+vtep1's eBPF FDB carries both bridge domains side by side — locally
+learned MACs with an age, remote ones bound to the right peer's VTEP,
+carried **native** in the engine's 16-byte address slot (not v4-mapped):
+
+```shell
+$ sudo ip netns exec vtep1 vty
+vtep1>show ebpf l2
+mac                 vlan      oif flags       age_ms remote_sid
+6a:2d:c6:c7:3a:5c     20        5 learned       2058
+0e:bb:a9:ab:64:70     10        0 remote           0 2001:db8::2
+ca:55:0d:4f:70:53     20        0 remote           0 2001:db8::3
+7e:62:f3:2e:ea:5d     10        4 learned         14
+```
+
+And in BGP each tenant keeps its own RD and its own ingress-replication
+tunnel, endpoints now IPv6:
+
+```shell
+vtep1>show bgp evpn
+Route Distinguisher: 10.0.0.1:10
+                    PMSI: ingress-replication endpoint:2001:db8::1 vni:10
+Route Distinguisher: 10.0.0.1:20
+                    PMSI: ingress-replication endpoint:2001:db8::1 vni:20
+Route Distinguisher: 10.0.0.2:10
+                    PMSI: ingress-replication endpoint:2001:db8::2 vni:10
+Route Distinguisher: 10.0.0.3:20
+                    PMSI: ingress-replication endpoint:2001:db8::3 vni:20
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host, VNI 10 | `h1-vtep1` 172.16.10.1/24 |
+| h2 | tenant host, VNI 10 | `h2-vtep2` 172.16.10.2/24 |
+| h3 | tenant host, VNI 20 | `h3-vtep3` 172.16.10.3/24 |
+| h4 | tenant host, VNI 20 | `h4-vtep1` 172.16.10.4/24 |
+| vtep1 | VTEP, VNIs 10+20 | `lo` 2001:db8::1/128, `vtep1-vtep2` 2001:db8:12::1/64, `vtep1-vtep3` 2001:db8:13::1/64 |
+| vtep2 | VTEP, VNI 10 | `lo` 2001:db8::2/128, `vtep2-vtep1` 2001:db8:12::2/64 |
+| vtep3 | VTEP, VNI 20 | `lo` 2001:db8::3/128, `vtep3-vtep1` 2001:db8:13::2/64 |

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/down.sh
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/down.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Tear down the BGP EVPN VXLAN multi-tenant over IPv6 underlay (eBPF)
+# namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/h1.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/h1.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h1-vtep1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/h2.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/h2.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h2-vtep2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/h3.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/h3.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h3-vtep3
+  ipv4:
+    address: 172.16.10.3/24
+system:
+  hostname: h3

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/h4.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/h4.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h4-vtep1
+  ipv4:
+    address: 172.16.10.4/24
+system:
+  hostname: h4

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/topology.sh
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/topology.sh
@@ -1,0 +1,19 @@
+# BGP EVPN VXLAN multi-tenant over an IPv6 underlay (eBPF data plane) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(vtep1 vtep2 vtep3 h1 h2 h3 h4)
+
+PLAYSET_LINKS=(
+    vtep1:vtep1-vtep2:vtep2:vtep2-vtep1
+    vtep1:vtep1-vtep3:vtep3:vtep3-vtep1
+    h1:h1-vtep1:vtep1:vtep1-h1
+    h2:h2-vtep2:vtep2:vtep2-h2
+    h3:h3-vtep3:vtep3:vtep3-h3
+    h4:h4-vtep1:vtep1:vtep1-h4
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(vtep1 vtep2 vtep3 h1 h2 h3 h4)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(vtep1 vtep2 vtep3 h1 h2 h3 h4)

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/up.sh
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/up.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Bring up the BGP EVPN VXLAN multi-tenant over IPv6 underlay (eBPF data
+# plane) demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF (both families — the underlay is IPv6) on the
+# VTEPs: the eBPF engine encapsulates, floods and decapsulates, and a
+# successful host-to-host ping must prove it — the kernel VXLAN path
+# stays configured but never sees a frame.
+for ns in vtep1 vtep2 vtep3; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/vtep1.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/vtep1.yaml
@@ -1,0 +1,77 @@
+# VTEP 1 — serves BOTH tenants on the eBPF data plane over an IPv6
+# underlay: bridge domain 10 (h1, stretched to vtep2) and bridge domain
+# 20 (h4, stretched to vtep3). Same engine shape as the v4 twin — one
+# fabric-wide VTEP source per family — so both vxlan devices ride the
+# same v6 loopback (2001:db8::1), the BGP sessions ride it too, and
+# static /128s toward the peers' loopbacks resolve the encapsulation via
+# the teed FIB6.
+system:
+  hostname: vtep1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: vtep1-vtep2
+  ipv6:
+    address: 2001:db8:12::1/64
+  ebpf:
+    enabled: true
+- if-name: vtep1-vtep3
+  ipv6:
+    address: 2001:db8:13::1/64
+  ebpf:
+    enabled: true
+- if-name: vtep1-h1
+  bridge: br10
+  ebpf:
+    enabled: true
+- if-name: vtep1-h4
+  bridge: br20
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+- name: br20
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 2001:db8::1
+  bridge: br10
+- name: vxlan20
+  vni: 20
+  local-address: 2001:db8::1
+  bridge: br20
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8::2/128
+        nexthop:
+        - address: 2001:db8:12::2
+      - prefix: 2001:db8::3/128
+        nexthop:
+        - address: 2001:db8:13::2
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true
+    - remote-address: 2001:db8::3
+      remote-as: 65001
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/vtep2.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/vtep2.yaml
@@ -1,0 +1,49 @@
+# VTEP 2 — tenant VNI 10 only (h2). v6 loopback VTEP 2001:db8::2; it
+# peers with vtep1 alone: its tenant is stretched to vtep1, never to
+# vtep3.
+system:
+  hostname: vtep2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: vtep2-vtep1
+  ipv6:
+    address: 2001:db8:12::2/64
+  ebpf:
+    enabled: true
+- if-name: vtep2-h2
+  bridge: br10
+  ebpf:
+    enabled: true
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 2001:db8::2
+  bridge: br10
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8::1/128
+        nexthop:
+        - address: 2001:db8:12::1
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65001
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/vtep3.yaml
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/vtep3.yaml
@@ -1,0 +1,49 @@
+# VTEP 3 — tenant VNI 20 only (h3). v6 loopback VTEP 2001:db8::3; it
+# peers with vtep1 alone: its tenant is stretched to vtep1, never to
+# vtep2.
+system:
+  hostname: vtep3
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: vtep3-vtep1
+  ipv6:
+    address: 2001:db8:13::2/64
+  ebpf:
+    enabled: true
+- if-name: vtep3-h3
+  bridge: br20
+  ebpf:
+    enabled: true
+bridge:
+- name: br20
+vxlan:
+- name: vxlan20
+  vni: 20
+  local-address: 2001:db8::3
+  bridge: br20
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8::1/128
+        nexthop:
+        - address: 2001:db8:13::1
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.3
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65001
+      update-source: 2001:db8::3
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1727,6 +1727,36 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+/// `router bgp afi-safi evpn vtep-source <ip>`: the VTEP advertised as
+/// the next hop of originated EVPN routes whose VNI has no local VXLAN
+/// device (a VPWS E-Line under `encapsulation vxlan` — the way a
+/// v6-underlay E-Line names its VTEP). Changing it moves the next hop of
+/// every such route, so re-originate them all.
+fn config_evpn_vtep_source(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let source = if op.is_set() {
+        Some(args.addr()?)
+    } else {
+        None
+    };
+    if bgp.evpn_vtep_source == source {
+        return Some(());
+    }
+    bgp.evpn_vtep_source = source;
+    if bgp.advertise_all_vni {
+        let entries: Vec<FdbEntry> = bgp.local_fdb.values().cloned().collect();
+        for entry in entries {
+            bgp.evpn_originate_macip(&entry);
+        }
+    }
+    reoriginate_all_imet(bgp);
+    bgp.vpws_reencap();
+    Some(())
+}
+
 /// `router bgp afi-safi evpn encapsulation {vxlan|srv6|mpls}`.
 /// With `srv6` (RFC 9252), Type-2 routes carry a per-VNI End.DT2U SID and
 /// Type-3 IMETs an End.DT2M SID (SRv6 L2 Service TLVs), both carved from
@@ -4976,6 +5006,10 @@ impl Bgp {
             "/router/bgp/afi-safi/encapsulation",
             config_evpn_encapsulation,
         );
+
+        // The VTEP advertised as the EVPN next hop when no VXLAN device
+        // supplies one (`router bgp afi-safi evpn vtep-source`).
+        self.callback_add("/router/bgp/afi-safi/vtep-source", config_evpn_vtep_source);
 
         // EVPN IGMP/MLD proxy capability (RFC 9251 §6) under
         // `router bgp afi-safi evpn igmp-mld-proxy`. When set, the

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1128,6 +1128,11 @@ pub struct Bgp {
     /// `router bgp afi-safi evpn encapsulation {vxlan|srv6|mpls}` — the
     /// overlay locally originated and received L2 routes ride.
     pub evpn_encap: EvpnEncap,
+    /// `router bgp afi-safi evpn vtep-source` — the VTEP (either family)
+    /// advertised as the next hop of originated EVPN routes whose VNI has
+    /// no local VXLAN device to take one from (a VPWS E-Line under
+    /// `encapsulation vxlan`); `None` falls back to the router-id.
+    pub evpn_vtep_source: Option<std::net::IpAddr>,
     /// EVPN Instances declared under `router bgp afi-safi evpn evi <id>`,
     /// keyed by EVI id. Populated only for `encapsulation mpls`, where there
     /// is no VXLAN device to infer a service identifier from. See
@@ -1385,6 +1390,7 @@ impl Bgp {
             evpn_dt2m_sids: BTreeMap::new(),
             evpn_dt2u_sids: BTreeMap::new(),
             evpn_encap: EvpnEncap::default(),
+            evpn_vtep_source: None,
             evpn_evis: BTreeMap::new(),
             srv6_ipv6_export: None,
             networks_v6: std::collections::BTreeSet::new(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7216,9 +7216,8 @@ fn evpn_vpws_sid(attr: &BgpAttr) -> Option<std::net::Ipv6Addr> {
 /// PE: an Encapsulation EC saying VXLAN makes it a VNI toward a VTEP
 /// (RFC 8365 §6); no Encapsulation EC (or an explicit MPLS one) makes it
 /// an MPLS service label toward the PE, RFC 8365 §5.1.3's default.
-/// `None` = nothing we can bind: an RFC 9572 A-D form, a zero label, a
-/// non-IPv4 VTEP (the cradle VXLAN underlay is IPv4), or some other
-/// explicitly-named tunnel type.
+/// `None` = nothing we can bind: an RFC 9572 A-D form, a zero label, or
+/// some other explicitly-named tunnel type.
 fn vpws_remote_endpoint(rib: &BgpRib) -> Option<VpwsEndpoint> {
     if let Some(sid) = evpn_vpws_sid(&rib.attr) {
         return Some(VpwsEndpoint::Srv6(sid));
@@ -7226,9 +7225,7 @@ fn vpws_remote_endpoint(rib: &BgpRib) -> Option<VpwsEndpoint> {
     let label = rib.label.as_ref().map(|l| l.label).filter(|&l| l != 0)?;
     if encap_ec_tunnel_type(&rib.attr) == Some(TunnelType::Vxlan as u16) {
         return match rib.attr.nexthop {
-            Some(BgpNexthop::Evpn(IpAddr::V4(vtep))) => {
-                Some(VpwsEndpoint::Vxlan { vtep, vni: label })
-            }
+            Some(BgpNexthop::Evpn(vtep)) => Some(VpwsEndpoint::Vxlan { vtep, vni: label }),
             _ => None,
         };
     }
@@ -7695,7 +7692,8 @@ fn route_evpn_export_selected(
                 // bridge domain's flood list, one slot per remote PE, so any
                 // number of remotes works (the old single-remote all-ones
                 // sentinel is superseded). Independent of the PMSI mode.
-                if let Some(dt2m) = evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M) {
+                let dt2m = evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M);
+                if let Some(dt2m) = dt2m {
                     let _ = bgp
                         .rib_client
                         .send(rib::Message::CradleReplAdd { vni, sid: dt2m });
@@ -7704,7 +7702,8 @@ fn route_evpn_export_selected(
                 // BUM service label in its PMSI. Same shape as the SRv6 slot
                 // above — one slot per remote PE in the bridge domain's flood
                 // list, independent of the AR/PMSI role machinery.
-                if let Some((pe, label)) = evpn_mpls_bum(best) {
+                let mpls_bum = evpn_mpls_bum(best);
+                if let Some((pe, label)) = mpls_bum {
                     let _ =
                         bgp.rib_client
                             .send(rib::Message::CradleReplAddMpls { bd: vni, pe, label });
@@ -7719,7 +7718,7 @@ fn route_evpn_export_selected(
                     bgp.local_rib
                         .evpn_flood
                         .update_sr_remote(vni, *orig, p.tree_id.unwrap_or(0));
-                } else {
+                } else if dt2m.is_none() && mpls_bum.is_none() {
                     let ar_ip = pmsi
                         .filter(|p| p.is_assisted_replication())
                         .map(|p| p.endpoint);
@@ -7728,6 +7727,14 @@ fn route_evpn_export_selected(
                     // RFC 9572 §6.1: the remote VTEP's region (the ingress
                     // peer's region-id, stamped on the path) lets a gateway
                     // partition its flood set for cross-boundary re-flooding.
+                    //
+                    // Only an IMET with neither a DT2M SID nor an MPLS BUM
+                    // label enters the VXLAN head-end flood set: those two
+                    // already teed their own replication slot above, and a
+                    // VXLAN flood entry for the same originator would be a
+                    // second copy of every BUM frame. (Under the old
+                    // v4-only VTEP gate that duplicate was inert; with v6
+                    // VTEPs live it would be real double delivery.)
                     let region = best.ingress_region;
                     bgp.local_rib.evpn_flood.update_remote(
                         vni,
@@ -16416,13 +16423,17 @@ impl Bgp {
     }
 
     /// The next hop an EVPN route for `vni` carries: the VNI's VTEP when
-    /// one is known, else the router-id. Under MPLS the router-id IS the
-    /// next hop — there is no VTEP and the transport LSP resolves on it —
-    /// so the fallback is the intended answer rather than a degraded one.
+    /// one is known, else the configured `vtep-source`, else the
+    /// router-id. Under MPLS the router-id IS the next hop — there is no
+    /// VTEP and the transport LSP resolves on it — so the final fallback
+    /// is the intended answer rather than a degraded one. The middle one
+    /// serves VXLAN services with no device to read a VTEP from (a VPWS
+    /// E-Line), which is the only way to advertise an IPv6 VTEP for them.
     fn evpn_nexthop_for_vni(&self, vni: u32) -> IpAddr {
         self.local_vxlans
             .get(&vni)
             .copied()
+            .or(self.evpn_vtep_source)
             .unwrap_or(IpAddr::V4(self.router_id))
     }
 
@@ -16641,10 +16652,7 @@ impl Bgp {
             svc.local_vni = local_vni;
             // The advertised next hop is what the remote encapsulates
             // toward — the tee programs it as the VXLAN decap source.
-            svc.local_vtep = match (local_vni, nexthop) {
-                (Some(_), IpAddr::V4(vtep)) => Some(vtep),
-                _ => None,
-            };
+            svc.local_vtep = local_vni.map(|_| nexthop);
         }
         self.evpn_originate_synch(rd, prefix, rib);
     }
@@ -18136,7 +18144,22 @@ mod vpws_endpoint_classify_tests {
         assert_eq!(
             vpws_remote_endpoint(&rib),
             Some(VpwsEndpoint::Vxlan {
-                vtep: VTEP,
+                vtep: IpAddr::V4(VTEP),
+                vni: 100
+            })
+        );
+    }
+
+    /// A v6 next hop under the VXLAN Encapsulation EC binds the same way —
+    /// the VTEP rides an IPv6 underlay (cradle's VXLAN_SRC6 side).
+    #[test]
+    fn vxlan_binds_v6_vtep() {
+        let vtep6: IpAddr = "2001:db8::2".parse().unwrap();
+        let rib = rib_with(false, Some(8), Some(100), Some(vtep6));
+        assert_eq!(
+            vpws_remote_endpoint(&rib),
+            Some(VpwsEndpoint::Vxlan {
+                vtep: vtep6,
                 vni: 100
             })
         );
@@ -18192,13 +18215,6 @@ mod vpws_endpoint_classify_tests {
         let rib = rib_with(false, Some(8), None, Some(IpAddr::V4(VTEP)));
         assert_eq!(vpws_remote_endpoint(&rib), None);
         let rib = rib_with(false, None, Some(0), Some(IpAddr::V4(VTEP)));
-        assert_eq!(vpws_remote_endpoint(&rib), None);
-    }
-
-    /// The cradle VXLAN underlay is IPv4 — a v6 VTEP cannot be bound.
-    #[test]
-    fn v6_vtep_is_not_bound() {
-        let rib = rib_with(false, Some(8), Some(100), Some(IpAddr::V6(SID)));
         assert_eq!(vpws_remote_endpoint(&rib), None);
     }
 }

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -30,7 +30,7 @@
 //! differs from our non-zero MTU is not bound (`mtu-mismatch`).
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv6Addr};
 
 use super::ethernet_segment::{EthernetSegment, VpwsRole};
 
@@ -46,9 +46,9 @@ pub enum VpwsEndpoint {
     /// §6.3).
     Srv6(Ipv6Addr),
     /// The advertised VTEP and VNI (RFC 8365 §6): the VNI rides the
-    /// Type-1's label field, the VTEP is the route's next hop. IPv4 only —
-    /// the cradle VXLAN underlay is IPv4.
-    Vxlan { vtep: Ipv4Addr, vni: u32 },
+    /// Type-1's label field, the VTEP — IPv4 or IPv6 underlay — is the
+    /// route's next hop.
+    Vxlan { vtep: IpAddr, vni: u32 },
     /// The advertised MPLS service label (RFC 7432 base encapsulation,
     /// signalled by the *absence* of an Encapsulation EC per RFC 8365
     /// §5.1.3), imposed toward the advertising PE — the route's next hop —
@@ -95,12 +95,11 @@ pub struct VpwsService {
     /// `End.DX2` entry in `VpwsState::sids`. `None` when the service
     /// originated under SRv6 (or not at all).
     pub local_vni: Option<u32>,
-    /// The IPv4 VTEP our Type-1 went out with as its next hop — what the
-    /// remote encapsulates toward, so the tee programs it as cradle's
-    /// fabric-wide VXLAN source (`SetVtepSource`, the decap match). Set
-    /// alongside `local_vni`; `None` under SRv6 or when the advertised
-    /// next hop is not IPv4.
-    pub local_vtep: Option<Ipv4Addr>,
+    /// The VTEP our Type-1 went out with as its next hop (either address
+    /// family) — what the remote encapsulates toward, so the tee programs
+    /// it as cradle's VXLAN source for that family (`SetVtepSource`, the
+    /// decap match). Set alongside `local_vni`; `None` under SRv6.
+    pub local_vtep: Option<IpAddr>,
     /// Set when the service's VNI is already claimed as a decap identity
     /// by someone else on this PE (another VPWS service, an L2VNI vxlan
     /// device, a VRF's L3VNI): who owns it. The service is parked — no
@@ -510,7 +509,7 @@ mod tests {
         // role bits, so the VXLAN primary wins — and losing it fails over
         // to the SRv6 backup, endpoint flavor notwithstanding.
         let vxlan = VpwsEndpoint::Vxlan {
-            vtep: Ipv4Addr::new(192, 0, 2, 2),
+            vtep: IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 2)),
             vni: 100,
         };
         let mut primary = mh(2, true, false);

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -94,11 +94,11 @@ struct CradleMirror {
     /// (bridge domain, remote End.DT2M SID) flood-set memberships.
     repl_slots: HashSet<(u32, Ipv6Addr)>,
     /// EVPN/VXLAN counterparts of `fdb`/`repl_slots`: (bridge domain, mac) →
-    /// remote VTEP IPv4 (Type-2), and (bridge domain, remote VTEP) flood-set
+    /// remote VTEP (Type-2), and (bridge domain, remote VTEP) flood-set
     /// memberships (Type-3). A `(vni, mac)` key is in exactly one of `fdb` /
     /// `fdb_vxlan` depending on the received route's encap.
-    fdb_vxlan: HashMap<(u32, [u8; 6]), Ipv4Addr>,
-    repl_slots_vxlan: HashSet<(u32, Ipv4Addr)>,
+    fdb_vxlan: HashMap<(u32, [u8; 6]), IpAddr>,
+    repl_slots_vxlan: HashSet<(u32, IpAddr)>,
     /// EVPN-over-MPLS counterparts: (bridge domain, mac) → (remote PE, that
     /// PE's EVI service label), and the per-(bd, PE) BUM replication slots
     /// with their BUM label. A `(vni, mac)` key lives in exactly one of
@@ -114,7 +114,11 @@ struct CradleMirror {
     vnis: HashMap<u32, u32>,
     /// L3VNI ↔ VRF bindings (symmetric IRB): vni → (vrf_table_id, rmac).
     vnis_l3: HashMap<u32, (u32, [u8; 6])>,
+    /// One slot per address family, mirroring cradle's own pair of
+    /// `VXLAN_SRC`/`VXLAN_SRC6` slots — a dual-stack fabric sets both and
+    /// a respawn replay must restore both.
     vtep_source: Option<Ipv4Addr>,
+    vtep_source6: Option<Ipv6Addr>,
     /// (AC port, vid, dx2v table) → (remote endpoint — SID, VTEP+VNI or
     /// PE+label, local decap SID, local decap VNI, local decap label).
     #[allow(clippy::type_complexity)]
@@ -554,7 +558,10 @@ impl CradleFib {
         // resolves its VNI from the SetVni binding), then the overlay FDB and
         // flood slots.
         if let Some(src) = m.vtep_source {
-            self.set_vtep_source(src).await;
+            self.set_vtep_source(IpAddr::V4(src)).await;
+        }
+        if let Some(src) = m.vtep_source6 {
+            self.set_vtep_source(IpAddr::V6(src)).await;
         }
         for (vni, vlan) in &m.vnis {
             self.set_vni(*vni, *vlan).await;
@@ -1501,7 +1508,7 @@ impl CradleFib {
     /// sits behind the remote VTEP `vtep`. The VNI stamped on encap comes
     /// from the bridge domain's `SetVni` binding; `nexthop_id: 0` — cradle
     /// resolves the underlay adjacency with a FIB4 lookup on the VTEP.
-    pub async fn fdb_add_vxlan(&self, vni: u32, mac: [u8; 6], vtep: std::net::Ipv4Addr) {
+    pub async fn fdb_add_vxlan(&self, vni: u32, mac: [u8; 6], vtep: IpAddr) {
         self.mirror.lock().await.fdb_vxlan.insert((vni, mac), vtep);
         let mac_str = format!(
             "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
@@ -1901,7 +1908,7 @@ impl CradleFib {
     /// joins VNI `vni`'s flood set. The VNI resolves from the bridge
     /// domain's `SetVni` binding, so a `cradle_vni_register` must have run
     /// first (it does — the VXLAN device is declared before any Type-3).
-    pub async fn repl_slot_add_vxlan(&self, vni: u32, vtep: std::net::Ipv4Addr) {
+    pub async fn repl_slot_add_vxlan(&self, vni: u32, vtep: IpAddr) {
         self.mirror
             .lock()
             .await
@@ -1982,7 +1989,7 @@ impl CradleFib {
     }
 
     /// Remove a `(vni, vtep)` VXLAN replication slot.
-    pub async fn repl_slot_del_vxlan(&self, vni: u32, vtep: std::net::Ipv4Addr) {
+    pub async fn repl_slot_del_vxlan(&self, vni: u32, vtep: IpAddr) {
         self.mirror
             .lock()
             .await
@@ -2076,10 +2083,17 @@ impl CradleFib {
         }
     }
 
-    /// Set the fabric-wide local VTEP source (VXLAN outer source + decap
-    /// match). Idempotent; last write wins.
-    pub async fn set_vtep_source(&self, addr: std::net::Ipv4Addr) {
-        self.mirror.lock().await.vtep_source = Some(addr);
+    /// Set the local VTEP source (VXLAN outer source + decap match) for
+    /// `addr`'s address family — cradle keeps one slot per family, so a
+    /// dual-stack fabric sets both. Idempotent; last write per family wins.
+    pub async fn set_vtep_source(&self, addr: IpAddr) {
+        {
+            let mut m = self.mirror.lock().await;
+            match addr {
+                IpAddr::V4(v4) => m.vtep_source = Some(v4),
+                IpAddr::V6(v6) => m.vtep_source6 = Some(v6),
+            }
+        }
         let result = async {
             self.client()
                 .await?

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -654,24 +654,28 @@ impl FibHandle {
 
     /// Declare an EVPN/VXLAN L2VNI to the cradle data plane when its VXLAN
     /// device appears: bind the VNI to its bridge domain (`bd == vni`) and
-    /// set the fabric-wide local VTEP source. Only an IPv4 VTEP is a cradle
-    /// datapath capability today; an IPv6-local (SRv6) device is a no-op
-    /// here (it needs neither map). No-op when cradle is disabled.
+    /// set the local VTEP source for the device-local's address family
+    /// (cradle keeps one slot per family — a v6-local device is a
+    /// v6-underlay VTEP). An EVPN-over-SRv6 deployment declares the same
+    /// device shape (its VNI declaration); registering it too is inert —
+    /// nothing sends VXLAN/UDP 4789 to an SRv6 PE, so the decap match
+    /// never claims a packet and the VNI binding is only consulted by
+    /// VXLAN decap. No-op when cradle is disabled.
     pub async fn cradle_vni_register(&self, vni: u32, local: IpAddr) {
-        if let Some(cradle) = &self.cradle
-            && let IpAddr::V4(v4) = local
-        {
+        if let Some(cradle) = &self.cradle {
             cradle.set_vni(vni, vni).await;
-            cradle.set_vtep_source(v4).await;
+            cradle.set_vtep_source(local).await;
         }
     }
 
     /// Declare an EVPN/VXLAN L3VNI (symmetric IRB, RFC 9135) to the cradle
     /// data plane: bind the VNI to a tenant `vrf_table_id` with this PE's
     /// router-MAC so a received VXLAN frame on `vni` routes its inner IP in
-    /// that VRF, and set the fabric-wide local VTEP source. Only an IPv4
-    /// VTEP is a cradle datapath capability today; an IPv6-local device is a
-    /// no-op here. No-op when cradle is disabled.
+    /// that VRF, and set the fabric-wide local VTEP source. The symmetric-IRB
+    /// VXLAN L3 encap is an IPv4-only cradle capability (`VxlanEncap` carries
+    /// a 4-byte VTEP), so an IPv6-local device is a no-op here — unlike the
+    /// L2VNI register, which serves either family. No-op when cradle is
+    /// disabled.
     pub async fn cradle_vni_register_l3(
         &self,
         vni: u32,
@@ -683,7 +687,7 @@ impl FibHandle {
             && let IpAddr::V4(v4) = local
         {
             cradle.set_vni_l3(vni, vrf_table_id, rmac).await;
-            cradle.set_vtep_source(v4).await;
+            cradle.set_vtep_source(IpAddr::V4(v4)).await;
         }
     }
 
@@ -749,7 +753,7 @@ impl FibHandle {
         remote: crate::rib::XconnectRemote,
         local_sid: Option<std::net::Ipv6Addr>,
         local_vni: Option<u32>,
-        local_vtep: Option<std::net::Ipv4Addr>,
+        local_vtep: Option<IpAddr>,
         local_label: Option<u32>,
         vid: u16,
         table: u32,
@@ -3597,14 +3601,13 @@ impl FibHandle {
             }
             return;
         }
-        // EVPN over VXLAN + cradle: the MAC sits behind a remote IPv4 VTEP,
-        // and the eBPF datapath is the forwarder — install the overlay FDB
-        // entry there and skip the kernel VXLAN FDB (cradle owns it). Fires
-        // whether or not a kernel VXLAN device exists. An IPv6 VTEP is not
-        // yet a cradle datapath capability, so it falls through to the
-        // kernel path below.
+        // EVPN over VXLAN + cradle: the MAC sits behind a remote VTEP of
+        // either address family, and the eBPF datapath is the forwarder —
+        // install the overlay FDB entry there and skip the kernel VXLAN FDB
+        // (cradle owns it). Fires whether or not a kernel VXLAN device
+        // exists.
         if let Some(cradle) = &self.cradle
-            && let Some(IpAddr::V4(vtep)) = tunnel_endpoint
+            && let Some(vtep) = tunnel_endpoint
         {
             cradle.fdb_add_vxlan(vni, mac.octets(), vtep).await;
             return;
@@ -3991,13 +3994,12 @@ impl FibHandle {
         _ifindex: u32,
         _seq: u32,
     ) {
-        // EVPN over VXLAN + cradle: the remote VTEP `group` joins the VNI's
-        // eBPF flood set (ingress replication); cradle owns the datapath, so
-        // skip the kernel zero-MAC FDB. An IPv6 VTEP falls through to kernel.
-        if let Some(cradle) = &self.cradle
-            && let IpAddr::V4(vtep) = group
-        {
-            cradle.repl_slot_add_vxlan(vni, vtep).await;
+        // EVPN over VXLAN + cradle: the remote VTEP `group` — either
+        // address family — joins the VNI's eBPF flood set (ingress
+        // replication); cradle owns the datapath, so skip the kernel
+        // zero-MAC FDB.
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_slot_add_vxlan(vni, group).await;
             return;
         }
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
@@ -4047,10 +4049,8 @@ impl FibHandle {
     /// Remove a remote VTEP from VXLAN BUM ingress replication.
     /// Counterpart of `mdb_add`; same rationale on naming.
     pub async fn mdb_del(&self, vni: u32, group: IpAddr, _source: Option<IpAddr>, _ifindex: u32) {
-        if let Some(cradle) = &self.cradle
-            && let IpAddr::V4(vtep) = group
-        {
-            cradle.repl_slot_del_vxlan(vni, vtep).await;
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_slot_del_vxlan(vni, group).await;
             return;
         }
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -37,9 +37,9 @@ pub enum XconnectRemote {
     /// The remote `End.DX2`/`End.DX2V` L2-Service SID (RFC 9252 §6.3).
     Srv6(Ipv6Addr),
     /// The remote VTEP and its advertised VNI (RFC 8365 §6: the VNI rides
-    /// the Type-1's label field, the VTEP is the route's next hop). IPv4
-    /// only — the cradle VXLAN underlay is IPv4.
-    Vxlan { vtep: Ipv4Addr, vni: u32 },
+    /// the Type-1's label field, the VTEP — IPv4 or IPv6 underlay — is
+    /// the route's next hop).
+    Vxlan { vtep: IpAddr, vni: u32 },
     /// The remote PE and the MPLS service label it advertised (RFC 7432
     /// base encapsulation — the Type-1's label field, imposed under
     /// whatever transport LSP reaches the PE).
@@ -438,7 +438,7 @@ pub enum Message {
         /// The IPv4 VTEP this PE advertised as the service's next hop —
         /// teed as cradle's fabric-wide `SetVtepSource` (the VXLAN decap
         /// match and outer source) before the VXLAN xconnect lands.
-        local_vtep: Option<Ipv4Addr>,
+        local_vtep: Option<IpAddr>,
         /// The MPLS service label this PE advertised — the E-Line's local
         /// decap identity under `encapsulation mpls` (pop-to-AC ILM), the
         /// `local_sid`/`local_vni` analog; at most one of the three.

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -129,6 +129,20 @@ module zebra-bgp-evpn {
          side is not gated by this leaf: each direction of an E-Line
          uses the encapsulation its originator signalled.";
     }
+    leaf vtep-source {
+      ext:help "VTEP advertised as the EVPN next hop";
+      type inet:ip-address;
+      description
+        "The VTEP address — IPv4 or IPv6 — advertised as the next hop
+         of locally originated EVPN routes when no local VXLAN device
+         supplies one for the VNI. A VPWS E-Line under `encapsulation
+         vxlan` has no VXLAN device (the service VNI is a decap identity,
+         not a bridge domain), so without this leaf its Type-1 falls back
+         to the IPv4 router-id — which cannot express a VTEP on an IPv6
+         underlay. Routes whose VNI does have a local VXLAN device keep
+         taking that device's local address; unset, the fallback remains
+         the router-id.";
+    }
     list evi {
       ext:help "EVPN Instance (bridge domain) for `encapsulation mpls`";
       key "id";


### PR DESCRIPTION
## Summary

Companion to cradle-rs #168 (IPv6-underlay VXLAN engine): zebra-rs now drives v6 VTEPs through the cradle tee instead of handing them to the kernel data path.

- **Un-gate the v4-only tees**: Type-2 MACs → `fdb_add_vxlan` with the VTEP native in the 16-byte slot; Type-3 flood members → replication slots; the L2VNI device registration programs the VTEP source for its local address's family (cradle keeps one slot per family — the FibHandle mirror now does too, so a respawn replay restores both); VPWS xconnects carry either family end to end (`VpwsEndpoint::Vxlan`, `XconnectRemote::Vxlan`, and the `local_vtep` chain widen `Ipv4Addr` → `IpAddr`). The symmetric-IRB L3 path stays v4-only (cradle's `VxlanEncap` is a 4-byte VTEP; separate arc).
- **IMET flood-set filter**: un-gating exposed a latent bug — SRv6/MPLS IMETs also landed in the VXLAN head-end flood set, inert only because the v4 gate (SRv6) or an unset VTEP source (MPLS) neutered the bogus entry; with v6 VTEPs live it becomes real double BUM delivery. Only an IMET with neither a DT2M SID nor an MPLS BUM label now enters the VXLAN flood set.
- **New `router bgp afi-safi evpn vtep-source` leaf**: the VTEP advertised as next hop when no local VXLAN device supplies one — a VPWS E-Line under `encapsulation vxlan` is exactly that case, and the router-id fallback can only express IPv4. This is how a v6-underlay E-Line names its VTEP.
- **Playsets** `bgp-evpn-vxlan6-ebpf` + `bgp-evpn-vxlan6-multi-ebpf` — eBPF twins of the kernel IPv6-transport labs, run live; README outputs are captured from the runs (both tenants forward, cross-tenant isolation holds, FDB shows native v6 VTEPs).

## Test plan

- cradle-rs e2e (new, on cradle branch `vxlan6-zebra-bdd`): `cradle_evpn_vxlan6_zebra` (fully dynamic E-LAN over an IPv6-only underlay) and `cradle_vpws_vxlan6_zebra` (untagged + VLAN-scoped E-Line pair via `vtep-source`) — **both passed first run**.
- Full zebra-driven EVPN regression across all three encapsulations (11 cradle features: SRv6, MPLS, VXLAN incl. IRB/aging/mobility/multi): green. The one initial failure (`cradle_vpws_zebra`) bisected to a pre-existing config miss from the `encapsulation`-knob arc (fixed on the cradle branch), not this diff.
- `cargo test -p zebra-rs` (1886 tests, incl. new v6-VTEP VPWS endpoint test), workspace clippy, fmt, config-audit docs, packaging playset gate: all green.

Generated with [Claude Code](https://claude.com/claude-code)