### PR TITLE
MPLS EVPN over IPv6 PEs: vtep-source origination, static ipv6 label routes

### DIFF
--- a/docs/design/bgp-evpn-support-status.md
+++ b/docs/design/bgp-evpn-support-status.md
@@ -20,13 +20,13 @@ datapath, driven from zebra-rs via the FibHandle tee.
 | **Multihoming ESI (Type-1/4, DF election)** | ✅ Control plane (shared) | ✅ Full signal set incl. Type-2 ESI (#2148/#2150/#2152) | ✅ Control plane (shared) |
 | **MAC aliasing / mass-withdraw consumers** | ❌ Open (receive side) | ❌ Open — exists for VPWS only | ❌ Open |
 | **E-Line / VPWS (RFC 8214)** | ✅ Type-1 VNI + Encapsulation EC + VTEP next hop; cradle eBPF xconnect (VTEP+VNI encap, E-Line-VNI decap) | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | ✅ Per-service label, no Encapsulation EC; cradle eBPF xconnect (label encap under the transport LSP, pop-to-AC decap) |
-| **IPv6 underlay transport** | ✅ Kernel: zero code changes (#1850); eBPF: native v6 VTEPs incl. E-Line + `vtep-source` origination knob (cradle #168) | ✅ (native) | — (IS-IS SR-MPLS underlay; MPLS-over-v6 PEs open) |
+| **IPv6 underlay transport** | ✅ Kernel: zero code changes (#1850); eBPF: native v6 VTEPs incl. E-Line + `vtep-source` origination knob (cradle #168) | ✅ (native) | ✅ v6 PEs: FIB6 service-label resolution (engine) + `vtep-source` next hops; labeled static v6 routes for transport (IS-IS SR-MPLS prefix-SIDs remain v4-only) |
 | **IGMP/MLD proxy / SMET (RFC 9251)** | ✅ Incl. per-VTEP selective MDB | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **Assisted Replication (RFC 9574)** | ✅ Control plane; AR-LEAF/RNVE forward natively. ❌ AR-REPLICATOR data plane deferred | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **BUM segmentation (RFC 9572, Types 9/10/11)** | ✅ Control plane complete (RBR/ASBR, DF, S-PMSI) | ✅ + SR-P2MP tree offload wiring | ✅ Control plane (shared) |
 | **P2MP replication tree** | — (head-end IR model) | ✅ RFC 9524 End.Replicate incl. Bud (zebra #1923 + cradle #131) | ❌ MPLS-P2MP forwarder not built |
 | **ARP suppression** | ❌ Open | ❌ Open | ❌ Open |
-| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra`, v6-underlay twins `cradle_evpn_vxlan6_zebra` + `cradle_vpws_vxlan6_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit) |
+| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra`, v6-underlay twins `cradle_evpn_vxlan6_zebra` + `cradle_vpws_vxlan6_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit), v6-PE twins `cradle_evpn_mpls6_zebra` + `cradle_vpws_mpls6_zebra` |
 
 **Legend**: ✅ supported · ❌ not yet · — not applicable. "Control plane
 (shared)" = the feature is encapsulation-agnostic in zebra-rs; the per-encap

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1745,6 +1745,26 @@ fn config_evpn_vtep_source(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     if bgp.evpn_vtep_source == source {
         return Some(());
     }
+    // The source is part of some route KEYS (an MPLS IMET's Originating
+    // Router IP, an ES route's originator), not just a next hop — those
+    // must be withdrawn under the OLD source or they linger as originated
+    // ghosts. Type-2/Type-5/VPWS Type-1 keys don't carry it, so their
+    // re-origination below updates them in place.
+    let old_source = bgp.evpn_local_source();
+    if bgp.evpn_encap.is_mpls() && bgp.advertise_all_vni {
+        let evis: Vec<u32> = bgp.evpn_evis.keys().copied().collect();
+        for evi in evis {
+            bgp.evpn_withdraw_imet(evi, old_source);
+        }
+    }
+    let segments: Vec<[u8; 10]> = bgp
+        .ethernet_segments
+        .values()
+        .filter_map(|es| es.esi)
+        .collect();
+    for esi in &segments {
+        bgp.evpn_withdraw_es_routes(*esi, old_source);
+    }
     bgp.evpn_vtep_source = source;
     if bgp.advertise_all_vni {
         let entries: Vec<FdbEntry> = bgp.local_fdb.values().cloned().collect();
@@ -1753,6 +1773,7 @@ fn config_evpn_vtep_source(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         }
     }
     reoriginate_all_imet(bgp);
+    es_df_election_changed(bgp);
     bgp.vpws_reencap();
     Some(())
 }
@@ -1852,7 +1873,7 @@ fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
             bgp.ethernet_segments.entry(name).or_default();
         }
         ConfigOp::Delete => {
-            let vtep = IpAddr::V4(bgp.router_id);
+            let vtep = bgp.evpn_local_source();
             if let Some(esi) = bgp.ethernet_segments.get(&name).and_then(|es| es.esi) {
                 bgp.evpn_withdraw_es_routes(esi, vtep);
             }
@@ -1887,7 +1908,7 @@ fn config_ethernet_segment_esi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
     } else {
         None
     };
-    let vtep = IpAddr::V4(bgp.router_id);
+    let vtep = bgp.evpn_local_source();
     // Withdraw the ES routes for the previously-configured ESI (if any), then
     // set the new one and originate under it.
     if let Some(old) = bgp.ethernet_segments.get(&name).and_then(|es| es.esi) {
@@ -1947,7 +1968,7 @@ fn config_ethernet_segment_redundancy_mode(
     // re-originate the ES routes with the new mode (a no-op for the Type-4,
     // an in-place update for the per-ES A-D).
     if let Some(esi) = esi {
-        let vtep = IpAddr::V4(bgp.router_id);
+        let vtep = bgp.evpn_local_source();
         bgp.evpn_originate_es_routes(esi, vtep, mode.single_active());
     }
     // Single-active carves one primary per service instance where all-active
@@ -2035,7 +2056,7 @@ fn config_es_startup_delay(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 /// change to the algorithm or preference has to reach peers *and* re-run the
 /// local election — our own Type-4 is one of the election's candidates.
 fn es_df_election_changed(bgp: &mut Bgp) {
-    let vtep = IpAddr::V4(bgp.router_id);
+    let vtep = bgp.evpn_local_source();
     let segments: Vec<([u8; 10], bool)> = bgp
         .ethernet_segments
         .values()
@@ -2474,7 +2495,7 @@ pub(super) fn reoriginate_all_imet(bgp: &mut Bgp) {
     // are the local L2 services, and the router-id stands in for the VTEP
     // (it is the BGP next hop the transport LSP resolves on).
     let services: Vec<(u32, IpAddr)> = if bgp.evpn_encap.is_mpls() {
-        let orig = IpAddr::V4(bgp.router_id);
+        let orig = bgp.evpn_local_source();
         bgp.evpn_evis.keys().map(|evi| (*evi, orig)).collect()
     } else {
         bgp.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect()

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15667,8 +15667,8 @@ impl Bgp {
             .get(&entry.vni)
             .copied()
             .or(entry.vxlan_local)
-            .unwrap_or(IpAddr::V4(self.router_id));
-        // Under MPLS the router-id IS the next hop — there is no VTEP to
+            .unwrap_or_else(|| self.evpn_local_source());
+        // Under MPLS the local source IS the next hop — there is no VTEP to
         // resolve, and the transport LSP is looked up on it — so the fallback
         // is the intended answer rather than a degraded one.
         if !self.evpn_encap.is_mpls()
@@ -15886,7 +15886,7 @@ impl Bgp {
                 IpAddr::V4(vtep)
             }
             (None, Some(v6)) => IpAddr::V6(v6),
-            (None, None) => IpAddr::V4(self.router_id),
+            (None, None) => self.evpn_local_source(),
         };
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
         // MPLS: the service label rides on the BgpRib (mirrored by the
@@ -16433,8 +16433,17 @@ impl Bgp {
         self.local_vxlans
             .get(&vni)
             .copied()
-            .or(self.evpn_vtep_source)
-            .unwrap_or(IpAddr::V4(self.router_id))
+            .unwrap_or_else(|| self.evpn_local_source())
+    }
+
+    /// This PE's EVPN source address when no VXLAN device supplies one: the
+    /// configured `vtep-source`, else the router-id. Every locally
+    /// originated EVPN identity that is not device-derived — MPLS IMET
+    /// origins, ES routes, deviceless next hops — must come from here, and
+    /// so must any self-identification against those routes (the DF
+    /// election's "me"), or a v6 source would break self-matching.
+    pub(crate) fn evpn_local_source(&self) -> IpAddr {
+        self.evpn_vtep_source.unwrap_or(IpAddr::V4(self.router_id))
     }
 
     /// Re-reconcile per-EVI A-D for every configured Ethernet Segment's
@@ -16629,7 +16638,7 @@ impl Bgp {
         attr.prefix_sid = prefix_sid;
         let nexthop = match local_vni {
             Some(vni) => self.evpn_nexthop_for_vni(vni),
-            None => IpAddr::V4(self.router_id),
+            None => self.evpn_local_source(),
         };
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
         let rib = BgpRib::new(
@@ -16686,7 +16695,7 @@ impl Bgp {
             EsRedundancyMode::AllActive
         };
         let cands = self.es_df_candidates(&esi);
-        let me = IpAddr::V4(self.router_id);
+        let me = self.evpn_local_source();
         // Inside the segment's startup hold this PE is deliberately missing
         // from `cands` — its Type-4 is suppressed — and `vpws_role` reads an
         // absent `me` as "the segment has not converged yet, stay primary
@@ -16990,7 +16999,7 @@ impl Bgp {
         // Already advertising (the delay was configured on a live segment, or
         // this commit applied `esi` first): retract before the hold begins.
         if let Some(esi) = esi {
-            self.evpn_withdraw_es_routes(esi, IpAddr::V4(self.router_id));
+            self.evpn_withdraw_es_routes(esi, self.evpn_local_source());
             vpws_mark_df_dirty(&mut self.local_rib, &esi);
             self.vpws_df_drain();
         }
@@ -17055,7 +17064,7 @@ impl Bgp {
             return;
         };
         let single_active = es.redundancy_mode.single_active();
-        self.evpn_originate_es_routes(esi, IpAddr::V4(self.router_id), single_active);
+        self.evpn_originate_es_routes(esi, self.evpn_local_source(), single_active);
         // Our own Type-4 rejoining the candidate set shifts every carving
         // ordinal on the segment, so the services on it re-elect.
         vpws_mark_df_dirty(&mut self.local_rib, &esi);
@@ -17338,7 +17347,7 @@ impl Bgp {
             eprintln!("[debug] igmp-sync: bad spec '{spec}' — want vni,esi,group[,source]");
             return;
         };
-        let vtep = IpAddr::V4(self.router_id);
+        let vtep = self.evpn_local_source();
         let flags = smet_flags(group, source);
         match action {
             "igmp-join-sync-originate" => {

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -424,9 +424,15 @@ fn config_builder<F: StaticFamily>(base: &str) -> ConfigBuilder<F> {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.entry(naddr).or_default();
-            n.labels.clear();
+            // Leaf-list values arrive ONE CALL PER VALUE (the commit
+            // text-diff serializes one line each), so clearing here would
+            // keep only the last label of a stack. Append in delivery
+            // order — YANG leaf-list values are unique, so an
+            // already-present value is a re-delivery, not a second push.
             while let Some(label) = args.u32() {
-                n.labels.push(label);
+                if !n.labels.contains(&label) {
+                    n.labels.push(label);
+                }
             }
             Ok(())
         })
@@ -434,28 +440,45 @@ fn config_builder<F: StaticFamily>(base: &str) -> ConfigBuilder<F> {
             let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.get_mut(&naddr).context(CONFIG_ERR)?;
-            n.labels.clear();
+            // Per-value delete removes just the named labels; a bare
+            // delete (whole leaf-list) clears the stack.
+            let mut any = false;
+            while let Some(label) = args.u32() {
+                n.labels.retain(|l| *l != label);
+                any = true;
+            }
+            if !any {
+                n.labels.clear();
+            }
             Ok(())
         })
         .path(&format!("{base}/{}/route/segments", F::FAMILY))
         .set(|config, cache, prefix, args| {
             const SEG_ERR: &str = "segment address parse error";
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
-            let mut segs: Vec<Ipv6Addr> = vec![];
+            // One call per value (see the `label` handler above): append,
+            // skipping re-deliveries, instead of replacing the whole list
+            // with this call's single value.
             while let Some(addr) = args.string() {
-                segs.push(addr.parse::<Ipv6Addr>().context(SEG_ERR)?);
+                let seg = addr.parse::<Ipv6Addr>().context(SEG_ERR)?;
+                if !s.segs.contains(&seg) {
+                    s.segs.push(seg);
+                }
             }
-            s.segs = segs;
             Ok(())
         })
         .del(|config, cache, prefix, args| {
             const SEG_ERR: &str = "segment address parse error";
             let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
-            let mut segs: Vec<Ipv6Addr> = vec![];
+            let mut any = false;
             while let Some(addr) = args.string() {
-                segs.push(addr.parse::<Ipv6Addr>().context(SEG_ERR)?);
+                let seg = addr.parse::<Ipv6Addr>().context(SEG_ERR)?;
+                s.segs.retain(|v| *v != seg);
+                any = true;
             }
-            s.segs.clear();
+            if !any {
+                s.segs.clear();
+            }
             Ok(())
         })
         .path(&format!("{base}/{}/route/encap-type", F::FAMILY))

--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -269,6 +269,17 @@ module config-static {
             type uint8;
             description "Weight of ECMP route.";
           }
+          leaf-list label {
+            ext:help "MPLS labels to push";
+            type uint32;
+            description
+              "MPLS label stack imposed toward this nexthop, outermost
+               first — the IPv6 sibling of the IPv4 nexthop's `label`
+               list. This is what gives a labeled transport route to an
+               IPv6 PE loopback (SR-MPLS-style over a v6-numbered core)
+               without an IGP: EVPN-over-MPLS resolves its transport
+               stack from the FIB entry this route installs.";
+          }
         }
         leaf distance {
           ext:help "Administrative distance";

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -130,18 +130,20 @@ module zebra-bgp-evpn {
          uses the encapsulation its originator signalled.";
     }
     leaf vtep-source {
-      ext:help "VTEP advertised as the EVPN next hop";
+      ext:help "EVPN source address (next hop / origin) when no VXLAN device supplies one";
       type inet:ip-address;
       description
-        "The VTEP address — IPv4 or IPv6 — advertised as the next hop
-         of locally originated EVPN routes when no local VXLAN device
-         supplies one for the VNI. A VPWS E-Line under `encapsulation
-         vxlan` has no VXLAN device (the service VNI is a decap identity,
-         not a bridge domain), so without this leaf its Type-1 falls back
-         to the IPv4 router-id — which cannot express a VTEP on an IPv6
-         underlay. Routes whose VNI does have a local VXLAN device keep
-         taking that device's local address; unset, the fallback remains
-         the router-id.";
+        "This PE's EVPN source address — IPv4 or IPv6 — used wherever a
+         locally originated EVPN route needs an address and no local
+         VXLAN device supplies one: the next hop of a VPWS Type-1 or a
+         deviceless Type-2/Type-5, the Originating Router IP of an
+         `encapsulation mpls` IMET, and the originator of Ethernet
+         Segment routes (also the DF election's self-identity). Without
+         it those fall back to the IPv4 router-id, which cannot express
+         a PE on an IPv6 underlay — under `encapsulation vxlan` the
+         address is the VTEP, under `mpls` it is the address the
+         transport LSP resolves on. Routes whose VNI does have a local
+         VXLAN device keep taking that device's local address.";
     }
     list evi {
       ext:help "EVPN Instance (bridge domain) for `encapsulation mpls`";


### PR DESCRIPTION
## Summary

The zebra half of MPLS-over-v6 PEs (engine: cradle-rs `mpls6-pe`). The cradle tee needed nothing — the MPLS fdb/repl/xconnect paths were already `IpAddr` — but every locally originated EVPN identity fell back to the IPv4 router-id:

- **`Bgp::evpn_local_source()`** (the `vtep-source` leaf, else the router-id) now feeds the deviceless Type-2 next hop, the Type-5 MPLS/L2 fallback, the VPWS Type-1 no-VNI arm, the MPLS IMET enumeration's Originating Router IP, all four Ethernet Segment route sites, and the DF election's self-identity (which must match our own Type-4's originator or a v6 source breaks self-recognition). The source is part of the IMET/ES route **keys**, so the `vtep-source` change handler withdraws those under the old source before re-originating. The leaf's YANG description is broadened to its encap-neutral role.
- **Static ipv6 routes gain the nexthop `label` leaf-list** — the v4 sibling's YANG was the only missing piece (the handler was already family-generic). This is the labeled transport to a v6 PE loopback without an IGP, since IS-IS prefix-SIDs remain v4-only.
- **Latent leaf-list bug fixed**: since the one-command-per-value serialization change, the static `label`/`segments` handlers' clear-then-push kept only the **last** value — a v4 static multi-label stack silently collapsed to its bottom label. Now append-in-order on set, per-value remove on delete; live-verified `label 100 200 300` in both families.
- Status doc: MPLS column's IPv6-underlay and BDD cells flipped.

## Test plan

- e2e (cradle repo, branch `mpls6-pe`): `cradle_evpn_mpls6_zebra` (dynamic E-LAN, v6 next hops, WatchFdb loop, BUM slot) and `cradle_vpws_mpls6_zebra` (whole-port + VID-scoped E-Line pair) — **both passed first run**.
- 23-feature regression green: every static MPLS feature (incl. new `cradle_evpn_mpls6`), every zebra-driven EVPN feature across SRv6/MPLS/VXLAN, and the vxlan6 twins.
- `cargo test -p zebra-rs` (1886), workspace clippy, fmt: green. Live vty verification of multi-label static routes both families.

Generated with [Claude Code](https://claude.com/claude-code)