### PR TITLE
bgp: MUP segment catalog drives GTP uplink match context and decap target

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -367,6 +367,48 @@ pub(crate) fn mup_dispatch_targets(
     targets
 }
 
+/// Build the config-derived MUP segment catalog: one entry per VRF whose
+/// `afi-safi mup segment` declares it an interwork or direct segment AND
+/// whose kernel table is known (`rib_known_vrfs` — the table id is what the
+/// `dataplane gtp` reconcilers scope matches and decap targets by, so an
+/// entry without one is unusable; it appears when `VrfAdd` lands). A
+/// `segment direct` without `mup-ext-comm` is skipped — nothing can
+/// correlate to it. Pure so the catalog rules are unit-testable without a
+/// `Bgp` (the [`mup_dispatch_targets`] pattern).
+pub(crate) fn mup_segment_catalog_from(
+    vrfs: &BTreeMap<String, super::vrf_config::BgpVrfConfig>,
+    known: &BTreeMap<String, RibKnownVrf>,
+) -> super::vrf_config::MupSegmentCatalog {
+    use super::vrf_config::{MupDirectEntry, MupInterworkEntry, MupSegmentMode};
+    let mut catalog = super::vrf_config::MupSegmentCatalog::default();
+    for (name, cfg) in vrfs {
+        let Some(mode) = cfg.mobile_uplane.segment else {
+            continue;
+        };
+        let Some(kernel) = known.get(name) else {
+            continue;
+        };
+        match mode {
+            MupSegmentMode::Interwork => catalog.interwork.push(MupInterworkEntry {
+                vrf: name.clone(),
+                table_id: kernel.table_id,
+                prefix: cfg.mobile_uplane.interwork_prefix,
+            }),
+            MupSegmentMode::Direct => {
+                let Some(id) = cfg.mobile_uplane.mup_ext_comm else {
+                    continue;
+                };
+                catalog.direct.push(MupDirectEntry {
+                    vrf: name.clone(),
+                    table_id: kernel.table_id,
+                    segment_id: id.val,
+                });
+            }
+        }
+    }
+    catalog
+}
+
 /// Extract the route-target set a route carries: every extended
 /// community with RT sub-type (`low_type == 0x02`), reinterpreted as a
 /// `RouteDistinguisher` (RT and RD share the on-wire 6-octet shape).
