### PR TITLE
bgp: MUP interwork lookup-network-instance + SID-less segments

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -126,6 +126,14 @@ bgp_mup_isd:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_isd"
 
+# MUP SID-less segments: a GTP-only PE (dataplane gtp, no SRv6 locator or
+# encapsulation) originates DSD/ISD routes without an SRv6 L3 Service
+# Prefix-SID, next-hop = the mup-c controller address; the peer receives
+# them as bare correlation objects. Needs root netns (kernel VRFs).
+bgp_mup_sidless_segment:
+	mkdir -p allure-results
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_sidless_segment"
+
 # MUP ST1->ISD encap: one interwork node originates a local ISD (`segment
 # interwork prefix <p>`) and, via its MUP-C, an ST1 whose UE is inside <p>.
 # The ST1 resolves to the local End.DT46 segment and an oif-only recursive

--- a/bdd/tests/configs/bgp_mup_sidless_segment/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_sidless_segment/z1.yaml
@@ -1,0 +1,53 @@
+# z1 — GTP-only MUP PE (dataplane gtp, NO segment-routing locator, no
+# `encapsulation srv6` on either VRF): `segment direct` on N6 and
+# `segment interwork` on N3 originate SID-less DSD / ISD routes — the
+# correlation objects a peer resolves by Direct-segment id / prefix
+# containment. The mup-c controller address is the exported next-hop.
+vrf:
+- name: N3
+- name: N6
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+router:
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    neighbor:
+    - remote-address: 2001:db8:0:12::2
+      remote-as: 65501
+      update-source: 2001:db8:0:12::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N3
+      rd: "65501:10"
+      afi-safi:
+        mup:
+          dataplane: gtp
+          segment:
+          - type: interwork
+            prefix: 10.0.1.0/24
+    - name: N6
+      rd: "65501:20"
+      afi-safi:
+        mup:
+          dataplane: gtp
+          segment:
+          - type: direct
+            mup-ext-comm: "1:6"
+    mup-c:
+      enabled: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 127.0.0.1

--- a/bdd/tests/configs/bgp_mup_sidless_segment/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_sidless_segment/z2.yaml
@@ -1,0 +1,25 @@
+# z2 — plain iBGP receiver with the MUP family enabled; asserts the
+# SID-less DSD/ISD from z1 arrive with no SRv6 L3 Service.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+router:
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    neighbor:
+    - remote-address: 2001:db8:0:12::1
+      remote-as: 65501
+      update-source: 2001:db8:0:12::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true

--- a/bdd/tests/features/bgp_mup_sidless_segment.feature
+++ b/bdd/tests/features/bgp_mup_sidless_segment.feature
@@ -1,0 +1,67 @@
+@serial
+@bgp_mup_sidless_segment
+Feature: A GTP-only MUP PE originates SID-less Segment Discovery routes
+  As a network operator running a GTP-only UPF (dataplane gtp, no SRv6)
+  I want `segment direct` / `segment interwork` to still advertise the
+  DSD / ISD routes — without an SRv6 L3 Service Prefix-SID — so a peer can
+  correlate Session-Transformed routes to my segments by Direct-segment id
+  and prefix containment (stage 6 of
+  docs/design/bgp-mup-gtp-segment-resolution-plan.md). The controller
+  address serves as the next-hop (there is no locator to derive one from).
+
+  Test Topology:
+  ```
+        2001:db8::1 (lo)                2001:db8::2 (lo)
+       ┌──────────────┐     iBGP (mup)  ┌──────────┐
+       │      z1      │═════════════════│    z2    │
+       │ GTP-only UPF │  over the link  │ receiver │
+       │ vrf N3 + N6  │                 │          │
+       └──────────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64       2001:db8:0:12::2/64
+  ```
+
+  z1 has NO segment-routing locator and neither VRF uses `encapsulation
+  srv6`; both declare `dataplane gtp`. N6 (`segment direct { mup-ext-comm
+  1:6 }`, rd 65501:20) originates a SID-less DSD; N3 (`segment interwork {
+  prefix 10.0.1.0/24 }`, rd 65501:10) a SID-less ISD.
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then BGP session in "z1" to "2001:db8:0:12::2" should be "Established"
+    And BGP session in "z2" to "2001:db8:0:12::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8:0:12::2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: z1 originates both segments without a Prefix-SID
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "[DSD][65501:20][10.0.0.1]"
+    And show command "show bgp mup" in namespace "z1" should eventually contain "[ISD][65501:10][10.0.1.0/24]"
+    # The Direct-segment id rides the DSD as usual.
+    And show command "show bgp mup" in namespace "z1" should contain "mup:1:6"
+    # SID-less: no SRv6 L3 Service on either segment; the controller
+    # address is the next-hop.
+    And show command "show bgp mup" in namespace "z1" should not contain "Local SID"
+    And show command "show bgp mup" in namespace "z1" should not contain "End.DT46"
+    And show command "show bgp mup" in namespace "z1" should contain "next-hop 2001:db8::1"
+
+  Scenario: z2 receives both SID-less segments
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[DSD][65501:20][10.0.0.1]"
+    And show command "show bgp mup" in namespace "z2" should eventually contain "[ISD][65501:10][10.0.1.0/24]"
+    And show command "show bgp mup" in namespace "z2" should contain "mup:1:6"
+    And show command "show bgp mup" in namespace "z2" should not contain "Remote SID"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -427,6 +427,13 @@ draft's GTP-U endpoint behaviours (GTP4.E / GTP6.E / H.M.GTP4.D) themselves
 are VPP/eBPF and not yet implemented — the kernel dataplane performs the
 SRv6 H.Encaps toward the segment, and the End.DT46 decap at the far end.
 
