### PR TITLE
bgp: MUP N9/SRGW composite — gtp VRF steers via remote SRv6 segments

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -134,6 +134,14 @@ bgp_mup_sidless_segment:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_sidless_segment"
 
+# MUP SRGW composite: a dataplane-gtp VRF whose segments are REMOTE steers
+# via SRv6 — the ST1 UE prefix H.Encaps toward a received ISD, and default
+# routes toward a received DSD for GTP-decapped uplink traffic. Needs
+# pfcp-inject on PATH + root netns (kernel VRF + seg6 + IS-IS SRv6).
+bgp_mup_srgw_gtp:
+	mkdir -p allure-results
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_srgw_gtp"
+
 # MUP ST1->ISD encap: one interwork node originates a local ISD (`segment
 # interwork prefix <p>`) and, via its MUP-C, an ST1 whose UE is inside <p>.
 # The ST1 resolves to the local End.DT46 segment and an oif-only recursive

--- a/bdd/tests/configs/bgp_mup_srgw_gtp/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_srgw_gtp/z1.yaml
@@ -1,0 +1,80 @@
+# z1 — owns BOTH remote MUP segments the SRGW (z2) resolves against:
+# VRF ACC (`segment interwork prefix 10.0.0.0/24`, the gNB N3 network) and
+# VRF ANC (`segment direct { mup-ext-comm 1:2 }`, the anchor). Each is
+# `encapsulation srv6`, carving an End.DT46 SID from locator S; the ISD and
+# DSD ride iBGP (mup) to z2 with their export RTs.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+vrf:
+- name: ACC
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+- name: ANC
+  mup:
+    route-target:
+      export:
+      - "65501:30"
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: ACC
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: interwork
+            prefix: 10.0.0.0/24
+    - name: ANC
+      rd: "65501:30"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: direct
+            mup-ext-comm: "1:2"

--- a/bdd/tests/configs/bgp_mup_srgw_gtp/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_srgw_gtp/z2.yaml
@@ -1,0 +1,78 @@
+# z2 — the dataplane-gtp SRGW: VRF mobile (rd 65501:20, NO srv6
+# encapsulation) imports z1's ISD (RT 65501:10) and DSD (RT 65501:30). Its
+# MUP-C originates — from one PFCP session on NI `access` — an ST1 whose
+# gNB endpoint falls inside the remote ISD prefix (→ the UE prefix steers
+# via SRv6 H.Encaps toward z1's interwork segment) and an ST2 stamped
+# `mup:1:2` (→ default v4+v6 H.Encaps routes toward z1's anchor segment
+# land in the VRF table, steering GTP-decapped traffic to it).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+vrf:
+- name: mobile
+  mup:
+    route-target:
+      import:
+      - "65501:10"
+      - "65501:30"
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile
+      rd: "65501:20"
+      afi-safi:
+        mup:
+          dataplane: gtp
+          route:
+          - type: st1
+            network-instance: access
+          - type: st2
+            network-instance: access
+            mup-ext-comm: "1:2"
+    mup-c:
+      enabled: true
+      controller-address: 2001:db8::2
+      pfcp:
+        listen-address: 127.0.0.1

