### PR TITLE
Playsets + book: MPLS-over-v6 E-LAN and E-Line labs

### DIFF
--- a/book/src/ch-02-40-bgp-evpn-mpls.md
+++ b/book/src/ch-02-40-bgp-evpn-mpls.md
@@ -185,13 +185,72 @@ diagnosis rather than a quiet success.
 > decap during config load, which is typically while the tee is still
 > connecting.
 
+## IPv6 PEs
+
+Nothing in RFC 7432 requires an IPv4 core — MPLS imposes no outer IP
+header, so the PE's address family lives only in the control plane and the
+adjacency. Three pieces make an IPv6-only deployment:
+
+* **`vtep-source`** names the v6 loopback the EVPN routes advertise. The
+  router-id — the default source for an MPLS PE's next hop and IMET
+  Originating Router IP — can only express IPv4, so a v6 PE sets it
+  explicitly (the leaf is shared with VXLAN, where it covers deviceless
+  services; here it covers every origination):
+
+  ```
+  afi-safi {
+    name evpn;
+    encapsulation mpls;
+    vtep-source 2001:db8:255::1;
+    ...
+  }
+  ```
+
+* **A labeled route to the far PE's v6 loopback** supplies the transport
+  LSP. IS-IS SR-MPLS prefix-SIDs are IPv4-only today, so on a v6 core the
+  static form carries the stack — the `label` list on an ipv6 route
+  nexthop, the exact sibling of the ipv4 one:
+
+  ```
+  router static ipv6 route 2001:db8:255::2/128 {
+    nexthop 2001:db8:12::2 {
+      label 100;
+    }
+  }
+  ```
+
+  The datapath resolves a remote MAC's service-label imposition by a FIB6
+  /128 lookup on the PE, picking up this route's transport labels — the
+  same nexthop-0 shape as the IPv4 core.
+
+* **Static label bindings with v6 nexthops** give a pure-transit P router
+  its pops. The explicit `interface` leaf opts each binding onto the eBPF
+  XDP fast path — the operator's assertion of a core-facing hop, needed
+  because the P holds no route for the exposed payload (the PEs'
+  loopbacks) and the XDP redirect delivers only between XDP-attached
+  ports. A binding without it keeps the FIB-assisted pop, which reaches
+  any device but needs a route for what the pop exposes:
+
+  ```
+  router static mpls label 100 {
+    nexthop 2001:db8:23::2 {
+      interface p-pe2;
+    }
+  }
+  ```
+
+The
+[`playset/bgp-evpn-mpls6`](https://github.com/zebra-rs/zebra-rs/tree/main/playset/bgp-evpn-mpls6)
+lab is the IPv6 twin of this chapter's — the same stretched segment and
+pure-transit P, with static labels replacing the IGP and even the PEs' own
+iBGP session riding the LSP through the routeless P. Its E-Line sibling is
+[`playset/bgp-evpn-vpws-mpls6`](https://github.com/zebra-rs/zebra-rs/tree/main/playset/bgp-evpn-vpws-mpls6).
+
 ## Limitations
 
 - **Requires cradle** (`system cradle enabled` plus an engine — see
   [Enabling the data plane](#enabling-the-data-plane)). Without it the routes
   are advertised and received but nothing forwards.
-- **IPv4 underlay only** in the data plane today; an IPv6-underlay PE punts
-  rather than misforwarding.
 - **Single-homed.** Multihoming (Type-1/Type-4 and the ESI label's
   split-horizon check) is not implemented for MPLS.
 - **No control word.** RFC 7432 leaves it optional and both ends must agree.

--- a/playset/README.md
+++ b/playset/README.md
@@ -108,13 +108,16 @@ endpoints, next hops, PMSI, and FDB `dst`, while the RD stays IPv4), and move
 down to add a **second isolated VNI** (three VTEPs, one serving both; per-VNI
 RD/RT — hosts in different VNIs share a subnet yet cannot reach each other).
 
-The IPv4 column also exists on the **eBPF engine** —
-[bgp-evpn-vxlan4-ebpf](bgp-evpn-vxlan4-ebpf/README.md) and
-[bgp-evpn-vxlan4-multi-ebpf](bgp-evpn-vxlan4-multi-ebpf/README.md): the same
+The whole matrix also exists on the **eBPF engine** —
+[bgp-evpn-vxlan4-ebpf](bgp-evpn-vxlan4-ebpf/README.md),
+[bgp-evpn-vxlan4-multi-ebpf](bgp-evpn-vxlan4-multi-ebpf/README.md),
+[bgp-evpn-vxlan6-ebpf](bgp-evpn-vxlan6-ebpf/README.md) and
+[bgp-evpn-vxlan6-multi-ebpf](bgp-evpn-vxlan6-multi-ebpf/README.md): the same
 labs with the forwarding moved into XDP (`system ebpf enabled`), loopback
-VTEPs (the engine has one fabric-wide VTEP source), and kernel forwarding
-off. There is no eBPF IPv6 pair: the engine's VXLAN underlay is IPv4-only,
-so the IPv6-underlay story stays with the kernel labs.
+VTEPs (the engine has one fabric-wide VTEP source per address family), and
+kernel forwarding off. In the IPv6 twins the outer header is
+Ethernet + IPv6 + UDP and the engine's tables carry the VTEPs native
+(not v4-mapped).
 
 The four EVPN labs reuse the same namespace names (`vtep1`..`vtep3`,
 `h1`..`h4`), so bring up only one at a time — `up.sh` sweeps leftovers of
@@ -132,6 +135,7 @@ runs in eBPF:
 |:--|:--|
 | [bgp-evpn-srv6](bgp-evpn-srv6/README.md) | MAC-in-SRv6 (RFC 9252): per-VNI End.DT2U on the Type-2, End.DT2M on the Type-3, SIDs carved from each PE's locator; IS-IS SRv6 underlay |
 | [bgp-evpn-mpls](bgp-evpn-mpls/README.md) | RFC 7432's original encapsulation: a dynamic per-EVI service label (no Encapsulation EC — absent means MPLS), IS-IS SR-MPLS transport through a pure-transit P router |
+| [bgp-evpn-mpls6](bgp-evpn-mpls6/README.md) | The same E-LAN between **IPv6 PEs** on an IPv6-only core with no IGP: `vtep-source` v6 next hops, labeled static v6 routes as the transport, and the P popping via static-ILM v6 bindings (`interface` leaf = XDP fast path) |
 
 Both share namespace names (`h1`, `h2`, `pe1`, `pe2`, plus `p` in the
 MPLS variant) — one at a time.
@@ -152,6 +156,7 @@ kernel has no E-Line disposition for any of them.
 | [bgp-evpn-vpws-srv6](bgp-evpn-vpws-srv6/README.md) | End.DX2 L2-Service SID carved from the SRv6 locator, IS-IS SRv6 underlay |
 | [bgp-evpn-vpws-vxlan](bgp-evpn-vpws-vxlan/README.md) | Service VNI in the Type-1 label field + VXLAN Encapsulation EC, loopback VTEPs — with deliberately asymmetric VNIs per direction |
 | [bgp-evpn-vpws-mpls](bgp-evpn-vpws-mpls/README.md) | Dynamic per-service MPLS label, no Encapsulation EC (RFC 8365 §5.1.3), IS-IS SR-MPLS transport through a pure-transit P router |
+| [bgp-evpn-vpws-mpls6](bgp-evpn-vpws-mpls6/README.md) | The MPLS E-Line between **IPv6 PEs**: static labeled v6 transport, `vtep-source` naming the Type-1's v6 next hop, the same pure-transit P |
 
 The labs share namespace names (`c1`, `c2`, `pe1`, `pe2`, plus `p` in the
 MPLS variant), so bring up only one at a time.

--- a/playset/bgp-evpn-mpls6/README.md
+++ b/playset/bgp-evpn-mpls6/README.md
@@ -1,0 +1,132 @@
+# EVPN over MPLS between IPv6 PEs: no IGP, no IPv4
+
+The [bgp-evpn-mpls](../bgp-evpn-mpls/README.md) demo re-run on an
+**IPv6-only core with no IGP at all**: the same stretched L2 segment
+(E-LAN), the same dynamic per-EVI service label, the same pure-transit
+**P router** — but every underlay address is IPv6 and the transport
+labels are static. MPLS imposes no outer IP header, so the PEs' address
+family lives only in the control plane and the adjacencies; RFC 7432
+never required an IPv4 core, and here there isn't one.
+
+Three pieces replace the IPv4 lab's IS-IS SR-MPLS:
+
+* **`vtep-source`** names the v6 loopback each PE's EVPN routes advertise
+  as next hop and Originating Router IP — the router-id fallback can only
+  express IPv4;
+* a **labeled static v6 route** per PE supplies the transport LSP toward
+  the far loopback (the `label` list on an ipv6 nexthop — IS-IS
+  prefix-SIDs are IPv4-only today);
+* the P's **static MPLS label bindings with v6 nexthops** pop the
+  transport label toward each PE (PHP). Their explicit `interface` leaf
+  opts the pop onto the eBPF XDP fast path — the operator's assertion of
+  a core-facing hop, since the P holds **no route** for what the pop
+  exposes and the XDP redirect delivers only between XDP-attached ports.
+
+The P carries no BGP, no EVPN state, no routes — it label-switches
+between v6 adjacencies, entirely in eBPF. Even the PEs' own iBGP session
+rides the LSP: pe1's kernel imposes label 100 on the TCP toward pe2's
+loopback, the P's eBPF stage pops it, pe2's stack receives it plain.
+
+```
+ h1 ── pe1 ═══════ p ═══════ pe2 ── h2     h1/h2: 172.16.10.1/24, .2/24
+   2001:db8:12::/64  2001:db8:23::/64      pe1: lo 2001:db8:255::1
+     static labels 100 → / ← 101           pe2: lo 2001:db8:255::2
+             EVI 100 / bridge domain 100 stretched across
+```
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: h2
+applied
+```
+
+(`up.sh` also turns kernel forwarding off — both families — on pe1/p/pe2,
+computes TCP checksums in software on the PEs' core veths, and warms up
+the P's neighbor entries with one ping per adjacency.)
+
+## Ping, then read the three layers back
+
+```shell
+$ sudo ip netns exec h1 ping -c 3 172.16.10.2
+...
+3 packets transmitted, 3 received, 0% packet loss
+```
+
+The EVPN routes carry v6 next hops and a label (not a VNI):
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn
+Route Distinguisher: 1.1.1.1:100
+ *>  [2]:[0]:[48]:[b6:73:86:a6:62:60]
+                    2001:db8:255::1            0         32768 i
+                    Extended community: RT:65000:100
+ *>  [3]:[0]:[128]:[2001:db8:255::1]
+                    2001:db8:255::1            0         32768 i
+                    Extended community: RT:65000:100
+                    PMSI: ingress-replication endpoint:2001:db8:255::1 label:16
+Route Distinguisher: 2.2.2.2:100
+ *>  [2]:[0]:[48]:[de:5e:45:63:20:cc]
+                    2001:db8:255::2            0    100      0 i
+                    Extended community: RT:65000:100
+ *>  [3]:[0]:[128]:[2001:db8:255::2]
+                    2001:db8:255::2            0    100      0 i
+                    Extended community: RT:65000:100
+                    PMSI: ingress-replication endpoint:2001:db8:255::2 label:16
+```
+
+pe1's ILM table holds its own EVI decap; the P's holds the two transport
+pops with their v6 nexthops and named interfaces:
+
+```shell
+pe1>show mpls ilm
+   P Dist Local  Outgoing    Prefix             Outgoing     Next Hop
+          Label  Label       or ID              Interface
+-- - ---- ------ ----------- ------------------ ------------ ---------------
+*> B 20   16     Pop         EVPN Decap (bd 100 ) -
+```
+
+```shell
+$ sudo ip netns exec p vty
+p>show mpls ilm
+   P Dist Local  Outgoing    Prefix             Outgoing     Next Hop
+          Label  Label       or ID              Interface
+-- - ---- ------ ----------- ------------------ ------------ ---------------
+*> S 1    100    Pop         -                  p-pe2        2001:db8:23::2
+*> S 1    101    Pop         -                  p-pe1        2001:db8:12::1
+```
+
+The engine's FDB binds the remote MAC to the far PE natively in its
+16-byte slot, and the P's counters show the transit pops:
+
+```shell
+pe1>show ebpf l2
+mac                 vlan      oif flags       age_ms remote_sid
+b6:73:86:a6:62:60    100        2 learned         46
+de:5e:45:63:20:cc    100        0 remote           0 2001:db8:255::2
+```
+
+```shell
+p>show ebpf stats
+...
+mpls_pop       48
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| h1 | tenant host | `h1-pe1` 172.16.10.1/24 |
+| pe1 | PE, EVI 100 | `lo` 2001:db8:255::1/128, `pe1-p` 2001:db8:12::1/64 |
+| p | transit LSR | `p-pe1` 2001:db8:12::2/64, `p-pe2` 2001:db8:23::1/64 |
+| pe2 | PE, EVI 100 | `lo` 2001:db8:255::2/128, `pe2-p` 2001:db8:23::2/64 |
+| h2 | tenant host | `h2-pe2` 172.16.10.2/24 |

--- a/playset/bgp-evpn-mpls6/down.sh
+++ b/playset/bgp-evpn-mpls6/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the EVPN over MPLS between IPv6 PEs namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-mpls6/h1.yaml
+++ b/playset/bgp-evpn-mpls6/h1.yaml
@@ -1,0 +1,7 @@
+# Host 1 — a plain tenant host on the stretched segment.
+interface:
+- if-name: h1-pe1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-mpls6/h2.yaml
+++ b/playset/bgp-evpn-mpls6/h2.yaml
@@ -1,0 +1,7 @@
+# Host 2 — a plain tenant host on the stretched segment.
+interface:
+- if-name: h2-pe2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-mpls6/p.yaml
+++ b/playset/bgp-evpn-mpls6/p.yaml
@@ -1,0 +1,34 @@
+# P — the transit LSR, now with static-ILM v6 bindings and no IGP. No
+# BGP and no EVPN state at all: label 100 pops toward pe2 and 101 toward
+# pe1 (PHP), exposing the service label to the egress PE. The explicit
+# `interface` leaf opts each pop onto the eBPF XDP fast path — the
+# operator's assertion of a core-facing hop, since the P holds no route
+# for the exposed payload (the PEs' loopbacks) and the XDP redirect
+# delivers only between XDP-attached ports.
+system:
+  hostname: p
+  ebpf:
+    enabled: true
+interface:
+- if-name: p-pe1
+  ipv6:
+    address: 2001:db8:12::2/64
+  ebpf:
+    enabled: true
+- if-name: p-pe2
+  ipv6:
+    address: 2001:db8:23::1/64
+  ebpf:
+    enabled: true
+router:
+  static:
+    mpls:
+      label:
+      - value: 100
+        nexthop:
+        - address: 2001:db8:23::2
+          interface: p-pe2
+      - value: 101
+        nexthop:
+        - address: 2001:db8:12::1
+          interface: p-pe1

--- a/playset/bgp-evpn-mpls6/pe1.yaml
+++ b/playset/bgp-evpn-mpls6/pe1.yaml
@@ -1,0 +1,58 @@
+# PE1 — an EVPN-over-MPLS provider edge on an IPv6-only core, no IGP
+# anywhere. A labeled static /128 supplies the transport LSP toward
+# PE2's v6 loopback (the P pops it); `vtep-source` names the v6 loopback
+# the EVPN routes advertise as next hop and Originating Router IP — the
+# router-id fallback could only express an IPv4 PE. Under
+# `encapsulation mpls` the `evi 100` instance takes a dynamic per-EVI
+# service label and installs its bridge-domain decap ILM. Everything
+# forwards in eBPF — no kernel action pops an MPLS label into a bridge.
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:255::1/128
+- if-name: pe1-p
+  ipv6:
+    address: 2001:db8:12::1/64
+  ebpf:
+    enabled: true
+- if-name: pe1-h1
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:255::2/128
+        nexthop:
+        - address: 2001:db8:12::2
+          label: [100]
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      vtep-source: 2001:db8:255::1
+      evi:
+      - id: 100
+        bridge: br100
+    neighbor:
+    - remote-address: 2001:db8:255::2
+      remote-as: 65000
+      update-source: 2001:db8:255::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-mpls6/pe2.yaml
+++ b/playset/bgp-evpn-mpls6/pe2.yaml
@@ -1,0 +1,52 @@
+# PE2 — mirror of pe1: v6 loopback 2001:db8:255::2 as `vtep-source`,
+# transport label 101 toward pe1's loopback, EVI 100 on br100.
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:255::2/128
+- if-name: pe2-p
+  ipv6:
+    address: 2001:db8:23::2/64
+  ebpf:
+    enabled: true
+- if-name: pe2-h2
+  bridge: br100
+  ebpf:
+    enabled: true
+bridge:
+- name: br100
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:255::1/128
+        nexthop:
+        - address: 2001:db8:23::1
+          label: [101]
+  bgp:
+    global:
+      as: 65000
+      router-id: 2.2.2.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      encapsulation: mpls
+      vtep-source: 2001:db8:255::2
+      evi:
+      - id: 100
+        bridge: br100
+    neighbor:
+    - remote-address: 2001:db8:255::1
+      remote-as: 65000
+      update-source: 2001:db8:255::2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-mpls6/topology.sh
+++ b/playset/bgp-evpn-mpls6/topology.sh
@@ -1,0 +1,18 @@
+# EVPN over MPLS between IPv6 PEs (E-LAN in eBPF) demo topology, with a
+# pure-transit P router between the PEs.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(h1 pe1 p pe2 h2)
+
+PLAYSET_LINKS=(
+    h1:h1-pe1:pe1:pe1-h1
+    pe1:pe1-p:p:p-pe1
+    p:p-pe2:pe2:pe2-p
+    pe2:pe2-h2:h2:h2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(h1 pe1 p pe2 h2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(h1 pe1 p pe2 h2)

--- a/playset/bgp-evpn-mpls6/up.sh
+++ b/playset/bgp-evpn-mpls6/up.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Bring up the EVPN over MPLS between IPv6 PEs (E-LAN in eBPF) namespace
+# demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF (both families — the core is IPv6) on the PEs
+# and the P router: the eBPF data plane does the label work, and a
+# successful host-to-host ping must prove it (the kernel has no action
+# that pops an MPLS label into a bridge).
+for ns in pe1 p pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done
+
+# The PEs' own iBGP session is router-originated TCP entering an
+# XDP-forwarded core: it leaves the stack with deferred (partial)
+# checksums that an XDP redirect never resolves, so the far end would
+# drop the segments while ICMP and transit traffic flow fine. Compute
+# checksums in software on the core-facing veths instead.
+run_in_netns pe1 ethtool -K pe1-p tx off
+run_in_netns pe2 ethtool -K pe2-p tx off
+
+# The P's eBPF egress rewrite needs its neighbors' MACs: its own kernel
+# never originates toward the PEs, so one warm-up ping each resolves ND
+# and the netlink monitor tees the entries to the engine.
+run_in_netns p ping -c 1 -W 2 2001:db8:12::1 > /dev/null 2>&1 || true
+run_in_netns p ping -c 1 -W 2 2001:db8:23::2 > /dev/null 2>&1 || true

--- a/playset/bgp-evpn-vpws-mpls6/README.md
+++ b/playset/bgp-evpn-vpws-mpls6/README.md
@@ -1,0 +1,109 @@
+# EVPN VPWS between IPv6 PEs: an E-Line over MPLS, no IGP, no IPv4
+
+The [bgp-evpn-vpws-mpls](../bgp-evpn-vpws-mpls/README.md) demo re-run on
+an **IPv6-only core with no IGP at all**: the same point-to-point E-Line
+(EVPN VPWS, RFC 8214) under RFC 7432's original encapsulation, the same
+pure-transit **P router** — but every underlay address is IPv6 and the
+transport labels are static.
+
+Three pieces replace the IPv4 lab's IS-IS SR-MPLS:
+
+* **`vtep-source`** names the v6 loopback each Type-1 advertises as next
+  hop — a VPWS service has no VXLAN device to take an address from, and
+  the router-id fallback can only express IPv4;
+* a **labeled static v6 route** per PE supplies the transport LSP toward
+  the far loopback;
+* the P's **static MPLS label bindings with v6 nexthops** pop the
+  transport label toward each PE (PHP), their explicit `interface` leaf
+  opting the pop onto the eBPF XDP fast path — the P holds no route for
+  the exposed service label's frame, and the XDP redirect delivers only
+  between XDP-attached ports.
+
+The P carries no BGP and no VPWS state; even the PEs' own iBGP session
+rides the LSP through it. The CEs stay oblivious: one subnet, ARP
+straight through the wire.
+
+```
+ c1 ── pe1 ═══════ p ═══════ pe2 ── c2     c1/c2: 10.0.0.1/24, 10.0.0.2/24
+   2001:db8:12::/64  2001:db8:23::/64      pe1: lo 2001:db8:255::1
+     static labels 100 → / ← 101           pe2: lo 2001:db8:255::2
+   vpws eline1: evi 100, pe1 svc-id 101 ⇄ pe2 svc-id 102
+```
+
+## Bring up all nodes
+
+```shell
+$ ./up.sh
+...
+apply config: c2
+applied
+```
+
+## Ping through the wire, then read the service back
+
+```shell
+$ sudo ip netns exec c1 ping -c 3 10.0.0.2
+...
+3 packets transmitted, 3 received, 0% packet loss
+```
+
+The Type-1s carry v6 next hops, the per-service label, and no
+Encapsulation EC — its absence is the MPLS signal:
+
+```shell
+$ sudo ip netns exec pe1 vty
+pe1>show bgp evpn
+Route Distinguisher: 1.1.1.1:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[101]
+                    2001:db8:255::1            0         32768 i
+                    Extended community: RT:65000:100 l2-attr:P:mtu0
+Route Distinguisher: 2.2.2.2:100
+ *>  [1]:[00:00:00:00:00:00:00:00:00:00]:[102]
+                    2001:db8:255::2            0    100      0 i
+                    Extended community: RT:65000:100 l2-attr:P:mtu0
+```
+
+```shell
+pe1>show bgp evpn vpws
+VPWS service: eline1
+  EVI: 100
+  Service ID: local 101, remote 102
+  Interface: pe1-c1
+  Local Label: 16
+  Remote PE: 2001:db8:255::2 (label 16) (via 2001:db8:255::2)
+  State: up
+```
+
+The PE counters show the imposition and the pop-to-AC disposition, and
+the P's show the transit pops that carried both the service and the BGP
+session itself:
+
+```shell
+pe1>show ebpf stats
+...
+mpls_l2_encap  4
+mpls_dx2       4
+```
+
+```shell
+$ sudo ip netns exec p vty
+p>show ebpf stats
+...
+mpls_pop       35
+```
+
+## Tear down
+
+```shell
+$ ./down.sh
+```
+
+## Appendix: Addresses
+
+| Node | Role | Addresses |
+|---|---|---|
+| c1 | CE | `c1-pe1` 10.0.0.1/24 |
+| pe1 | PE, eline1 | `lo` 2001:db8:255::1/128, `pe1-p` 2001:db8:12::1/64 |
+| p | transit LSR | `p-pe1` 2001:db8:12::2/64, `p-pe2` 2001:db8:23::1/64 |
+| pe2 | PE, eline1 | `lo` 2001:db8:255::2/128, `pe2-p` 2001:db8:23::2/64 |
+| c2 | CE | `c2-pe2` 10.0.0.2/24 |

--- a/playset/bgp-evpn-vpws-mpls6/c1.yaml
+++ b/playset/bgp-evpn-vpws-mpls6/c1.yaml
@@ -1,0 +1,9 @@
+# CE 1 — a plain host on the E-Line. It shares 10.0.0.0/24 with c2 and
+# resolves it by ARP straight through the service: no routing, no
+# gateway, nothing E-Line-aware.
+interface:
+- if-name: c1-pe1
+  ipv4:
+    address: 10.0.0.1/24
+system:
+  hostname: c1

--- a/playset/bgp-evpn-vpws-mpls6/c2.yaml
+++ b/playset/bgp-evpn-vpws-mpls6/c2.yaml
@@ -1,0 +1,7 @@
+# CE 2 — the other end of the wire.
+interface:
+- if-name: c2-pe2
+  ipv4:
+    address: 10.0.0.2/24
+system:
+  hostname: c2

--- a/playset/bgp-evpn-vpws-mpls6/down.sh
+++ b/playset/bgp-evpn-vpws-mpls6/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the EVPN VPWS over MPLS between IPv6 PEs namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vpws-mpls6/p.yaml
+++ b/playset/bgp-evpn-vpws-mpls6/p.yaml
@@ -1,0 +1,33 @@
+# P — the transit LSR, static-ILM v6 bindings, no IGP, no BGP, no EVPN
+# state. Label 100 pops toward pe2 and 101 toward pe1 (PHP), exposing
+# the service label to the egress PE. The explicit `interface` leaf
+# opts each pop onto the eBPF XDP fast path — the operator's assertion
+# of a core-facing hop, since the P holds no route for the exposed
+# payload and the XDP redirect delivers only between XDP-attached ports.
+system:
+  hostname: p
+  ebpf:
+    enabled: true
+interface:
+- if-name: p-pe1
+  ipv6:
+    address: 2001:db8:12::2/64
+  ebpf:
+    enabled: true
+- if-name: p-pe2
+  ipv6:
+    address: 2001:db8:23::1/64
+  ebpf:
+    enabled: true
+router:
+  static:
+    mpls:
+      label:
+      - value: 100
+        nexthop:
+        - address: 2001:db8:23::2
+          interface: p-pe2
+      - value: 101
+        nexthop:
+        - address: 2001:db8:12::1
+          interface: p-pe1

--- a/playset/bgp-evpn-vpws-mpls6/pe1.yaml
+++ b/playset/bgp-evpn-vpws-mpls6/pe1.yaml
@@ -1,0 +1,58 @@
+# PE1 — EVPN VPWS provider edge over MPLS on an IPv6-only core, no IGP
+# anywhere. A labeled static /128 supplies the transport LSP toward
+# PE2's v6 loopback (the P pops it). A VPWS service has no VXLAN device
+# to take an address from and the router-id fallback is IPv4-only, so
+# `vtep-source` names the v6 loopback the Type-1 advertises as next
+# hop. Under `encapsulation mpls` the Type-1 carries a per-service
+# label with NO Encapsulation extended community — its absence is the
+# MPLS signal (RFC 8365 §5.1.3). cradle is the E-Line data plane: the
+# kernel has no action that pops a label onto a port.
+system:
+  hostname: pe1
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:255::1/128
+- if-name: pe1-p
+  ipv6:
+    address: 2001:db8:12::1/64
+  ebpf:
+    enabled: true
+- if-name: pe1-c1
+  ebpf:
+    enabled: true
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:255::2/128
+        nexthop:
+        - address: 2001:db8:12::2
+          label: [100]
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      encapsulation: mpls
+      vtep-source: 2001:db8:255::1
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: pe1-c1
+    neighbor:
+    - remote-address: 2001:db8:255::2
+      remote-as: 65000
+      update-source: 2001:db8:255::1
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-mpls6/pe2.yaml
+++ b/playset/bgp-evpn-vpws-mpls6/pe2.yaml
@@ -1,0 +1,51 @@
+# PE2 — mirror of pe1: v6 loopback 2001:db8:255::2 as `vtep-source`,
+# transport label 101 toward pe1's loopback, eline1 svc-id 102 ⇄ 101.
+system:
+  hostname: pe2
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:255::2/128
+- if-name: pe2-p
+  ipv6:
+    address: 2001:db8:23::2/64
+  ebpf:
+    enabled: true
+- if-name: pe2-c2
+  ebpf:
+    enabled: true
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:255::1/128
+        nexthop:
+        - address: 2001:db8:23::1
+          label: [101]
+  bgp:
+    global:
+      as: 65000
+      router-id: 2.2.2.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    afi-safi:
+    - name: evpn
+      encapsulation: mpls
+      vtep-source: 2001:db8:255::2
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: pe2-c2
+    neighbor:
+    - remote-address: 2001:db8:255::1
+      remote-as: 65000
+      update-source: 2001:db8:255::2
+      enabled: true
+      afi-safi:
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vpws-mpls6/topology.sh
+++ b/playset/bgp-evpn-vpws-mpls6/topology.sh
@@ -1,0 +1,18 @@
+# EVPN VPWS (E-Line over MPLS) between IPv6 PEs demo topology, with a
+# pure-transit P router between the PEs.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(c1 pe1 p pe2 c2)
+
+PLAYSET_LINKS=(
+    c1:c1-pe1:pe1:pe1-c1
+    pe1:pe1-p:p:p-pe1
+    p:p-pe2:pe2:pe2-p
+    pe2:pe2-c2:c2:c2-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(c1 pe1 p pe2 c2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(c1 pe1 p pe2 c2)

--- a/playset/bgp-evpn-vpws-mpls6/up.sh
+++ b/playset/bgp-evpn-vpws-mpls6/up.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Bring up the EVPN VPWS (E-Line over MPLS) between IPv6 PEs namespace
+# demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up
+
+# Kernel forwarding OFF (both families — the core is IPv6) on the PEs
+# and the P router: the eBPF data plane is the E-Line end to end (the
+# kernel has no pop-to-port MPLS disposition at all).
+for ns in pe1 p pe2; do
+    run_in_netns "$ns" sysctl -wq net.ipv4.ip_forward=0
+    run_in_netns "$ns" sysctl -wq net.ipv6.conf.all.forwarding=0
+done
+
+# The PEs' own iBGP session is router-originated TCP entering an
+# XDP-forwarded core: it leaves the stack with deferred (partial)
+# checksums that an XDP redirect never resolves, so the far end would
+# drop the segments while ICMP and transit traffic flow fine. Compute
+# checksums in software on the core-facing veths instead.
+run_in_netns pe1 ethtool -K pe1-p tx off
+run_in_netns pe2 ethtool -K pe2-p tx off
+
+# The P's eBPF egress rewrite needs its neighbors' MACs: its own kernel
+# never originates toward the PEs, so one warm-up ping each resolves ND
+# and the netlink monitor tees the entries to the engine.
+run_in_netns p ping -c 1 -W 2 2001:db8:12::1 > /dev/null 2>&1 || true
+run_in_netns p ping -c 1 -W 2 2001:db8:23::2 > /dev/null 2>&1 || true

--- a/playset/lib/zebra-rs.sh
+++ b/playset/lib/zebra-rs.sh
@@ -10,7 +10,34 @@ playset_zebra_rs_bin() {
         echo "$built"
         return
     fi
+    local staged="${PLAYSET_ROOT}/../bdd/.stage/bin/zebra-rs"
+    if [[ -x "$staged" ]]; then
+        echo "$staged"
+        return
+    fi
     echo "zebra-rs"
+}
+
+# The YANG schemas matching the binary playset_zebra_rs_bin picked — the
+# BDD `.stage` contract (see bdd/Makefile): a worktree binary must run
+# against this worktree's YANG, never /usr's, or a schema the binary
+# knows is rejected at apply (and vice versa). Emitted as `--yang-path`
+# args; empty for a PATH-resolved (installed) binary, whose schemas are
+# the installed ones.
+playset_zebra_rs_yang_args() {
+    local bin
+    bin="$(playset_zebra_rs_bin)"
+    case "$bin" in
+        "${PLAYSET_ROOT}/../target/debug/zebra-rs")
+            echo "--yang-path=${PLAYSET_ROOT}/../zebra-rs/yang"
+            ;;
+        "${PLAYSET_ROOT}/../bdd/.stage/bin/zebra-rs")
+            echo "--yang-path=${PLAYSET_ROOT}/../bdd/.stage/share/zebra-rs/yang"
+            ;;
+        *)
+            :
+            ;;
+    esac
 }
 
 playset_vtyctl_bin() {
@@ -57,7 +84,10 @@ playset_start_zebra() {
     local log_file pid_file
     log_file="${PLAYSET_RUN_DIR}/${netns}.log"
     pid_file="$(playset_pid_file "$netns")"
+    # shellcheck disable=SC2046 — the yang args are zero-or-one flag,
+    # deliberately word-split.
     run_in_netns "$netns" "$(playset_zebra_rs_bin)" \
+        $(playset_zebra_rs_yang_args) \
         --daemon \
         --log-output=file \
         --log-file="$log_file" \


### PR DESCRIPTION
## Summary

- **`playset/bgp-evpn-mpls6`** — the stretched-segment (E-LAN) MPLS demo between IPv6 PEs on an IPv6-only core with **no IGP**: `vtep-source` v6 next hops, labeled static v6 routes as the transport, and the pure-transit P popping via static-ILM v6 bindings with the explicit `interface` leaf (XDP fast path; the P holds no route for what the pop exposes — even the PEs' iBGP session rides the LSP through it).
- **`playset/bgp-evpn-vpws-mpls6`** — the E-Line sibling, same core shape.
- Both labs run live; README outputs are captured from the runs (v6 next hops + `label:` PMSIs, the P's named-interface pops, native-v6 FDB slots, `mpls_pop` counters).
- **Book**: the MPLS chapter's stale "IPv4 underlay only" limitation is replaced by an "IPv6 PEs" section (the three config pieces, with snippets, pointing at both labs). The playset index gains both rows and drops the "no eBPF IPv6 pair" claim left over from before the VXLAN-v6 arc.

## Test plan

Both labs brought up and verified live (pings 3/3 through the label-switched v6 core, shows captured); `mdbook build` clean; `make -C packaging playset` asset gate green.

Generated with [Claude Code](https://claude.com/claude-code)