### PR TITLE
config: interface ipv4 address dhcp as feature-gated union value

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -137,9 +137,10 @@ tonic-prost.workspace = true
 tower = { version = "0.5", default-features = false, features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 console-subscriber = "0.5"
-# 2.1 is the feature / if-feature release (`YangStore::enable_feature`).
-libyang = "2.1"
-#libyang = { git = "https://github.com/zebra-rs/libyang", rev = "bdb6cadf604a766e8051032ac77e03b0bb737f07" }
+# Pinned to the enum-arm if-feature evaluation (libyang PR #36); flip
+# back to the crates.io line once libyang 2.2 is published.
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "1dada0e" }
+#libyang = "2.1"
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -5364,8 +5364,9 @@ mod feature_gate_tests {
     /// A scratch module that augments `set router` in the real
     /// configure tree with a container gated on `feat:iso` from the
     /// shipped zebra-features registry, exercising the augment path of
-    /// the gating (the shipped `interface ipv4 dhcp` leaf covers the
-    /// in-module path — see `shipped_interface_ipv4_dhcp_gated_on_iso`).
+    /// the gating (the shipped `interface ipv4 address dhcp` enum arm
+    /// covers the in-module path — see
+    /// `shipped_interface_ipv4_address_dhcp_gated_on_iso`).
     const FIXTURE: &str = r#"
 module test-iso-gated {
   yang-version "1";
@@ -5461,9 +5462,11 @@ module test-iso-gated {
         );
     }
 
-    /// Whether the shipped `interface <name> ipv4 dhcp` leaf (the
-    /// first real feature-gated node, `if-feature feat:iso` in
-    /// config.yang) exists in the configure tree.
+    /// Whether the shipped `interface <name> ipv4 address` union
+    /// accepts the `dhcp` value — the first real feature-gated schema
+    /// element (`if-feature feat:iso` on the enum arm in config.yang).
+    /// The gate is on the value, not the node: the address leaf-list
+    /// itself must exist either way.
     fn shipped_dhcp_present(features: &[&str]) -> bool {
         let mut yang = YangStore::new();
         yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
@@ -5481,18 +5484,69 @@ module test-iso-gated {
         let set = child(&entry, "set").expect("set subtree");
         let interface = child(&set, "interface").expect("interface list");
         let ipv4 = child(&interface, "ipv4").expect("ipv4 container");
-        child(&ipv4, "dhcp").is_some()
+        let address = child(&ipv4, "address").expect("address leaf-list");
+        address
+            .type_node
+            .as_ref()
+            .expect("address type resolved")
+            .union
+            .iter()
+            .any(|arm| arm.enum_stmt.iter().any(|e| e.name == "dhcp"))
     }
 
     #[test]
-    fn shipped_interface_ipv4_dhcp_gated_on_iso() {
+    fn shipped_interface_ipv4_address_dhcp_gated_on_iso() {
         assert!(
             !shipped_dhcp_present(&[]),
-            "interface ipv4 dhcp must be absent on a stock start"
+            "the dhcp address value must be absent on a stock start"
         );
         assert!(
             shipped_dhcp_present(&["iso"]),
-            "interface ipv4 dhcp must appear with --feature iso"
+            "interface ipv4 address dhcp must appear with --feature iso"
         );
+    }
+
+    /// End-to-end CLI grammar for the gated value: `set interface eth0
+    /// ipv4 address dhcp` parses only when iso is enabled, while the
+    /// plain prefix form always parses.
+    #[test]
+    fn address_dhcp_command_parses_only_with_iso() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+
+        let tree = |features: &[&str]| {
+            let mut yang = YangStore::new();
+            yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+            let specs: Vec<String> = features.iter().map(|s| s.to_string()).collect();
+            enable_features(&mut yang, &specs);
+            yang.read_with_resolve("configure")
+                .expect("configure loads");
+            yang.identity_resolve();
+            let module = yang.find_module("configure").expect("configure module");
+            to_entry(&yang, module)
+        };
+
+        let dhcp = "set interface eth0 ipv4 address dhcp";
+        let prefix = "set interface eth0 ipv4 address 10.0.0.1/24";
+
+        let entry = tree(&[]);
+        let (code, _, _) = parse(dhcp, entry.clone(), None, State::new());
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "dhcp value must be rejected on a stock start"
+        );
+        let (code, _, _) = parse(prefix, entry, None, State::new());
+        assert_eq!(code, ExecCode::Success, "prefix form must always parse");
+
+        let entry = tree(&["iso"]);
+        let (code, _, _) = parse(dhcp, entry.clone(), None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "dhcp value must parse with --feature iso"
+        );
+        let (code, _, _) = parse(prefix, entry, None, State::new());
+        assert_eq!(code, ExecCode::Success, "prefix form must always parse");
     }
 }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -1543,9 +1543,25 @@ pub async fn link_config_exec(
         // `address` is a leaf-list: each commit line carries one value,
         // but drain the deque so a bundled delivery would not silently
         // drop trailing values.
+        //
+        // `dhcp` is the feature-gated enum arm of the address union
+        // (present only under `--feature iso`). The daemon-side DHCP
+        // client is not implemented yet, so the value is accepted
+        // without kernel action — and it must be consumed here: an
+        // unparsed value left in the deque would read as the
+        // value-less delete form below, which removes every
+        // configured address on the interface.
+        let mut dhcp = false;
         let mut values: Vec<Ipv4Net> = Vec::new();
-        while let Some(v4addr) = args.v4net() {
-            values.push(v4addr);
+        while let Some(value) = args.string() {
+            if value == "dhcp" {
+                dhcp = true;
+            } else if let Ok(v4addr) = value.parse::<Ipv4Net>() {
+                values.push(v4addr);
+            }
+        }
+        if dhcp && values.is_empty() {
+            return Ok(());
         }
 
         if op.is_set() {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4948,27 +4948,29 @@ module config {
       container ipv4 {
         ext:help "IPv4 configuration";
         leaf-list address {
-          ext:help "IPv4 interface address";
-          type inet:ipv4-prefix;
+          ext:help "IPv4 interface address, or dhcp to acquire one";
+          type union {
+            type inet:ipv4-prefix;
+            type enumeration {
+              enum dhcp {
+                if-feature feat:iso;
+              }
+            }
+          }
           description
             "Interface IPv4 addresses. Multiple addresses may be
              configured; the kernel marks an address secondary when it
              shares its mask and subnet with an existing primary on the
              interface (shown by `show interface`). Within a subnet the
              first address installed becomes the primary, so on a full
-             config replay the leaf-list order decides.";
-        }
-        leaf dhcp {
-          if-feature feat:iso;
-          ext:help "Acquire the interface IPv4 address via DHCP";
-          type empty;
-          description
-            "Acquire the interface's IPv4 address dynamically instead
-             of static `address` entries. First consumer of conditional
-             schema: the node exists only when the daemon runs with
-             `--feature iso` (RFC 7950 if-feature); the daemon-side
-             DHCP client lands in a later change, so setting it today
-             stores config without acting on it.";
+             config replay the leaf-list order decides.
+
+             `dhcp` — acquire the address dynamically instead — is the
+             first consumer of conditional schema: the value exists
+             only when the daemon runs with `--feature iso` (RFC 7950
+             if-feature on the enum arm). The daemon-side DHCP client
+             lands in a later change, so setting it today stores
+             config without acting on it.";
         }
       }
       container ipv6 {


### PR DESCRIPTION
## Summary

Delivers the literal form of the first gated schema element: `/interface/ipv4/address/dhcp` — `dhcp` as a *value* of the address leaf-list rather than the interim sibling leaf from #2232. The gate moves onto the union's enum arm (`if-feature feat:iso`, RFC 7950 §9.6.4.1), which libyang evaluates as of zebra-rs/libyang#36.

```
$ zebra-rs                  # stock: `address dhcp` rejected, schema unchanged
$ zebra-rs --feature iso    # set interface eth0 ipv4 address dhcp parses
```

**Depends on zebra-rs/libyang#36** — pinned by git rev until libyang 2.2 is published (then the pin flips back to the registry, as #2231 did for 2.1).

## Changes

- **config.yang**: the `ipv4 dhcp` leaf from #2232 is replaced by a union on `address` — `inet:ipv4-prefix | enumeration { dhcp { if-feature feat:iso; } }` (same shape as the static-route nexthop's `blackhole`). The value is pruned from the type while the feature is off; the leaf-list itself always exists.
- **link.rs handler**: the address handler now drains values as strings and consumes `dhcp` explicitly, accepting it without kernel action (DHCP client comes later). This is load-bearing, not cosmetic: an unparsed value left in the deque would make `delete interface X ipv4 address dhcp` fall into the value-less delete form, which removes **every** configured address on the interface.
- **Tests**: `shipped_interface_ipv4_address_dhcp_gated_on_iso` pins the union arm in the entry tree; new `address_dhcp_command_parses_only_with_iso` drives the actual CLI parser — `set interface eth0 ipv4 address dhcp` rejected stock / accepted with `--feature iso`, prefix form always accepted.

## Testing

`cargo test --workspace --exclude bdd` all green (39 suites); clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)