--- a/bdd/tests/features/bgp_mup_srgw_gtp.feature
+++ b/bdd/tests/features/bgp_mup_srgw_gtp.feature
@@ -1,0 +1,73 @@
+@serial
+@bgp_mup_srgw_gtp
+Feature: A dataplane-gtp SRGW steers via remote SRv6 MUP segments
+  The N9/SRGW composite (stage 6 of
+  docs/design/bgp-mup-gtp-segment-resolution-plan.md): a `dataplane gtp`
+  VRF whose segments are REMOTE composes GTP with SRv6 instead of ignoring
+  them. Downlink: an ST1 whose gNB endpoint is covered by a received ISD
+  (with a usable End.DT46 SID and resolved transport) steers the UE prefix
+  via SRv6 H.Encaps toward that interwork segment — the segment owner
+  performs the GTP conversion. Uplink: an ST2 whose Direct-segment id
+  resolves to a received DSD gets default v4+v6 H.Encaps routes in the
+  VRF's table, so GTP-decapped traffic rides SRv6 to the anchor. Local
+  segments always win (this node converts / holds the table itself).
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ ISD(ACC) │   iBGP (mup)    │ SRGW     │
+       │ DSD(ANC) │                 │ gtp VRF  │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1 owns BOTH remote segments: VRF ACC (rd 65501:10, `segment interwork
+  prefix 10.0.0.0/24`, export RT 65501:10) and VRF ANC (rd 65501:30,
+  `segment direct { mup-ext-comm 1:2 }`, export RT 65501:30), each with an
+  End.DT46 SID from locator S. z2's VRF mobile (rd 65501:20, `dataplane
+  gtp`, NO srv6 encapsulation) imports both and originates — from one PFCP
+  session on NI `access` — an ST1 (UE 10.60.1.5, gNB 10.0.0.1 inside the
+  ISD prefix) and an ST2 stamped `mup:1:2`.
+
+  NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel
+  VRF + seg6 + IS-IS SRv6 underlay).
+
+  Scenario: Build topology and import both remote segments
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp vrf mobile mup" in namespace "z2" should eventually contain "[ISD][65501:20][10.0.0.0/24]"
+    And show command "show bgp vrf mobile mup" in namespace "z2" should eventually contain "[DSD][65501:20]"
+
+  Scenario: One session drives both composites — SRv6 downlink steer and uplink default
+    Given the test topology exists
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 10.60.1.5 --teid 0x12345678 --endpoint 10.0.0.1 --n3-endpoint 10.0.99.2 --n3-teid 0x500 --network-instance access" in namespace "z2"
+    # Downlink composite: the ST1's gNB endpoint (10.0.0.1) is covered by
+    # the REMOTE ISD, so the UE prefix steers via SRv6 toward z1's segment
+    # (locator S = fcbb:bbbb:1::/48) instead of local GTP encap.
+    Then show command "show bgp vrf mobile mup" in namespace "z2" should eventually contain "resolved 10.60.1.5/32 (endpoint 10.0.0.1) -> End.DT46"
+    And command "ip route show table all" in namespace "z2" should eventually contain "10.60.1.5"
+    And command "ip route show table all" in namespace "z2" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:1:"
+    # Uplink composite: the ST2's Direct-segment id (mup:1:2) resolves to
+    # the REMOTE DSD — default v4+v6 H.Encaps routes appear in the VRF
+    # table, steering decapped traffic to the anchor.
+    And command "ip route show table all" in namespace "z2" should eventually contain "default"
+    And command "ip -6 route show table all" in namespace "z2" should eventually contain "default"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -564,6 +564,27 @@ The datapath is regression-tested by the cradle `@cradle_mup_gtp_n3_vrf`
 BDD (dual-segment origination, round-trip ICMP through both re-scoped
 lookups, tunnel counters on both ends).
 
+#### IPv6 N3 transport (GTP6) and composing with SRv6 segments
+
+The GTP datapath is **family-complete**: a session whose tunnel endpoints
+are IPv6 drives v6-outer GTP-U (`GTP6.E` / `H.M.GTP6.D`) through the same
+resolution rules, with any-family UE prefixes (the mixed v4-UE-behind-v6-N3
+case included). The v6 outer's UDP checksum is 0 — RFC 6935/6936
+zero-checksum tunnel mode, which cradle's own decap never validates;
+interop with a non-cradle GTP peer requires zero-checksum acceptance on
+their end. Regression: `@cradle_gtp6`, `@cradle_mup_gtp6_zebra`.
+
+A `dataplane gtp` VRF also **composes with remote SRv6 segments** (the
+N9/SRGW shape). An ST1 whose gNB endpoint is covered by a *received* ISD —
+with a usable End.DT46 SID and resolved transport, and not by this node's
+own catalog — steers the UE prefix via SRv6 H.Encaps toward that interwork
+segment, which performs the GTP conversion; an ST2 whose Direct-segment id
+resolves to a *received* DSD installs default v4+v6 H.Encaps routes in the
+VRF table, so GTP-decapped traffic rides SRv6 to the anchor. Local
+segments always win, and a SID-less remote segment produces no steer — the
+GTP outer then resolves by ordinary FIB toward the peer, which is the N9
+GTP-to-GTP case. Regression: `bgp_mup_srgw_gtp`.
+
 ## From PFCP session to ST route
 
 When an SMF establishes a session, the controller:

--- a/docs/design/bgp-mup-gtp-segment-resolution-plan.md
+++ b/docs/design/bgp-mup-gtp-segment-resolution-plan.md
@@ -1,12 +1,21 @@
 # BGP MUP — explicit interwork/direct segment resolution for `dataplane gtp`
 
-> **Status:** COMPLETE (2026-08-01). Stages 1–5 merged (zebra
-> #2206/#2207/#2208/#2209/#2210, cradle #170/#171/#172); stage 6's two
-> knobs (`lookup-network-instance`, SID-less segment origination) are
-> implemented as well — only the N9/SRGW composite and GTP6 remain out of
-> scope by design. Every PR was independently shippable and the single-N6
-> lab stayed green at each stage. Implementation notes from verification
-> are folded into §3.4 and Stages 4–6 below.
+> **Status:** COMPLETE (2026-08-01), including the final extensions.
+> Stages 1–5 merged (zebra #2206/#2207/#2208/#2209/#2210, cradle
+> #170/#171/#172); stage 6's knobs (`lookup-network-instance` #2212 +
+> cradle #174, SID-less segment origination #2212) merged; and the two
+> items originally out of scope are now implemented too — **GTP6** (v6
+> outer: cradle `GTP_PDR6`/`GTP6_ENCAP`, zebra family-wide seam, UDP
+> zero-checksum tunnel mode per RFC 6935/6936) and the **N9/SRGW
+> composite** (a `dataplane gtp` VRF steers via REMOTE SRv6 segments:
+> ST1→received-ISD H.Encaps for the UE prefix with local-catalog
+> precedence, ST2→received-DSD default H.Encaps routes for decapped
+> uplink; N9 GTP-toward-a-GTP-peer is the emergent fallback — a SID-less
+> remote segment yields no SRv6 steer, so the outer resolves by ordinary
+> FIB). Proven by `@cradle_gtp6`, `@cradle_mup_gtp6_zebra` and
+> `bgp_mup_srgw_gtp`. Every PR was independently shippable and the
+> single-N6 lab stayed green at each stage. Implementation notes from
+> verification are folded into §3.4 and Stages 4–6 below.
 >
 > Origin: design review of the single-N6 configuration (`bdd/mup-lab`,
 > issue #1947 arc). The `dataplane gtp` datapath hard-codes three forwarding
@@ -386,9 +395,26 @@ preserving).*
   derive one from). `MupSegmentDesired.sid` became `Option`; the SRv6 path
   is untouched. Proven by the `bgp_mup_sidless_segment` BDD (originate +
   receive, `should not contain` SID assertions).
-* **GTP encap toward a remote interwork segment** (N9 / SRGW composite) and
-  **GTP6** (v6 outer): remain out of scope; the GTP datapath stays
-  v4-outer.
+* **N9 / SRGW composite** — *implemented, zebra-only*: `reconcile_mup_gtp`
+  composes with the existing SRv6 machinery. Downlink: an ST1 whose gNB
+  endpoint is covered by a received ISD (usable SID + resolved transport)
+  — and not by the local catalog — steers via `reconcile_mup_st1_isd`
+  (now filterable) instead of local GTP; precedence is local catalog →
+  remote ISD → fallback GTP. Uplink: an ST2 whose Direct-segment id
+  resolves to a received DSD (and no local direct segment) installs
+  default v4+v6 H.Encaps routes in the VRF table, steering GTP-decapped
+  traffic to the anchor (the PDR decap is unchanged). **N9 between GTP
+  peers is emergent**: a SID-less remote segment produces no SRv6 steer,
+  so the GTP outer resolves by ordinary FIB toward the peer — exactly the
+  fallback path. Proven by `bgp_mup_srgw_gtp`.
+* **GTP6** (v6 outer) — *implemented*: cradle gains `GTP_PDR6` /
+  `GTP6_ENCAP` (`H.M.GTP6.D` / `GTP6.E`, `NH_F_GTP6`, a bpf-to-bpf decap
+  frame to stay under the 512-byte combined-stack ceiling), the zebra
+  seam is family-wide (`IpAddr`/`IpNet` end to end), and the reconcilers
+  accept either same-family tunnel pair with any-family UE prefix. The
+  outer UDP checksum is 0 (RFC 6935/6936 zero-checksum tunnel mode —
+  cradle's decap never validates it; non-cradle peers need zero-checksum
+  acceptance). Proven by `@cradle_gtp6` and `@cradle_mup_gtp6_zebra`.
 
 ## 5. Compatibility summary
 

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -323,6 +323,12 @@ pub struct BgpVrf {
     /// oif)` teed to cradle. Diff base for the downlink reconcile — a changed
     /// key re-installs, a vanished UE prefix withdraws.
     pub mup_gtp_encap_installed: std::collections::BTreeMap<ipnet::IpNet, MupGtpEncapKey>,