+A **GTP-only PE** (`dataplane gtp`, no SRv6 locator and no `encapsulation
+srv6`) still originates its DSD/ISD routes — **SID-less**: no SRv6 L3
+Service Prefix-SID, next-hop = the `mup-c` `controller-address` (which must
+be configured; there is no locator to derive one from). The segments are
+then pure correlation objects a peer resolves by Direct-segment id and
+prefix containment. Regression-tested by the `bgp_mup_sidless_segment` BDD.
+
 ### The faithful interwork/direct split — N3 in a VRF (`dataplane gtp`)
 
 Beyond advertising DSD/ISD routes, `segment direct` / `segment interwork`
@@ -503,6 +510,43 @@ the UE route belongs to the direct segment) and the **ST2 under N3's RD**
 With **no** `segment` declared, all three defaults apply and the behaviour
 is exactly the single-N6 shape above — that configuration is the
 degenerate case of this one, and remains the recommended simple form.
+
+#### The GTP-gateway variant — `lookup-network-instance`
+
+The service VRF need not be split in two. `segment interwork` may instead
+name a **separate VRF as the GTP-side routing context** — the single-N6
+shape lifted to N3-in-a-VRF (validated by the cradle
+`@cradle_mup_gtp_lookup_ni` BDD; the named VRF needs no `router bgp vrf`
+block of its own):
+
+```
+vrf N3 { }                      # the GTP-side context — kernel VRF only
+vrf mobile { }
+interface z1n3 { vrf N3; ipv4 { address 10.0.12.1/24; } }
+interface z1n6 { vrf mobile; ipv4 { address 10.0.60.1/24; } }
+
+router bgp {
+  vrf mobile {
+    rd 65000:1;
+    afi-safi mup {
+      dataplane gtp;
+      segment interwork {
+        prefix 10.0.12.0/24;
+        lookup-network-instance N3;   # GTP-U matches and resolves in N3
+      }
+      route st1 { network-instance internet; }
+      route st2 { network-instance internet; }
+    }
+  }
+}
+```
+
+The ST2's decap PDR is scoped to **N3's** table (where G-PDUs arrive) and
+decaps into `mobile`'s own table (the fallback — no Direct-segment id
+needed when both directions share one VRF); the ST1's gNB endpoint falls
+inside the interwork prefix, so the outer `(gw, oif)` resolves in **N3's**
+table. Without the leaf, the declaring VRF is its own GTP context — the
+two-VRF split above.
 
 Two deployment notes:
 

--- a/docs/design/bgp-mup-gtp-segment-resolution-plan.md
+++ b/docs/design/bgp-mup-gtp-segment-resolution-plan.md
@@ -1,14 +1,12 @@
 # BGP MUP — explicit interwork/direct segment resolution for `dataplane gtp`
 