@@ -809,6 +851,11 @@ pub struct Bgp {
     /// route while an unrelated commit doesn't churn a re-advertise. A VRF has
     /// at most one segment (its `segment` is direct XOR interwork).
     pub mup_segment_desired: BTreeMap<String, super::route::MupSegmentKey>,
+    /// Last MUP segment catalog pushed to the per-VRF tasks
+    /// ([`mup_segment_catalog_from`]) — the diff base for
+    /// [`Self::push_mup_segment_catalog`], and the seed a freshly spawned
+    /// task receives ([`Self::seed_mup_segment_catalog`]).
+    pub mup_segment_catalog: super::vrf_config::MupSegmentCatalog,
     /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
     /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
     /// durable state (not just one-shot event handling) because the
@@ -1321,6 +1368,7 @@ impl Bgp {
             mup_c_view: crate::mup_c::inst::MupCView::default(),
             mup_c_dirty: false,
             mup_segment_desired: BTreeMap::new(),
+            mup_segment_catalog: Default::default(),
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             l2_port_evis: BTreeMap::new(),
@@ -1994,6 +2042,7 @@ impl Bgp {
             self.policy_tx.clone(),
             self.bfd_client_tx.clone(),
         );
+        self.seed_mup_segment_catalog(&new_handle);
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
         // Re-seed the respawned VRF with the colour-steering snapshot.
@@ -2774,6 +2823,7 @@ impl Bgp {
                 self.policy_tx.clone(),
                 self.bfd_client_tx.clone(),
             );
+            self.seed_mup_segment_catalog(&handle);
             self.register_vrf_show(&name, &handle);
             self.vrf_registry.insert(name, handle);
         }
@@ -3214,6 +3264,7 @@ impl Bgp {
             self.policy_tx.clone(),
             self.bfd_client_tx.clone(),
         );
+        self.seed_mup_segment_catalog(&new_handle);
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
         bgp_vrf_trace!(
@@ -4110,6 +4161,40 @@ impl Bgp {
         }
     }
 
+    /// Rebuild the config-derived MUP segment catalog and, when it changed,
+    /// push it to every per-VRF task (`tracing`-style broadcast, diff-gated
+    /// against the last pushed copy). Hooked at the top of
+    /// `reconcile_mup_segment`, which already runs at every site where
+    /// segment config or kernel table ids move (commit diff, `VrfAdd` via
+    /// the kernel-ctx respawn, `VrfDel`, MUP RT changes, router-id).
+    pub(super) fn push_mup_segment_catalog(&mut self) {
+        let catalog = mup_segment_catalog_from(&self.vrfs, &self.rib_known_vrfs);
+        if catalog == self.mup_segment_catalog {
+            return;
+        }
+        for handle in self.vrf_registry.values() {
+            let _ = handle
+                .inbox
+                .send(super::vrf::msg::BgpVrfMsg::MupSegmentCatalog(
+                    catalog.clone(),
+                ));
+        }
+        self.mup_segment_catalog = catalog;
+    }
+
+    /// Seed one freshly spawned per-VRF task with the current catalog. The
+    /// broadcast above only fires on *change*, and a (re)spawned task must
+    /// still learn the standing entries of the other segments (its own
+    /// default is empty). The colour-steering re-seed after each spawn is
+    /// the precedent.
+    fn seed_mup_segment_catalog(&self, handle: &super::vrf::BgpVrfHandle) {
+        let _ = handle
+            .inbox
+            .send(super::vrf::msg::BgpVrfMsg::MupSegmentCatalog(
+                self.mup_segment_catalog.clone(),
+            ));
+    }
+
     pub fn process_rib_msg(&mut self, msg: RibRx) {
         // println!("RIB Message {:?}", msg);
         match msg {
@@ -4785,6 +4870,7 @@ impl Bgp {
             self.policy_tx.clone(),
             self.bfd_client_tx.clone(),
         );
+        self.seed_mup_segment_catalog(&new_handle);
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
         bgp_label_trace!(self.tracing, vrf = %name, label, "bgp: assigned dynamic label to VRF");
@@ -7231,6 +7317,82 @@ mod tests {
             assert_eq!(
                 mup_dispatch_targets(&index, &ecom, None),
                 vec!["N3".to_string()]
+            );
+        }
+
+        #[test]
+        fn mup_segment_catalog_requires_kernel_table_and_correlatable_id() {
+            use crate::bgp::inst::mup_segment_catalog_from;
+            use crate::bgp::vrf_config::{BgpVrfConfig, BgpVrfMobileUplane, MupSegmentMode};
+            fn vrf_cfg(mobile_uplane: BgpVrfMobileUplane) -> BgpVrfConfig {
+                BgpVrfConfig {
+                    mobile_uplane,
+                    ..Default::default()
+                }
+            }
+            fn known(table_id: u32) -> RibKnownVrf {
+                RibKnownVrf {
+                    table_id,
+                    ..Default::default()
+                }
+            }
+            let mut vrfs = BTreeMap::new();
+            vrfs.insert(
+                "N3".to_string(),
+                vrf_cfg(BgpVrfMobileUplane {
+                    segment: Some(MupSegmentMode::Interwork),
+                    interwork_prefix: Some("10.0.1.0/24".parse().unwrap()),
+                    ..Default::default()
+                }),
+            );
+            vrfs.insert(
+                "N6".to_string(),
+                vrf_cfg(BgpVrfMobileUplane {
+                    segment: Some(MupSegmentMode::Direct),
+                    mup_ext_comm: Some("1:6".parse().unwrap()),
+                    ..Default::default()
+                }),
+            );
+            // Direct without a Direct-segment id: uncorrelatable → skipped.
+            vrfs.insert(
+                "N7".to_string(),
+                vrf_cfg(BgpVrfMobileUplane {
+                    segment: Some(MupSegmentMode::Direct),
+                    ..Default::default()
+                }),
+            );
+            // Interwork whose kernel table hasn't arrived: skipped until
+            // `VrfAdd` lands and the catalog is rebuilt.
+            vrfs.insert(
+                "N8".to_string(),
+                vrf_cfg(BgpVrfMobileUplane {
+                    segment: Some(MupSegmentMode::Interwork),
+                    ..Default::default()
+                }),
+            );
+            // No segment declared at all.
+            vrfs.insert("N9".to_string(), BgpVrfConfig::default());
+
+            let mut kn = BTreeMap::new();
+            kn.insert("N3".to_string(), known(7));
+            kn.insert("N6".to_string(), known(9));
+            kn.insert("N7".to_string(), known(11));
+            kn.insert("N9".to_string(), known(13));
+
+            let cat = mup_segment_catalog_from(&vrfs, &kn);
+            assert!(cat.is_interwork("N3"));
+            assert!(
+                !cat.is_interwork("N8"),
+                "no kernel table yet → not cataloged"
+            );
+            assert!(!cat.is_interwork("N6"), "a direct segment is not interwork");
+            let seg: bgp_packet::RouteDistinguisher = "1:6".parse().unwrap();
+            assert_eq!(cat.direct_table(&seg.val), Some(9));
+            assert_eq!(cat.direct.len(), 1, "the id-less direct segment is skipped");
+            assert_eq!(cat.interwork.len(), 1);
+            assert_eq!(
+                cat.interwork[0].prefix,
+                Some("10.0.1.0/24".parse().unwrap())
             );
         }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14594,6 +14594,10 @@ impl Bgp {
     /// VRF for that change detection. A VRF has at most one segment route (its
     /// `segment` is direct XOR interwork).
     pub(super) fn reconcile_mup_segment(&mut self) {
+        // Segment config or kernel table ids may have moved — refresh the
+        // per-VRF tasks' config-derived segment catalog first (diff-gated;
+        // this fn is already invoked from every such site).
+        self.push_mup_segment_catalog();
         let names: Vec<String> = self.vrfs.keys().cloned().collect();
         let mut desired: std::collections::BTreeMap<String, MupSegmentDesired> =
             std::collections::BTreeMap::new();

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -295,9 +295,19 @@ pub struct BgpVrf {
     /// `reconcile_mup_st2_dsd`, mirroring `mup_st1_isd_installed`.
     pub mup_st2_dsd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
     /// Installed GTP-U decap PDRs for `dataplane gtp` (the ST2 uplink /
-    /// `H.M.GTP4.D`): the set of (endpoint, TEID) tunnels teed to cradle. Diff
-    /// base for `reconcile_mup_gtp`.
-    pub mup_gtp_pdr_installed: std::collections::BTreeSet<(std::net::Ipv4Addr, u32)>,
+    /// `H.M.GTP4.D`), teed to cradle: `(match VRF, endpoint, TEID)` → the
+    /// inner-lookup table. Diff base for `reconcile_mup_gtp` — a vanished
+    /// key withdraws; a changed inner table re-installs in place (the
+    /// cradle map insert overwrites).
+    pub mup_gtp_pdr_installed: std::collections::BTreeMap<(u32, std::net::Ipv4Addr, u32), u32>,
+    /// Config-derived MUP segment catalog (which VRFs are interwork /
+    /// direct segments, with their kernel tables). Seeded by the global
+    /// task right after spawn and refreshed via
+    /// `BgpVrfMsg::MupSegmentCatalog` (`tracing`-style). Consumed by the
+    /// `dataplane gtp` reconcilers: interwork membership of THIS VRF picks
+    /// the uplink PDR match context, and the Direct-segment id of an ST2's
+    /// MUP Extended Community picks its decap target.
+    pub mup_segment_catalog: super::super::vrf_config::MupSegmentCatalog,
     /// Resolved v4 underlay transport for each selected ST1's GTP endpoint
     /// (gNB), keyed by the ST1's `(rd, prefix)`. Supplied by the global NHT via
     /// `MupUpdate.endpoint_transport` (register-then-gate on `st1.endpoint`) and
@@ -843,7 +853,8 @@ impl BgpVrf {
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
             mup_segment_transport: std::collections::BTreeMap::new(),
             mup_st2_dsd_installed: std::collections::BTreeMap::new(),
-            mup_gtp_pdr_installed: std::collections::BTreeSet::new(),
+            mup_gtp_pdr_installed: std::collections::BTreeMap::new(),
+            mup_segment_catalog: Default::default(),
             mup_endpoint_transport: std::collections::BTreeMap::new(),
             mup_gtp_encap_installed: std::collections::BTreeMap::new(),
         };
@@ -1083,55 +1094,74 @@ impl BgpVrf {
 
     /// Install GTP-U decap PDRs for a `dataplane gtp` VRF — the ST2 uplink
     /// (`H.M.GTP4.D`). Each selected Type-2 ST route's `(endpoint, TEID)`
-    /// becomes a cradle PDR: a G-PDU arriving on that tunnel is stripped and
-    /// its inner packet forwarded in this VRF's table. Cradle-only (the kernel
-    /// has no GTP action), diff-gated against `mup_gtp_pdr_installed`.
+    /// becomes a cradle PDR, resolved against the segment catalog
+    /// (docs/design/bgp-mup-gtp-segment-resolution-plan.md §3.2/§3.3):
+    ///
+    ///   * **match context** — when THIS VRF is a `segment interwork`, the
+    ///     PDR is scoped to its own table (GTP-U terminates on its ports);
+    ///     otherwise VRF 0 (N3 in the global table — the single-N6 shape).
+    ///   * **decap target** — the direct segment whose Direct-segment id
+    ///     matches the ST2's MUP Extended Community (the DSD correlation,
+    ///     draft §3.3.12), else this VRF's own table.
+    ///
+    /// Cradle-only (the kernel has no GTP action), diff-gated against
+    /// `mup_gtp_pdr_installed`.
     fn reconcile_mup_gtp_uplink(&mut self) {
         use std::net::{IpAddr, Ipv4Addr};
-        let table_id = self.ctx.vrf_id();
-        // Desired PDRs: each selected ST2 with a v4 endpoint + non-zero TEID.
-        let mut desired: std::collections::BTreeSet<(Ipv4Addr, u32)> =
-            std::collections::BTreeSet::new();
+        let own_table = self.ctx.vrf_id();
+        let match_vrf = if self.mup_segment_catalog.is_interwork(&self.name) {
+            own_table
+        } else {
+            0
+        };
+        // Desired PDRs: each selected ST2 with a v4 endpoint + non-zero TEID,
+        // mapped to its resolved inner-lookup table.
+        let mut desired: std::collections::BTreeMap<(u32, Ipv4Addr, u32), u32> =
+            std::collections::BTreeMap::new();
         for table in self.local_rib.mup.values() {
-            for prefix in table.selected.keys() {
+            for (prefix, rib) in table.selected.iter() {
                 if let bgp_packet::MupPrefix::T2st { endpoint, teid } = prefix
                     && let IpAddr::V4(v4) = endpoint
                     && *teid != 0
                 {
-                    desired.insert((*v4, *teid));
+                    let inner = mup_direct_segment_id(&rib.attr)
+                        .and_then(|seg| self.mup_segment_catalog.direct_table(&seg))
+                        .unwrap_or(own_table);
+                    desired.insert((match_vrf, *v4, *teid), inner);
                 }
             }
         }
-        // Withdraw PDRs no longer desired.
-        let stale: Vec<(Ipv4Addr, u32)> = self
+        // Withdraw PDRs whose key is no longer desired (a catalog change
+        // re-keys the match context, so the old-context entry must go). An
+        // inner-table change alone re-installs in place below — the cradle
+        // map insert overwrites.
+        let stale: Vec<(u32, Ipv4Addr, u32)> = self
             .mup_gtp_pdr_installed
-            .iter()
-            .filter(|k| !desired.contains(k))
+            .keys()
+            .filter(|k| !desired.contains_key(*k))
             .copied()
             .collect();
-        for (dst, teid) in stale {
+        for (mv, dst, teid) in stale {
             let _ = self.ctx.rib.send(crate::rib::Message::CradleGtpPdrDel {
                 dst,
                 teid,
-                match_vrf: 0,
+                match_vrf: mv,
             });
-            self.mup_gtp_pdr_installed.remove(&(dst, teid));
+            self.mup_gtp_pdr_installed.remove(&(mv, dst, teid));
         }
-        // Install new PDRs. The match context is the global table for now —
-        // GTP-U terminates on ports in VRF 0, today's only supported
-        // placement; the interwork-segment resolution
-        // (docs/design/bgp-mup-gtp-segment-resolution-plan.md stage 3) will
-        // derive it from the segment catalog instead.
-        for (dst, teid) in &desired {
-            if !self.mup_gtp_pdr_installed.insert((*dst, *teid)) {
+        // Install new / retargeted PDRs.
+        for ((mv, dst, teid), inner) in &desired {
+            if self.mup_gtp_pdr_installed.get(&(*mv, *dst, *teid)) == Some(inner) {
                 continue;
             }
             let _ = self.ctx.rib.send(crate::rib::Message::CradleGtpPdrAdd {
                 dst: *dst,
                 teid: *teid,
-                table_id,
-                match_vrf: 0,
+                table_id: *inner,
+                match_vrf: *mv,
             });
+            self.mup_gtp_pdr_installed
+                .insert((*mv, *dst, *teid), *inner);
         }
     }
 
@@ -3502,6 +3532,18 @@ impl BgpVrf {
                 // logging switch — nothing to re-run.
                 self.tracing = tracing;
             }
+            BgpVrfMsg::MupSegmentCatalog(catalog) => {
+                // The interwork/direct segment associations moved (or this
+                // is the post-spawn seed). Re-derive the GTP datapath —
+                // match contexts and decap targets both come from the
+                // catalog. Diff-gated locally: the seed is unconditional.
+                if self.mup_segment_catalog != catalog {
+                    self.mup_segment_catalog = catalog;
+                    if matches!(self.dataplane, super::super::vrf_config::MupDataplane::Gtp) {
+                        self.reconcile_mup_gtp();
+                    }
+                }
+            }
             BgpVrfMsg::Accept(stream, sockaddr) => {
                 // Passive accept forwarded by the global dispatcher (the
                 // pre-respawn fallback, before this task's own listener
@@ -4475,9 +4517,11 @@ mod tests {
         }
 
         vrf.reconcile_mup_gtp();
-        assert!(
+        assert_eq!(
             vrf.mup_gtp_pdr_installed
-                .contains(&(Ipv4Addr::new(10, 9, 0, 1), 0x1234))
+                .get(&(0, Ipv4Addr::new(10, 9, 0, 1), 0x1234)),
+            Some(&42),
+            "no segment catalog: global match context, own table as decap target"
         );
         assert_eq!(
             vrf.mup_gtp_pdr_installed.len(),
@@ -4492,6 +4536,195 @@ mod tests {
             vrf.mup_gtp_pdr_installed.is_empty(),
             "the decap PDR is withdrawn when its ST2 is gone"
         );
+    }
+
+    /// Build a `BgpAttr` carrying the MUP Direct-segment id `seg` (the
+    /// 0x0c/0x00 extended community an ST2 is stamped with).
+    fn attr_with_segment_id(seg: [u8; 6]) -> bgp_packet::BgpAttr {
+        use bgp_packet::{ExtCommunity, MupExtCom, MupExtComSubType};
+        let mut attr = bgp_packet::BgpAttr::new();
+        let mut ecom = ExtCommunity::default();
+        ecom.0
+            .insert(MupExtCom::new(MupExtComSubType::Sub00, seg).into());
+        attr.ecom = Some(ecom);
+        attr
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_uplink_resolves_match_context_and_decap_target() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::bgp::vrf_config::{MupDirectEntry, MupInterworkEntry, MupSegmentCatalog};
+        use bgp_packet::MupPrefix;
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        // The interwork/N3 VRF: kernel table 7.
+        let ctx = test_ctx_for_vrf(7, "N3");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "N3".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+        let seg: bgp_packet::RouteDistinguisher = "1:6".parse().unwrap();
+        let other: bgp_packet::RouteDistinguisher = "9:9".parse().unwrap();
+        vrf.mup_segment_catalog = MupSegmentCatalog {
+            interwork: vec![MupInterworkEntry {
+                vrf: "N3".to_string(),
+                table_id: 7,
+                prefix: None,
+            }],
+            direct: vec![MupDirectEntry {
+                vrf: "N6".to_string(),
+                table_id: 9,
+                segment_id: seg.val,
+            }],
+        };
+
+        let mk = |attr: &bgp_packet::BgpAttr| {
+            BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                attr,
+                None,
+                None,
+                false,
+            )
+        };
+        let rd: bgp_packet::RouteDistinguisher = "65000:3".parse().unwrap();
+        {
+            let table = vrf.local_rib.mup.entry(rd).or_default();
+            // Direct-segment id matches the cataloged N6 segment → the
+            // decap target is N6's table.
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2)),
+                    teid: 0x100,
+                },
+                mk(&attr_with_segment_id(seg.val)),
+            );
+            // A Direct-segment id no direct segment carries → own table.
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 12, 3)),
+                    teid: 0x200,
+                },
+                mk(&attr_with_segment_id(other.val)),
+            );
+            // No MUP Extended Community at all → own table.
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 12, 4)),
+                    teid: 0x300,
+                },
+                mk(&bgp_packet::BgpAttr::new()),
+            );
+        }
+
+        vrf.reconcile_mup_gtp();
+        // All three PDRs are scoped to the interwork VRF's own table.
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed
+                .get(&(7, Ipv4Addr::new(10, 0, 12, 2), 0x100)),
+            Some(&9),
+            "matching Direct-segment id decaps into the direct segment's table"
+        );
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed
+                .get(&(7, Ipv4Addr::new(10, 0, 12, 3), 0x200)),
+            Some(&7),
+            "an uncataloged Direct-segment id falls back to the holding VRF"
+        );
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed
+                .get(&(7, Ipv4Addr::new(10, 0, 12, 4), 0x300)),
+            Some(&7),
+            "no MUP Extended Community falls back to the holding VRF"
+        );
+        assert_eq!(vrf.mup_gtp_pdr_installed.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_uplink_catalog_change_rekeys_match_context() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::bgp::vrf_config::{MupInterworkEntry, MupSegmentCatalog};
+        use bgp_packet::{BgpAttr, MupPrefix};
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(7, "N3");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "N3".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+
+        let attr = BgpAttr::new();
+        let rd: bgp_packet::RouteDistinguisher = "65000:3".parse().unwrap();
+        vrf.local_rib.mup.entry(rd).or_default().selected.insert(
+            MupPrefix::T2st {
+                endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2)),
+                teid: 0x100,
+            },
+            BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            ),
+        );
+
+        // No catalog: global match context.
+        vrf.reconcile_mup_gtp();
+        assert!(
+            vrf.mup_gtp_pdr_installed
+                .contains_key(&(0, Ipv4Addr::new(10, 0, 12, 2), 0x100))
+        );
+
+        // The VRF becomes an interwork segment: the PDR re-keys onto its
+        // own table — the old global-context entry is withdrawn, not
+        // leaked (a stale (0, dst, teid) would keep matching global-port
+        // arrivals after the operator scoped the segment).
+        vrf.mup_segment_catalog = MupSegmentCatalog {
+            interwork: vec![MupInterworkEntry {
+                vrf: "N3".to_string(),
+                table_id: 7,
+                prefix: None,
+            }],
+            direct: Vec::new(),
+        };
+        vrf.reconcile_mup_gtp();
+        assert!(
+            !vrf.mup_gtp_pdr_installed
+                .contains_key(&(0, Ipv4Addr::new(10, 0, 12, 2), 0x100)),
+            "the global-context PDR is withdrawn on re-scope"
+        );
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed
+                .get(&(7, Ipv4Addr::new(10, 0, 12, 2), 0x100)),
+            Some(&7),
+            "the PDR re-keys onto the interwork VRF's table"
+        );
+        assert_eq!(vrf.mup_gtp_pdr_installed.len(), 1);
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -281,6 +281,15 @@ pub enum BgpVrfMsg {
     /// task never runs a single event with a stale snapshot.
     Tracing(crate::bgp::tracing::BgpTracing),
 
+    /// Refresh the config-derived MUP segment catalog (which VRFs are
+    /// interwork / direct segments, with their kernel tables). The global
+    /// task seeds it right after spawn and re-broadcasts diff-gated
+    /// whenever segment config or table ids change (`Tracing`-style — the
+    /// per-VRF `ConfigChannel` never sees the *other* VRFs' segment
+    /// config). Consumed by the `dataplane gtp` reconcilers for the PDR
+    /// match context and the decap target.
+    MupSegmentCatalog(crate::bgp::vrf_config::MupSegmentCatalog),
+
     /// Tear the VRF task down cleanly. The event loop exits on the
     /// next select iteration after receiving this. Used by
     /// `despawn_bgp_vrf` and during daemon shutdown.

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -211,6 +211,64 @@ impl MupSegmentMode {
     }
 }
 
