### PR TITLE
config: first iso-gated schema node — interface ipv4 dhcp

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -5363,9 +5363,9 @@ mod feature_gate_tests {
 
     /// A scratch module that augments `set router` in the real
     /// configure tree with a container gated on `feat:iso` from the
-    /// shipped zebra-features registry. No such node exists in the
-    /// shipped schema yet, so the fixture stands in for the first
-    /// real consumer.
+    /// shipped zebra-features registry, exercising the augment path of
+    /// the gating (the shipped `interface ipv4 dhcp` leaf covers the
+    /// in-module path — see `shipped_interface_ipv4_dhcp_gated_on_iso`).
     const FIXTURE: &str = r#"
 module test-iso-gated {
   yang-version "1";
@@ -5458,6 +5458,41 @@ module test-iso-gated {
         assert!(
             !gated_node_present(&["config:iso"]),
             "a feature enabled against the wrong module stays off"
+        );
+    }
+
+    /// Whether the shipped `interface <name> ipv4 dhcp` leaf (the
+    /// first real feature-gated node, `if-feature feat:iso` in
+    /// config.yang) exists in the configure tree.
+    fn shipped_dhcp_present(features: &[&str]) -> bool {
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        let specs: Vec<String> = features.iter().map(|s| s.to_string()).collect();
+        enable_features(&mut yang, &specs);
+        yang.read_with_resolve("configure")
+            .expect("configure loads");
+        yang.identity_resolve();
+        let module = yang.find_module("configure").expect("configure module");
+        let entry = to_entry(&yang, module);
+
+        let child = |e: &Rc<Entry>, name: &str| -> Option<Rc<Entry>> {
+            e.dir.borrow().iter().find(|c| c.name == name).cloned()
+        };
+        let set = child(&entry, "set").expect("set subtree");
+        let interface = child(&set, "interface").expect("interface list");
+        let ipv4 = child(&interface, "ipv4").expect("ipv4 container");
+        child(&ipv4, "dhcp").is_some()
+    }
+
+    #[test]
+    fn shipped_interface_ipv4_dhcp_gated_on_iso() {
+        assert!(
+            !shipped_dhcp_present(&[]),
+            "interface ipv4 dhcp must be absent on a stock start"
+        );
+        assert!(
+            shipped_dhcp_present(&["iso"]),
+            "interface ipv4 dhcp must appear with --feature iso"
         );
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -16,6 +16,10 @@ module config {
     prefix ext;
   }
 
+  import zebra-features {
+    prefix feat;
+  }
+
   import dhcp {
     prefix dhcp;
   }
@@ -4953,6 +4957,18 @@ module config {
              interface (shown by `show interface`). Within a subnet the
              first address installed becomes the primary, so on a full
              config replay the leaf-list order decides.";
+        }
+        leaf dhcp {
+          if-feature feat:iso;
+          ext:help "Acquire the interface IPv4 address via DHCP";
+          type empty;
+          description
+            "Acquire the interface's IPv4 address dynamically instead
+             of static `address` entries. First consumer of conditional
+             schema: the node exists only when the daemon runs with
+             `--feature iso` (RFC 7950 if-feature); the daemon-side
+             DHCP client lands in a later change, so setting it today
+             stores config without acting on it.";
         }
       }
       container ipv6 {


### PR DESCRIPTION
## Summary

First real consumer of the conditional-schema mechanism (#2230): a `dhcp` leaf under `interface <name> ipv4`, guarded by `if-feature feat:iso`. `config.yang` now imports the `zebra-features` registry.

```
$ zebra-rs                  # stock: node absent, schema unchanged
$ zebra-rs --feature iso    # set interface eth0 ipv4 dhcp becomes available
```

## Notes

- **Why not the literal `address dhcp` value form**: `address` is a leaf-list of `inet:ipv4-prefix`; making `dhcp` one of its values would require if-feature on a union/enum arm, which libyang parses but does not yet evaluate. The sibling-leaf form (`ipv4 dhcp`) is the gateable shape today; enum-arm gating is a possible libyang follow-up if the value form is preferred.
- **Schema-only for now**: the daemon-side DHCP client is a later change; the leaf's description says so explicitly. On a stock start the node does not exist, so nothing changes for current users, configs, or BDD.
- The BGP-scoped audit docs are untouched (the node is outside `/router/bgp`, and off by default regardless).

## Testing

- `feature_gate_tests::shipped_interface_ipv4_dhcp_gated_on_iso`: walks the real configure tree — `set interface ipv4 dhcp` absent with no features, present with `--feature iso`.
- `cargo test --workspace --exclude bdd`: all green; `cargo clippy --workspace --all-targets` and `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)