### PR TITLE
Fix silent no-op on show segment-routing srv6 prefix

### DIFF
--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1310,6 +1310,50 @@ mod tests {
         }
     }
 
+    /// Pin the `show segment-routing` grammar. `srv6` is a presence
+    /// container that doubles as a prefix alias for the SID table, so
+    /// both spellings must parse to a path a `ShowCallback` is
+    /// registered under — the bare `srv6` used to complete into the
+    /// unhandled `/show/segment-routing/srv6` and silently print
+    /// nothing. The outer `segment-routing` container is a pure
+    /// grouping node (no presence), so it must come back Incomplete
+    /// instead of completing into an unhandled path.
+    #[test]
+    fn show_segment_routing_grammar() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            (
+                "show segment-routing srv6",
+                "/show/segment-routing/srv6",
+                vec![],
+            ),
+            (
+                "show segment-routing srv6 sid",
+                "/show/segment-routing/srv6/sid",
+                vec![],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+
+        let (code, _comps, _state) =
+            parse("show segment-routing", entry.clone(), None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Incomplete,
+            "`show segment-routing` must be incomplete, not a silent no-op"
+        );
+    }
+
     /// The BGP RIB views moved off the legacy `show ip bgp` tree onto
     /// `show bgp …`; the whole `show ip bgp` subtree is gone, so every
     /// old spelling must no longer parse and each `show bgp …` twin must.

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -2024,6 +2024,8 @@ impl Rib {
             .set(mac_show)
             .path("/show/l2/neighbor")
             .set(l2_neighbor_show)
+            .path("/show/segment-routing/srv6")
+            .set(sid_show)
             .path("/show/segment-routing/srv6/sid")
             .set(sid_show)
             .path("/show/vrf")
@@ -2248,10 +2250,11 @@ pub fn l2_neighbor_show(rib: &Rib, _args: Args, json: bool) -> String {
     buf
 }
 
-/// Render `show segment-routing srv6 sid`. Always emits the header row
-/// (matches FRR-style output where an empty body still tells the
-/// operator the command is wired and they're just not allocating any
-/// SIDs yet).
+/// Render `show segment-routing srv6 [sid]` — the bare `srv6` prefix is
+/// registered as an alias so it can't complete into an unhandled path
+/// and silently print nothing. Always emits the header row (matches
+/// FRR-style output where an empty body still tells the operator the
+/// command is wired and they're just not allocating any SIDs yet).
 pub fn sid_show(rib: &Rib, _args: Args, json: bool) -> String {
     // `redirected_sids` maps each SID currently in its egress-protection
     // redirect form to the protector's Mirror SID it H.Encaps to — a live,

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1465,7 +1465,6 @@ module exec {
     }
     container segment-routing {
       ext:help "Show segment-routing";
-      presence "Segment Routing";
       container srv6 {
         ext:help "Show SRv6";
         presence "SRv6";


### PR DESCRIPTION
## Summary

A user ran `show segment-routing srv6` on a PE in an EVPN-over-SRv6 lab and got no output at all — no table, no error. The `srv6` node is a presence container, so the parser accepted the bare prefix as a complete command and built `/show/segment-routing/srv6`, a path no `ShowCallback` is registered under; the interactive vty then silently swallowed the empty response. This is the mirror image of the `show int` → `/show/int` defect already pinned in `config/parse.rs`.

- Register `/show/segment-routing/srv6` as a prefix alias for `sid_show`, so it renders the SRv6 SID table (which always emits its header row, even when empty).
- Drop `presence` from the outer `segment-routing` container — matching the `mpls` grouping-node convention — so bare `show segment-routing` reports `Incomplete` instead of completing into another unhandled path.
- Add a `show_segment_routing_grammar` pin test covering both spellings and the Incomplete case, alongside `show_l2_grammar`.

## Testing

- `cargo test --workspace --exclude bdd` — all green.
- Live check against a throwaway non-root daemon (`--yang-path` at the worktree, unique vty socket):
  - `show segment-routing srv6` → SID table header (was: silence)
  - `show segment-routing srv6 sid` → unchanged
  - `show segment-routing` → `command rejected: Incomplete` (was: silence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)