-> **Status:** confirmed (2026-08-01); stages 1–5 implemented on review
-> branches — cradle `decap-meta-precedence` → `gtp-pdr-vrf-scope` →
-> `mup-n3-vrf-lab`, zebra `gtp-pdr-match-vrf` → `mup-segment-catalog` →
-> `mup-endpoint-nht-vrf` → `mup-n3-vrf-lab`. Staged so every PR is
-> independently shippable and the current single-N6 lab stays green at
-> each stage. The stage-5 proof — `@cradle_mup_gtp_n3_vrf`, the §2 target
-> configuration with the N3 port inside a kernel VRF — passes end-to-end.
-> Implementation notes from verification are folded into §3.4, Stage 4 and
-> Stage 5 below. Stage 6 remains deferred.
+> **Status:** COMPLETE (2026-08-01). Stages 1–5 merged (zebra
+> #2206/#2207/#2208/#2209/#2210, cradle #170/#171/#172); stage 6's two
+> knobs (`lookup-network-instance`, SID-less segment origination) are
+> implemented as well — only the N9/SRGW composite and GTP6 remain out of
+> scope by design. Every PR was independently shippable and the single-N6
+> lab stayed green at each stage. Implementation notes from verification
+> are folded into §3.4 and Stages 4–6 below.
 >
 > Origin: design review of the single-N6 configuration (`bdd/mup-lab`,
 > issue #1947 arc). The `dataplane gtp` datapath hard-codes three forwarding
@@ -368,19 +366,29 @@ preserving).*
   retiring the "N3 stays in the global table" invariant notes (Stage 1/2
   turned it from a correctness requirement into a mere default).
 
-### Stage 6 — deferred (revisit after 1–5)
+### Stage 6 — the deferred knobs (implemented)
 
-* **Remote-entry-point interwork** (the split-SRGW case): `segment interwork`
-  on the **N6** VRF advertising an ISD whose SID is the N6 VRF's DT SID (the
-  downlink entry point for remote PEs), with an explicit
-  `lookup-network-instance <n3-vrf>` leaf on the segment entry naming the
-  post-encap context — it cannot be inferred there. New grammar; only knob
-  this plan adds, and only if/when the split deployment is wanted.
-* **SID-less segment origination** for GTP-only interop (relaxing the
-  `encapsulation srv6` gate in `compute_mup_segment_desired`) — needed only
-  when a GTP-only node must advertise its segments to peers.
+* **`lookup-network-instance`** — *as implemented, generalized*: the leaf
+  lives on the `segment interwork` entry and names the segment's **GTP-side
+  routing context** when it is not the declaring VRF itself. The catalog's
+  interwork entry carries the named VRF's kernel table (entry gated on that
+  table being known); the uplink match context and the downlink endpoint
+  resolution both consume it, so the split shape needs no per-rule special
+  cases. The flagship use is the **GTP-gateway variant**: ONE service VRF
+  binds both `route` directions (the single-N6 shape) while its interwork
+  declaration names a bare kernel VRF as N3 — no `router bgp vrf` block on
+  the named VRF at all. Proven end-to-end by `@cradle_mup_gtp_lookup_ni`.
+  The only new grammar in the whole plan.
+* **SID-less segment origination** — *implemented*: a `dataplane gtp` VRF
+  without `encapsulation srv6` originates its DSD/ISD with no SRv6 L3
+  Service Prefix-SID; the export stamps the `mup-c` `controller-address` as
+  the next-hop (gated on it being configured — there is no locator to
+  derive one from). `MupSegmentDesired.sid` became `Option`; the SRv6 path
+  is untouched. Proven by the `bgp_mup_sidless_segment` BDD (originate +
+  receive, `should not contain` SID assertions).
 * **GTP encap toward a remote interwork segment** (N9 / SRGW composite) and
-  **GTP6** (v6 outer): out of scope; the GTP datapath stays v4-outer.
+  **GTP6** (v6 outer): remain out of scope; the GTP datapath stays
+  v4-outer.
 
 ## 5. Compatibility summary
 

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -216,6 +216,7 @@
 /router/bgp/vrf/afi-safi/mup/route/mup-ext-comm
 /router/bgp/vrf/afi-safi/mup/route/network-instance
 /router/bgp/vrf/afi-safi/mup/segment
+/router/bgp/vrf/afi-safi/mup/segment/lookup-network-instance
 /router/bgp/vrf/afi-safi/mup/segment/mup-ext-comm
 /router/bgp/vrf/afi-safi/mup/segment/prefix
 /router/bgp/vrf/encapsulation

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -23,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 328
-Handled: 313
+Total settable schema nodes: 329
+Handled: 314
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -300,6 +300,7 @@
 /router/bgp/vrf/afi-safi/mup/route/mup-ext-comm	leaf
 /router/bgp/vrf/afi-safi/mup/route/network-instance	leaf
 /router/bgp/vrf/afi-safi/mup/segment	list keys=type
