### PR TITLE
build: libyang 2.2 from crates.io

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -137,10 +137,9 @@ tonic-prost.workspace = true
 tower = { version = "0.5", default-features = false, features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 console-subscriber = "0.5"
-# Pinned to the enum-arm if-feature evaluation (libyang PR #36); flip
-# back to the crates.io line once libyang 2.2 is published.
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "1dada0e" }
-#libyang = "2.1"
+# 2.2 evaluates if-feature on enum arms (feature-gated union values).
+libyang = "2.2"
+#libyang = { git = "https://github.com/zebra-rs/libyang", rev = "1dada0e" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary

libyang 2.2.0 — the enum-arm if-feature evaluation release (zebra-rs/libyang#36, tagged `v2.2.0`) — is now published on crates.io, so this drops the temporary git-rev pin introduced in #2233 and returns to a registry dependency: `libyang = "2.2"`. Same release step as #2231 was for 2.1.

## Testing

- `cargo update -p libyang` resolves `libyang v2.2.0` from crates.io (replacing the git source).
- `cargo test --workspace --exclude bdd`: all green (39 suites), including the feature-gate and CLI-parse tests for `interface ipv4 address dhcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)