### PR TITLE
fib: carry the GTP PDR match VRF through the cradle seam

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -408,16 +408,19 @@ message L7Service {
   repeated L7Route routes = 3;
 }
 
-// A GTP-U decap PDR (H.M.GTP4.D): a G-PDU arriving on (dst, teid) is stripped
-// and its inner packet forwarded in vrf (0 = global). Mirrors the cradle server.
+// A GTP-U decap PDR (H.M.GTP4.D): a G-PDU arriving on (dst, teid) in
+// match_vrf is stripped and its inner packet forwarded in vrf (0 = global).
+// Mirrors the cradle server.
 message GtpPdr {
-  string dst = 1;   // local outer IPv4 destination the G-PDU arrives on
-  uint32 teid = 2;  // GTP-U TEID
-  uint32 vrf = 3;   // inner VRF table id (0 = global)
+  string dst = 1;        // local outer IPv4 destination the G-PDU arrives on
+  uint32 teid = 2;       // GTP-U TEID
+  uint32 vrf = 3;        // inner VRF table id (0 = global)
+  uint32 match_vrf = 4;  // match context: ingress port's VRF (0 = global)
 }
 message GtpPdrDel {
   string dst = 1;
   uint32 teid = 2;
+  uint32 match_vrf = 3;  // match context the PDR was installed for
 }
 
 // ---- Forwarding-table dump (`show ebpf <table>` / `cradle dump`) ----

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1110,13 +1110,18 @@ impl BgpVrf {
             .copied()
             .collect();
         for (dst, teid) in stale {
-            let _ = self
-                .ctx
-                .rib
-                .send(crate::rib::Message::CradleGtpPdrDel { dst, teid });
+            let _ = self.ctx.rib.send(crate::rib::Message::CradleGtpPdrDel {
+                dst,
+                teid,
+                match_vrf: 0,
+            });
             self.mup_gtp_pdr_installed.remove(&(dst, teid));
         }
-        // Install new PDRs.
+        // Install new PDRs. The match context is the global table for now —
+        // GTP-U terminates on ports in VRF 0, today's only supported
+        // placement; the interwork-segment resolution
+        // (docs/design/bgp-mup-gtp-segment-resolution-plan.md stage 3) will
+        // derive it from the segment catalog instead.
         for (dst, teid) in &desired {
             if !self.mup_gtp_pdr_installed.insert((*dst, *teid)) {
                 continue;
@@ -1125,6 +1130,7 @@ impl BgpVrf {
                 dst: *dst,
                 teid: *teid,
                 table_id,
+                match_vrf: 0,
             });
         }
     }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -86,7 +86,7 @@ struct CradleMirror {
     /// (SID address, prefix len) → (registry Sid, ifindex).
     local_sids: HashMap<(Ipv6Addr, u8), (crate::rib::Sid, u32)>,
     /// (outer dst, teid) → decap table (original kernel table id).
-    gtp_pdrs: HashMap<(Ipv4Addr, u32), u32>,
+    gtp_pdrs: HashMap<(Ipv4Addr, u32, u32), u32>,
     /// (UE prefix, kernel table) → (gtp_src, gtp_dst, teid, underlay gw, oif).
     gtp_encaps: HashMap<(Ipv4Net, u32), (Ipv4Addr, Ipv4Addr, u32, Option<Ipv4Addr>, u32)>,
     /// (bridge domain, mac) → remote End.DT2U/DT2M service SID.
@@ -586,8 +586,8 @@ impl CradleFib {
             )
             .await;
         }