+    /// SRGW-composite default steering state for a `dataplane gtp` VRF whose
+    /// ST2s resolve to a REMOTE direct segment: the End.DT46-family SIDs the
+    /// installed v4/v6 default H.Encaps routes currently point at (`None` =
+    /// no default installed for that family). Diff base for
+    /// `reconcile_mup_gtp_srgw_uplink`.
+    pub mup_gtp_srgw_default: (Option<std::net::Ipv6Addr>, Option<std::net::Ipv6Addr>),
 }
 
 /// The cradle GTP-U encap install key for one downlink (`GTP4.E`) UE prefix:
@@ -857,6 +863,7 @@ impl BgpVrf {
             mup_segment_catalog: Default::default(),
             mup_endpoint_transport: std::collections::BTreeMap::new(),
             mup_gtp_encap_installed: std::collections::BTreeMap::new(),
+            mup_gtp_srgw_default: (None, None),
         };
         (vrf, inbox_tx)
     }
@@ -892,6 +899,15 @@ impl BgpVrf {
     /// resolution in `render_mup_table`; the ST2→DSD reconcile is the uplink
     /// twin (dst = the ST2 endpoint, matched by Direct-segment id).
     fn reconcile_mup_st1_isd(&mut self) {
+        self.reconcile_mup_st1_isd_filtered(&|_| true);
+    }
+
+    /// [`Self::reconcile_mup_st1_isd`] with an `allow` filter over UE
+    /// prefixes: the `dataplane gtp` SRGW composite passes exactly the
+    /// remote-steered set (local GTP handles the rest), the `end-dt46`
+    /// dataplane passes everything. A previously-installed entry the filter
+    /// no longer allows is withdrawn by the ordinary stale sweep.
+    fn reconcile_mup_st1_isd_filtered(&mut self, allow: &dyn Fn(&ipnet::IpNet) -> bool) {
         use std::net::Ipv6Addr;
         type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
         // Index imported ISDs by their advertised prefix → (service SIDs,
@@ -949,6 +965,7 @@ impl BgpVrf {
                         })
                         .max_by_key(|(p, _, _)| p.prefix_len())
                         .map(|(_p, sid, transport)| (sid, transport))
+                    && allow(ue)
                 {
                     desired.insert(*ue, (sid, transport.clone()));
                 }
@@ -1089,7 +1106,165 @@ impl BgpVrf {
     /// `dataplane` is `gtp`.
     fn reconcile_mup_gtp(&mut self) {
         self.reconcile_mup_gtp_uplink();
-        self.reconcile_mup_gtp_downlink();
+        // The SRGW composite, downlink: an ST1 whose gNB endpoint is covered
+        // by a REMOTE interwork segment (a received ISD with a usable SID
+        // and resolved transport) — and not by this node's own catalog —
+        // steers via SRv6 H.Encaps toward that segment instead of local GTP
+        // encap; the segment owner performs the GTP conversion. Local
+        // segments win: this node IS the interwork there.
+        let remote = self.mup_remote_isd_st1_ues();
+        self.reconcile_mup_gtp_downlink_excluding(&remote);
+        self.reconcile_mup_st1_isd_filtered(&|ue| remote.contains(ue));
+        // The SRGW composite, uplink: ST2s resolving to a REMOTE direct
+        // segment get default H.Encaps routes in this table, so decapped
+        // traffic rides SRv6 to the anchor.
+        self.reconcile_mup_gtp_srgw_uplink();
+    }
+
+    /// UE prefixes of selected ST1s the SRGW composite steers via SRv6: the
+    /// gNB endpoint is covered by an ISD in this VRF's RIB carrying a SID
+    /// able to decap the UE's family plus a resolved underlay transport, and
+    /// NOT by this node's own interwork catalog (a locally-owned segment
+    /// performs the GTP conversion here — including the ISD this node
+    /// originates itself, whose prefix the catalog carries).
+    fn mup_remote_isd_st1_ues(&self) -> std::collections::BTreeSet<ipnet::IpNet> {
+        use std::net::Ipv6Addr;
+        let mut out = std::collections::BTreeSet::new();
+        let mut isds: Vec<(ipnet::IpNet, Vec<(Ipv6Addr, u16)>)> = Vec::new();
+        for (rd, table) in self.local_rib.mup.iter() {
+            for (prefix, rib) in table.selected.iter() {
+                if let bgp_packet::MupPrefix::Isd { prefix: p } = prefix {
+                    let sids: Vec<_> = rib.attr.srv6_l3_sids().collect();
+                    if sids.is_empty() {
+                        continue;
+                    }
+                    let Some(t) = self.mup_segment_transport.get(&(*rd, prefix.clone())) else {
+                        continue;
+                    };
+                    if t.is_empty() {
+                        continue;
+                    }
+                    isds.push((*p, sids));
+                }
+            }
+        }
+        if isds.is_empty() {
+            return out;
+        }
+        for table in self.local_rib.mup.values() {
+            for (prefix, rib) in table.selected.iter() {
+                if let bgp_packet::MupPrefix::T1st { prefix: ue } = prefix
+                    && let Some(st1) = &rib.mup_st1
+                {
+                    if self
+                        .mup_segment_catalog
+                        .interwork
+                        .iter()
+                        .any(|e| e.prefix.is_some_and(|p| p.contains(&st1.endpoint)))
+                    {
+                        continue;
+                    }
+                    if isds.iter().any(|(p, sids)| {
+                        p.contains(&st1.endpoint)
+                            && bgp_packet::srv6_l3_sid_for_dest(
+                                sids,
+                                matches!(ue, ipnet::IpNet::V4(_)),
+                            )
+                            .is_some()
+                    }) {
+                        out.insert(*ue);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// SRGW composite, uplink: this VRF's selected ST2s resolve (by
+    /// Direct-segment id) to a REMOTE direct segment — a DSD in this VRF's
+    /// RIB with usable SIDs and resolved transport, and no matching segment
+    /// in the local catalog. The decap PDR already lands the inner packet in
+    /// this VRF's table; install default v4+v6 H.Encaps routes toward the
+    /// DSD's SID so every decapped packet rides SRv6 to the anchor
+    /// (draft §3.3.12 on the SRGW). Diff-gated per family on the resolved
+    /// SID in `mup_gtp_srgw_default`.
+    fn reconcile_mup_gtp_srgw_uplink(&mut self) {
+        use std::net::Ipv6Addr;
+        type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
+        let mut dsd_index: std::collections::BTreeMap<[u8; 6], (Vec<(Ipv6Addr, u16)>, Transport)> =
+            std::collections::BTreeMap::new();
+        for (rd, table) in self.local_rib.mup.iter() {
+            for (prefix, rib) in table.selected.iter() {
+                if !matches!(prefix, bgp_packet::MupPrefix::Dsd { .. }) {
+                    continue;
+                }
+                let Some(seg) = mup_direct_segment_id(&rib.attr) else {
+                    continue;
+                };
+                let sids: Vec<_> = rib.attr.srv6_l3_sids().collect();
+                if sids.is_empty() {
+                    continue;
+                }
+                let Some(t) = self.mup_segment_transport.get(&(*rd, prefix.clone())) else {
+                    continue;
+                };
+                if t.is_empty() {
+                    continue;
+                }
+                dsd_index.insert(seg, (sids, t.clone()));
+            }
+        }
+        // Desired: the first selected ST2 whose Direct-segment id matches a
+        // remote DSD and is NOT claimed by a local direct segment.
+        let mut want: Option<(Vec<(Ipv6Addr, u16)>, Transport)> = None;
+        'outer: for table in self.local_rib.mup.values() {
+            for (prefix, rib) in table.selected.iter() {
+                if !matches!(prefix, bgp_packet::MupPrefix::T2st { .. }) {
+                    continue;
+                }
+                let Some(seg) = mup_direct_segment_id(&rib.attr) else {
+                    continue;
+                };
+                if self.mup_segment_catalog.direct_table(&seg).is_some() {
+                    continue;
+                }
+                if let Some(entry) = dsd_index.get(&seg) {
+                    want = Some(entry.clone());
+                    break 'outer;
+                }
+            }
+        }
+        let v4_default: ipnet::IpNet = ipnet::IpNet::V4("0.0.0.0/0".parse().unwrap());
+        let v6_default: ipnet::IpNet = ipnet::IpNet::V6("::/0".parse().unwrap());
+        let desired = want
+            .map(|(sids, transport)| {
+                (
+                    bgp_packet::srv6_l3_sid_for_dest(&sids, true)
+                        .map(|(s, _)| (s, transport.clone())),
+                    bgp_packet::srv6_l3_sid_for_dest(&sids, false).map(|(s, _)| (s, transport)),
+                )
+            })
+            .unwrap_or((None, None));
+        let (want_v4, want_v6) = desired;
+        let (have_v4, have_v6) = self.mup_gtp_srgw_default;
+        if have_v4 != want_v4.as_ref().map(|(s, _)| *s) {
+            if have_v4.is_some() {
+                self.mup_encap_withdraw(v4_default);
+            }
+            if let Some((sid, transport)) = &want_v4 {
+                self.mup_encap_install(v4_default, *sid, transport);
+            }
+            self.mup_gtp_srgw_default.0 = want_v4.map(|(s, _)| s);
+        }
+        if have_v6 != want_v6.as_ref().map(|(s, _)| *s) {
+            if have_v6.is_some() {
+                self.mup_encap_withdraw(v6_default);
+            }
+            if let Some((sid, transport)) = &want_v6 {
+                self.mup_encap_install(v6_default, *sid, transport);
+            }
+            self.mup_gtp_srgw_default.1 = want_v6.map(|(s, _)| s);
+        }
     }
 
     /// Install GTP-U decap PDRs for a `dataplane gtp` VRF — the ST2 uplink
@@ -1181,10 +1356,16 @@ impl BgpVrf {
     /// the UE prefix is the FIB destination (draft §3.1.3 / §3.3.9) — the
     /// same key/destination split as `reconcile_mup_st1_isd`, but a real GTP
     /// tunnel instead of the End.DT46 stand-in.
-    fn reconcile_mup_gtp_downlink(&mut self) {
+    fn reconcile_mup_gtp_downlink_excluding(
+        &mut self,
+        skip: &std::collections::BTreeSet<ipnet::IpNet>,
+    ) {
         let table_id = self.ctx.vrf_id();
         // Desired encaps: each selected ST1 whose GTP endpoint has resolved
-        // to an underlay next-hop → the cradle encap key.
+        // to an underlay next-hop → the cradle encap key. `skip` holds the
+        // UE prefixes the SRGW composite steers via SRv6 instead — a
+        // previously GTP-installed entry that moves there is withdrawn by
+        // the stale sweep.
         let mut desired: std::collections::BTreeMap<ipnet::IpNet, MupGtpEncapKey> =
             std::collections::BTreeMap::new();
         for (rd, table) in self.local_rib.mup.iter() {
@@ -1192,6 +1373,9 @@ impl BgpVrf {
                 let bgp_packet::MupPrefix::T1st { prefix: ue } = prefix else {
                     continue;
                 };
+                if skip.contains(ue) {
+                    continue;
+                }
                 let Some(st1) = &rib.mup_st1 else {
                     continue;
                 };
@@ -4803,6 +4987,253 @@ mod tests {
             "PDR matches in the named GTP context, decaps into the service VRF"
         );
         assert_eq!(vrf.mup_gtp_pdr_installed.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_downlink_steers_via_remote_isd_with_local_precedence() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::bgp::vrf_config::{MupInterworkEntry, MupSegmentCatalog};
+        use crate::rib::nht::ResolvedNexthop;
+        use bgp_packet::{
+            BgpAttr, MupPrefix, MupSt1Fields, PrefixSid, PrefixSidTlv, SRV6_BEHAVIOR_END_DT46,
+            Srv6ServiceTlv, Srv6SidInfo,
+        };
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+        // A dataplane-gtp SRGW-ish node: the ST1's gNB endpoint is covered
+        // by a REMOTE ISD (received, with a usable SID and resolved
+        // transport) — the UE prefix must steer via SRv6, NOT local GTP,
+        // even though the endpoint's own transport resolved (a globally
+        // routable gNB). A local catalog entry then flips it back to GTP.
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(5, "srgw");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "srgw".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+
+        let dt46: Ipv6Addr = "fcbb:aaaa::46".parse().unwrap();
+        let rd: bgp_packet::RouteDistinguisher = "65000:1".parse().unwrap();
+        let isd_prefix = MupPrefix::Isd {
+            prefix: "10.0.12.0/24".parse().unwrap(),
+        };
+        let ue: ipnet::IpNet = "10.60.1.0/24".parse().unwrap();
+        let gnb = IpAddr::V4(Ipv4Addr::new(10, 0, 12, 1));
+        {
+            let table = vrf.local_rib.mup.entry(rd).or_default();
+            let mut attr = BgpAttr::new();
+            attr.prefix_sid = Some(PrefixSid {
+                tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                    sids: vec![Srv6SidInfo::new(dt46, 0, SRV6_BEHAVIOR_END_DT46, None)],
+                    ..Default::default()
+                })],
+            });
+            table.selected.insert(
+                isd_prefix.clone(),
+                BgpRib::new(
+                    1,
+                    Ipv4Addr::UNSPECIFIED,
+                    BgpRibType::EBGP,
+                    0,
+                    0,
+                    &attr,
+                    None,
+                    None,
+                    false,
+                ),
+            );
+            let st1_attr = BgpAttr::new();
+            let mut rib = BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &st1_attr,
+                None,
+                None,
+                false,
+            );
+            rib.mup_st1 = Some(MupSt1Fields {
+                teid: 0x100,
+                qfi: 5,
+                endpoint: gnb,
+                source: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2))),
+            });
+            table.selected.insert(MupPrefix::T1st { prefix: ue }, rib);
+        }
+        let transport = vec![ResolvedNexthop {
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 99, 1)),
+            ifindex: 7,
+            labels: Vec::new(),
+            segs: vec![],
+            seg_encap: None,
+        }];
+        vrf.mup_segment_transport
+            .insert((rd, isd_prefix.clone()), transport.clone());
+        vrf.mup_endpoint_transport
+            .insert((rd, MupPrefix::T1st { prefix: ue }), transport);
+
+        vrf.reconcile_mup_gtp();
+        assert_eq!(
+            vrf.mup_st1_isd_installed.get(&ue),
+            Some(&dt46),
+            "the remote ISD steers the UE prefix via SRv6"
+        );
+        assert!(
+            !vrf.mup_gtp_encap_installed.contains_key(&ue),
+            "no local GTP encap for a remotely-steered UE"
+        );
+
+        // A local interwork segment covering the endpoint takes over: this
+        // node performs the GTP conversion itself.
+        vrf.mup_segment_catalog = MupSegmentCatalog {
+            interwork: vec![MupInterworkEntry {
+                vrf: "srgw".to_string(),
+                table_id: 5,
+                prefix: Some("10.0.12.0/24".parse().unwrap()),
+            }],
+            direct: Vec::new(),
+        };
+        vrf.reconcile_mup_gtp();
+        assert!(
+            !vrf.mup_st1_isd_installed.contains_key(&ue),
+            "the SRv6 steer is withdrawn once the segment is local"
+        );
+        assert!(
+            vrf.mup_gtp_encap_installed.contains_key(&ue),
+            "the local GTP encap takes over"
+        );
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_uplink_default_steers_to_remote_dsd() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::bgp::vrf_config::{MupDirectEntry, MupSegmentCatalog};
+        use crate::rib::nht::ResolvedNexthop;
+        use bgp_packet::{
+            MupPrefix, PrefixSid, PrefixSidTlv, SRV6_BEHAVIOR_END_DT46, Srv6ServiceTlv, Srv6SidInfo,
+        };
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+        // A dataplane-gtp SRGW: the ST2's Direct-segment id resolves to a
+        // REMOTE DSD → default v4+v6 H.Encaps routes steer decapped traffic
+        // to the anchor. A local direct segment with the same id wins.
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(5, "srgw-ul");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "srgw-ul".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+
+        let dt46: Ipv6Addr = "fcbb:bbbb::46".parse().unwrap();
+        let seg: bgp_packet::RouteDistinguisher = "1:2".parse().unwrap();
+        let rd: bgp_packet::RouteDistinguisher = "65000:1".parse().unwrap();
+        let dsd = MupPrefix::Dsd {
+            address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)),
+        };
+        {
+            let table = vrf.local_rib.mup.entry(rd).or_default();
+            let mut attr = attr_with_segment_id(seg.val);
+            attr.prefix_sid = Some(PrefixSid {
+                tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                    sids: vec![Srv6SidInfo::new(dt46, 0, SRV6_BEHAVIOR_END_DT46, None)],
+                    ..Default::default()
+                })],
+            });
+            table.selected.insert(
+                dsd.clone(),
+                BgpRib::new(
+                    1,
+                    Ipv4Addr::UNSPECIFIED,
+                    BgpRibType::EBGP,
+                    0,
+                    0,
+                    &attr,
+                    None,
+                    None,
+                    false,
+                ),
+            );
+            let st2_attr = attr_with_segment_id(seg.val);
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2)),
+                    teid: 0x500,
+                },
+                BgpRib::new(
+                    1,
+                    Ipv4Addr::UNSPECIFIED,
+                    BgpRibType::EBGP,
+                    0,
+                    0,
+                    &st2_attr,
+                    None,
+                    None,
+                    false,
+                ),
+            );
+        }
+        vrf.mup_segment_transport.insert(
+            (rd, dsd.clone()),
+            vec![ResolvedNexthop {
+                addr: IpAddr::V4(Ipv4Addr::new(10, 0, 99, 1)),
+                ifindex: 7,
+                labels: Vec::new(),
+                segs: vec![],
+                seg_encap: None,
+            }],
+        );
+
+        vrf.reconcile_mup_gtp();
+        assert_eq!(
+            vrf.mup_gtp_srgw_default,
+            (Some(dt46), Some(dt46)),
+            "default v4+v6 H.Encaps steer decapped traffic to the remote anchor"
+        );
+        // The decap PDR itself still lands in this VRF's table.
+        assert!(vrf.mup_gtp_pdr_installed.contains_key(&(
+            0,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2)),
+            0x500
+        )));
+
+        // A LOCAL direct segment claims the id: the defaults are withdrawn
+        // and the decap target is its table instead.
+        vrf.mup_segment_catalog = MupSegmentCatalog {
+            interwork: Vec::new(),
+            direct: vec![MupDirectEntry {
+                vrf: "N6".to_string(),
+                table_id: 9,
+                segment_id: seg.val,
+            }],
+        };
+        vrf.reconcile_mup_gtp();
+        assert_eq!(
+            vrf.mup_gtp_srgw_default,
+            (None, None),
+            "a local direct segment withdraws the default steer"
+        );
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed
+                .get(&(0, IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2)), 0x500)),
+            Some(&9),
+            "the decap target becomes the local direct segment's table"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The last open item of `docs/design/bgp-mup-gtp-segment-resolution-plan.md`, composed entirely from existing machinery. `reconcile_mup_gtp` now consults the segments this node does NOT own:

