### PR TITLE
bgp+rib: resolve the MUP ST1 endpoint in its interwork segment's table

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4180,6 +4180,51 @@ impl Bgp {
                 ));
         }
         self.mup_segment_catalog = catalog;
+        // Mirror the interwork view into the NHT cache — it picks the table
+        // a MUP ST1 endpoint (gNB) registers and resolves in — then migrate
+        // any live endpoint registration the change re-homed, so track and
+        // untrack always agree on the table.
+        let interwork: Vec<(ipnet::IpNet, u32)> = self
+            .mup_segment_catalog
+            .interwork
+            .iter()
+            .filter_map(|e| e.prefix.map(|p| (p, e.table_id)))
+            .collect();
+        self.nexthop_cache.set_mup_interwork(interwork);
+        self.remap_mup_endpoint_registrations();
+    }
+
+    /// Move every `MupEndpoint` registration whose table no longer matches
+    /// the interwork view onto the right one: untrack (and unregister when
+    /// last) under the old table, track (and register when first) under the
+    /// new. A fresh registration's sync-first `NexthopUpdate` reply drives
+    /// the downlink re-dispatch; when the new entry was already live no
+    /// update fires, so the ST1 is re-dispatched here with the entry's
+    /// current resolution.
+    fn remap_mup_endpoint_registrations(&mut self) {
+        for (old_vrf, new_vrf, nh, deps) in self.nexthop_cache.mup_endpoint_moves() {
+            for dep in deps {
+                if self.nexthop_cache.untrack(old_vrf, nh, &dep) {
+                    let _ = self.ctx.rib.send(crate::rib::Message::NexthopUnregister {
+                        proto: "bgp".to_string(),
+                        nh,
+                        vrf_id: old_vrf,
+                    });
+                }
+                let (needs_register, _reachable) =
+                    self.nexthop_cache.track(new_vrf, nh, dep.clone());
+                if needs_register {
+                    let _ = self.ctx.rib.send(crate::rib::Message::NexthopRegister {
+                        proto: "bgp".to_string(),
+                        nh,
+                        vrf_id: new_vrf,
+                    });
+                } else if let super::nht::NhtDep::MupEndpoint(rd, prefix) = dep {
+                    let reachable = !self.nexthop_cache.transport_for(new_vrf, nh).is_empty();
+                    self.mup_redispatch_endpoint(new_vrf, nh, rd, prefix, reachable);
+                }
+            }
+        }
     }
 
     /// Seed one freshly spawned per-VRF task with the current catalog. The
@@ -4563,8 +4608,12 @@ impl Bgp {
                 self.flex_algo_srv6_routes.remove(algo, prefix);
                 self.broadcast_colour_steering();
             }