+/router/bgp/vrf/afi-safi/mup/segment/lookup-network-instance	leaf
 /router/bgp/vrf/afi-safi/mup/segment/mup-ext-comm	leaf
 /router/bgp/vrf/afi-safi/mup/segment/prefix	leaf
 /router/bgp/vrf/encapsulation	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4852,6 +4852,10 @@ impl Bgp {
             super::vrf_config::config_vrf_mup_segment_prefix,
         );
         self.callback_add(
+            "/router/bgp/vrf/afi-safi/mup/segment/lookup-network-instance",
+            super::vrf_config::config_vrf_mup_segment_lookup_ni,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/mup/route",
             super::vrf_config::config_vrf_mup_route,
         );

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -389,11 +389,26 @@ pub(crate) fn mup_segment_catalog_from(
             continue;
         };
         match mode {
-            MupSegmentMode::Interwork => catalog.interwork.push(MupInterworkEntry {
-                vrf: name.clone(),
-                table_id: kernel.table_id,
-                prefix: cfg.mobile_uplane.interwork_prefix,
-            }),
+            MupSegmentMode::Interwork => {
+                // The GTP-side routing context: the named
+                // `lookup-network-instance` VRF when set (the
+                // split/GTP-gateway shape — the declaring VRF advertises
+                // the downlink entry point while GTP-U rides a separate
+                // N3 VRF), else the declaring VRF itself. The entry is
+                // only usable once the context's kernel table is known.
+                let context = match &cfg.mobile_uplane.interwork_lookup_ni {
+                    Some(ni) => known.get(ni),
+                    None => Some(kernel),
+                };
+                let Some(context) = context else {
+                    continue;
+                };
+                catalog.interwork.push(MupInterworkEntry {
+                    vrf: name.clone(),
+                    table_id: context.table_id,
+                    prefix: cfg.mobile_uplane.interwork_prefix,
+                });
+            }
             MupSegmentMode::Direct => {
                 let Some(id) = cfg.mobile_uplane.mup_ext_comm else {
                     continue;
@@ -7450,12 +7465,21 @@ mod tests {
             kn.insert("N9".to_string(), known(13));
 
             let cat = mup_segment_catalog_from(&vrfs, &kn);
-            assert!(cat.is_interwork("N3"));
-            assert!(
-                !cat.is_interwork("N8"),
+            assert_eq!(
+                cat.gtp_context_of("N3"),
+                Some(7),
+                "self-context interwork: the declaring VRF's own table"
+            );
+            assert_eq!(
+                cat.gtp_context_of("N8"),
+                None,
                 "no kernel table yet → not cataloged"
             );
-            assert!(!cat.is_interwork("N6"), "a direct segment is not interwork");
+            assert_eq!(
+                cat.gtp_context_of("N6"),
+                None,
+                "a direct segment is not interwork"
+            );
             let seg: bgp_packet::RouteDistinguisher = "1:6".parse().unwrap();
             assert_eq!(cat.direct_table(&seg.val), Some(9));
             assert_eq!(cat.direct.len(), 1, "the id-less direct segment is skipped");
@@ -7463,6 +7487,66 @@ mod tests {
             assert_eq!(
                 cat.interwork[0].prefix,
                 Some("10.0.1.0/24".parse().unwrap())
+            );
+        }
+
+        #[test]
+        fn mup_segment_catalog_lookup_ni_overrides_the_gtp_context() {
+            use crate::bgp::inst::mup_segment_catalog_from;
+            use crate::bgp::vrf_config::{BgpVrfConfig, BgpVrfMobileUplane, MupSegmentMode};
+            fn vrf_cfg(mobile_uplane: BgpVrfMobileUplane) -> BgpVrfConfig {
+                BgpVrfConfig {
+                    mobile_uplane,
+                    ..Default::default()
+                }
+            }
+            fn known(table_id: u32) -> RibKnownVrf {
+                RibKnownVrf {
+                    table_id,
+                    ..Default::default()
+                }
+            }
+            // The split/GTP-gateway shape: the service VRF declares the
+            // interwork association, naming N3 as the GTP-side context.
+            let mut vrfs = BTreeMap::new();
+            vrfs.insert(
+                "mobile".to_string(),
+                vrf_cfg(BgpVrfMobileUplane {
+                    segment: Some(MupSegmentMode::Interwork),
+                    interwork_prefix: Some("10.0.12.0/24".parse().unwrap()),
+                    interwork_lookup_ni: Some("N3".to_string()),
+                    ..Default::default()
+                }),
+            );
+            // A second declarer whose named context has no kernel table yet.
+            vrfs.insert(
+                "early".to_string(),
+                vrf_cfg(BgpVrfMobileUplane {
+                    segment: Some(MupSegmentMode::Interwork),
+                    interwork_lookup_ni: Some("missing".to_string()),
+                    ..Default::default()
+                }),
+            );
+            let mut kn = BTreeMap::new();
+            kn.insert("mobile".to_string(), known(2));
+            kn.insert("early".to_string(), known(4));
+            kn.insert("N3".to_string(), known(1));
+
+            let cat = mup_segment_catalog_from(&vrfs, &kn);
+            assert_eq!(
+                cat.gtp_context_of("mobile"),
+                Some(1),
+                "lookup-network-instance overrides the context to N3's table"
+            );
+            assert_eq!(
+                cat.interwork[0].prefix,
+                Some("10.0.12.0/24".parse().unwrap()),
+                "the prefix still resolves downlink endpoints — into table 1"
+            );
+            assert_eq!(
+                cat.gtp_context_of("early"),
+                None,
+                "a named context without a kernel table is not cataloged yet"
             );
         }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8677,7 +8677,7 @@ pub(super) fn build_mup_segment_attr(
 pub(super) type MupSegmentKey = (
     RouteDistinguisher,
     MupPrefix,
-    std::net::Ipv6Addr,
+    Option<std::net::Ipv6Addr>,
     std::collections::BTreeSet<RouteDistinguisher>,
     Option<RouteDistinguisher>,
 );
@@ -8688,7 +8688,10 @@ pub(super) type MupSegmentKey = (
 struct MupSegmentDesired {
     rd: RouteDistinguisher,
     prefix: MupPrefix,
-    sid: std::net::Ipv6Addr,
+    /// The VRF's End.DT46 SID (SRv6 PE), or `None` for the SID-less
+    /// GTP-only origination — the segment is advertised purely as the
+    /// correlation object (Direct-segment id / interwork prefix).
+    sid: Option<std::net::Ipv6Addr>,
     rts: std::collections::BTreeSet<RouteDistinguisher>,
     ext_comm: Option<RouteDistinguisher>,
     mode: super::vrf_config::MupSegmentMode,
@@ -14322,25 +14325,40 @@ impl Bgp {
                 }
             }
             MupPrefix::Dsd { .. } | MupPrefix::Isd { .. } => {
-                // The reconcile gated on these being ready before dispatching;
-                // re-check defensively (a locator/SID change could race the
-                // round-trip) and drop the export rather than advertise a
-                // SID-less segment.
-                let (Some(locator), Some((sid, _))) = (
-                    self.srv6_locator.as_ref(),
-                    self.vrf_registry.get(&vrf).and_then(|h| h.srv6_sid),
-                ) else {
-                    return false;
-                };
-                let Some(node) = locator.node_sid_addr() else {
-                    return false;
-                };
-                attr.nexthop = Some(BgpNexthop::Ipv6(node));
-                attr.prefix_sid = Some(super::inst::srv6_l3_service_prefix_sid(
-                    sid,
-                    locator.sid_structure(),
-                    bgp_packet::SRV6_BEHAVIOR_END_DT46,
-                ));
+                let srv6 = self
+                    .vrfs
+                    .get(&vrf)
+                    .map(|c| c.encapsulation == super::vrf_config::BgpVrfEncapsulation::Srv6)
+                    .unwrap_or(false);
+                if srv6 {
+                    // The reconcile gated on these being ready before
+                    // dispatching; re-check defensively (a locator/SID change
+                    // could race the round-trip) and drop the export rather
+                    // than advertise a segment missing its SID.
+                    let (Some(locator), Some((sid, _))) = (
+                        self.srv6_locator.as_ref(),
+                        self.vrf_registry.get(&vrf).and_then(|h| h.srv6_sid),
+                    ) else {
+                        return false;
+                    };
+                    let Some(node) = locator.node_sid_addr() else {
+                        return false;
+                    };
+                    attr.nexthop = Some(BgpNexthop::Ipv6(node));
+                    attr.prefix_sid = Some(super::inst::srv6_l3_service_prefix_sid(
+                        sid,
+                        locator.sid_structure(),
+                        bgp_packet::SRV6_BEHAVIOR_END_DT46,
+                    ));
+                } else {
+                    // GTP-only PE (dataplane gtp, no SRv6 encapsulation):
+                    // SID-less segment — no Prefix-SID TLV; the controller
+                    // address is the next-hop (the reconcile gated on it).
+                    let Some(addr) = self.mup_c_config.controller_address else {
+                        return false;
+                    };
+                    attr.nexthop = Some(BgpNexthop::Ipv6(addr));
+                }
             }
             MupPrefix::Unknown { .. } => return false,
         }
@@ -14665,18 +14683,29 @@ impl Bgp {
         use super::vrf_config::BgpVrfEncapsulation;
         let cfg = self.vrfs.get(name)?;
         let mode = cfg.mobile_uplane.segment?;
-        if cfg.encapsulation != BgpVrfEncapsulation::Srv6 {
-            return None;
-        }
         let rd = cfg.rd?;
-        // A known kernel VRF is the proxy for "End.DT46 decap installed".
+        // A known kernel VRF is the proxy for "the segment's table exists"
+        // (and, for SRv6, "End.DT46 decap installed").
         if !self.rib_known_vrfs.contains_key(name) {
             return None;
         }
-        let (sid, _function) = self.vrf_registry.get(name)?.srv6_sid?;
-        let locator = self.srv6_locator.as_ref()?;
-        // Locator node next-hop must be resolvable (applied at export).
-        locator.node_sid_addr()?;
+        let sid = if cfg.encapsulation == BgpVrfEncapsulation::Srv6 {
+            // SRv6 PE: the segment carries the VRF's End.DT46 SID, and the
+            // locator node next-hop must be resolvable (applied at export).
+            let (sid, _function) = self.vrf_registry.get(name)?.srv6_sid?;
+            let locator = self.srv6_locator.as_ref()?;
+            locator.node_sid_addr()?;
+            Some(sid)
+        } else if cfg.mobile_uplane.dataplane == super::vrf_config::MupDataplane::Gtp {
+            // GTP-only PE: SID-less origination. The segment is the
+            // correlation object a peer resolves by Direct-segment id /
+            // prefix containment; the export stamps the controller address
+            // as the next-hop, so one must be configured.
+            self.mup_c_config.controller_address?;
+            None
+        } else {
+            return None;
+        };
         let router_id = cfg.router_id.unwrap_or(self.router_id);
         // Confirm the NLRI key is available now (non-zero router-id for Direct
         // / set interwork prefix for Interwork) so we don't dispatch a segment

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -6365,6 +6365,7 @@ mod detail_tests {
                 segment: None,
                 mup_ext_comm: None,
                 interwork_prefix: None,
+                interwork_lookup_ni: None,
                 dataplane: Default::default(),
             },
             ..Default::default()
@@ -6378,6 +6379,7 @@ mod detail_tests {
                 segment: None,
                 mup_ext_comm: None,
                 interwork_prefix: None,
+                interwork_lookup_ni: None,
                 dataplane: Default::default(),
             },
             ..Default::default()
@@ -6396,6 +6398,7 @@ mod detail_tests {
                 segment: None,
                 mup_ext_comm: None,
                 interwork_prefix: None,
+                interwork_lookup_ni: None,
                 dataplane: Default::default(),
             },
             ..Default::default()

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1097,9 +1097,12 @@ impl BgpVrf {
     /// becomes a cradle PDR, resolved against the segment catalog
     /// (docs/design/bgp-mup-gtp-segment-resolution-plan.md §3.2/§3.3):
     ///
-    ///   * **match context** — when THIS VRF is a `segment interwork`, the
-    ///     PDR is scoped to its own table (GTP-U terminates on its ports);
-    ///     otherwise VRF 0 (N3 in the global table — the single-N6 shape).
+    ///   * **match context** — when THIS VRF declares a `segment interwork`,
+    ///     the PDR is scoped to that segment's GTP-side context: its
+    ///     `lookup-network-instance` VRF's table when named (the
+    ///     split/GTP-gateway shape), else this VRF's own (GTP-U terminates
+    ///     on its ports); otherwise VRF 0 (N3 in the global table — the
+    ///     single-N6 shape).
     ///   * **decap target** — the direct segment whose Direct-segment id
     ///     matches the ST2's MUP Extended Community (the DSD correlation,
     ///     draft §3.3.12), else this VRF's own table.
@@ -1109,11 +1112,10 @@ impl BgpVrf {
     fn reconcile_mup_gtp_uplink(&mut self) {
         use std::net::{IpAddr, Ipv4Addr};
         let own_table = self.ctx.vrf_id();
-        let match_vrf = if self.mup_segment_catalog.is_interwork(&self.name) {
-            own_table
-        } else {
-            0
-        };
+        let match_vrf = self
+            .mup_segment_catalog
+            .gtp_context_of(&self.name)
+            .unwrap_or(0);
         // Desired PDRs: each selected ST2 with a v4 endpoint + non-zero TEID,
         // mapped to its resolved inner-lookup table.
         let mut desired: std::collections::BTreeMap<(u32, Ipv4Addr, u32), u32> =
@@ -4723,6 +4725,71 @@ mod tests {
                 .get(&(7, Ipv4Addr::new(10, 0, 12, 2), 0x100)),
             Some(&7),
             "the PDR re-keys onto the interwork VRF's table"
+        );
+        assert_eq!(vrf.mup_gtp_pdr_installed.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_uplink_lookup_ni_scopes_match_to_the_named_context() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::bgp::vrf_config::{MupInterworkEntry, MupSegmentCatalog};
+        use bgp_packet::{BgpAttr, MupPrefix};
+        use std::net::{IpAddr, Ipv4Addr};
+
+        // The split/GTP-gateway shape: ONE service VRF (table 2) holds the
+        // ST2, and its interwork declaration names N3 (table 1) as the
+        // GTP-side context via lookup-network-instance — the catalog entry
+        // carries the NAMED table.
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(2, "mobile");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "mobile".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+        vrf.mup_segment_catalog = MupSegmentCatalog {
+            interwork: vec![MupInterworkEntry {
+                vrf: "mobile".to_string(),
+                table_id: 1,
+                prefix: Some("10.0.12.0/24".parse().unwrap()),
+            }],
+            direct: Vec::new(),
+        };
+
+        let attr = BgpAttr::new();
+        let rd: bgp_packet::RouteDistinguisher = "65000:1".parse().unwrap();
+        vrf.local_rib.mup.entry(rd).or_default().selected.insert(
+            MupPrefix::T2st {
+                endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 12, 1)),
+                teid: 0x500,
+            },
+            BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            ),
+        );
+
+        vrf.reconcile_mup_gtp();
+        // Match context = the named N3 table (1); decap target = the
+        // holding service VRF's own table (2) — no direct segment needed.
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed
+                .get(&(1, Ipv4Addr::new(10, 0, 12, 1), 0x500)),
+            Some(&2),
+            "PDR matches in the named GTP context, decaps into the service VRF"
         );
         assert_eq!(vrf.mup_gtp_pdr_installed.len(), 1);
     }

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -228,11 +228,17 @@ pub struct MupSegmentCatalog {
 }
 
 impl MupSegmentCatalog {
-    /// Whether `vrf` is declared an interwork segment — its ports terminate
-    /// GTP-U, so the uplink PDR match is scoped to its own table instead of
-    /// the global context.
-    pub fn is_interwork(&self, vrf: &str) -> bool {
-        self.interwork.iter().any(|e| e.vrf == vrf)
+    /// The GTP-side routing context of the interwork segment `vrf`
+    /// declares: the table G-PDUs arrive in, so the uplink PDR match for
+    /// ST2s held in `vrf` is scoped to it. With `lookup-network-instance`
+    /// this is the named VRF's table (the split/GTP-gateway shape); without
+    /// it, the declaring VRF's own. `None` when `vrf` declares no interwork
+    /// segment — the match context stays global.
+    pub fn gtp_context_of(&self, vrf: &str) -> Option<u32> {
+        self.interwork
+            .iter()
+            .find(|e| e.vrf == vrf)
+            .map(|e| e.table_id)
     }
 
     /// The kernel table of the direct segment carrying Direct-segment id
@@ -246,10 +252,13 @@ impl MupSegmentCatalog {
     }
 }
 
-/// One interwork segment (`segment interwork` on a VRF): a GTP/N3 routing
-/// context. `prefix` is the configured gNB network (`segment interwork
-/// prefix <p>`), absent when only the membership is declared — the ISD does
-/// not originate without it, but the match-context scoping already applies.
+/// One interwork segment (`segment interwork` on a VRF). `table_id` is the
+/// segment's **GTP-side routing context** — the `lookup-network-instance`
+/// VRF's kernel table when named, else the declaring VRF's own — consumed
+/// by both the uplink match scoping and the downlink endpoint resolution.
+/// `prefix` is the configured gNB network (`segment interwork prefix <p>`),
+/// absent when only the association is declared — the ISD does not
+/// originate without it, but the match-context scoping already applies.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MupInterworkEntry {
     pub vrf: String,
@@ -348,6 +357,12 @@ pub struct BgpVrfMobileUplane {
     /// `interwork` segment; the ISD does not originate until it is set, and
     /// its AFI follows this prefix's family.
     pub interwork_prefix: Option<IpNet>,
+    /// `afi-safi mup segment interwork lookup-network-instance <vrf>` — the
+    /// VRF that is the GTP-side routing context for this interwork segment
+    /// when it is not the declaring VRF itself (the split/GTP-gateway shape:
+    /// the service VRF declares the interwork association while GTP-U rides
+    /// a separate N3 VRF). `None` = the declaring VRF.
+    pub interwork_lookup_ni: Option<String>,
     /// `afi-safi mup dataplane {end-dt46|gtp}` — the forwarding-plane
     /// behaviour for this VRF's MUP service. `EndDt46` (default) installs the
     /// SRv6 End.DT46 stand-in into the mainline kernel; `Gtp` programs a real
@@ -700,6 +715,24 @@ pub fn config_vrf_mup_segment_prefix(bgp: &mut Bgp, mut args: Args, op: ConfigOp
             cfg.mobile_uplane.interwork_prefix = Some(IpNet::from_str(&raw).ok()?);
         }
         ConfigOp::Delete => cfg.mobile_uplane.interwork_prefix = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> afi-safi mup segment interwork
+/// lookup-network-instance <vrf>` — names the GTP-side routing context for
+/// the interwork segment (skips the segment list key like the `prefix`
+/// handler).
+pub fn config_vrf_mup_segment_lookup_ni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let _segment = args.string()?; // segment list key (direct|interwork)
+    let cfg = vrf_entry(bgp, name, op)?;
+    match op {
+        ConfigOp::Set => {
+            cfg.mobile_uplane.interwork_lookup_ni = Some(args.string()?);
+        }
+        ConfigOp::Delete => cfg.mobile_uplane.interwork_lookup_ni = None,
         _ => {}
     }
     Some(())

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2275,6 +2275,7 @@ mod yang_load_tests {
             "set router bgp vrf N3 afi-safi mup segment interwork",
             "set router bgp vrf N3 afi-safi mup segment direct mup-ext-comm 1:20",
             "set router bgp vrf N3 afi-safi mup segment interwork prefix 10.60.0.0/16",
+            "set router bgp vrf N3 afi-safi mup segment interwork lookup-network-instance N3",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -785,6 +785,21 @@ module zebra-bgp-vrf {
                `interwork` segment; the ISD does not originate until it is
                set.";
           }
+          leaf lookup-network-instance {
+            ext:help "VRF the GTP-side (N3) lookup runs in for this interwork segment";
+            type string;
+            description
+              "Names the VRF that is the GTP-side routing context for this
+               interwork segment, when it is not the declaring VRF itself.
+               With `dataplane gtp` the declaring VRF's ST1 endpoints
+               (falling inside `prefix`) resolve their post-encap outer
+               (gw, oif) in the named VRF's table, and its ST2 decap PDRs
+               match G-PDUs arriving on the named VRF's ports — the
+               split/GTP-gateway shape where the service VRF advertises the
+               downlink entry point (its own DT SID) while GTP-U rides a
+               separate N3 VRF. Defaults to the declaring VRF. Meaningful
+               only under the `interwork` segment.";
+          }
         }
         list route {
           ext:help "Session-Transformed (ST) route to originate";


### PR DESCRIPTION
## Summary

The two stage-6 knobs of `docs/design/bgp-mup-gtp-segment-resolution-plan.md`, closing the plan (only the N9/SRGW composite and GTP6 stay out of scope).

**`segment interwork lookup-network-instance <vrf>`** — names the segment's GTP-side routing context when it is not the declaring VRF. The catalog's interwork entry carries the named VRF's kernel table (gated on it being known; the named VRF needs no `router bgp vrf` block), and both consumers follow it: the uplink PDR match scoping (`is_interwork()` → `gtp_context_of()`) and the downlink endpoint resolution. Flagship shape: the GTP gateway — ONE service VRF binds both `route` directions (the single-N6 form) while its interwork declaration names a bare kernel VRF as N3. Without the leaf the declaring VRF is its own context, so all stage-3/4/5 behavior is unchanged.

**SID-less segment origination** — a `dataplane gtp` VRF without `encapsulation srv6` originates its DSD/ISD with no SRv6 L3 Service Prefix-SID; next-hop = the `mup-c` `controller-address` (origination gates on it). `MupSegmentDesired.sid` became `Option`; the SRv6 path is untouched.

Audit docs regenerated for the new settable node; book ch-02-35 gains the GTP-gateway variant and the SID-less note; the design doc is marked complete.

## Test plan

- New BDDs, both first-run green: zebra `bgp_mup_sidless_segment` (originate + receive, should-not-contain SID assertions); cradle `@cradle_mup_gtp_lookup_ni` (round trip through the named N3 context — cradle-rs PR follows).
- Regression green on the staged toolchain: `bgp_mup_{segment_dsd,isd,interwork,dual_st,e2e}`; cradle-coupled `cradle_mup_gtp_{n3_vrf,single_n6}` against the merged cradle.
- `cargo fmt --check`, workspace clippy `-D warnings`, 2732 workspace tests; `mdbook build` clean.

Generated with [Claude Code](https://claude.com/claude-code)