**Downlink**: an ST1 whose gNB endpoint is covered by a received ISD with a usable End.DT46 SID and resolved transport — and not by the local catalog — steers its UE prefix via SRv6 H.Encaps toward that interwork segment (`reconcile_mup_st1_isd`, now filterable, runs from the gtp path for exactly the remote-steered set while the GTP downlink excludes it). Precedence: local catalog → remote ISD → fallback GTP; entries migrate between the two installers through their ordinary stale sweeps.

**Uplink**: an ST2 whose Direct-segment id resolves to a received DSD (and no local direct segment) installs default v4+v6 H.Encaps routes in the VRF table via the existing `mup_encap_install`, so GTP-decapped traffic rides SRv6 to the anchor; the decap PDR is unchanged.

**N9 between GTP peers is emergent**: a SID-less remote segment yields no SRv6 steer, so the outer resolves by ordinary FIB. The design doc and book record the composite and GTP6 as implemented — nothing in the plan remains open.

## Test plan

- New BDD `bgp_mup_srgw_gtp`: z1 owns both remote segments (ISD + DSD over SRv6), z2 is a dataplane-gtp SRGW; one PFCP session drives the UE-prefix seg6 steer and the default routes into z2's kernel VRF table. Units cover both precedence flips.
- Regression green: all eight zebra MUP features (including the end-dt46 st1_isd/st2_dsd/forwarding set the filter refactor touches) and the four cradle-coupled labs; 2734 workspace tests, fmt + clippy `-D warnings` clean; `mdbook build` clean.

Generated with [Claude Code](https://claude.com/claude-code)