### PR TITLE
book: SRv6 EVPN flood isolation; correct the implied-tee knob story

### DIFF
--- a/book/src/ch-02-40-bgp-evpn-mpls.md
+++ b/book/src/ch-02-40-bgp-evpn-mpls.md
@@ -95,16 +95,13 @@ slot, and a flooded frame gets one copy per slot carrying that PE's BUM label.
 ### Enabling the data plane
 
 Because none of this forwarding exists in the kernel, the EVI's label, its
-decap and every remote MAC are programmed **only** into cradle. Three
+decap and every remote MAC are programmed **only** into cradle. Two
 separate things have to be true — the control plane will happily advertise
-and receive routes with any of them missing:
+and receive routes with either of them missing:
 
 ```
 system {
   ebpf {
-    enabled true;
-  }
-  cradle {
     enabled true;
   }
 }
@@ -120,13 +117,12 @@ interface enp0s7 {
 }
 ```
 
-- **`system ebpf enabled`** supervises the engine as a child process. On its
-  own it yields a plain eBPF L2 switch with nothing programmed into it.
-- **`system cradle enabled`** is the FIB tee — the switch that actually
-  carries the service label, the decap ILM and the EVPN FDB across. An
-  externally-run cradle is teed to with this leaf alone (point it with
-  `system cradle grpc-endpoint`; that leaf is an endpoint override and
-  enables nothing by itself).
+- **`system ebpf enabled`** supervises the engine as a child process and
+  **implies the FIB tee** — the service label, the decap ILM and the EVPN
+  FDB are carried across as soon as the managed engine is up. For an
+  **externally-run** cradle, `system cradle enabled` activates the tee
+  standalone instead (point it with `system cradle grpc-endpoint`; that
+  leaf is an endpoint override and enables nothing by itself).
 - **`interface <name> ebpf enabled`** attaches a port. Both the core-facing
   port (where labelled frames arrive) and the CE-facing port (where the
   bridge's access traffic arrives) must be attached.

--- a/book/src/ch-02-41-bgp-evpn-srv6.md
+++ b/book/src/ch-02-41-bgp-evpn-srv6.md
@@ -78,7 +78,11 @@ binding the routes carry: a per-VNI `End.DT2U` on every Type-2 and an
 
 A receiver classifies by the SID's presence — the SRv6 L2 Services
 attribute wins before any Encapsulation-EC reasoning — so SRv6, VXLAN and
-MPLS PEs can coexist under one route reflector.
+MPLS PEs can coexist under one route reflector. Flood state is partitioned
+the same way: an IMET carrying an `End.DT2M` SID populates only SRv6
+replication slots and never enters the VXLAN head-end flood set (an MPLS
+BUM-label IMET likewise stays out), so a mixed-encapsulation fabric cannot
+deliver a BUM frame twice.
 
 ## Forwarding
 

--- a/book/src/ch-16-00-ebpf.md
+++ b/book/src/ch-16-00-ebpf.md
@@ -49,16 +49,17 @@ interface enp0s6 {
 ```
 
 - **`system ebpf enabled true`** runs the data plane: zebra-rs launches the
-  engine as a managed child process and keeps it healthy. On its own it is a
-  pure eBPF L2 switch — no routing state is programmed into it.
-- **`system cradle enabled true`** is the **FIB tee**: every route zebra-rs
-  installs — plus ILMs, SRv6 SIDs and EVPN state — is programmed into the
-  engine in addition to the kernel, and the data plane's MAC learning is fed
-  back into EVPN Type-2 origination. This is the switch that turns the
-  switch into a forwarder for zebra-rs's routing state, and it is
-  independent of `system ebpf`: an externally-run cradle is teed to with
-  this leaf alone, and `system cradle grpc-endpoint` only overrides the
-  endpoint (default `unix:cradle/grpc`) — it enables nothing by itself.
+  engine as a managed child process, keeps it healthy, and **implies the
+  FIB tee** — a managed engine is always programmed with zebra-rs's routing
+  state.
+- **`system cradle enabled true`** is the **FIB tee** standalone: every
+  route zebra-rs installs — plus ILMs, SRv6 SIDs and EVPN state — is
+  programmed into the engine in addition to the kernel, and the data
+  plane's MAC learning is fed back into EVPN Type-2 origination. Set it
+  when the engine is run **externally** rather than managed by `system
+  ebpf` (with `system ebpf enabled` it is already implied). `system cradle
+  grpc-endpoint` only overrides the endpoint (default `unix:cradle/grpc`) —
+  it enables nothing by itself.
 - **`interface <name> ebpf enabled true`** makes that interface a data-plane
   port: the forwarding programs attach to it and it participates in eBPF
   forwarding. The port follows the interface's VRF binding
@@ -67,8 +68,8 @@ interface enp0s6 {
 
 | YANG leaf | Type | Default | Notes |
 |---|---|---|---|
-| `/system/ebpf/enabled` | `boolean` | `false` | Engine lifecycle: spawn and supervise the data plane. |
-| `/system/cradle/enabled` | `boolean` | `false` | The FIB tee: program routes / ILM / SRv6 / EVPN into the engine. |
+| `/system/ebpf/enabled` | `boolean` | `false` | Engine lifecycle: spawn and supervise the data plane. Implies the FIB tee. |
+| `/system/cradle/enabled` | `boolean` | `false` | The FIB tee standalone (for an externally-run engine): program routes / ILM / SRv6 / EVPN into the engine. |
 | `/system/cradle/grpc-endpoint` | `string` | `unix:cradle/grpc` | Endpoint override, shared by the tee and the managed engine. Does not enable the tee. |
 | `/interface/ebpf/enabled` | `boolean` | `false` | Per-interface port membership. |
 


### PR DESCRIPTION
## Summary
- Bring `ch-02-41-bgp-evpn-srv6.md` current with #2205: an IMET carrying an `End.DT2M` SID populates only SRv6 replication slots and never the VXLAN head-end flood set, so mixed-encapsulation fabrics cannot double-deliver BUM.
- Correct a stale knob story found while verifying the chapter: since 677417e4, `system ebpf enabled` (managed engine) **implies the FIB tee** — `rib/inst.rs` resolves the tee endpoint from either knob, and the ebpf-only playsets forward through cradle. `system cradle enabled` is for teeing to an externally-run engine. Fixed in `ch-16-00-ebpf.md` (knob bullets + YANG-leaf table) and `ch-02-40-bgp-evpn-mpls.md` ("Enabling the data plane": three required knobs → two, cradle knob reframed as the external-engine variant). ch-02-41's own "implies the tee" wording was already correct.
- Left for a code-side PR: the pre-677417e4 comments/help text in `config.yang` still tell the sole-switch story.

## Test plan
- `mdbook build book` succeeds.
- Semantics verified against `rib/inst.rs` (`cradle_endpoint`: `cradle_enabled || ebpf_enabled`), `cradle/inst.rs` (`teeEnabled`), and `playset/bgp-evpn-srv6` (ebpf-only config, validated lab).

Generated with [Claude Code](https://claude.com/claude-code)