### PR TITLE
system: show vpn ipsec — sa/connections via vici, state/policy via ip xfrm

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1428,6 +1428,8 @@ impl ConfigManager {
                                 "ND"
                             } else if is_firewall(&paths) {
                                 "Firewall"
+                            } else if is_vpn(&paths) {
+                                "IPsec"
                             } else if is_policy(&paths) {
                                 "Policy"
                             } else {
@@ -1590,6 +1592,13 @@ fn is_firewall(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "firewall")
 }
 
+/// `show vpn ...` — the whole VPN show tree (only IPsec today) is
+/// served by the IPsec task (iso-gated exec grammar; the task always
+/// runs, so no not-running fallback in practice).
+fn is_vpn(paths: &[CommandPath]) -> bool {
+    paths.iter().any(|x| x.name == "vpn")
+}
+
 /// `show pim ...`, `show igmp ...` and `show mroute` — all served by
 /// the PIM task (IGMP membership tracking and the multicast routing
 /// table live inside the PIM module).
@@ -1644,6 +1653,8 @@ fn show_proto(paths: &[CommandPath]) -> &'static str {
         "cradle"
     } else if is_firewall(paths) {
         "firewall"
+    } else if is_vpn(paths) {
+        "ipsec"
     } else if is_policy(paths) {
         "policy"
     } else {
@@ -6062,6 +6073,47 @@ module test-iso-gated {
         assert_ne!(code, ExecCode::Success, "gated off without --feature iso");
         let (code, _, _) = parse("show interface", entry, None, State::new());
         assert_eq!(code, ExecCode::Success, "the rest of show survives");
+    }
+
+    /// The `show vpn ipsec` exec grammar: iso-gated like the config
+    /// subtree, every view parses to the path the ipsec task
+    /// dispatches on, and the manager routes any vpn path to the
+    /// `"ipsec"` show subscriber.
+    #[test]
+    fn show_vpn_ipsec_grammar_gated_on_iso() {
+        use crate::config::parse::{State, parse};
+        use crate::config::path_from_command;
+
+        let entry = shipped_tree_mode("exec", &["iso"]);
+
+        let cases: Vec<(&str, &str)> = vec![
+            ("show vpn ipsec sa", "/show/vpn/ipsec/sa"),
+            ("show vpn ipsec connections", "/show/vpn/ipsec/connections"),
+            ("show vpn ipsec policy", "/show/vpn/ipsec/policy"),
+            ("show vpn ipsec state", "/show/vpn/ipsec/state"),
+            // Abbreviations canonicalize into the dispatch path.
+            ("show vpn ips sa", "/show/vpn/ipsec/sa"),
+            ("show vpn ipsec conn", "/show/vpn/ipsec/connections"),
+        ];
+        for &(cmd, want_path) in &cases {
+            let (code, _, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, _args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            assert_eq!(show_proto(&state.paths), "ipsec", "routing for `{cmd}`");
+        }
+
+        // Bare `show vpn` / `show vpn ipsec` are not commands — a
+        // view must be named, like VyOS.
+        for cmd in ["show vpn", "show vpn ipsec"] {
+            let (code, _, _) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
+        }
+
+        // Stock start: the whole tree is absent.
+        let entry = shipped_tree_mode("exec", &[]);
+        let (code, _, _) = parse("show vpn ipsec sa", entry, None, State::new());
+        assert_ne!(code, ExecCode::Success, "gated off without --feature iso");
     }
 
     /// The VyOS-style `vpn ipsec` subtree (ipsec.yang, used inside

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -234,6 +234,7 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
 
     let ipsec = system::Ipsec::new();
     config.subscribe_json(&["vpn", "ipsec"], ipsec.tx.clone());
+    config.subscribe_show("ipsec", ipsec.show.tx.clone());
 
     let cli = Cli::new(config.tx.clone());
 

--- a/zebra-rs/src/system/ipsec.rs
+++ b/zebra-rs/src/system/ipsec.rs
@@ -43,12 +43,15 @@ use serde::Deserialize;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use super::json::{Flex, de_flex_vec, de_presence};
-use crate::config::JsonConfigUpdate;
+use super::vici;
+use crate::config::{DisplayRequest, JsonConfigUpdate, ShowChannel, path_from_command};
 
 pub struct Ipsec {
     pub tx: UnboundedSender<JsonConfigUpdate>,
     rx: UnboundedReceiver<JsonConfigUpdate>,
+    pub show: ShowChannel,
     conf_dir: PathBuf,
+    vici_socket: PathBuf,
 }
 
 impl Ipsec {
@@ -57,13 +60,19 @@ impl Ipsec {
         Self {
             tx,
             rx,
+            show: ShowChannel::new(),
             conf_dir: PathBuf::from("/etc/swanctl"),
+            vici_socket: PathBuf::from("/var/run/charon.vici"),
         }
     }
 
     pub async fn event_loop(mut self) {
-        while let Some(update) = self.rx.recv().await {
-            process(update, &self.conf_dir).await;
+        loop {
+            tokio::select! {
+                Some(update) = self.rx.recv() => process(update, &self.conf_dir).await,
+                Some(req) = self.show.rx.recv() => process_show(&self.vici_socket, req).await,
+                else => break,
+            }
         }
     }
 }
@@ -1019,6 +1028,445 @@ fn render_tunnel_child(
     }
 }
 
+// ---------------------------------------------------------------
+// show vpn ipsec
+//
+// `sa` and `connections` read live data over charon's vici socket —
+// the same channel VyOS's op-mode scripts use — and format it with
+// the same row/column semantics as vyos-1x src/op_mode/ipsec.py.
+// `state` and `policy` shell out to `ip xfrm`, exactly like the VyOS
+// op-mode definitions. One deviation: multi-value traffic-selector
+// cells join with "," where VyOS embeds newlines in table cells.
+// ---------------------------------------------------------------
+
+async fn process_show(vici_socket: &Path, req: DisplayRequest) {
+    let (path, _args) = path_from_command(&req.paths);
+    let out = match path.as_str() {
+        "/show/vpn/ipsec/sa" => show_sa(vici_socket, req.json).await,
+        "/show/vpn/ipsec/connections" => show_connections(vici_socket, req.json).await,
+        "/show/vpn/ipsec/policy" => xfrm_show("policy", req.json).await,
+        "/show/vpn/ipsec/state" => xfrm_show("state", req.json).await,
+        _ => String::from("% Unknown ipsec show command\n"),
+    };
+    let _ = req.resp.send(out).await;
+}
+
+async fn show_sa(socket: &Path, json: bool) -> String {
+    match vici::streamed_request(socket, "list-sas", "list-sa").await {
+        Err(err) => {
+            tracing::debug!("ipsec: vici list-sas failed: {err:#}");
+            String::from("% IPsec process not running\n")
+        }
+        Ok(msgs) => {
+            if json {
+                let all: Vec<serde_json::Value> = msgs.iter().map(|m| m.to_json()).collect();
+                format!("{:#}\n", serde_json::Value::Array(all))
+            } else {
+                format_sa_table(&msgs)
+            }
+        }
+    }
+}
+
+async fn show_connections(socket: &Path, json: bool) -> String {
+    let conns = match vici::streamed_request(socket, "list-conns", "list-conn").await {
+        Err(err) => {
+            tracing::debug!("ipsec: vici list-conns failed: {err:#}");
+            return String::from("% IPsec process not running\n");
+        }
+        Ok(conns) => conns,
+    };
+    let sas = vici::streamed_request(socket, "list-sas", "list-sa")
+        .await
+        .unwrap_or_default();
+    let raw = connections_raw(&conns, &sas);
+    if json {
+        format!("{:#}\n", serde_json::Value::Array(raw))
+    } else {
+        format_connections_table(&raw)
+    }
+}
+
+/// `ip xfrm state|policy list` — kernel truth, no strongSwan needed.
+async fn xfrm_show(object: &str, json: bool) -> String {
+    let text = match tokio::process::Command::new("ip")
+        .args(["xfrm", object, "list"])
+        .output()
+        .await
+    {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).into_owned()
+        }
+        Ok(output) => format!(
+            "% ip xfrm {object} list failed: {}\n",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+        Err(err) => format!("% ip xfrm {object} list failed: {err}\n"),
+    };
+    if json {
+        // iproute2 has no JSON output for xfrm objects; wrap the text.
+        format!("{:#}\n", serde_json::json!({ "output": text }))
+    } else {
+        text
+    }
+}
+
+/// One row per child SA, VyOS `show vpn ipsec sa` columns.
+fn format_sa_table(msgs: &[vici::Value]) -> String {
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for msg in msgs {
+        for (_, parent) in msg.entries() {
+            let Some(children) = parent.get("child-sas") else {
+                continue;
+            };
+            for (_, child) in children.entries() {
+                let state = match child.str("state") {
+                    Some("INSTALLED") => "up".to_string(),
+                    Some(_) => "down".to_string(),
+                    None => "N/A".to_string(),
+                };
+                let uptime = child
+                    .str("install-time")
+                    .and_then(|t| t.parse::<u64>().ok())
+                    .map(seconds_to_human)
+                    .unwrap_or_else(|| "N/A".to_string());
+                let bytes = match (child.str("bytes-in"), child.str("bytes-out")) {
+                    (Some(i), Some(o)) => format!(
+                        "{}/{}",
+                        filesize(i.parse().unwrap_or(0), 1024),
+                        filesize(o.parse().unwrap_or(0), 1024)
+                    ),
+                    _ => "N/A".to_string(),
+                };
+                let packets = match (child.str("packets-in"), child.str("packets-out")) {
+                    (Some(i), Some(o)) => format!(
+                        "{}/{}",
+                        filesize(i.parse().unwrap_or(0), 1000).trim_end_matches('B'),
+                        filesize(o.parse().unwrap_or(0), 1000).trim_end_matches('B')
+                    ),
+                    _ => "N/A".to_string(),
+                };
+                let mut proposal = child.str("encr-alg").unwrap_or("N/A").to_string();
+                if let Some(keysize) = child.str("encr-keysize") {
+                    proposal = format!("{proposal}_{keysize}");
+                }
+                if let Some(integ) = child.str("integ-alg") {
+                    proposal = format!("{proposal}/{integ}");
+                }
+                if let Some(dh) = child.str("dh-group") {
+                    proposal = format!("{proposal}/{dh}");
+                }
+                rows.push(vec![
+                    child.str("name").unwrap_or("N/A").to_string(),
+                    state,
+                    uptime,
+                    bytes,
+                    packets,
+                    parent.str("remote-host").unwrap_or("N/A").to_string(),
+                    parent.str("remote-id").unwrap_or("N/A").to_string(),
+                    proposal,
+                ]);
+            }
+        }
+    }
+    rows.sort_by_key(|row| natural_key(&row[0]));
+    table(
+        &[
+            "Connection",
+            "State",
+            "Uptime",
+            "Bytes In/Out",
+            "Packets In/Out",
+            "Remote address",
+            "Remote ID",
+            "Proposal",
+        ],
+        &rows,
+    )
+}
+
+/// The `{cipher}_{mode}/{key_size}/{hash}/{dh}` proposal object VyOS
+/// derives from an SA section, as JSON (empty object when the SA has
+/// no encr-alg — e.g. a rekeying/down connection).
+fn proposal_json(sa: &vici::Value) -> serde_json::Value {
+    let Some(encr) = sa.str("encr-alg") else {
+        return serde_json::json!({});
+    };
+    // python `encr.split('_')[0]` / `[1]`: AES_GCM_16 → AES / GCM.
+    let mut parts = encr.split('_');
+    let cipher = parts.next().unwrap_or("");
+    let mode = parts.next().unwrap_or("");
+    serde_json::json!({
+        "cipher": cipher,
+        "mode": mode,
+        "key_size": sa.str("encr-keysize"),
+        "hash": sa.str("integ-alg"),
+        "dh": sa.str("dh-group"),
+    })
+}
+
+fn proposal_text(proposal: &serde_json::Value) -> String {
+    if proposal.as_object().is_none_or(|o| o.is_empty()) {
+        return "-".to_string();
+    }
+    let s = |k: &str| -> String {
+        match &proposal[k] {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Null => "None".to_string(),
+            other => other.to_string(),
+        }
+    };
+    format!(
+        "{}_{}/{}/{}/{}",
+        s("cipher"),
+        s("mode"),
+        s("key_size"),
+        s("hash"),
+        s("dh")
+    )
+}
+
+/// Find the parent SA section for a connection name across the
+/// list-sas messages.
+fn find_parent_sa<'a>(sas: &'a [vici::Value], conn: &str) -> Option<&'a vici::Value> {
+    sas.iter()
+        .flat_map(|m| m.entries())
+        .find(|(name, _)| name == conn)
+        .map(|(_, sa)| sa)
+}
+
+/// The last INSTALLED child SA carrying this tunnel name (there can
+/// be several during a rekey; VyOS takes the newest).
+fn find_child_sa<'a>(sas: &'a [vici::Value], conn: &str, tunnel: &str) -> Option<&'a vici::Value> {
+    let parent = find_parent_sa(sas, conn)?;
+    parent
+        .get("child-sas")?
+        .entries()
+        .iter()
+        .filter(|(_, child)| {
+            child.str("name") == Some(tunnel) && child.str("state") == Some("INSTALLED")
+        })
+        .map(|(_, child)| child)
+        .next_back()
+}
+
+/// vyos-1x `_get_raw_data_connections`: configured connections joined
+/// with live SA state — the machine-readable view, and the input for
+/// the text table.
+fn connections_raw(conns: &[vici::Value], sas: &[vici::Value]) -> Vec<serde_json::Value> {
+    let mut out = Vec::new();
+    for msg in conns {
+        for (name, conf) in msg.entries() {
+            let ike_state = match find_parent_sa(sas, name) {
+                Some(sa)
+                    if sa
+                        .str("state")
+                        .unwrap_or("")
+                        .eq_ignore_ascii_case("established") =>
+                {
+                    "up"
+                }
+                _ => "down",
+            };
+            let ike_proposal = find_parent_sa(sas, name)
+                .map(proposal_json)
+                .unwrap_or_else(|| serde_json::json!({}));
+            let mut children = Vec::new();
+            if let Some(section) = conf.get("children") {
+                for (tunnel, opts) in section.entries() {
+                    let child_sa = find_child_sa(sas, name, tunnel);
+                    let state = if child_sa.is_some() { "up" } else { "down" };
+                    children.push(serde_json::json!({
+                        "name": tunnel,
+                        "state": state,
+                        "local_ts": opts.list("local-ts"),
+                        "remote_ts": opts.list("remote-ts"),
+                        "dpd_action": opts.str("dpd_action"),
+                        "close_action": opts.str("close_action"),
+                        "esp_proposal": child_sa
+                            .map(proposal_json)
+                            .unwrap_or_else(|| serde_json::json!({})),
+                    }));
+                }
+            }
+            out.push(serde_json::json!({
+                "ike_connection_name": name,
+                "ike_connection_state": ike_state,
+                "ike_remote_address": conf.list("remote_addrs"),
+                "ike_proposal": ike_proposal,
+                "local_id": conf.get("local-1").and_then(|l| l.str("id")),
+                "remote_id": conf.get("remote-1").and_then(|r| r.str("id")),
+                "version": conf.str("version").unwrap_or("IKE"),
+                "children": children,
+            }));
+        }
+    }
+    out
+}
+
+/// vyos-1x `_get_formatted_output_conections`: one row for the IKE
+/// connection, then one per child.
+fn format_connections_table(raw: &[serde_json::Value]) -> String {
+    let text = |v: &serde_json::Value| -> String {
+        match v {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Null => String::new(),
+            other => other.to_string(),
+        }
+    };
+    let join = |v: &serde_json::Value| -> String {
+        v.as_array()
+            .map(|items| items.iter().map(text).collect::<Vec<_>>().join(","))
+            .unwrap_or_default()
+    };
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for entry in raw {
+        let remote_addrs = join(&entry["ike_remote_address"]);
+        let local_id = text(&entry["local_id"]);
+        let remote_id = text(&entry["remote_id"]);
+        rows.push(vec![
+            text(&entry["ike_connection_name"]),
+            text(&entry["ike_connection_state"]),
+            text(&entry["version"]),
+            remote_addrs.clone(),
+            "-".to_string(),
+            "-".to_string(),
+            local_id.clone(),
+            remote_id.clone(),
+            proposal_text(&entry["ike_proposal"]),
+        ]);
+        if let Some(children) = entry["children"].as_array() {
+            for child in children {
+                rows.push(vec![
+                    text(&child["name"]),
+                    text(&child["state"]),
+                    "IPsec".to_string(),
+                    remote_addrs.clone(),
+                    join(&child["local_ts"]),
+                    join(&child["remote_ts"]),
+                    local_id.clone(),
+                    remote_id.clone(),
+                    proposal_text(&child["esp_proposal"]),
+                ]);
+            }
+        }
+    }
+    table(
+        &[
+            "Connection",
+            "State",
+            "Type",
+            "Remote address",
+            "Local TS",
+            "Remote TS",
+            "Local id",
+            "Remote id",
+            "Proposal",
+        ],
+        &rows,
+    )
+}
+
+/// tabulate's `simple` format: header, dashes, left-aligned rows,
+/// two-space column gap, no trailing padding.
+fn table(headers: &[&str], rows: &[Vec<String>]) -> String {
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if cell.len() > widths[i] {
+                widths[i] = cell.len();
+            }
+        }
+    }
+    let mut out = String::new();
+    let mut line = |cells: &[String]| {
+        let mut parts = Vec::new();
+        for (i, cell) in cells.iter().enumerate() {
+            parts.push(format!("{cell:<width$}", width = widths[i]));
+        }
+        let joined = parts.join("  ");
+        out.push_str(joined.trim_end());
+        out.push('\n');
+    };
+    line(&headers.iter().map(|h| h.to_string()).collect::<Vec<_>>());
+    line(&widths.iter().map(|w| "-".repeat(*w)).collect::<Vec<_>>());
+    for row in rows {
+        line(row);
+    }
+    out
+}
+
+/// vyos seconds_to_human with the default empty separator:
+/// `93784` → `1d2h3m4s`.
+fn seconds_to_human(mut secs: u64) -> String {
+    const UNITS: [(u64, &str); 5] = [
+        (60 * 60 * 24 * 7, "w"),
+        (60 * 60 * 24, "d"),
+        (60 * 60, "h"),
+        (60, "m"),
+        (1, "s"),
+    ];
+    let mut out = String::new();
+    for (factor, suffix) in UNITS {
+        let amount = secs / factor;
+        secs %= factor;
+        if amount > 0 {
+            out.push_str(&format!("{amount}{suffix}"));
+        }
+    }
+    if out.is_empty() {
+        out.push_str("0s");
+    }
+    out
+}
+
+/// hurry.filesize semantics (used by the VyOS sa table): largest unit
+/// whose factor fits, integer amount, one-letter suffix. Base 1024
+/// for bytes, base 1000 (with the trailing `B` stripped by the
+/// caller) for packet counts.
+fn filesize(n: u64, base: u64) -> String {
+    const SUFFIXES: [&str; 6] = ["P", "T", "G", "M", "K", "B"];
+    for (i, suffix) in SUFFIXES.iter().enumerate() {
+        let factor = base.pow((SUFFIXES.len() - 1 - i) as u32);
+        if n >= factor && factor > 1 {
+            return format!("{}{suffix}", n / factor);
+        }
+    }
+    format!("{n}B")
+}
+
+/// Natural-sort key: digit runs compare numerically, so
+/// `peer-2-tunnel-10` sorts after `peer-2-tunnel-2`.
+fn natural_key(s: &str) -> Vec<(u64, String)> {
+    let mut key = Vec::new();
+    let mut chars = s.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() {
+            let mut n = 0u64;
+            while let Some(&d) = chars.peek() {
+                if let Some(v) = d.to_digit(10) {
+                    n = n.saturating_mul(10).saturating_add(u64::from(v));
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            key.push((n, String::new()));
+        } else {
+            let mut run = String::new();
+            while let Some(&d) = chars.peek() {
+                if d.is_ascii_digit() {
+                    break;
+                }
+                run.push(d);
+                chars.next();
+            }
+            key.push((u64::MAX, run));
+        }
+    }
+    key
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1432,5 +1880,181 @@ secrets {
         assert!(conf.contains("remote_addrs = %any"));
         // `any` prefix widened to both families
         assert!(conf.contains("local_ts = 0.0.0.0/0,::/0"));
+    }
+
+    use crate::system::vici::test_encode::{key_value, list, section};
+
+    /// One list-sa event message with three child SAs (numbers 1, 2
+    /// and 10 out of order, to pin the natural sort).
+    fn sample_sas() -> Vec<vici::Value> {
+        let mut buf = Vec::new();
+        section(&mut buf, "peer-1", |out| {
+            key_value(out, "state", "ESTABLISHED");
+            key_value(out, "remote-host", "203.0.113.9");
+            key_value(out, "remote-id", "right");
+            key_value(out, "encr-alg", "AES_CBC");
+            key_value(out, "encr-keysize", "256");
+            key_value(out, "integ-alg", "HMAC_SHA2_256_128");
+            key_value(out, "dh-group", "MODP_2048");
+            section(out, "child-sas", |out| {
+                section(out, "peer-1-tunnel-10-9", |out| {
+                    key_value(out, "name", "peer-1-tunnel-10");
+                    key_value(out, "state", "INSTALLED");
+                    key_value(out, "install-time", "5");
+                    key_value(out, "bytes-in", "0");
+                    key_value(out, "bytes-out", "0");
+                    key_value(out, "packets-in", "0");
+                    key_value(out, "packets-out", "0");
+                    key_value(out, "encr-alg", "AES_GCM_16");
+                    key_value(out, "encr-keysize", "256");
+                });
+                section(out, "peer-1-tunnel-1-7", |out| {
+                    key_value(out, "name", "peer-1-tunnel-1");
+                    key_value(out, "state", "INSTALLED");
+                    key_value(out, "install-time", "125");
+                    key_value(out, "bytes-in", "2048");
+                    key_value(out, "bytes-out", "532");
+                    key_value(out, "packets-in", "12");
+                    key_value(out, "packets-out", "7");
+                    key_value(out, "encr-alg", "AES_GCM_16");
+                    key_value(out, "encr-keysize", "256");
+                });
+                section(out, "peer-1-tunnel-2-8", |out| {
+                    key_value(out, "name", "peer-1-tunnel-2");
+                    key_value(out, "state", "REKEYING");
+                });
+            });
+        });
+        vec![vici::parse_message(&buf).expect("sample parses")]
+    }
+
+    #[test]
+    fn sa_table_from_vici() {
+        let out = format_sa_table(&sample_sas());
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].starts_with("Connection"));
+        assert!(lines[0].contains("Bytes In/Out"));
+        assert!(lines[1].chars().all(|c| c == '-' || c == ' '));
+        // Natural sort: tunnel-1, tunnel-2, tunnel-10.
+        let row: Vec<&str> = lines[2].split_whitespace().collect();
+        assert_eq!(
+            row,
+            [
+                "peer-1-tunnel-1",
+                "up",
+                "2m5s",
+                "2K/532B",
+                "12/7",
+                "203.0.113.9",
+                "right",
+                "AES_GCM_16_256"
+            ]
+        );
+        let row: Vec<&str> = lines[3].split_whitespace().collect();
+        assert_eq!(row[..3], ["peer-1-tunnel-2", "down", "N/A"]);
+        let row: Vec<&str> = lines[4].split_whitespace().collect();
+        assert_eq!(
+            row,
+            [
+                "peer-1-tunnel-10",
+                "up",
+                "5s",
+                "0B/0B",
+                "0/0",
+                "203.0.113.9",
+                "right",
+                "AES_GCM_16_256"
+            ]
+        );
+    }
+
+    #[test]
+    fn connections_table_from_vici() {
+        let mut buf = Vec::new();
+        section(&mut buf, "peer-1", |out| {
+            list(out, "local_addrs", &["192.0.2.1"]);
+            list(out, "remote_addrs", &["203.0.113.9"]);
+            key_value(out, "version", "IKEv2");
+            section(out, "local-1", |out| {
+                key_value(out, "id", "left");
+            });
+            section(out, "remote-1", |out| {
+                key_value(out, "id", "right");
+            });
+            section(out, "children", |out| {
+                section(out, "peer-1-tunnel-1", |out| {
+                    key_value(out, "mode", "TUNNEL");
+                    key_value(out, "dpd_action", "restart");
+                    key_value(out, "close_action", "none");
+                    list(out, "local-ts", &["10.0.1.0/24"]);
+                    list(out, "remote-ts", &["10.0.2.0/24", "10.0.3.0/24"]);
+                });
+            });
+        });
+        let conns = vec![vici::parse_message(&buf).expect("conn parses")];
+        let sas = sample_sas();
+
+        let raw = connections_raw(&conns, &sas);
+        assert_eq!(raw[0]["ike_connection_state"], "up");
+        assert_eq!(raw[0]["ike_proposal"]["cipher"], "AES");
+        assert_eq!(raw[0]["ike_proposal"]["mode"], "CBC");
+        let child = &raw[0]["children"][0];
+        assert_eq!(child["state"], "up");
+        assert_eq!(child["dpd_action"], "restart");
+        // AES_GCM_16 → cipher AES, mode GCM (python split('_')[1]),
+        // no integ/dh on an AEAD SA → null.
+        assert_eq!(child["esp_proposal"]["mode"], "GCM");
+        assert!(child["esp_proposal"]["hash"].is_null());
+
+        let out = format_connections_table(&raw);
+        let lines: Vec<&str> = out.lines().collect();
+        let row: Vec<&str> = lines[2].split_whitespace().collect();
+        assert_eq!(
+            row,
+            [
+                "peer-1",
+                "up",
+                "IKEv2",
+                "203.0.113.9",
+                "-",
+                "-",
+                "left",
+                "right",
+                "AES_CBC/256/HMAC_SHA2_256_128/MODP_2048"
+            ]
+        );
+        let row: Vec<&str> = lines[3].split_whitespace().collect();
+        assert_eq!(
+            row,
+            [
+                "peer-1-tunnel-1",
+                "up",
+                "IPsec",
+                "203.0.113.9",
+                "10.0.1.0/24",
+                "10.0.2.0/24,10.0.3.0/24",
+                "left",
+                "right",
+                "AES_GCM/256/None/None"
+            ]
+        );
+    }
+
+    #[test]
+    fn show_humanizers() {
+        assert_eq!(seconds_to_human(0), "0s");
+        assert_eq!(seconds_to_human(125), "2m5s");
+        assert_eq!(seconds_to_human(93784), "1d2h3m4s");
+        assert_eq!(seconds_to_human(604801), "1w1s");
+
+        assert_eq!(filesize(0, 1024), "0B");
+        assert_eq!(filesize(532, 1024), "532B");
+        assert_eq!(filesize(2048, 1024), "2K");
+        assert_eq!(filesize(3 * 1024 * 1024 + 5, 1024), "3M");
+        assert_eq!(filesize(2000, 1000), "2K");
+
+        let mut names = vec!["t-10", "t-2", "t-1"];
+        names.sort_by_key(|n| natural_key(n));
+        assert_eq!(names, ["t-1", "t-2", "t-10"]);
     }
 }

