### PR TITLE
book: MPLS EVPN chapter — flood isolation and the engine-knob bullet

### DIFF
--- a/book/src/ch-02-40-bgp-evpn-mpls.md
+++ b/book/src/ch-02-40-bgp-evpn-mpls.md
@@ -74,7 +74,11 @@ That last row is the encapsulation signal itself: RFC 8365 §5.1.3 makes MPLS
 the default and marks it by *omitting* the Encapsulation extended community.
 zebra-rs reads a received route the same way (and also accepts an explicit
 tunnel type 10), so a route reflector — which has no `encapsulation` of its
-own — classifies traffic exactly as a PE does.
+own — classifies traffic exactly as a PE does. Flood state is partitioned by
+the same classification: an IMET carrying an MPLS BUM label populates only
+MPLS replication slots and never enters the VXLAN head-end flood set (an
+`End.DT2M`-bearing IMET likewise stays out), so a mixed-encapsulation fabric
+cannot deliver a BUM frame twice.
 
 ## Forwarding
 
@@ -244,7 +248,8 @@ iBGP session riding the LSP through the routeless P. Its E-Line sibling is
 
 ## Limitations
 
-- **Requires cradle** (`system cradle enabled` plus an engine — see
+- **Requires cradle** (`system ebpf enabled` for the managed engine, or
+  `system cradle enabled` teeing to an external one — see
   [Enabling the data plane](#enabling-the-data-plane)). Without it the routes
   are advertised and received but nothing forwards.
 - **Single-homed.** Multihoming (Type-1/Type-4 and the ESI label's


### PR DESCRIPTION
## Summary
- Mirror the #2205 guarantee ch-02-41 already states: an IMET carrying an MPLS BUM label populates only MPLS replication slots and never the VXLAN head-end flood set, so mixed-encapsulation fabrics cannot double-deliver BUM.
- Finish the implied-tee correction from #2224: the Limitations bullet still named `system cradle enabled` as the requirement; it now names `system ebpf enabled` (managed engine) with the cradle leaf as the external-engine variant, matching the section it links to.

## Test plan
- `mdbook build book` succeeds.
- Flood-isolation claim matches the #2205 IMET flood-set gating in `bgp/inst.rs`; knob semantics match `rib/inst.rs` (`cradle_enabled || ebpf_enabled`) as verified in #2224/#2225.

Generated with [Claude Code](https://claude.com/claude-code)