### PR TITLE
yang: correct the stale sole-switch tee descriptions

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -568,20 +568,25 @@ module config {
         type inet:ipv4-address;
       }
       // The zebra-rs side of the cradle-rs eBPF data-plane integration:
-      // when enabled, every route zebra-rs installs is teed to cradle in
-      // addition to the kernel, and cradle's datapath MAC learning is fed
-      // back into EVPN (see `rib/inst.rs cradle_apply`). The tee is active
-      // only when `system cradle enabled true` is set.
+      // while the tee is active, every route zebra-rs installs is teed to
+      // cradle in addition to the kernel, and cradle's datapath MAC
+      // learning is fed back into EVPN (see `rib/inst.rs`). The tee is
+      // active when either switch is on: `system ebpf enabled` (managed
+      // engine) implies it, and this container's `enabled` activates it
+      // standalone for an externally-run engine.
       container cradle {
         ext:help "cradle eBPF data-plane integration";
         leaf enabled {
           ext:help "Enable the cradle eBPF data-plane tee";
           type boolean;
           description
-            "The sole switch for the cradle eBPF data-plane tee. When true,
-             the endpoint is `system cradle grpc-endpoint` if set, otherwise
-             the default `unix:cradle/grpc` (a Linux abstract socket, matching
-             cradle's own default).";
+            "Activate the cradle eBPF data-plane tee without a managed
+             engine — the switch for teeing to an externally-run cradle.
+             (`system ebpf enabled` already implies the tee for the engine
+             it manages, so this leaf is not needed there.) The endpoint is
+             `system cradle grpc-endpoint` if set, otherwise the default
+             `unix:cradle/grpc` (a Linux abstract socket, matching cradle's
+             own default).";
         }
         // gRPC endpoint of the cradle eBPF data plane to tee FIB route
         // installs to (e.g. `unix:/run/cradle.sock` or `127.0.0.1:50151`).
@@ -597,11 +602,11 @@ module config {
       // The engine-lifecycle half of the eBPF data-plane integration:
       // when enabled, zebra-rs spawns the cradle daemon as a managed,
       // supervised child process (adopting an instance already listening
-      // on the endpoint instead of spawning a second one). This knob
-      // only manages the process — the FIB tee stays under
-      // `system cradle enabled`, and interfaces join the data plane via
-      // `interface <if-name> ebpf enabled` — so `system ebpf` alone
-      // yields a pure eBPF L2 switch with no routes teed.
+      // on the endpoint instead of spawning a second one) and implies the
+      // FIB tee — a managed engine is always programmed with zebra-rs's
+      // routing state once it is up. Interfaces join the data plane via
+      // `interface <if-name> ebpf enabled`; with no ports attached the
+      // engine forwards nothing.
       container ebpf {
         ext:help "eBPF data-plane engine (managed cradle process)";
         leaf enabled {
@@ -609,13 +614,15 @@ module config {
           type boolean;
           description
             "When true, zebra-rs launches the cradle eBPF data plane as a
-             managed child process and restarts it on failure. The child
-             serves its gRPC API on `system cradle grpc-endpoint` if set,
-             otherwise on the default `unix:cradle/grpc` abstract socket;
-             a cradle instance already listening there is adopted rather
-             than duplicated. When false or unset no process is managed —
-             an externally-run cradle can still be teed to through
-             `system cradle enabled`.";
+             managed child process, restarts it on failure, and implies the
+             FIB tee — routes, ILMs, SRv6 SIDs and EVPN state are programmed
+             into the managed engine with no separate `system cradle
+             enabled`. The child serves its gRPC API on `system cradle
+             grpc-endpoint` if set, otherwise on the default
+             `unix:cradle/grpc` abstract socket; a cradle instance already
+             listening there is adopted rather than duplicated. When false
+             or unset no process is managed — an externally-run cradle can
+             still be teed to through `system cradle enabled`.";
         }
         leaf mode {
           ext:help "Single-hook datapath benchmark mode (tc-only|xdp-only)";


### PR DESCRIPTION
## Summary
- `config.yang` still told operators `system cradle enabled` is "the sole switch" for the FIB tee and that `system ebpf` alone "yields a pure eBPF L2 switch with no routes teed" — stale since 677417e4, where `system ebpf enabled` (managed engine) started implying the tee (`rib/inst.rs cradle_endpoint`: `cradle_enabled || ebpf_enabled`).
- Bring both containers' comments, `description` texts and surrounding notes in line with the code: `system ebpf enabled` spawns/supervises the engine **and implies the tee**; `system cradle enabled` activates the tee standalone for an externally-run engine. The book side was fixed in #2224.

## Test plan
- `cargo test -p zebra-rs config::manager` — all 89 `yang_load_tests` pass (config.yang parses with the edits).
- Comment/description-only change; no schema nodes added, removed, or retyped.

Generated with [Claude Code](https://claude.com/claude-code)