### PR TITLE
Static-ILM v6 nexthops + explicit interface leaf for transit pops

### DIFF
--- a/docs/design/bgp-evpn-support-status.md
+++ b/docs/design/bgp-evpn-support-status.md
@@ -20,13 +20,13 @@ datapath, driven from zebra-rs via the FibHandle tee.
 | **Multihoming ESI (Type-1/4, DF election)** | ✅ Control plane (shared) | ✅ Full signal set incl. Type-2 ESI (#2148/#2150/#2152) | ✅ Control plane (shared) |
 | **MAC aliasing / mass-withdraw consumers** | ❌ Open (receive side) | ❌ Open — exists for VPWS only | ❌ Open |
 | **E-Line / VPWS (RFC 8214)** | ✅ Type-1 VNI + Encapsulation EC + VTEP next hop; cradle eBPF xconnect (VTEP+VNI encap, E-Line-VNI decap) | ✅ End.DX2/DX2V, VLAN scoping, MTU check, P/B multihoming (#2116) | ✅ Per-service label, no Encapsulation EC; cradle eBPF xconnect (label encap under the transport LSP, pop-to-AC decap) |
-| **IPv6 underlay transport** | ✅ Kernel: zero code changes (#1850); eBPF: native v6 VTEPs incl. E-Line + `vtep-source` origination knob (cradle #168) | ✅ (native) | ✅ v6 PEs: FIB6 service-label resolution (engine) + `vtep-source` next hops; labeled static v6 routes for transport (IS-IS SR-MPLS prefix-SIDs remain v4-only) |
+| **IPv6 underlay transport** | ✅ Kernel: zero code changes (#1850); eBPF: native v6 VTEPs incl. E-Line + `vtep-source` origination knob (cradle #168) | ✅ (native) | ✅ v6 PEs: FIB6 service-label resolution (engine) + `vtep-source` next hops; labeled static v6 routes + static-ILM v6 bindings for transport incl. pure-P transit (IS-IS SR-MPLS prefix-SIDs remain v4-only) |
 | **IGMP/MLD proxy / SMET (RFC 9251)** | ✅ Incl. per-VTEP selective MDB | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **Assisted Replication (RFC 9574)** | ✅ Control plane; AR-LEAF/RNVE forward natively. ❌ AR-REPLICATOR data plane deferred | ✅ Control plane (shared) | ✅ Control plane (shared) |
 | **BUM segmentation (RFC 9572, Types 9/10/11)** | ✅ Control plane complete (RBR/ASBR, DF, S-PMSI) | ✅ + SR-P2MP tree offload wiring | ✅ Control plane (shared) |
 | **P2MP replication tree** | — (head-end IR model) | ✅ RFC 9524 End.Replicate incl. Bud (zebra #1923 + cradle #131) | ❌ MPLS-P2MP forwarder not built |
 | **ARP suppression** | ❌ Open | ❌ Open | ❌ Open |
-| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra`, v6-underlay twins `cradle_evpn_vxlan6_zebra` + `cradle_vpws_vxlan6_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit), v6-PE twins `cradle_evpn_mpls6_zebra` + `cradle_vpws_mpls6_zebra` |
+| **Datapath BDD (CE-to-CE ping, zebra-driven)** | ✅ `cradle_evpn_vxlan_zebra*`, `cradle_vpws_vxlan_zebra`, v6-underlay twins `cradle_evpn_vxlan6_zebra` + `cradle_vpws_vxlan6_zebra` + kernel playsets | ✅ `cradle_evpn_srv6_zebra*`, `cradle_vpws_zebra` — deepest coverage | ✅ `cradle_evpn_mpls_zebra`, `cradle_vpws_mpls_zebra` (IS-IS SR-MPLS transport + pure-P transit), v6-PE twins `cradle_evpn_mpls6_zebra` + `cradle_vpws_mpls6_zebra` + P-transit `cradle_evpn_mpls6_zebra_transit` |
 
 **Legend**: ✅ supported · ❌ not yet · — not applicable. "Control plane
 (shared)" = the feature is encapsulation-agnostic in zebra-rs; the per-encap

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -727,6 +727,13 @@ pub struct IlmEntry {
     pub rtype: RibType,
     pub ilm_type: IlmType,
     pub nexthop: Nexthop,
+    /// Egress interface the operator named on a static label binding
+    /// (`mpls label ... nexthop <gw> interface <name>`), resolved to the
+    /// nexthop's ifindex by `Rib::ilm_add`. `None` for every other
+    /// producer — IGP ILMs carry their adjacency ifindex directly, and an
+    /// unnamed static nexthop deliberately stays oif-less (FIB-assisted
+    /// pop). Single-nexthop bindings only; ECMP members ignore it.
+    pub nexthop_ifname: Option<String>,
     /// Administrative distance, mirroring the IP RIB convention
     /// (static 1, OSPF 110, IS-IS 115, BGP 20). Set by
     /// `IlmEntry::new` from the owning `rtype`. Primary tie-break key
@@ -759,6 +766,7 @@ impl IlmEntry {
             rtype,
             ilm_type: IlmType::None,
             nexthop: Nexthop::default(),
+            nexthop_ifname: None,
             distance: ilm_distance(rtype),
             metric: 0,
             selected: false,

--- a/zebra-rs/src/rib/mpls/config.rs
+++ b/zebra-rs/src/rib/mpls/config.rs
@@ -152,20 +152,36 @@ fn config_builder() -> ConfigBuilder {
         .path("/router/static/mpls/label/nexthop")
         .set(|config, cache, label, args| {
             let s = cache_get(config, cache, &label).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let naddr = args.addr().context(NEXTHOP_ERR)?;
             let _ = s.nexthops.entry(naddr).or_default();
             Ok(())
         })
         .del(|config, cache, label, args| {
             let s = cache_lookup(config, cache, &label).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let naddr = args.addr().context(NEXTHOP_ERR)?;
             s.nexthops.remove(&naddr).context(CONFIG_ERR)?;
+            Ok(())
+        })
+        .path("/router/static/mpls/label/nexthop/interface")
+        .set(|config, cache, label, args| {
+            const IFNAME_ERR: &str = "missing interface arg";
+            let s = cache_get(config, cache, &label).context(CONFIG_ERR)?;
+            let naddr = args.addr().context(NEXTHOP_ERR)?;
+            let n = s.nexthops.entry(naddr).or_default();
+            n.interface = Some(args.string().context(IFNAME_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, label, args| {
+            let s = cache_lookup(config, cache, &label).context(CONFIG_ERR)?;
+            let naddr = args.addr().context(NEXTHOP_ERR)?;
+            let n = s.nexthops.get_mut(&naddr).context(CONFIG_ERR)?;
+            n.interface = None;
             Ok(())
         })
         .path("/router/static/mpls/label/nexthop/outgoing-label")
         .set(|config, cache, label, args| {
             let s = cache_get(config, cache, &label).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let naddr = args.addr().context(NEXTHOP_ERR)?;
             let n = s.nexthops.entry(naddr).or_default();
             let olabel = args.u32().context(OUT_LABEL_ERR)?;
             n.out_label = Some(olabel);
@@ -173,7 +189,7 @@ fn config_builder() -> ConfigBuilder {
         })
         .del(|config, cache, label, args| {
             let s = cache_lookup(config, cache, &label).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let naddr = args.addr().context(NEXTHOP_ERR)?;
             let n = s.nexthops.get_mut(&naddr).context(CONFIG_ERR)?;
             n.out_label = None;
             Ok(())

--- a/zebra-rs/src/rib/mpls/route.rs
+++ b/zebra-rs/src/rib/mpls/route.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 use crate::rib::inst::IlmEntry;
 use crate::rib::nexthop::NexthopUni;
@@ -8,11 +8,14 @@ use crate::rib::{Nexthop, NexthopMulti, RibType};
 #[derive(Debug, Default, Clone)]
 pub struct MplsNexthop {
     pub out_label: Option<u32>,
+    /// Explicit egress interface — opts the pop onto the eBPF XDP fast
+    /// path (see `IlmEntry::nexthop_ifname`).
+    pub interface: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct MplsRoute {
-    pub nexthops: BTreeMap<Ipv4Addr, MplsNexthop>,
+    pub nexthops: BTreeMap<IpAddr, MplsNexthop>,
     pub delete: bool,
 }
 
@@ -27,12 +30,13 @@ impl MplsRoute {
         if self.nexthops.len() == 1 {
             let (&addr, n) = self.nexthops.iter().next()?;
             let mut nhop = NexthopUni {
-                addr: std::net::IpAddr::V4(addr),
+                addr,
                 ..Default::default()
             };
             if let Some(out_label) = n.out_label {
                 nhop.mpls_label.push(out_label);
             }
+            ilm.nexthop_ifname = n.interface.clone();
             ilm.nexthop = Nexthop::Uni(nhop);
             return Some(ilm);
         }
@@ -40,7 +44,7 @@ impl MplsRoute {
         let mut multi = NexthopMulti::default();
         for (&addr, n) in self.nexthops.iter() {
             let mut nhop = NexthopUni {
-                addr: std::net::IpAddr::V4(addr),
+                addr,
                 ..Default::default()
             };
             if let Some(out_label) = n.out_label {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -848,6 +848,20 @@ impl Rib {
     /// `table_id` parameter, and the inbound dispatcher doesn't pass
     /// one for these variants.
     pub async fn ilm_add(&mut self, label: u32, mut ilm: IlmEntry) {
+        // Resolve an explicitly named egress interface (`mpls label ...
+        // nexthop <gw> interface <name>`) to its ifindex. Deliberately
+        // opt-in, never inferred from connected prefixes: a resolved oif
+        // moves the eBPF pop onto the XDP fast path, whose redirect only
+        // delivers toward XDP-attached ports — naming the interface is
+        // the operator asserting this is a core-facing transit hop. An
+        // unnamed nexthop stays oif-less and pops via the FIB-assisted
+        // path, which reaches any device.
+        if let Some(name) = ilm.nexthop_ifname.clone()
+            && let Nexthop::Uni(u) = &mut ilm.nexthop
+            && u.ifindex().is_none()
+        {
+            u.ifindex_resolved = self.link_by_name(&name).map(|l| l.index);
+        }
         // Stamp the local-delivery pops (see `IlmEntry::local_pop`): a
         // nexthop egressing a loopback means the label's owner is this
         // node — every producer's self prefix-SID entry has this shape.

--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -46,6 +46,11 @@ module config-static {
             ext:help "Nexthop address, or blackhole to discard";
             type union {
               type inet:ipv4-address;
+              // An IPv6 nexthop makes this a static ILM over a
+              // v6-numbered core (RTA_VIA inet6 in the kernel, a v6
+              // adjacency in the eBPF tee) — the transit shape of
+              // MPLS-over-v6 PEs.
+              type inet:ipv6-address;
               // `blackhole` at the nexthop-key position turns the
               // route into a discard route (kernel RTN_BLACKHOLE),
               // satisfying the route's `ext:non-empty "nexthop"`.
@@ -58,6 +63,20 @@ module config-static {
           leaf "outgoing-label" {
             ext:help "Outgoing MPLS label";
             type uint32;
+          }
+          leaf interface {
+            ext:help "Egress interface (opts into the eBPF XDP fast-path pop)";
+            type string;
+            description
+              "Explicit egress interface for this label nexthop. Naming
+               it opts the pop onto the eBPF XDP fast path, whose
+               redirect delivers only toward XDP-attached ports — the
+               operator's assertion that this is a core-facing transit
+               hop (e.g. a pure-P router popping toward the egress PE,
+               which holds no route to the frame's inner destination).
+               Left unset, the pop stays on the FIB-assisted path, which
+               reaches any device but requires a route for the exposed
+               payload.";
           }
         }
       }


### PR DESCRIPTION
## Summary

The last v4-only piece of the MPLS-over-v6 arc: static `mpls label` bindings accept IPv6 nexthops (YANG union + `MplsRoute` keyed by `IpAddr` + dual-family parses — kernel `RTA_VIA inet6` and the cradle tee were already ready).

A new optional `interface` leaf on the label nexthop opts the pop onto the eBPF XDP fast path. This is deliberately **opt-in, never inferred**: a resolved oif makes the engine pop-and-forward via `bpf_redirect`, which only delivers between XDP-attached ports — naming the interface is the operator's assertion of a core-facing transit hop (a pure-P router popping toward the egress PE, which holds no route for the exposed payload). Unnamed nexthops keep the FIB-assisted pop that reaches any device, so **every existing config behaves exactly as before** (an earlier connected-prefix-inference draft broke `cradle_mpls_zebra`'s edge pop and was replaced by this design).

## Test plan

- Live vty: v6 swap and PHP-pop shapes apply and render (`show mpls ilm`).
- e2e (cradle branch `static-ilm-v6`): `cradle_evpn_mpls6_zebra_transit` — pure-P IPv6 label switching where even the PEs' iBGP session rides the LSP through the routeless P — passes.
- 29-feature all-encap overlay sweep green; targeted pop-path set (static/IS-IS/TI-LFA/TTL/zebra-driven) 6/6.
- `cargo test -p zebra-rs` (1892), workspace clippy, fmt green.

Generated with [Claude Code](https://claude.com/claude-code)