### PR TITLE
ospf: a request satisfied by a parallel serve is not BadLSReq

### DIFF
--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -1021,7 +1021,6 @@ enum LsaProcessResult {
     AckAndDiscard,       // Step 4 MaxAge / Step 7 same: ack, don't install
     DiscardNoAck,        // Step 3 / Step 7 implied ack / Step 8 MaxAge+MaxSeq: no ack
     DbCopyNewer,         // Step 8: DB copy sent back, no ack
-    BadLSReq,            // Step 6: stop processing entire packet
 }
 
 fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -> LsaProcessResult {
@@ -1172,19 +1171,17 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
         return LsaProcessResult::InstalledDelayedAck;
     }
 
-    // Step 6: If LSA is on neighbor's request list, this is a BadLSReq event.
-    if ospf_ls_request_lookup(nbr, &lsa.h).is_some() {
-        ospf_packet_trace!(
-            oi.tracing,
-            LsUpdate,
-            Recv,
-            "[LS Update] BadLSReq: LSA on request list type={:?} id={} adv={}",
-            lsa.h.ls_type,
-            lsa.h.ls_id,
-            lsa.h.adv_router
-        );
-        nbr_sched_event(nbr, NfsmEvent::BadLSReq);
-        return LsaProcessResult::BadLSReq;
+    // Step 6: an instance still on this neighbor's request list, not
+    // newer than our database copy. With per-neighbor request lists
+    // and parallel exchanges this is routine (the other neighbor's
+    // serve landed first), not the exchange corruption the literal
+    // RFC text assumes — the database copy is at least as new, so
+    // the request is SATISFIED: remove it and fall through (step 7
+    // acks an equal instance, step 8 sends our newer copy back for
+    // an older one). See the v3 twin in `ospfv3_ls_upd_proc` for
+    // the livelock the literal BadLSReq caused.
+    if let Some(idx) = ospf_ls_request_lookup(nbr, &lsa.h) {
+        nbr.ls_req.remove(idx);
     }
 
     // Step 7: Same instance (duplicate).
@@ -1296,10 +1293,6 @@ pub fn ospf_ls_upd_validate_proc(
             LsaProcessResult::InstalledDelayedAck => {
                 delayed_ack_headers.push(lsa.h.clone());
             }
-            LsaProcessResult::BadLSReq => {
-                // Stop processing entire packet, no acks sent.
-                return;
-            }
             LsaProcessResult::DiscardNoAck | LsaProcessResult::DbCopyNewer => {
                 // No ack for these cases.
             }
@@ -1316,6 +1309,12 @@ pub fn ospf_ls_upd_validate_proc(
         let msg = Message::DelayedAckQueue(nbr.ifindex, delayed_ack_headers);
         let _ = oi.tx.send(msg);
     }
+
+    // A step-6 duplicate-satisfied removal drains `ls_req` without
+    // going through the install path (`ospf_flood`), so re-check for
+    // LoadingDone here — mirrors the v3 handler's end-of-packet
+    // check. No-op unless the neighbor is Loading with an empty list.
+    super::nfsm::ospf_nfsm_check_nbr_loading(nbr);
 }
 
 /// RFC 3623 §3.1 helper-entry gate. Called from `ospf_ls_upd_proc`

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1370,8 +1370,6 @@ enum LsaProcessResult {
     /// Step 3 area-type filter / Step 7 implied-ack via retransmit
     /// list / Step 8 MaxAge+MaxSeq: drop without acking.
     DiscardNoAck,
-    /// Step 6: aborts the rest of the packet (NFSM `BadLSReq`).
-    BadLSReq,
     /// Step 8: our DB copy is newer; sent it back to the peer.
     /// No ack contributed.
     DbCopyNewer,
@@ -1571,11 +1569,29 @@ fn ospfv3_ls_upd_proc(
         return LsaProcessResult::Installed;
     }
 
-    // Step 6: same-or-older LSA but still on our request list →
-    // protocol violation. Fire BadLSReq, force renegotiation.
-    if ospfv3_ls_request_lookup(nbr, h).is_some() {
-        ospfv3_nbr_sched_event(nbr, NfsmEvent::BadLSReq);
-        return LsaProcessResult::BadLSReq;
+    // Step 6 (RFC 2328 §13): an instance still on this neighbor's
+    // request list, not newer than our database copy. The literal
+    // RFC text calls this a Database Exchange error (BadLSReq), but
+    // with per-neighbor request lists and PARALLEL exchanges the
+    // collision is routine, not corruption: both neighbors' DD
+    // summaries list the same LSAs, both request lists carry them,
+    // and whichever serve lands second delivers an instance the
+    // first already installed (equal — or older, when the
+    // originator re-originated in between and the parallel serve
+    // outran this one). Firing BadLSReq here aborted the serving
+    // LSU mid-packet and reset the adjacency; both lists were then
+    // rebuilt and re-collided every round, so the tail of a
+    // multi-LSA serve (deterministically the same LSAs) never
+    // installed — a permanent LSDB hole on any router with two
+    // exchange partners, and the mechanism behind the ospfv3_tilfa
+    // / srv6_tilfa_v3 reverse-ping intermittents. The database copy
+    // is at least as new as the serve either way, so the request is
+    // SATISFIED: remove it and fall through — step 7 acks an equal
+    // instance, step 8 unicasts our newer copy back for an older
+    // one. Genuine exchange corruption is still caught by the DD
+    // sequence/option checks (SeqNumberMismatch).
+    if let Some(idx) = ospfv3_ls_request_lookup(nbr, h) {
+        nbr.ls_req.remove(idx);
     }
 
     // Step 7: same instance. Treat retransmit-list match as
@@ -1645,10 +1661,6 @@ pub fn ospfv3_ls_upd_recv(
         match ospfv3_ls_upd_proc(oi, nbr, lsa, src) {
             LsaProcessResult::Installed | LsaProcessResult::AckAndDiscard => {
                 ack_headers.push(h_for_ack);
-            }
-            LsaProcessResult::BadLSReq => {
-                // Abort — don't process remaining LSAs, don't ack.
-                return;
             }
             LsaProcessResult::DiscardNoAck | LsaProcessResult::DbCopyNewer => {
                 // No ack contributed; continue with next LSA.


### PR DESCRIPTION
Follow-up to #2249 — this commit was pushed to that branch after it had
already merged, so it never landed. Same branch, re-opened against main.

## The bug

The long-standing `ospfv3_tilfa` / `srv6_tilfa_v3` reverse-ping intermittent
(on the watch list since 2026-07-27, ~1/7 solo, written off as load margin) is
a protocol livelock, and it reproduces on unmodified `main`.

RFC 2328 §13 step 6 taken literally: any LSA still on the sending neighbour's
request list that is not newer than our database copy is a Database Exchange
error → `BadLSReq`, which aborts the rest of the LS Update and resets the
adjacency. With per-neighbour request lists and **parallel** exchanges that
collision is routine, not corruption: two neighbours' DD summaries list the
same LSAs, both request lists carry them, both LS Requests are in flight at
once, and whichever serve lands second delivers an instance the first already
installed.

Treating that as an error livelocked the exchange. The abort dropped the tail
of the serving LS Update, both request lists were rebuilt on the reset, and the
same collision recurred every round — so the same LSAs were lost every time. A
router with two exchange partners reached Full carrying a **permanent LSDB
hole**: in the eight-router RFC 9855 topology, `d` ended up missing exactly s's
Router-LSA and Intra-Area-Prefix-LSA — no vertex for s, no `2001:db8::1/128`,
reverse ping dead while every other route converged.

Evidence: reproduced deterministically against the poisoned LSDB (a fresh full
exchange, daemon restart included, re-hit `BadLSReq` and re-lost the same tail)
and confirmed on the wire with tcpdump — the DD summary contained the LSAs, the
LS Request asked for them, and the serving LS Update was truncated by the reset.

## The fix

The database copy is at least as new as the serve, so the request is
*satisfied*: drop the request-list entry and fall through. Step 7 acks an equal
instance; step 8 unicasts our newer copy back so a lagging peer catches up.
Genuine exchange corruption is still caught by the DD sequence/options/flag
checks (`SeqNumberMismatch`), and the legitimate `BadLSReq` (a neighbour
requests an LSA we don't hold, §10.7) is untouched in both LS Request handlers.
The now-unreachable `BadLSReq` process result is removed from both step
machines, and the v2 LS Update handler gains the v3 handler's end-of-packet
`LoadingDone` re-check, since satisfying a request this way drains `ls_req`
without passing through `ospf_flood`.

Prior art: FRR follows step 6 literally but avoids the collision via §13.3 step
1(b) (pruning *other* neighbours' request lists on the flood path), which we
don't implement. Flooding here is asynchronous (`Message::Flood` is queued), so
1(b) alone would not be airtight against a serve already on the wire — the
receive-side fix is the robust one. Implementing 1(b) properly is in flight as
a follow-up.

## Verification

- `cargo clippy --workspace` clean under `-D warnings`; `cargo test -p zebra-rs`
  1932 passed.
- Repro rig (the failing scenario, tracing on, looped under `BDD_KEEP=1`):
  **12/12 green with zero `BadLSReq`/`SeqNumberMismatch` transitions** across
  all eight daemons. Pre-fix: reproducible failure within ~7 iterations, 2-5
  resets per run.
- `srv6_tilfa_v3` solo **3/3 green** — pre-fix it failed 1/3 on both this branch
  and the unmodified base `abd40505`.
- Full BDD suite at c=16: **281 ran, 279 passed**, no leaked namespaces or
  daemons. The two failures are the documented fixed-wait / bare-assert
  load-margin pattern and both pass solo: `ospfv2_tilfa` (3/3 solo) and
  `bgp_v6_incremental` (1/1 solo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
