### PR TITLE
config: VyOS-style whole-subtree delete at any config node

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -5859,4 +5859,120 @@ module test-iso-gated {
             assert!(script.contains(needle), "missing `{needle}` in:\n{script}");
         }
     }
+
+    /// VyOS-style whole-subtree delete (found by live namespace
+    /// testing of the firewall): a delete may stop at any node that
+    /// exists in the config — plain containers, bare lists, value
+    /// leaves without their value — not only presence containers,
+    /// list entries and full leaf+value spellings. Exercised on the
+    /// firewall tree because that's where VyOS operators expect it,
+    /// but the mechanics are generic to the whole config CLI.
+    #[test]
+    fn firewall_subtree_delete_matches_vyos() {
+        use crate::config::parse::{State, parse};
+        use crate::config::path_from_command;
+
+        let entry = shipped_tree(&["iso"]);
+        let store = ConfigStore::new();
+
+        let apply_set = |cmd: &str| {
+            let candidate = store.candidate.borrow().clone();
+            let (code, _, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            set(path_try_trim("set", state.paths), candidate);
+        };
+        // Parse + apply a delete against the candidate config; returns
+        // the ExecCode and (on success) the trimmed command path.
+        let apply_delete = |cmd: &str| -> (ExecCode, String) {
+            let candidate = store.candidate.borrow().clone();
+            let (code, _, state) = parse(cmd, entry.clone(), Some(candidate.clone()), State::new());
+            if code != ExecCode::Success {
+                return (code, String::new());
+            }
+            let paths = path_try_trim("delete", state.paths);
+            let (path_str, _) = path_from_command(&paths);
+            delete(paths, candidate);
+            (code, path_str)
+        };
+        let config_text = || {
+            let mut out = String::new();
+            store.candidate.borrow().list(&mut out);
+            out
+        };
+
+        for cmd in [
+            "set firewall group address-group SERVERS address 10.0.0.1",
+            "set firewall ipv4 forward filter default-action drop",
+            "set firewall ipv4 forward filter default-log",
+            "set firewall ipv4 forward filter rule 10 action accept",
+            "set firewall ipv4 forward filter rule 20 action drop",
+            "set firewall ipv4 prerouting raw rule 5 action notrack",
+            "set firewall ipv6 input filter rule 7 action accept",
+            "set firewall global-options state-policy established action accept",
+        ] {
+            apply_set(cmd);
+        }
+
+        // Plain container mid-tree.
+        let (code, path) = apply_delete("delete firewall ipv4 prerouting");
+        assert_eq!(code, ExecCode::Success, "container delete");
+        assert_eq!(path, "/firewall/ipv4/prerouting");
+        assert!(!config_text().contains("prerouting"));
+        assert!(config_text().contains("forward"), "siblings survive");
+
+        // Plain container holding only containers.
+        let (code, _) = apply_delete("delete firewall global-options");
+        assert_eq!(code, ExecCode::Success, "global-options delete");
+        assert!(!config_text().contains("state-policy"));
+
+        // Value leaf without its value.
+        let (code, _) = apply_delete("delete firewall ipv4 forward filter default-action");
+        assert_eq!(code, ExecCode::Success, "value-less leaf delete");
+        assert!(!config_text().contains("default-action"));
+        assert!(
+            config_text().contains("default-log"),
+            "sibling leaf survives"
+        );
+
+        // Bare list: removes every entry (the ipv6 rule list survives).
+        let (code, _) = apply_delete("delete firewall ipv4 forward filter rule");
+        assert_eq!(code, ExecCode::Success, "bare list delete");
+        assert!(!config_text().contains("ipv4 forward filter rule"));
+        assert!(config_text().contains("ipv6 input filter rule 7"));
+
+        // Whole subtree, abbreviated — the CommandPath canonicalizes.
+        let (code, path) = apply_delete("delete firew");
+        assert_eq!(code, ExecCode::Success, "abbreviated root delete");
+        assert_eq!(path, "/firewall", "abbreviation canonicalizes");
+        assert!(
+            store
+                .candidate
+                .borrow()
+                .lookup(&"firewall".to_string())
+                .is_none(),
+            "firewall subtree gone"
+        );
+
+        // Once gone, the same delete is Nomatch — existence is checked
+        // against config, not schema.
+        let (code, _) = apply_delete("delete firewall");
+        assert_eq!(code, ExecCode::Nomatch, "delete of absent subtree");
+
+        // The bare `delete` keyword stays Incomplete: no silent
+        // whole-config wipe.
+        let (code, _) = apply_delete("delete");
+        assert_eq!(code, ExecCode::Incomplete, "bare delete");
+
+        // Set mode is untouched: a bare container is still not a
+        // command there.
+        apply_set("set firewall ipv4 forward filter default-log");
+        let candidate = store.candidate.borrow().clone();
+        let (code, _, _) = parse(
+            "set firewall ipv4 forward",
+            entry.clone(),
+            Some(candidate),
+            State::new(),
+        );
+        assert_ne!(code, ExecCode::Success, "set at container stays incomplete");
+    }
 }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -547,6 +547,23 @@ pub fn ymatch_complete(ymatch: YangMatch, list_presence: bool, is_delete: bool) 
         || (is_delete && ymatch == YangMatch::LeafList)
 }
 
