### PR TITLE
build: libyang 2.1 from crates.io

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -137,10 +137,9 @@ tonic-prost.workspace = true
 tower = { version = "0.5", default-features = false, features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 console-subscriber = "0.5"
-# Pinned to the feature/if-feature merge (libyang PR #35); flip back to
-# the crates.io line once libyang 2.1 is published.
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "bdb6cadf604a766e8051032ac77e03b0bb737f07" }
-#libyang = "2"
+# 2.1 is the feature / if-feature release (`YangStore::enable_feature`).
+libyang = "2.1"
+#libyang = { git = "https://github.com/zebra-rs/libyang", rev = "bdb6cadf604a766e8051032ac77e03b0bb737f07" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary

libyang 2.1.0 — the feature / if-feature release (zebra-rs/libyang#35) — is now published on crates.io, so this drops the temporary git-rev pin introduced in #2230 and returns to a registry dependency: `libyang = "2.1"` (2.1 is the minimum carrying `YangStore::enable_feature`).

## Testing

- `cargo update -p libyang` resolves `libyang v2.1.0` from crates.io (replacing the git source).
- `cargo test --workspace --exclude bdd`: all green, including the `feature_gate_tests` and the `bgp_config_audit` trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)