### PR TITLE
book: record the free5GC live validation of the N3-in-a-VRF split

### DIFF
--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -555,14 +555,33 @@ Two deployment notes:
   keep it on loopback (collocated SMF/injector) or on a dedicated N4
   interface in the global table. Placing it on an address inside the N3
   VRF would require VRF-aware control-plane sockets, which the MUP
-  controller does not do.
+  controller does not do. Note this is a *control-plane* separation only:
+  the UPF's **N3 endpoint address is unchanged** by it, so an SMF that
+  CH=0-allocates the UPF's N3 F-TEID keeps allocating at the address that
+  now lives inside the N3 VRF.
 * A **catalog change on live sessions is handled**: re-scoping a segment
   re-keys the installed PDRs (withdrawing the old match context) and
   migrates the gNB endpoint's NHT registration to its new table.
 
 The datapath is regression-tested by the cradle `@cradle_mup_gtp_n3_vrf`
 BDD (dual-segment origination, round-trip ICMP through both re-scoped
-lookups, tunnel counters on both ends).
+lookups, tunnel counters on both ends), and was validated against real
+free5GC v4.0.1 + free-ran-ue — the `bdd/mup-lab` N4-separated variant
+(`setup-topo-n3vrf.sh` + `upf-n3vrf.yaml` + `smfcfg-n3vrf.yaml`), which
+moves N4 onto its own global-table link and puts N3 in a kernel VRF. One
+PFCP session originated all four routes across the two segments (ISD +
+ST2 under N3's RD, DSD + ST1 under N6's), and the single installed decap
+PDR states the whole resolution:
+
+```
+key: (vrf 1, 10.0.12.2, TEID 2)   ->   value: vrf 2
+      ^ match context = N3's table        ^ decap target = N6's table
+        (where the G-PDU arrives)           (picked by the ST2's mup:1:6)
+```
+
+UE ping at 0% loss and iperf3 at ~1.6 Gbit/s uplink / ~2.6 Gbit/s
+downlink on a single box with debug builds — within noise of the
+single-N6 lab's ~1.9 / ~2.6, so the split costs no throughput.
 
 #### IPv6 N3 transport (GTP6) and composing with SRv6 segments
 


### PR DESCRIPTION
## Summary

Follow-up to #2217 (the `bdd/mup-lab` N4-separated variant). ch-02-35's faithful interwork/direct section cited only its cradle BDD, while the single-N6 section above it carries a live free5GC validation — this gives the split the same standing.

It now names the lab variant files, shows the one installed decap PDR as the whole resolution in a single line (key `vrf 1` = N3's table where the G-PDU arrives, value `vrf 2` = N6's table picked by the ST2's `mup:1:6`), and reports UE ping at 0% loss with iperf3 ~1.6 Gbit/s up / ~2.6 down — within noise of the single-N6 lab's ~1.9 / ~2.6, so the split costs no throughput.

The N4 deployment note also gains the consequence that matters when wiring a real SMF: the separation is control-plane only, so the UPF's N3 endpoint address is unchanged and an SMF that CH=0-allocates the N3 F-TEID keeps allocating at the address now inside the N3 VRF.

## Test plan

- Docs-only (`book/src/ch-02-35-bgp-mup.md`); `mdbook build` clean and the new content renders.
- The numbers come from the 2026-08-01 live run against free5GC v4.0.1 + free-ran-ue on the variant topology merged in #2217.

Generated with [Claude Code](https://claude.com/claude-code)