+/// VyOS-style whole-subtree delete: in delete mode a command may stop
+/// at ANY node that exists in the config tree — a plain container
+/// (`delete firewall`), a bare list (`delete … filter rule`, removing
+/// every entry) or a value leaf without its value (`delete …
+/// default-action`) — not only the `ymatch_complete` terminals. This
+/// is sound because the per-token delete guard in [`parse`] has
+/// already returned Nomatch/Ambiguous unless every typed token matched
+/// the candidate config, so the target subtree is known to exist;
+/// `delete()` then removes the final node and prunes emptied
+/// ancestors. `paths.len() > 1` keeps the bare `delete` keyword
+/// Incomplete instead of turning it into a silent whole-config wipe.
+fn delete_subtree_terminal(s: &State) -> bool {
+    s.delete
+        && s.paths.len() > 1
+        && matches!(s.ymatch, YangMatch::Dir | YangMatch::Leaf | YangMatch::Key)
+}
+
 fn matched_enumeration(mx: &Match) -> Option<String> {
     let type_node = mx.matched_entry.type_node.as_ref()?;
     let last_match = mx.last_match.as_ref()?;
@@ -820,7 +837,8 @@ pub fn parse(
     }
     s.paths.push(path);
 
-    if ymatch_complete(s.ymatch, mx.matched_entry.presence, s.delete)
+    if (ymatch_complete(s.ymatch, mx.matched_entry.presence, s.delete)
+        || delete_subtree_terminal(&s))
         && mx.matched_type == MatchType::Exact
     {
         comps_add_cr(&mut mx.comps);
@@ -860,6 +878,9 @@ pub fn parse(
             return (ExecCode::Success, mx.comps, s);
         }
         if !ymatch_complete(s.ymatch, mx.matched_entry.presence, s.delete) {
+            if delete_subtree_terminal(&s) && mx.matched_type != MatchType::Incomplete {
+                return (ExecCode::Success, mx.comps, s);
+            }
             return (ExecCode::Incomplete, mx.comps, s);
         }
         if mx.matched_type == MatchType::Incomplete {


### PR DESCRIPTION
## Problem

Found by live namespace testing of the firewall backend (#2238): delete commands could only terminate where `ymatch_complete` allows — presence containers, list entries, full leaf+value spellings, bare leaf-lists. So `delete firewall`, `delete firewall ipv4 prerouting`, `delete firewall global-options`, value-less `delete … default-action` and bare `delete … rule` were all rejected as `Incomplete`. VyOS accepts subtree deletion at any level, and the ISO config surface should match.

## Fix

In delete mode, allow the command to complete at `Dir`, `Leaf` and `Key` states as well (`delete_subtree_terminal` in parse.rs). This is sound because the per-token delete guard already returns `Nomatch`/`Ambiguous` unless every typed token matched the candidate config — reaching end-of-input in delete mode proves the target subtree exists — and `configs::delete()` has always removed a mid-tree node and pruned emptied ancestors. Guards:

- bare `delete` stays `Incomplete` (`paths.len() > 1`), so it can't become a silent whole-config wipe;
- `set`/`show`/`exec` parsing untouched;
- the `<cr>` completion hint follows the same rule, so interactive vty advertises the newly valid stopping points.

## Tests

`firewall_subtree_delete_matches_vyos` drives the real iso-enabled schema end to end: container delete with sibling survival, bare-list delete (ipv6 twin list survives), value-less leaf delete, abbreviation canonicalization (`delete firew` → `/firewall`), `Nomatch` once the subtree is gone, `Incomplete` for bare `delete`, and set-mode unaffected.

Verified live in a namespace against real nft: all previously-failing deletes now apply and re-render the kernel ruleset; `delete firewall` empties it to zero bytes. A delete that leaves a dangling `jump-target` fails atomically inside nft with the old ruleset intact and an error logged — commit-time reference validation remains a follow-up.

`cargo test --workspace --exclude bdd` all green (1911 zebra-rs tests); fmt + workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)