-        for ((dst, teid), table) in &m.gtp_pdrs {
-            self.gtp_pdr_add(*dst, *teid, *table).await;
+        for ((dst, teid, match_vrf), table) in &m.gtp_pdrs {
+            self.gtp_pdr_add(*dst, *teid, *table, *match_vrf).await;
         }
         for ((prefix, table), (src, dst, teid, gw, oif)) in &m.gtp_encaps {
             self.gtp_encap_install(*prefix, *table, *src, *dst, *teid, *gw, *oif)
@@ -1307,15 +1307,16 @@ impl CradleFib {
     }
 
     /// Install a GTP-U decap PDR (`H.M.GTP4.D`): a G-PDU arriving on
-    /// (`dst`, `teid`) is stripped and its inner packet forwarded in the VRF
-    /// table `table_id` (0 = global). Cradle-only — the mainline kernel has no
-    /// GTP action, so this is never a kernel route.
-    pub async fn gtp_pdr_add(&self, dst: Ipv4Addr, teid: u32, table_id: u32) {
+    /// (`dst`, `teid`) on a port bound to VRF table `match_vrf` (0 = global)
+    /// is stripped and its inner packet forwarded in the VRF table `table_id`
+    /// (0 = global). Cradle-only — the mainline kernel has no GTP action, so
+    /// this is never a kernel route.
+    pub async fn gtp_pdr_add(&self, dst: Ipv4Addr, teid: u32, table_id: u32, match_vrf: u32) {
         self.mirror
             .lock()
             .await
             .gtp_pdrs
-            .insert((dst, teid), table_id);
+            .insert((dst, teid, match_vrf), table_id);
         if let Err(e) = async {
             self.client()
                 .await?
@@ -1323,6 +1324,7 @@ impl CradleFib {
                     dst: dst.to_string(),
                     teid,
                     vrf: cradle_vrf(table_id),
+                    match_vrf: cradle_vrf(match_vrf),
                 })
                 .await?;
             anyhow::Ok(())
@@ -1334,14 +1336,19 @@ impl CradleFib {
     }
 
     /// Remove a GTP-U decap PDR.
-    pub async fn gtp_pdr_del(&self, dst: Ipv4Addr, teid: u32) {
-        self.mirror.lock().await.gtp_pdrs.remove(&(dst, teid));
+    pub async fn gtp_pdr_del(&self, dst: Ipv4Addr, teid: u32, match_vrf: u32) {
+        self.mirror
+            .lock()
+            .await
+            .gtp_pdrs
+            .remove(&(dst, teid, match_vrf));
         if let Err(e) = async {
             self.client()
                 .await?
                 .del_gtp_pdr(pb::GtpPdrDel {
                     dst: dst.to_string(),
                     teid,
+                    match_vrf: cradle_vrf(match_vrf),
                 })
                 .await?;
             anyhow::Ok(())

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -697,18 +697,25 @@ impl FibHandle {
     }
 
     /// Install a GTP-U decap PDR (`H.M.GTP4.D`) into the cradle data plane: a
-    /// G-PDU on (`dst`, `teid`) is stripped and its inner packet forwarded in
+    /// G-PDU on (`dst`, `teid`), arriving on a port bound to VRF table
+    /// `match_vrf` (0 = global), is stripped and its inner packet forwarded in
     /// VRF `table_id`. No kernel counterpart — the mainline kernel has no GTP
     /// action, so cradle is the only forwarder for the MUP `dataplane gtp` mode.
-    pub async fn cradle_gtp_pdr_add(&self, dst: std::net::Ipv4Addr, teid: u32, table_id: u32) {
+    pub async fn cradle_gtp_pdr_add(
+        &self,
+        dst: std::net::Ipv4Addr,
+        teid: u32,
+        table_id: u32,
+        match_vrf: u32,
+    ) {
         if let Some(cradle) = &self.cradle {
-            cradle.gtp_pdr_add(dst, teid, table_id).await;
+            cradle.gtp_pdr_add(dst, teid, table_id, match_vrf).await;
         }
     }
 
-    pub async fn cradle_gtp_pdr_del(&self, dst: std::net::Ipv4Addr, teid: u32) {
+    pub async fn cradle_gtp_pdr_del(&self, dst: std::net::Ipv4Addr, teid: u32, match_vrf: u32) {
         if let Some(cradle) = &self.cradle {
-            cradle.gtp_pdr_del(dst, teid).await;
+            cradle.gtp_pdr_del(dst, teid, match_vrf).await;
         }
     }
     #[allow(clippy::too_many_arguments)]

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -410,16 +410,19 @@ pub enum Message {
         pe: IpAddr,
     },
     /// MUP `dataplane gtp` uplink decap (`H.M.GTP4.D`): a GTP-U decap PDR teed
-    /// to cradle — a G-PDU on (`dst`, `teid`) is stripped and its inner packet
+    /// to cradle — a G-PDU on (`dst`, `teid`), arriving on a port bound to VRF
+    /// table `match_vrf` (0 = global), is stripped and its inner packet
     /// forwarded in VRF `table_id`. Cradle-only (the kernel has no GTP action).
     CradleGtpPdrAdd {
         dst: std::net::Ipv4Addr,
         teid: u32,
         table_id: u32,
+        match_vrf: u32,
     },
     CradleGtpPdrDel {
         dst: std::net::Ipv4Addr,
         teid: u32,
+        match_vrf: u32,
     },
     /// EVPN VPWS (RFC 8214): bind attachment circuit `ifname` to the
     /// remote PE's service endpoint — teed to cradle as an XCONNECT entry
@@ -3770,13 +3773,20 @@ impl Rib {
                 dst,
                 teid,
                 table_id,
+                match_vrf,
             } => {
                 self.fib_handle
-                    .cradle_gtp_pdr_add(dst, teid, table_id)
+                    .cradle_gtp_pdr_add(dst, teid, table_id, match_vrf)
                     .await;
             }
-            Message::CradleGtpPdrDel { dst, teid } => {
-                self.fib_handle.cradle_gtp_pdr_del(dst, teid).await;
+            Message::CradleGtpPdrDel {
+                dst,
+                teid,
+                match_vrf,
+            } => {
+                self.fib_handle
+                    .cradle_gtp_pdr_del(dst, teid, match_vrf)
+                    .await;
             }
             Message::XconnectAdd {
                 ifname,


### PR DESCRIPTION
## Summary

cradle's GTP-U decap PDR is now keyed by a match context — the VRF the ingress port is bound to — alongside (outer dst, TEID). Mirror the proto (`GtpPdr.match_vrf = 4`, `GtpPdrDel.match_vrf = 3`; proto3 default 0 = global keeps either side compatible with an older peer) and pass the field through `Message::CradleGtpPdrAdd/Del`, the fib handle, and the cradle client (reconnect-replay mirror re-keyed `(dst, teid, match_vrf)`).

The MUP `dataplane gtp` uplink reconciler sends `match_vrf 0` — behavior-preserving; deriving it from the interwork segment is stage 3 of `docs/design/bgp-mup-gtp-segment-resolution-plan.md`.

## Test plan

- Validated live against the new cradle: `cradle_mup_gtp_single_n6` and `cradle_mup_gtp_zebra` green with this zebra, and also green with a pre-change zebra (match_vrf absent = 0) — both sides of the proto skew covered.
- `cargo fmt --check`, workspace clippy `-D warnings`, full workspace tests.

Generated with [Claude Code](https://claude.com/claude-code)