+/// Config-derived MUP segment catalog: which VRFs are interwork / direct
+/// segments, with their kernel tables — the local materialization of the
+/// ISD/DSD associations the `dataplane gtp` reconcilers resolve against
+/// (docs/design/bgp-mup-gtp-segment-resolution-plan.md §3.1). Built by the
+/// global task from every `BgpVrfConfig.mobile_uplane.segment` plus the
+/// kernel table ids in `rib_known_vrfs` (an entry appears only once its
+/// kernel table is known), pushed to the per-VRF tasks via
+/// `BgpVrfMsg::MupSegmentCatalog` (`tracing`-style: seeded at spawn,
+/// refreshed diff-gated on change). Deliberately config-scoped rather than
+/// RT-import-gated — see the design doc's "one deliberate divergence".
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MupSegmentCatalog {
+    pub interwork: Vec<MupInterworkEntry>,
+    pub direct: Vec<MupDirectEntry>,
+}
+
+impl MupSegmentCatalog {
+    /// Whether `vrf` is declared an interwork segment — its ports terminate
+    /// GTP-U, so the uplink PDR match is scoped to its own table instead of
+    /// the global context.
+    pub fn is_interwork(&self, vrf: &str) -> bool {
+        self.interwork.iter().any(|e| e.vrf == vrf)
+    }
+
+    /// The kernel table of the direct segment carrying Direct-segment id
+    /// `seg` — the decap target for an ST2 stamped with the matching MUP
+    /// Extended Community (the DSD correlation, draft §3.3.12).
+    pub fn direct_table(&self, seg: &[u8; 6]) -> Option<u32> {
+        self.direct
+            .iter()
+            .find(|e| e.segment_id == *seg)
+            .map(|e| e.table_id)
+    }
+}
+
+/// One interwork segment (`segment interwork` on a VRF): a GTP/N3 routing
+/// context. `prefix` is the configured gNB network (`segment interwork
+/// prefix <p>`), absent when only the membership is declared — the ISD does
+/// not originate without it, but the match-context scoping already applies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MupInterworkEntry {
+    pub vrf: String,
+    pub table_id: u32,
+    pub prefix: Option<IpNet>,
+}
+
+/// One direct segment (`segment direct { mup-ext-comm <2:4> }` on a VRF): an
+/// N6 routing context, correlated by its Direct-segment id (the 6-byte MUP
+/// Extended Community value — `RouteDistinguisher::val` maps onto it
+/// directly). A `segment direct` without `mup-ext-comm` is not cataloged:
+/// nothing can correlate to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MupDirectEntry {
+    pub vrf: String,
+    pub table_id: u32,
+    pub segment_id: [u8; 6],
+}
+
 /// MUP forwarding-plane behaviour for a per-VRF service (`afi-safi mup
 /// dataplane {end-dt46|gtp}`). `EndDt46` (default) installs the SRv6 End.DT46
 /// stand-in into the mainline kernel; `Gtp` programs a real GTP-U tunnel from