--- a/zebra-rs/src/system/mod.rs
+++ b/zebra-rs/src/system/mod.rs
@@ -7,6 +7,7 @@
 pub mod firewall;
 pub mod ipsec;
 mod json;
+pub mod vici;
 
 pub use firewall::Firewall;
 pub use ipsec::Ipsec;

--- a/zebra-rs/src/system/vici.rs
+++ b/zebra-rs/src/system/vici.rs
@@ -1,0 +1,343 @@
+//! Minimal client for charon's VICI control interface, used by
+//! `show vpn ipsec` — the same channel VyOS's op-mode scripts use
+//! (python-vici), rather than scraping `swanctl` text output.
+//!
+//! Implements exactly the subset the show commands need: the
+//! command-event streaming pattern (`list-sas` streams one `list-sa`
+//! EVENT per IKE_SA, then an empty CMD_RESPONSE; same for
+//! `list-conns`/`list-conn`). Wire protocol per the strongSwan vici
+//! README: 32-bit network-order length framing, 8-bit packet types,
+//! 8-bit name lengths, message elements as a flat byte stream of
+//! typed sections / key-values / lists.
+
+use std::path::Path;
+
+use anyhow::{Context, bail};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+// Packet types.
+const CMD_REQUEST: u8 = 0;
+const CMD_RESPONSE: u8 = 1;
+const CMD_UNKNOWN: u8 = 2;
+const EVENT_REGISTER: u8 = 3;
+const EVENT_UNREGISTER: u8 = 4;
+const EVENT_CONFIRM: u8 = 5;
+const EVENT_UNKNOWN: u8 = 6;
+const EVENT: u8 = 7;
+
+// Message element types.
+const SECTION_START: u8 = 1;
+const SECTION_END: u8 = 2;
+const KEY_VALUE: u8 = 3;
+const LIST_START: u8 = 4;
+const LIST_ITEM: u8 = 5;
+const LIST_END: u8 = 6;
+
+/// A decoded vici message tree. Sections keep their key order — the
+/// show views iterate them in charon's order, like the VyOS scripts
+/// iterate python-vici's OrderedDicts.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// Nested section: ordered (name, value) pairs.
+    Section(Vec<(String, Value)>),
+    /// List of scalar items (vici lists cannot nest).
+    List(Vec<String>),
+    /// Scalar value. Charon emits ASCII here for everything the show
+    /// views read.
+    Scalar(String),
+}
+
+impl Value {
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        match self {
+            Value::Section(items) => items.iter().find(|(k, _)| k == key).map(|(_, v)| v),
+            _ => None,
+        }
+    }
+
+    /// Scalar value of a child key, if present.
+    pub fn str(&self, key: &str) -> Option<&str> {
+        match self.get(key)? {
+            Value::Scalar(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn list(&self, key: &str) -> Vec<String> {
+        match self.get(key) {
+            Some(Value::List(items)) => items.clone(),
+            _ => Vec::new(),
+        }
+    }
+
+    pub fn entries(&self) -> &[(String, Value)] {
+        match self {
+            Value::Section(items) => items,
+            _ => &[],
+        }
+    }
+
+    /// Convert to serde_json for the machine-readable show views.
+    pub fn to_json(&self) -> serde_json::Value {
+        match self {
+            Value::Scalar(s) => serde_json::Value::String(s.clone()),
+            Value::List(items) => items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect(),
+            Value::Section(items) => {
+                let mut map = serde_json::Map::new();
+                for (k, v) in items {
+                    map.insert(k.clone(), v.to_json());
+                }
+                serde_json::Value::Object(map)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Message codec
+// ---------------------------------------------------------------
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn u8(&mut self) -> anyhow::Result<u8> {
+        let Some(&b) = self.buf.get(self.pos) else {
+            bail!("vici: truncated message");
+        };
+        self.pos += 1;
+        Ok(b)
+    }
+
+    fn bytes(&mut self, len: usize) -> anyhow::Result<&'a [u8]> {
+        let Some(chunk) = self.buf.get(self.pos..self.pos + len) else {
+            bail!("vici: truncated message");
+        };
+        self.pos += len;
+        Ok(chunk)
+    }
+
+    fn name(&mut self) -> anyhow::Result<String> {
+        let len = self.u8()? as usize;
+        Ok(String::from_utf8_lossy(self.bytes(len)?).into_owned())
+    }
+
+    fn value(&mut self) -> anyhow::Result<String> {
+        let len = u16::from_be_bytes(self.bytes(2)?.try_into().unwrap()) as usize;
+        Ok(String::from_utf8_lossy(self.bytes(len)?).into_owned())
+    }
+
+    fn done(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+}
+
+/// Decode a message byte stream into a root section.
+pub fn parse_message(buf: &[u8]) -> anyhow::Result<Value> {
+    let mut r = Reader { buf, pos: 0 };
+    let root = parse_section(&mut r, true)?;
+    Ok(root)
+}
+
+fn parse_section(r: &mut Reader, root: bool) -> anyhow::Result<Value> {
+    let mut items: Vec<(String, Value)> = Vec::new();
+    loop {
+        if r.done() {
+            if root {
+                return Ok(Value::Section(items));
+            }
+            bail!("vici: unterminated section");
+        }
+        match r.u8()? {
+            SECTION_START => {
+                let name = r.name()?;
+                items.push((name, parse_section(r, false)?));
+            }
+            SECTION_END if !root => return Ok(Value::Section(items)),
+            KEY_VALUE => {
+                let name = r.name()?;
+                items.push((name, Value::Scalar(r.value()?)));
+            }
+            LIST_START => {
+                let name = r.name()?;
+                let mut list = Vec::new();
+                loop {
+                    match r.u8()? {
+                        LIST_ITEM => list.push(r.value()?),
+                        LIST_END => break,
+                        t => bail!("vici: unexpected element {t} in list"),
+                    }
+                }
+                items.push((name, Value::List(list)));
+            }
+            t => bail!("vici: unexpected element type {t}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------
+
+fn named_packet(ptype: u8, name: &str) -> Vec<u8> {
+    let mut pkt = vec![ptype, name.len() as u8];
+    pkt.extend_from_slice(name.as_bytes());
+    pkt
+}
+
+async fn send(stream: &mut UnixStream, pkt: &[u8]) -> anyhow::Result<()> {
+    stream.write_all(&(pkt.len() as u32).to_be_bytes()).await?;
+    stream.write_all(pkt).await?;
+    Ok(())
+}
+
+async fn recv(stream: &mut UnixStream) -> anyhow::Result<(u8, Vec<u8>)> {
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await?;
+    let len = u32::from_be_bytes(len) as usize;
+    // The protocol caps segments at 512 KiB; anything larger means a
+    // framing bug, so refuse rather than allocate unboundedly.
+    if len == 0 || len > 512 * 1024 {
+        bail!("vici: bad segment length {len}");
+    }
+    let mut pkt = vec![0u8; len];
+    stream.read_exact(&mut pkt).await?;
+    Ok((pkt[0], pkt[1..].to_vec()))
+}
+
+/// Run one streamed command: register `event`, issue `command`,
+/// collect one decoded message per event, stop at the response.
+/// Errors if charon is unreachable or rejects the command/event.
+pub async fn streamed_request(
+    socket: &Path,
+    command: &str,
+    event: &str,
+) -> anyhow::Result<Vec<Value>> {
+    let mut stream = UnixStream::connect(socket)
+        .await
+        .with_context(|| format!("connect {}", socket.display()))?;
+
+    send(&mut stream, &named_packet(EVENT_REGISTER, event)).await?;
+    match recv(&mut stream).await? {
+        (EVENT_CONFIRM, _) => {}
+        (EVENT_UNKNOWN, _) => bail!("vici: event {event} unknown to charon"),
+        (t, _) => bail!("vici: unexpected packet {t} to event registration"),
+    }
+
+    send(&mut stream, &named_packet(CMD_REQUEST, command)).await?;
+    let mut out = Vec::new();
+    loop {
+        match recv(&mut stream).await? {
+            (EVENT, body) => {
+                // 8-bit name length + name, then the message.
+                let Some(&name_len) = body.first() else {
+                    bail!("vici: empty event packet");
+                };
+                let msg_at = 1 + name_len as usize;
+                if body.len() < msg_at {
+                    bail!("vici: truncated event packet");
+                }
+                out.push(parse_message(&body[msg_at..])?);
+            }
+            (CMD_RESPONSE, _) => break,
+            (CMD_UNKNOWN, _) => bail!("vici: command {command} unknown to charon"),
+            (t, _) => bail!("vici: unexpected packet {t} to {command}"),
+        }
+    }
+
+    // Best effort: the socket is dropped right after either way.
+    let _ = send(&mut stream, &named_packet(EVENT_UNREGISTER, event)).await;
+    Ok(out)
+}
+
+#[cfg(test)]
+pub mod test_encode {
+    //! Encoding helpers for tests (the client itself only ever sends
+    //! empty request messages, so production code needs no encoder).
+
+    use super::*;
+
+    pub fn section(out: &mut Vec<u8>, name: &str, body: impl FnOnce(&mut Vec<u8>)) {
+        out.push(SECTION_START);
+        out.push(name.len() as u8);
+        out.extend_from_slice(name.as_bytes());
+        body(out);
+        out.push(SECTION_END);
+    }
+
+    pub fn key_value(out: &mut Vec<u8>, name: &str, value: &str) {
+        out.push(KEY_VALUE);
+        out.push(name.len() as u8);
+        out.extend_from_slice(name.as_bytes());
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        out.extend_from_slice(value.as_bytes());
+    }
+
+    pub fn list(out: &mut Vec<u8>, name: &str, items: &[&str]) {
+        out.push(LIST_START);
+        out.push(name.len() as u8);
+        out.extend_from_slice(name.as_bytes());
+        for item in items {
+            out.push(LIST_ITEM);
+            out.extend_from_slice(&(item.len() as u16).to_be_bytes());
+            out.extend_from_slice(item.as_bytes());
+        }
+        out.push(LIST_END);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_encode::*;
+    use super::*;
+
+    #[test]
+    fn parse_round_trip() {
+        let mut buf = Vec::new();
+        section(&mut buf, "peer-1", |out| {
+            key_value(out, "state", "ESTABLISHED");
+            key_value(out, "remote-host", "203.0.113.9");
+            list(out, "remote-ts", &["10.0.2.0/24", "10.0.3.0/24"]);
+            section(out, "child-sas", |out| {
+                section(out, "peer-1-tunnel-1-7", |out| {
+                    key_value(out, "name", "peer-1-tunnel-1");
+                    key_value(out, "state", "INSTALLED");
+                });
+            });
+        });
+
+        let msg = parse_message(&buf).expect("parses");
+        let (name, sa) = &msg.entries()[0];
+        assert_eq!(name, "peer-1");
+        assert_eq!(sa.str("state"), Some("ESTABLISHED"));
+        assert_eq!(sa.list("remote-ts"), vec!["10.0.2.0/24", "10.0.3.0/24"]);
+        let child = sa.get("child-sas").unwrap().entries();
+        assert_eq!(child[0].0, "peer-1-tunnel-1-7");
+        assert_eq!(child[0].1.str("state"), Some("INSTALLED"));
+
+        let json = msg.to_json();
+        assert_eq!(json["peer-1"]["state"], "ESTABLISHED");
+        assert_eq!(json["peer-1"]["remote-ts"][1], "10.0.3.0/24");
+    }
+
+    #[test]
+    fn truncated_and_malformed_fail_cleanly() {
+        let mut buf = Vec::new();
+        key_value(&mut buf, "state", "ESTABLISHED");
+        buf.truncate(buf.len() - 3);
+        assert!(parse_message(&buf).is_err());
+
+        // section never closed
+        let buf = vec![SECTION_START, 1, b'x', KEY_VALUE, 1, b'k', 0, 1, b'v'];
+        assert!(parse_message(&buf).is_err());
+
+        // unknown element type
+        assert!(parse_message(&[9]).is_err());
+    }
+}

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -356,6 +356,29 @@ module exec {
         }
       }
     }
+    container vpn {
+      if-feature feat:iso;
+      ext:help "VPN information";
+      container ipsec {
+        ext:help "IPsec (Internet Protocol Security) information";
+        container sa {
+          ext:help "IPsec security associations";
+          presence "Active security associations from charon";
+        }
+        container connections {
+          ext:help "IPsec connections";
+          presence "Loaded connections with live SA state";
+        }
+        container policy {
+          ext:help "Kernel XFRM policies";
+          presence "Kernel XFRM policy list";
+        }
+        container state {
+          ext:help "Kernel XFRM states";
+          presence "Kernel XFRM state list";
+        }
+      }
+    }
     container evpn {
       ext:help "EVPN information";
       container vni {


### PR DESCRIPTION
## Summary

PR 3 of the VyOS 1.5 IPsec port (#2241 schema, #2242 backend): the operational views.

- exec.yang grows an iso-gated `show vpn ipsec sa | connections | policy | state` grammar; the manager routes `/show/vpn/*` to a new `"ipsec"` show subscriber on the IPsec task.
- **New `system/vici.rs`**: minimal in-tree client for charon's VICI control socket — framing, packet types, section/key-value/list codec, and the command-event streaming pattern (`list-sas`/`list-sa`, `list-conns`/`list-conn`), verified against the strongSwan vici README. This is the same channel VyOS's op-mode scripts use; no `swanctl` text scraping.
- `sa` and `connections` tables mirror vyos-1x `src/op_mode/ipsec.py` row for row: humanized uptimes, hurry.filesize-style byte/packet columns, natural sort, IKE row + per-child rows with proposal strings including python's `split('_')[1]` AEAD semantics. `state`/`policy` shell out to `ip xfrm ... list` like the VyOS op-mode definitions. `--json` returns the raw vici tree (sa) / the VyOS raw-data shape (connections).
- Charon unreachable → `% IPsec process not running`, mirroring VyOS's wrapper. One deviation: multi-value traffic-selector cells join with `,` instead of embedded newlines.

Remaining: PR 4 — live two-namespace validation with real charon + BDD.

## Test plan

- vici codec round-trip and malformed-input rejection.
- `sa_table_from_vici` / `connections_table_from_vici` — golden rows from synthetic vici messages (AEAD proposal split, natural sort 1 < 2 < 10, REKEYING child shown down, missing integ/dh → `None`).
- `show_humanizers` — seconds_to_human / filesize / natural_key.
- `show_vpn_ipsec_grammar_gated_on_iso` — paths, abbreviations, `show_proto` routing, stock-start gating.
- Live smoke: daemon + vtyctl session answers all four views with the expected degradation texts absent charon/privileges.
- Full workspace suite (`--exclude bdd`) green; fmt + workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)