-            RibRx::NexthopUpdate { nh, resolution } => {
-                self.nht_handle_update(nh, &resolution);
+            RibRx::NexthopUpdate {
+                vrf_id,
+                nh,
+                resolution,
+            } => {
+                self.nht_handle_update(vrf_id, nh, &resolution);
             }
             RibRx::LabelBlock { start, size } => {
                 self.label_block_arrived(start, size);
@@ -4878,15 +4927,17 @@ impl Bgp {
 
     /// Apply a NHT resolution change: refresh the cached resolution
     /// (reachability + resolved transport) and re-evaluate every
-    /// dependent prefix.
+    /// dependent prefix. `vrf_id` is the table the registration named
+    /// (0 = global — every dep type except the MUP ST1 endpoint).
     fn nht_handle_update(
         &mut self,
+        vrf_id: u32,
         nh: std::net::IpAddr,
         resolution: &crate::rib::nht::NexthopResolution,
     ) {
         use super::nht::CacheChange;
         let reachable = resolution.reachable;
-        match self.nexthop_cache.update(nh, resolution) {
+        match self.nexthop_cache.update(vrf_id, nh, resolution) {
             CacheChange::Unchanged => {}
             // Gate flipped → full re-eval: best-path, advertise, install.
             CacheChange::Reachability(deps) => {
@@ -4925,7 +4976,7 @@ impl Bgp {
                     inline.extend(deps);
                 }
                 for dep in inline {
-                    self.nht_reeval_dep(nh, reachable, dep);
+                    self.nht_reeval_dep(vrf_id, nh, reachable, dep);
                 }
             }
             // PE still reachable but its transport rerouted → only the
@@ -4933,7 +4984,7 @@ impl Bgp {
             // without re-advertising (best-path is unchanged).
             CacheChange::Transport(deps) => {
                 for dep in deps {
-                    self.nht_reinstall_transport(nh, dep);
+                    self.nht_reinstall_transport(vrf_id, nh, dep);
                 }
             }
         }
@@ -4949,7 +5000,12 @@ impl Bgp {
     /// be re-programmed — a plain entry (bare BGP next-hop, RIB
     /// re-resolves recursively) makes the re-install an idempotent
     /// re-send. No re-advertise anywhere here: best-path is unchanged.
-    fn nht_reinstall_transport(&mut self, nh: std::net::IpAddr, dep: super::nht::NhtDep) {
+    fn nht_reinstall_transport(
+        &mut self,
+        vrf_id: u32,
+        nh: std::net::IpAddr,
+        dep: super::nht::NhtDep,
+    ) {
         use super::nht::NhtDep;
         // Unicast arms first — they need a `BgpTop` carrying the NHT
         // cache, which conflicts with the shared `transport` borrow
@@ -4973,7 +5029,7 @@ impl Bgp {
             rib_known_vrfs: &self.rib_known_vrfs,
             vrf_registry: &self.vrf_registry,
         };
-        let transport = self.nexthop_cache.transport_for(nh);
+        let transport = self.nexthop_cache.transport_for(vrf_id, nh);
         match dep {
             NhtDep::V4vpn(rd, p) => {
                 let selected = self.shard.select_best_path_vpn(&rd, p);
@@ -5086,13 +5142,13 @@ impl Bgp {
             // each dependent encap (ST2→DSD / ST1→ISD) re-installs toward the
             // new egress.
             NhtDep::Mup(rd, prefix) => {
-                self.mup_redispatch_segment(nh, rd, prefix, true);
+                self.mup_redispatch_segment(vrf_id, nh, rd, prefix, true);
             }
             // MUP: a received/originated ST1's GTP endpoint (gNB) rerouted →
             // re-dispatch the ST1 with the fresh endpoint transport so the
             // `dataplane gtp` downlink encap re-installs toward the new egress.
             NhtDep::MupEndpoint(rd, prefix) => {
-                self.mup_redispatch_endpoint(nh, rd, prefix, true);
+                self.mup_redispatch_endpoint(vrf_id, nh, rd, prefix, true);
             }
             // Handled by the early match above.
             NhtDep::V4(_) | NhtDep::V6(_) => {}
@@ -5138,6 +5194,7 @@ impl Bgp {
     /// already borrows `local_rib` there.
     fn mup_redispatch_segment(
         &mut self,
+        vrf_id: u32,
         nh: std::net::IpAddr,
         rd: bgp_packet::RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,
@@ -5148,7 +5205,7 @@ impl Bgp {
             return;
         };
         let transport = if reachable {
-            self.nexthop_cache.transport_for(nh).to_vec()
+            self.nexthop_cache.transport_for(vrf_id, nh).to_vec()
         } else {
             Vec::new()
         };
@@ -5177,6 +5234,7 @@ impl Bgp {
     /// stays empty for an ST1).
     fn mup_redispatch_endpoint(
         &mut self,
+        vrf_id: u32,
         nh: std::net::IpAddr,
         rd: bgp_packet::RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,
@@ -5200,7 +5258,7 @@ impl Bgp {
             None
         };
         let endpoint_transport = if reachable {
-            self.nexthop_cache.transport_for(nh).to_vec()
+            self.nexthop_cache.transport_for(vrf_id, nh).to_vec()
         } else {
             Vec::new()
         };
@@ -5226,7 +5284,13 @@ impl Bgp {
     /// import with the resolved transport — register-then-gate means an
     /// imported route only becomes best-path here, so this is where the
     /// VRF dataplane install is triggered.
-    fn nht_reeval_dep(&mut self, nh: std::net::IpAddr, reachable: bool, dep: super::nht::NhtDep) {
+    fn nht_reeval_dep(
+        &mut self,
+        vrf_id: u32,
+        nh: std::net::IpAddr,
+        reachable: bool,
+        dep: super::nht::NhtDep,
+    ) {
         use super::nht::NhtDep;
         // Refresh gate flags + re-select (mutates `local_rib`). At N>1 the
         // v4-unicast deps are batched per shard by the caller
@@ -5372,7 +5436,7 @@ impl Bgp {
                     let transport = top
                         .nexthop_cache
                         .as_deref()
-                        .map_or(&[][..], |c| c.transport_for(nh));
+                        .map_or(&[][..], |c| c.transport_for(vrf_id, nh));
                     super::vrf::dispatch_import_v4(
                         &dispatcher,
                         *rd,
@@ -5416,7 +5480,7 @@ impl Bgp {
                     let transport = top
                         .nexthop_cache
                         .as_deref()
-                        .map_or(&[][..], |c| c.transport_for(nh));
+                        .map_or(&[][..], |c| c.transport_for(vrf_id, nh));
                     super::vrf::dispatch_import_v6(
                         &dispatcher,
                         *rd,
@@ -5456,7 +5520,7 @@ impl Bgp {
                     let transport = top
                         .nexthop_cache
                         .as_deref()
-                        .map_or(&[][..], |c| c.transport_for(nh));
+                        .map_or(&[][..], |c| c.transport_for(vrf_id, nh));
                     match net {
                         ipnet::IpNet::V4(p) => {
                             if reachable {
@@ -5532,7 +5596,7 @@ impl Bgp {
                     let transport = if reachable {
                         top.nexthop_cache
                             .as_deref()
-                            .map_or(Vec::new(), |c| c.transport_for(nh).to_vec())
+                            .map_or(Vec::new(), |c| c.transport_for(vrf_id, nh).to_vec())
                     } else {
                         Vec::new()
                     };
@@ -5573,7 +5637,7 @@ impl Bgp {
                     let endpoint_transport = if reachable {
                         top.nexthop_cache
                             .as_deref()
-                            .map_or(Vec::new(), |c| c.transport_for(nh).to_vec())
+                            .map_or(Vec::new(), |c| c.transport_for(vrf_id, nh).to_vec())
                     } else {
                         Vec::new()
                     };

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -88,21 +88,33 @@ pub struct NhtCacheEntry {
     pub deps: BTreeSet<NhtDep>,
 }
 
-/// Per-instance BGP next-hop cache.
+/// Per-instance BGP next-hop cache. Entries are keyed `(vrf_id, address)`
+/// — the table the RIB registration named (0 = global) — because the same
+/// address may be tracked in several tables with independent resolutions
+/// (a gNB inside an interwork VRF, overlapping slice address spaces).
+/// Every pre-existing user tracks in the global table and passes `0`; only
+/// the MUP ST1 endpoint path resolves a table (`mup_endpoint_table`).
 #[derive(Debug, Default)]
 pub struct NexthopCache {
-    pub entries: HashMap<IpAddr, NhtCacheEntry>,
+    pub entries: HashMap<(u32, IpAddr), NhtCacheEntry>,
+    /// Interwork-segment prefixes → kernel table, mirrored from the MUP
+    /// segment catalog by `Bgp::push_mup_segment_catalog`. Consulted by
+    /// [`Self::mup_endpoint_table`] to pick the registration table for
+    /// `NhtDep::MupEndpoint` deps — kept on the cache itself so the
+    /// track/untrack helpers resolve it without threading the catalog
+    /// through every `BgpTop`.
+    mup_interwork: Vec<(ipnet::IpNet, u32)>,
 }
 
 impl NexthopCache {
-    /// Record that `dep` uses `nh`. Returns `(needs_register,
-    /// reachable_now)`: `needs_register` is true on the first sighting
-    /// of `nh` (the caller registers it with the RIB), and
-    /// `reachable_now` is the current cached reachability (`false`
-    /// while a fresh registration is pending — register-then-gate).
-    pub fn track(&mut self, nh: IpAddr, dep: NhtDep) -> (bool, bool) {
+    /// Record that `dep` uses `nh` in table `vrf_id`. Returns
+    /// `(needs_register, reachable_now)`: `needs_register` is true on the
+    /// first sighting of `(vrf_id, nh)` (the caller registers it with the
+    /// RIB), and `reachable_now` is the current cached reachability
+    /// (`false` while a fresh registration is pending — register-then-gate).
+    pub fn track(&mut self, vrf_id: u32, nh: IpAddr, dep: NhtDep) -> (bool, bool) {
         use std::collections::hash_map::Entry;
-        match self.entries.entry(nh) {
+        match self.entries.entry((vrf_id, nh)) {
             Entry::Occupied(mut e) => {
                 e.get_mut().deps.insert(dep);
                 (false, e.get().reachable)
@@ -131,8 +143,13 @@ impl NexthopCache {
     ///   re-installing — no peer re-advertisement (which for VPNv4 isn't
     ///   deduped and would flood PEs).
     /// - [`CacheChange::Unchanged`] — nothing moved; a no-op.
-    pub fn update(&mut self, nh: IpAddr, resolution: &NexthopResolution) -> CacheChange {
-        match self.entries.get_mut(&nh) {
+    pub fn update(
+        &mut self,
+        vrf_id: u32,
+        nh: IpAddr,
+        resolution: &NexthopResolution,
+    ) -> CacheChange {
+        match self.entries.get_mut(&(vrf_id, nh)) {
             Some(e) => {
                 let reachability_flipped = e.reachable != resolution.reachable;
                 let transport_changed = e.nexthops != resolution.nexthops;
@@ -156,25 +173,70 @@ impl NexthopCache {
     /// its watcher. Callers must only untrack a next-hop no surviving
     /// route still uses (a `NhtDep` can be tracked under several
     /// next-hops via multiple paths). A no-op for an untracked `nh`.
-    pub fn untrack(&mut self, nh: IpAddr, dep: &NhtDep) -> bool {
-        if let Some(e) = self.entries.get_mut(&nh) {
+    pub fn untrack(&mut self, vrf_id: u32, nh: IpAddr, dep: &NhtDep) -> bool {
+        if let Some(e) = self.entries.get_mut(&(vrf_id, nh)) {
             e.deps.remove(dep);
             if e.deps.is_empty() {
-                self.entries.remove(&nh);
+                self.entries.remove(&(vrf_id, nh));
                 return true;
             }
         }
         false
     }
 
-    /// The resolved transport egress(es) for `nh` — what the VPN
-    /// dataplane install pushes the service label over. Empty slice
-    /// when `nh` isn't tracked or hasn't resolved yet.
-    pub fn transport_for(&self, nh: IpAddr) -> &[ResolvedNexthop] {
+    /// The resolved transport egress(es) for `nh` in table `vrf_id` — what
+    /// the VPN dataplane install pushes the service label over. Empty slice
+    /// when the entry isn't tracked or hasn't resolved yet.
+    pub fn transport_for(&self, vrf_id: u32, nh: IpAddr) -> &[ResolvedNexthop] {
         self.entries
-            .get(&nh)
+            .get(&(vrf_id, nh))
             .map(|e| e.nexthops.as_slice())
             .unwrap_or(&[])
+    }
+
+    /// Replace the interwork-prefix view ([`Self::mup_endpoint_table`]'s
+    /// input). Called by `Bgp::push_mup_segment_catalog` whenever the MUP
+    /// segment catalog changes.
+    pub fn set_mup_interwork(&mut self, interwork: Vec<(ipnet::IpNet, u32)>) {
+        self.mup_interwork = interwork;
+    }
+
+    /// The table a MUP ST1 GTP endpoint (gNB) resolves in: the most-specific
+    /// interwork-segment prefix containing it, else the global table — the
+    /// design's downlink rule (endpoint ∈ ISD prefix → that segment's VRF).
+    pub fn mup_endpoint_table(&self, endpoint: &IpAddr) -> u32 {
+        self.mup_interwork
+            .iter()
+            .filter(|(p, _)| p.contains(endpoint))
+            .max_by_key(|(p, _)| p.prefix_len())
+            .map(|(_, table)| *table)
+            .unwrap_or(0)
+    }
+
+    /// `MupEndpoint` registrations whose table no longer matches the
+    /// interwork view — computed after [`Self::set_mup_interwork`] so the
+    /// caller can migrate them (untrack the old key, retrack + register
+    /// under the new one). Each move is `(old_vrf, new_vrf, endpoint,
+    /// the MupEndpoint deps to carry over)`; non-endpoint deps sharing the
+    /// entry stay where they are.
+    pub fn mup_endpoint_moves(&self) -> Vec<(u32, u32, IpAddr, Vec<NhtDep>)> {
+        let mut moves = Vec::new();
+        for ((vrf_id, nh), entry) in &self.entries {
+            let deps: Vec<NhtDep> = entry
+                .deps
+                .iter()
+                .filter(|d| matches!(d, NhtDep::MupEndpoint(..)))
+                .cloned()
+                .collect();
+            if deps.is_empty() {
+                continue;
+            }
+            let want = self.mup_endpoint_table(nh);
+            if want != *vrf_id {
+                moves.push((*vrf_id, want, *nh, deps));
+            }
+        }
+        moves
     }
 }
 
@@ -226,9 +288,76 @@ mod tests {
         let p2: Ipv4Net = "2.0.0.0/24".parse().unwrap();
 
         // First sighting → register, pending-unreachable.
-        assert_eq!(c.track(nh, NhtDep::V4(p1)), (true, false));
+        assert_eq!(c.track(0, nh, NhtDep::V4(p1)), (true, false));
         // Second route, same nexthop → no re-register, still pending.
-        assert_eq!(c.track(nh, NhtDep::V4(p2)), (false, false));
+        assert_eq!(c.track(0, nh, NhtDep::V4(p2)), (false, false));
+    }
+
+    #[test]
+    fn same_address_in_two_tables_is_two_entries() {
+        // The faithful-MUP identity: a gNB address inside an interwork VRF
+        // and the same literal address in the global table are independent
+        // registrations with independent resolutions.
+        let mut c = NexthopCache::default();
+        let nh: IpAddr = "10.0.1.2".parse().unwrap();
+        let p1: Ipv4Net = "1.0.0.0/24".parse().unwrap();
+
+        assert_eq!(c.track(0, nh, NhtDep::V4(p1)), (true, false), "global");
+        assert_eq!(c.track(7, nh, NhtDep::V4(p1)), (true, false), "vrf 7");
+
+        // Resolving the VRF-7 entry leaves the global one untouched.
+        assert_eq!(
+            c.update(7, nh, &reachable(vec![])),
+            CacheChange::Reachability(vec![NhtDep::V4(p1)])
+        );
+        assert!(c.transport_for(0, nh).is_empty());
+        assert!(!c.transport_for(7, nh).is_empty());
+
+        // Untracking one table's last dep unregisters only that table.
+        assert!(c.untrack(0, nh, &NhtDep::V4(p1)));
+        assert!(c.entries.contains_key(&(7, nh)));
+    }
+
+    #[test]
+    fn mup_endpoint_table_picks_most_specific_interwork_prefix() {
+        let mut c = NexthopCache::default();
+        let ep: IpAddr = "10.0.1.2".parse().unwrap();
+        assert_eq!(c.mup_endpoint_table(&ep), 0, "no interwork view → global");
+        c.set_mup_interwork(vec![
+            ("10.0.0.0/8".parse().unwrap(), 5),
+            ("10.0.1.0/24".parse().unwrap(), 7),
+        ]);
+        assert_eq!(c.mup_endpoint_table(&ep), 7, "most-specific wins");
+        let outside: IpAddr = "192.0.2.1".parse().unwrap();
+        assert_eq!(c.mup_endpoint_table(&outside), 0, "uncovered → global");
+    }
+
+    #[test]
+    fn mup_endpoint_moves_reports_only_stale_endpoint_registrations() {
+        let mut c = NexthopCache::default();
+        let ep: IpAddr = "10.0.1.2".parse().unwrap();
+        let rd: RouteDistinguisher = "65000:6".parse().unwrap();
+        let ue: Ipv4Net = "10.60.1.0/24".parse().unwrap();
+        let dep = NhtDep::MupEndpoint(
+            rd,
+            bgp_packet::MupPrefix::T1st {
+                prefix: ipnet::IpNet::V4(ue),
+            },
+        );
+        // Registered under the global table before any interwork existed;
+        // a plain unicast dep shares the address and must NOT move.
+        c.track(0, ep, dep.clone());
+        c.track(0, ep, NhtDep::V4(ue));
+        assert!(c.mup_endpoint_moves().is_empty());
+
+        // The endpoint becomes covered by an interwork segment → exactly
+        // the MupEndpoint dep is reported as a (0 → 7) move.
+        c.set_mup_interwork(vec![("10.0.1.0/24".parse().unwrap(), 7)]);
+        let moves = c.mup_endpoint_moves();
+        assert_eq!(moves.len(), 1);
+        let (old_vrf, new_vrf, nh, deps) = &moves[0];
+        assert_eq!((*old_vrf, *new_vrf, *nh), (0, 7, ep));
+        assert_eq!(deps.as_slice(), &[dep]);
     }
 
     fn reachable(labels: Vec<u32>) -> NexthopResolution {
@@ -250,38 +379,38 @@ mod tests {
         let mut c = NexthopCache::default();
         let nh: IpAddr = "10.0.0.8".parse().unwrap();
         let p1: Ipv4Net = "1.0.0.0/24".parse().unwrap();
-        c.track(nh, NhtDep::V4(p1));
+        c.track(0, nh, NhtDep::V4(p1));
 
         // pending(false) -> reachable(true): reachability flip → full
         // re-eval, and the resolved transport is now retrievable.
         assert_eq!(
-            c.update(nh, &reachable(vec![16800])),
+            c.update(0, nh, &reachable(vec![16800])),
             CacheChange::Reachability(vec![NhtDep::V4(p1)])
         );
-        assert_eq!(c.transport_for(nh)[0].labels, vec![16800]);
-        assert_eq!(c.transport_for(nh)[0].ifindex, 3);
+        assert_eq!(c.transport_for(0, nh)[0].labels, vec![16800]);
+        assert_eq!(c.transport_for(0, nh)[0].ifindex, 3);
 
         // still reachable, transport label changed (IGP reroute of the
         // PE): transport-only → re-install, no advertise. Cache refreshed.
         assert_eq!(
-            c.update(nh, &reachable(vec![16801])),
+            c.update(0, nh, &reachable(vec![16801])),
             CacheChange::Transport(vec![NhtDep::V4(p1)])
         );
-        assert_eq!(c.transport_for(nh)[0].labels, vec![16801]);
+        assert_eq!(c.transport_for(0, nh)[0].labels, vec![16801]);
 
         // identical resolution again: nothing moved.
         assert_eq!(
-            c.update(nh, &reachable(vec![16801])),
+            c.update(0, nh, &reachable(vec![16801])),
             CacheChange::Unchanged
         );
 
         // unknown nexthop: unchanged, empty transport.
         let unknown: IpAddr = "9.9.9.9".parse().unwrap();
         assert_eq!(
-            c.update(unknown, &NexthopResolution::default()),
+            c.update(0, unknown, &NexthopResolution::default()),
             CacheChange::Unchanged
         );
-        assert!(c.transport_for(unknown).is_empty());
+        assert!(c.transport_for(0, unknown).is_empty());
     }
 
     #[test]
@@ -290,18 +419,18 @@ mod tests {
         let nh: IpAddr = "10.0.0.8".parse().unwrap();
         let p1: Ipv4Net = "1.0.0.0/24".parse().unwrap();
         let p2: Ipv4Net = "2.0.0.0/24".parse().unwrap();
-        c.track(nh, NhtDep::V4(p1));
-        c.track(nh, NhtDep::V4(p2));
+        c.track(0, nh, NhtDep::V4(p1));
+        c.track(0, nh, NhtDep::V4(p2));
 
         // First withdrawal: a dep remains, so the next-hop stays tracked.
-        assert!(!c.untrack(nh, &NhtDep::V4(p1)));
-        assert!(c.entries.contains_key(&nh));
+        assert!(!c.untrack(0, nh, &NhtDep::V4(p1)));
+        assert!(c.entries.contains_key(&(0, nh)));
 
         // Last dep gone: entry dropped, caller should unregister.
-        assert!(c.untrack(nh, &NhtDep::V4(p2)));
-        assert!(!c.entries.contains_key(&nh));
+        assert!(c.untrack(0, nh, &NhtDep::V4(p2)));
+        assert!(!c.entries.contains_key(&(0, nh)));
 
         // Untracking an already-gone next-hop is a no-op (not "last").
-        assert!(!c.untrack(nh, &NhtDep::V4(p1)));
+        assert!(!c.untrack(0, nh, &NhtDep::V4(p1)));
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -803,7 +803,7 @@ pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selecte
     // SRv6-encapsulated route.
     let nht_transport = bgp.nexthop_cache.as_deref().and_then(|cache| {
         best.and_then(|b| super::nht::bgp_nexthop_ip(&b.attr))
-            .map(|nh| cache.transport_for(nh))
+            .map(|nh| cache.transport_for(0, nh))
     });
     let entry = best.and_then(|b| select_fib_entry_v4(b, transport, nht_transport));
     match entry {
@@ -1043,7 +1043,7 @@ pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selecte
     // `fib_install_v4`.
     let nht_transport = bgp.nexthop_cache.as_deref().and_then(|cache| {
         best.and_then(|b| super::nht::bgp_nexthop_ip(&b.attr))
-            .map(|nh| cache.transport_for(nh))
+            .map(|nh| cache.transport_for(0, nh))
     });
     let entry = best.and_then(|b| select_fib_entry_v6(b, transport, nht_transport));
     match entry {
@@ -1127,7 +1127,7 @@ fn select_fib_entry_label(
     // not transport+3. 0 already means "no service label".
     let service_label = best.label.map(|l| l.label).filter(|&l| l != 3).unwrap_or(0);
     let transport = match (cache, super::nht::bgp_nexthop_ip(&best.attr)) {
-        (Some(c), Some(nh)) => c.transport_for(nh),
+        (Some(c), Some(nh)) => c.transport_for(0, nh),
         _ => &[][..],
     };
     build_vpn_fib_entry(service_label, transport)
@@ -1154,7 +1154,7 @@ pub(super) fn reconcile_swap_ilm(
         return;
     }
     let transport = match (cache, super::nht::bgp_nexthop_ip(&best.attr)) {
-        (Some(c), Some(nh)) => c.transport_for(nh),
+        (Some(c), Some(nh)) => c.transport_for(0, nh),
         _ => &[][..],
     };
     if transport.is_empty() {
@@ -3219,7 +3219,7 @@ fn nht_track_received(bgp: &mut BgpTop, rib: &mut BgpRib, dep: super::nht::NhtDe
     let Some(nh) = super::nht::nht_target(&rib.attr) else {
         return;
     };
-    let (needs_register, reachable) = cache.track(nh, dep);
+    let (needs_register, reachable) = cache.track(0, nh, dep);
     rib.nexthop_reachable = reachable;
     if needs_register {
         let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
@@ -3244,7 +3244,7 @@ fn nht_track_received_attr(bgp: &mut BgpTop, attr: &BgpAttr, dep: super::nht::Nh
     let Some(nh) = super::nht::nht_target(attr) else {
         return true;
     };
-    let (needs_register, reachable) = cache.track(nh, dep);
+    let (needs_register, reachable) = cache.track(0, nh, dep);
     if needs_register {
         let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
@@ -3280,7 +3280,7 @@ fn mup_segment_track(
     let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
         return Vec::new();
     };
-    let (needs_register, _reachable) = cache.track(nh, dep);
+    let (needs_register, _reachable) = cache.track(0, nh, dep);
     if needs_register {
         let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
@@ -3288,7 +3288,7 @@ fn mup_segment_track(
             vrf_id: 0,
         });
     }
-    cache.transport_for(nh).to_vec()
+    cache.transport_for(0, nh).to_vec()
 }
 
 /// Symmetric to [`mup_segment_track`]: drop the segment dep from `nh` and,
@@ -3299,7 +3299,7 @@ fn mup_segment_untrack(bgp: &mut BgpTop, rd: RouteDistinguisher, prefix: &MupPre
     let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
         return;
     };
-    if cache.untrack(nh, &dep) {
+    if cache.untrack(0, nh, &dep) {
         let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh,
@@ -3344,16 +3344,22 @@ pub(super) fn mup_endpoint_track_cache(
     let Some(endpoint) = best.and_then(|b| b.mup_st1).map(|st1| st1.endpoint) else {
         return Vec::new();
     };
+    // The design's downlink rule: resolve the gNB endpoint in the table of
+    // the most-specific interwork segment covering it, else the global
+    // table (the cache mirrors the segment catalog's interwork view;
+    // `Bgp::push_mup_segment_catalog` migrates live registrations when it
+    // changes, so track and untrack always agree on the table).
+    let vrf_id = cache.mup_endpoint_table(&endpoint);
     let dep = super::nht::NhtDep::MupEndpoint(rd, prefix.clone());
-    let (needs_register, _reachable) = cache.track(endpoint, dep);
+    let (needs_register, _reachable) = cache.track(vrf_id, endpoint, dep);
     if needs_register {
         let _ = rib_client.send(rib::Message::NexthopRegister {
             proto: "bgp".to_string(),
             nh: endpoint,
-            vrf_id: 0,
+            vrf_id,
         });
     }
-    cache.transport_for(endpoint).to_vec()
+    cache.transport_for(vrf_id, endpoint).to_vec()
 }
 
 /// Symmetric to [`mup_endpoint_track`]: drop the endpoint dep from `endpoint`
@@ -3385,12 +3391,16 @@ pub(super) fn mup_endpoint_untrack_cache(
     prefix: &MupPrefix,
     endpoint: IpAddr,
 ) {
+    // Same table derivation as the track side — the catalog-change
+    // migration keeps live registrations aligned with the current view,
+    // so this always names the table the dep was registered under.
+    let vrf_id = cache.mup_endpoint_table(&endpoint);
     let dep = super::nht::NhtDep::MupEndpoint(rd, prefix.clone());
-    if cache.untrack(endpoint, &dep) {
+    if cache.untrack(vrf_id, endpoint, &dep) {
         let _ = rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh: endpoint,
-            vrf_id: 0,
+            vrf_id,
         });
     }
 }
@@ -3428,7 +3438,7 @@ fn nht_untrack_withdrawn(
             continue;
         }
         if let Some(cache) = bgp.nexthop_cache.as_deref_mut()
-            && cache.untrack(nh, &dep)
+            && cache.untrack(0, nh, &dep)
         {
             to_unregister.push(nh);
         }
@@ -3457,7 +3467,7 @@ fn vpn_import_transport<'a>(
         bgp.nexthop_cache.as_deref(),
         super::nht::nht_target(&winner.attr),
     ) {
-        (Some(cache), Some(nh)) => cache.transport_for(nh),
+        (Some(cache), Some(nh)) => cache.transport_for(0, nh),
         _ => &[][..],
     };
     (label, transport)
@@ -9681,7 +9691,7 @@ fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
     let wants = bgp.local_rib.sr_policy.wants_mpls(color, endpoint);
 
     if wants && let Some(cache) = bgp.nexthop_cache.as_deref_mut() {
-        let (needs_register, _reachable) = cache.track(endpoint, dep.clone());
+        let (needs_register, _reachable) = cache.track(0, endpoint, dep.clone());
         if needs_register {
             let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
                 proto: "bgp".to_string(),
@@ -9709,7 +9719,7 @@ fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
 
     if !wants
         && let Some(cache) = bgp.nexthop_cache.as_deref_mut()
-        && cache.untrack(endpoint, &dep)
+        && cache.untrack(0, endpoint, &dep)
     {
         let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
@@ -9736,7 +9746,7 @@ pub(super) fn sr_policy_reconcile_mpls(
     color: u32,
     endpoint: IpAddr,
 ) -> bool {
-    let reachable = !cache.transport_for(endpoint).is_empty();
+    let reachable = !cache.transport_for(0, endpoint).is_empty();
     let action = db.mpls_reconcile(color, endpoint, reachable);
     if let Some(label) = action.remove {
         srpolicy_ilm_remove(rib_client, label);
@@ -9746,7 +9756,7 @@ pub(super) fn sr_policy_reconcile_mpls(
             rib_client,
             install.bsid,
             &install.segments,
-            cache.transport_for(endpoint),
+            cache.transport_for(0, endpoint),
         );
     }
     action.activated

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -434,7 +434,10 @@ impl<A: PimAf> Pim<A> {
             RibRx::LinkDel(ifindex) => self.link_del(ifindex),
             RibRx::AddrAdd(addr) => self.addr_add(addr),
             RibRx::AddrDel(addr) => self.addr_del(addr),
-            RibRx::NexthopUpdate { nh, resolution } => {
+            // PIM registers RPF nexthops in the global table only, so an
+            // update can only carry `vrf_id == 0` here; the identity is
+            // dropped, not dispatched on.
+            RibRx::NexthopUpdate { nh, resolution, .. } => {
                 self.rpf_nexthop_update(nh, resolution);
                 return;
             }

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -283,6 +283,10 @@ pub enum RibRx {
     // the covering route changes. `reachable == false` means the
     // nexthop no longer resolves.
     NexthopUpdate {
+        /// The table the registration named (`Message::NexthopRegister`'s
+        /// `vrf_id`, 0 = global) — the same address may be tracked in
+        /// several tables with independent resolutions.
+        vrf_id: u32,
         nh: IpAddr,
         resolution: super::nht::NexthopResolution,
     },

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1380,7 +1380,11 @@ impl Rib {
             entry.resolution = resolution.clone();
         }
         if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
-            let _ = sub.rib_rx_tx.send(RibRx::NexthopUpdate { nh, resolution });
+            let _ = sub.rib_rx_tx.send(RibRx::NexthopUpdate {
+                vrf_id,
+                nh,
+                resolution,
+            });
         }
     }
 
@@ -1403,14 +1407,15 @@ impl Rib {
 
     /// Re-resolve every tracked nexthop; where the resolution changed,
     /// update the cache and notify all its watchers. Called after a
-    /// global-table route change. (Recompute-all for now; narrowing to
-    /// only the affected nexthops is a follow-up, as is firing on
-    /// link/addr changes.)
+    /// global-table or VRF-table route change. (Recompute-all for now;
+    /// narrowing to only the affected nexthops/tables is a follow-up, as
+    /// is firing on link/addr changes.)
     pub(crate) fn nht_recompute_and_notify(&mut self) {
         if self.nht.entries.is_empty() {
             return;
         }
-        let mut updates: Vec<(IpAddr, super::nht::NexthopResolution, Vec<String>)> = Vec::new();
+        let mut updates: Vec<(u32, IpAddr, super::nht::NexthopResolution, Vec<String>)> =
+            Vec::new();
         for (vrf_id, nh) in self.nht.tracked() {
             let resolution = self.nht_resolve(vrf_id, nh);
             if let Some(entry) = self.nht.entries.get_mut(&(vrf_id, nh))
@@ -1418,13 +1423,14 @@ impl Rib {
             {
                 entry.resolution = resolution.clone();
                 let watchers = entry.watchers.iter().cloned().collect();
-                updates.push((nh, resolution, watchers));
+                updates.push((vrf_id, nh, resolution, watchers));
             }
         }
-        for (nh, resolution, watchers) in updates {
+        for (vrf_id, nh, resolution, watchers) in updates {
             for proto in watchers {
                 if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
                     let _ = sub.rib_rx_tx.send(RibRx::NexthopUpdate {
+                        vrf_id,
                         nh,
                         resolution: resolution.clone(),
                     });
@@ -3276,6 +3282,9 @@ impl Rib {
                 // populates these on install; a follow-up will add
                 // the matching withdraw walk.
                 self.vrf_tables.remove(&vrf.table_id);
+                // Nexthops tracked in the dropped table no longer
+                // resolve — push the unreachable flip to their watchers.
+                self.nht_recompute_and_notify();
                 self.fib_handle.vrf_del(&name).await;
                 self.vrf_id_alloc.release(vrf.table_id);
                 tracing::info!("vrf_del: {} (table_id={})", name, vrf.table_id);


### PR DESCRIPTION
## Summary

Stage 4 of `docs/design/bgp-mup-gtp-segment-resolution-plan.md`. The `dataplane gtp` downlink resolved the gNB endpoint with a hard-coded `NexthopRegister vrf_id 0`; the endpoint now registers and resolves in the table of the most-specific interwork-segment prefix covering it, else the global table — a faithful N3-in-a-VRF UPF resolves its outer (gw, oif) where the gNB routes actually live.

Identity plumbing: `RibRx::NexthopUpdate` carries the registration's `vrf_id` (the RIB side already keyed and resolved per `(vrf_id, nh)`), and BGP's `NexthopCache` is re-keyed `(vrf_id, nh)` — the same address tracked in several tables holds independent resolutions. Every pre-existing user passes `(0, nh)` mechanically; the update/reeval/transport chain threads the fired entry's vrf; PIM binds and ignores the field. The endpoint-table choice lives on the cache as a mirrored interwork-prefix view (set by `push_mup_segment_catalog`); on a catalog change, live `MupEndpoint` registrations are migrated to their new table. Of the two RIB gaps the design flagged, only the identity one was real — VRF-table changes already re-fire watchers; the missing `VrfDel` table-drop recompute is added.

## Test plan

- Units: `(vrf, nh)` entry independence, most-specific interwork containment with global fallback, migration reporting exactly the stale endpoint deps.
- Live: `bgp_mup_{segment_dsd,isd,interwork,dual_st,e2e,dynamic_rt}` green on the staged toolchain; `cradle_mup_gtp_single_n6` / `cradle_mup_gtp_zebra` green against the stage-2 cradle.
- `cargo fmt --check`, workspace clippy `-D warnings`, full workspace tests (2730 passed).

Generated with [Claude Code](https://claude.com/claude-code)