### PR DESCRIPTION
## Summary

Stage 3 of `docs/design/bgp-mup-gtp-segment-resolution-plan.md`. A config-derived `MupSegmentCatalog` (which VRFs declare `segment interwork` / `segment direct`, their Direct-segment ids, interwork prefixes and kernel tables) is pushed to every per-VRF task tracing-style: seeded right after each spawn and re-broadcast diff-gated from `reconcile_mup_segment` — the chokepoint already invoked from every site where segment config or table ids move.

`reconcile_mup_gtp_uplink` then resolves per the design's rules: the match context is the holding VRF's own table when it is a `segment interwork` (else VRF 0 — N3 in the global table, the single-N6 shape), and the decap target is the direct segment whose `mup-ext-comm` equals the ST2's MUP Extended Community (else the holding VRF's table). The install diff base widens to (match VRF, endpoint, TEID) → inner table, so a catalog change re-keys the PDR and withdraws the old context instead of leaking it.

With no segment configured the catalog is empty and every emission is byte-identical to before.

## Test plan

- Units: catalog builder gating (kernel-table required, id-less direct skipped), uplink resolution (id hit / miss / no-EC), re-key on catalog change.
- Live: `cradle_mup_gtp_single_n6` and `cradle_mup_gtp_zebra` green against the stage-2 cradle; `bgp_mup_{segment_dsd,isd,interwork,dual_st,e2e}` green on the staged toolchain.
- `cargo fmt --check`, workspace clippy `-D warnings`, full workspace tests.

Generated with [Claude Code](https://claude.com/claude-code)