### PR TITLE
ospf: implement RFC 2328 §13.3 step 1(b) flood-time request reconciliation

### DIFF
--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -34,12 +34,19 @@ pub fn ospf_ls_request_isempty<V: super::version::OspfVersion>(nbr: &Neighbor<V>
     nbr.ls_req.is_empty()
 }
 
-/// Look up an LSA in the neighbor's ls_req list and return its index if found.
-pub fn ospf_ls_request_lookup(nbr: &Neighbor, h: &OspfLsaHeader) -> Option<usize> {
-    nbr.ls_req.iter().position(|req| {
-        req.ls_type == u32::from(u8::from(h.ls_type))
-            && req.ls_id == h.ls_id
-            && req.adv_router == h.adv_router
+/// Index of the request-list entry naming the same LSA as `h`, if the
+/// neighbor has one outstanding. Matches on the identity triple only —
+/// the caller decides what to do with the advertised instance stored
+/// in the entry.
+pub fn ospf_ls_request_lookup<V: OspfVersion>(
+    nbr: &Neighbor<V>,
+    h: &V::LsaHeader,
+) -> Option<usize> {
+    let (ls_type, ls_id, adv_router) = (V::ls_type(h), V::ls_id(h), V::adv_router(h));
+    nbr.ls_req.iter().position(|advertised| {
+        V::ls_type(advertised) == ls_type
+            && V::ls_id(advertised) == ls_id
+            && V::adv_router(advertised) == adv_router
     })
 }
 

--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -50,6 +50,63 @@ pub fn ospf_ls_request_lookup<V: OspfVersion>(
     })
 }
 
+/// Whether a flooded LSA should still be sent to a given neighbor
+/// after the RFC 2328 §13.3 step 1(b) reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloodTarget {
+    /// The neighbor already holds an instance at least as recent as
+    /// the one being flooded — sending it would be redundant.
+    Skip,
+    Send,
+}
+
+/// RFC 2328 §13.3 step 1(b). Only adjacencies that are not yet Full
+/// carry a request list, and each entry records the instance the
+/// neighbor advertised in its Database Description. If the LSA being
+/// flooded names one of those entries, the advertised instance tells
+/// us what the neighbor already has:
+///
+/// * flooded LSA less recent — the neighbor's copy is newer, so it
+///   still owes us that copy. Keep the request and don't flood ours.
+/// * same instance — the neighbor already has exactly this LSA, so
+///   the request is satisfied. Drop it and don't flood.
+/// * flooded LSA more recent — ours beats what the neighbor
+///   advertised, so we no longer need to ask for theirs. Drop the
+///   request and flood.
+///
+/// Dropping a request can empty the list, so the Loading check runs
+/// here — without it a neighbor whose requests are all satisfied by
+/// parallel floods sits in Loading until its next LS Update.
+///
+/// The advertised header is compared using its own stored `ls_age`
+/// (the age at DD time). Age only participates via the MaxAge and
+/// MaxAgeDiff rules, and this is not a database copy, so there is no
+/// dynamic age to compute.
+pub fn ospf_flood_reconcile_ls_req<V: OspfVersion>(
+    nbr: &mut Neighbor<V>,
+    lsa: &V::Lsa,
+) -> FloodTarget {
+    if nbr.state >= NfsmState::Full {
+        return FloodTarget::Send;
+    }
+    let h = V::lsa_header(lsa);
+    let Some(idx) = ospf_ls_request_lookup(nbr, h) else {
+        return FloodTarget::Send;
+    };
+    let advertised = &nbr.ls_req[idx];
+    let cmp = V::lsa_more_recent(h, V::ls_age(h), advertised, V::ls_age(advertised));
+    if cmp < 0 {
+        return FloodTarget::Skip;
+    }
+    nbr.ls_req.remove(idx);
+    ospf_nfsm_check_nbr_loading(nbr);
+    if cmp == 0 {
+        FloodTarget::Skip
+    } else {
+        FloodTarget::Send
+    }
+}
+
 // OSPF LSA flooding -- RFC2328 Section 13.3.
 // Following the ref/ospfd/ospf_flood.c ospf_flood_through_interface() pattern.
 pub fn ospf_flood_through_interface(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
@@ -232,4 +289,217 @@ pub fn ospf_ls_retransmit_lookup<'a, V: OspfVersion>(
 ) -> Option<&'a V::Lsa> {
     let key: OspfLsaKey = lsa_to_key::<V>(lsa);
     nbr.ls_rxmt.get(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ospf::version::{Ospfv2, Ospfv3};
+    use ospf_packet::{
+        OSPFV3_ROUTER_LSA_TYPE, Ospfv3LsBody, Ospfv3LsaHeader, Ospfv3Options, Ospfv3RouterLsa,
+        RouterLsa,
+    };
+    use std::net::Ipv4Addr;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    const ADV: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+    const LS_ID: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+
+    fn v2_nbr() -> Neighbor<Ospfv2> {
+        let (tx, _rx) = unbounded_channel();
+        let (ptx, _prx) = unbounded_channel();
+        // The Loading check emits on `tx`; keeping both receivers alive
+        // in the caller isn't needed since send errors are ignored.
+        let mut nbr = Neighbor::<Ospfv2>::new(
+            tx,
+            1,
+            Default::default(),
+            &Ipv4Addr::new(10, 0, 0, 2),
+            40,
+            ptx,
+        );
+        nbr.state = NfsmState::Loading;
+        nbr
+    }
+
+    fn v2_header(seq: u32, age: u16) -> OspfLsaHeader {
+        let mut h = OspfLsaHeader::new(OspfLsType::Router, LS_ID, ADV);
+        h.ls_seq_number = seq;
+        h.ls_age = age;
+        h
+    }
+
+    fn v2_lsa(seq: u32, age: u16) -> OspfLsa {
+        OspfLsa::from(
+            v2_header(seq, age),
+            OspfLsp::Router(RouterLsa {
+                flags: 0,
+                links: vec![],
+            }),
+        )
+    }
+
+    fn v3_nbr() -> Neighbor<Ospfv3> {
+        let (tx, _rx) = unbounded_channel();
+        let (ptx, _prx) = unbounded_channel();
+        let mut nbr = Neighbor::<Ospfv3>::new(
+            tx,
+            1,
+            Default::default(),
+            &Ipv4Addr::new(10, 0, 0, 2),
+            40,
+            ptx,
+        );
+        nbr.state = NfsmState::Loading;
+        nbr
+    }
+
+    fn v3_header(seq: u32, age: u16) -> Ospfv3LsaHeader {
+        Ospfv3LsaHeader {
+            ls_age: age,
+            ls_type: OSPFV3_ROUTER_LSA_TYPE,
+            link_state_id: 0,
+            advertising_router: ADV,
+            ls_seq_number: seq,
+            ls_checksum: 0,
+            length: 20,
+        }
+    }
+
+    fn v3_lsa(seq: u32, age: u16) -> ospf_packet::Ospfv3Lsa {
+        ospf_packet::Ospfv3Lsa {
+            h: v3_header(seq, age),
+            body: Ospfv3LsBody::Router(Ospfv3RouterLsa {
+                flags: 0,
+                options: Ospfv3Options::default(),
+                links: vec![],
+            }),
+            raw: None,
+        }
+    }
+
+    // Not on the request list at all: nothing to reconcile, flood it.
+    #[test]
+    fn reconcile_v2_not_requested() {
+        let mut nbr = v2_nbr();
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v2_lsa(5, 0)),
+            FloodTarget::Send
+        );
+        assert!(nbr.ls_req.is_empty());
+    }
+
+    // The neighbor advertised a NEWER instance than the one we are
+    // flooding: it still owes us that copy, so keep the request and
+    // don't push our stale one at it.
+    #[test]
+    fn reconcile_v2_advertised_is_newer_keeps_request() {
+        let mut nbr = v2_nbr();
+        nbr.ls_req.push(v2_header(9, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v2_lsa(5, 0)),
+            FloodTarget::Skip
+        );
+        assert_eq!(nbr.ls_req.len(), 1, "request must survive");
+    }
+
+    // Same instance — a parallel neighbor's serve already gave us what
+    // this one advertised. Request satisfied, and it needs no copy.
+    #[test]
+    fn reconcile_v2_same_instance_drops_request_and_skips() {
+        let mut nbr = v2_nbr();
+        nbr.ls_req.push(v2_header(5, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v2_lsa(5, 0)),
+            FloodTarget::Skip
+        );
+        assert!(nbr.ls_req.is_empty());
+    }
+
+    // Ours is newer than what the neighbor advertised: stop asking for
+    // theirs, and do flood ours.
+    #[test]
+    fn reconcile_v2_flooded_is_newer_drops_request_and_sends() {
+        let mut nbr = v2_nbr();
+        nbr.ls_req.push(v2_header(5, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v2_lsa(9, 0)),
+            FloodTarget::Send
+        );
+        assert!(nbr.ls_req.is_empty());
+    }
+
+    // A Full adjacency has no request list to reconcile.
+    #[test]
+    fn reconcile_v2_full_neighbor_is_untouched() {
+        let mut nbr = v2_nbr();
+        nbr.state = NfsmState::Full;
+        nbr.ls_req.push(v2_header(5, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v2_lsa(5, 0)),
+            FloodTarget::Send
+        );
+        assert_eq!(nbr.ls_req.len(), 1);
+    }
+
+    // Only the matching entry is reconciled; other requests stand.
+    #[test]
+    fn reconcile_v2_leaves_other_requests_alone() {
+        let mut nbr = v2_nbr();
+        let mut other = v2_header(5, 0);
+        other.ls_id = Ipv4Addr::new(10, 0, 0, 7);
+        nbr.ls_req.push(other);
+        nbr.ls_req.push(v2_header(5, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v2_lsa(5, 0)),
+            FloodTarget::Skip
+        );
+        assert_eq!(nbr.ls_req.len(), 1);
+        assert_eq!(nbr.ls_req[0].ls_id, Ipv4Addr::new(10, 0, 0, 7));
+    }
+
+    #[test]
+    fn reconcile_v3_not_requested() {
+        let mut nbr = v3_nbr();
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v3_lsa(5, 0)),
+            FloodTarget::Send
+        );
+    }
+
+    #[test]
+    fn reconcile_v3_advertised_is_newer_keeps_request() {
+        let mut nbr = v3_nbr();
+        nbr.ls_req.push(v3_header(9, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v3_lsa(5, 0)),
+            FloodTarget::Skip
+        );
+        assert_eq!(nbr.ls_req.len(), 1);
+    }
+
+    // The v3 case the tilfa topology actually hit: d requested s's
+    // Router-LSA from two neighbors at once and the second serve
+    // carried the instance the first had already installed.
+    #[test]
+    fn reconcile_v3_same_instance_drops_request_and_skips() {
+        let mut nbr = v3_nbr();
+        nbr.ls_req.push(v3_header(5, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v3_lsa(5, 0)),
+            FloodTarget::Skip
+        );
+        assert!(nbr.ls_req.is_empty());
+    }
+
+    #[test]
+    fn reconcile_v3_flooded_is_newer_drops_request_and_sends() {
+        let mut nbr = v3_nbr();
+        nbr.ls_req.push(v3_header(5, 0));
+        assert_eq!(
+            ospf_flood_reconcile_ls_req(&mut nbr, &v3_lsa(9, 0)),
+            FloodTarget::Send
+        );
+        assert!(nbr.ls_req.is_empty());
+    }
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -5638,21 +5638,21 @@ impl Ospf<Ospfv2> {
                     continue;
                 }
 
+                // RFC 2328 Section 13.3 Step 1(b): reconcile against
+                // the instance this neighbor advertised. A neighbor
+                // that already holds this LSA doesn't need our copy.
+                if super::flood::ospf_flood_reconcile_ls_req(nbr, lsa)
+                    == super::flood::FloodTarget::Skip
+                {
+                    continue;
+                }
+
                 // RFC 2328 Section 13.3 Step 1(c): Skip the source neighbor.
                 if let Some((src_ifindex, src_addr)) = source
                     && nbr.ifindex == src_ifindex
                     && nbr.ident.prefix.addr() == src_addr
                 {
                     continue;
-                }
-
-                // RFC 2328 Section 13.3 Step 1(b): For neighbors in
-                // Exchange or Loading state, remove from ls_req if present.
-                if nbr.state >= NfsmState::Exchange
-                    && nbr.state < NfsmState::Full
-                    && let Some(idx) = super::ospf_ls_request_lookup(nbr, &lsa.h)
-                {
-                    nbr.ls_req.remove(idx);
                 }
 
                 // RFC 2328 Section 13.3 Step 1(d): Add LSA to retransmit list.
@@ -9724,9 +9724,21 @@ impl Ospf<Ospfv3> {
                 link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
 
             for nbr in link.nbrs.values_mut() {
+                // RFC 2328 §13.3 step 1(a).
                 if nbr.state < NfsmState::Exchange {
                     continue;
                 }
+
+                // RFC 2328 §13.3 step 1(b): reconcile against the
+                // instance this neighbor advertised. A neighbor that
+                // already holds this LSA doesn't need our copy.
+                if super::flood::ospf_flood_reconcile_ls_req(nbr, lsa)
+                    == super::flood::FloodTarget::Skip
+                {
+                    continue;
+                }
+
+                // RFC 2328 §13.3 step 1(c): skip the source neighbor.
                 if let Some((src_if, src_v6)) = source
                     && ifindex == src_if
                     && nbr.ident.prefix.addr() == src_v6
@@ -9774,10 +9786,9 @@ impl Ospf<Ospfv3> {
 
     /// Flood a self-originated v3 LSA to every Exchange-or-later
     /// neighbor in the area. Minimal RFC 2328 §13.3 — no DR / BDR
-    /// ordering, no ls_req cleanup for Exchange / Loading neighbors.
-    /// Those land alongside the §13.1 hardening of
-    /// `ospfv3_ls_upd_recv`. Retransmit-list bookkeeping happens
-    /// in `flood_lsa_through_area`.
+    /// ordering. Request-list reconciliation (step 1(b)) and
+    /// retransmit-list bookkeeping (step 1(d)) happen in
+    /// `flood_lsa_through_area`.
     ///
     /// The LSU goes through the dedicated `Ospfv3Send` channel so
     /// `network_v6::write_packet_v6` stamps the IPv6 pseudo-header

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -165,7 +165,15 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     pub dd: NeighborDbDesc<V>,
     pub ptx: UnboundedSender<Message<V>>,
     pub db_sum: Vec<V::LsaHeader>,
-    pub ls_req: Vec<V::LsRequestEntry>,
+    /// Link State Request list (RFC 2328 §10). Holds the LSA
+    /// *headers* the neighbor advertised in its Database Description,
+    /// not the 12-octet wire request records — the advertised
+    /// instance (sequence number / checksum / age) is what §13.3
+    /// step 1(b) compares a flooded LSA against, and what §10.6 needs
+    /// to decide whether our database copy is already current. The
+    /// wire form is derived at send time via `V::ls_request_entry`.
+    /// Same shape as `db_sum` above.
+    pub ls_req: Vec<V::LsaHeader>,
     pub ls_req_last: Option<V::LsRequest>,
     pub ls_rxmt: BTreeMap<OspfLsaKey, V::Lsa>,
     pub uptime: Instant,

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -653,8 +653,24 @@ fn ospf_db_desc_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, dd: &OspfDbDesc
     nbr.dd.recv = dd.clone();
 
     for lsah in dd.lsa_headers.iter() {
-        let find = ospf_lsa_lookup(oi, lsah.ls_type, lsah.ls_id, lsah.adv_router);
-        if find.is_none() {
+        // RFC 2328 §10.6: request the LSA when we hold no copy, or
+        // when the instance the neighbor advertised is more recent
+        // than ours. Testing only for absence — as this did — leaves
+        // a stale copy in place until the originator's next refresh,
+        // up to LSRefreshTime later.
+        //
+        // Both sides are compared on their stored `ls_age`: the age
+        // tiebreak only runs when sequence number and checksum are
+        // identical, and identical instances need no request either
+        // way. The case that matters is a MaxAge advertisement over a
+        // live copy, which this still catches.
+        let need = match ospf_lsa_lookup(oi, lsah.ls_type, lsah.ls_id, lsah.adv_router) {
+            None => true,
+            Some(current) => {
+                ospf_lsa_more_recent(lsah, lsah.ls_age, &current.h, current.h.ls_age) > 0
+            }
+        };
+        if need {
             ospf_ls_request_add(nbr, lsah);
             ospf_nfsm_ls_req_timer_on(nbr, oi.retransmit_interval);
         }

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -980,7 +980,12 @@ pub fn ospf_ls_req_recv(
 // Returns true if lsa1 is more recent than lsa2 (RFC 2328 Section 13.1).
 // age1/age2 are the current ages of the respective LSAs (callers must pass
 // dynamic current_age for database copies).
-fn ospf_lsa_more_recent(lsa1: &OspfLsaHeader, age1: u16, lsa2: &OspfLsaHeader, age2: u16) -> i32 {
+pub(super) fn ospf_lsa_more_recent(
+    lsa1: &OspfLsaHeader,
+    age1: u16,
+    lsa2: &OspfLsaHeader,
+    age2: u16,
+) -> i32 {
     // RFC 2328 §A.4.1: `ls_seq_number` is a SIGNED 32-bit integer
     // wrapping from `InitialSequenceNumber` (0x80000001, most-negative)
     // up to `MaxSequenceNumber` (0x7FFFFFFF). Comparison must be

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -598,8 +598,10 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
 }
 
 pub fn ospf_packet_ls_req_set(nbr: &mut Neighbor, ls_req: &mut OspfLsRequest) {
-    for ls_req_entry in nbr.ls_req.iter() {
-        ls_req.reqs.push(ls_req_entry.clone());
+    // The request list stores the headers the neighbor advertised;
+    // the wire record carries only the identity triple.
+    for advertised in nbr.ls_req.iter() {
+        ls_req.reqs.push(ospf_ls_rquest_new(advertised));
     }
 }
 
@@ -641,8 +643,10 @@ fn ospf_lsa_lookup<'a>(
     }
 }
 
-fn ospf_ls_request_add(nbr: &mut Neighbor, ls_req: OspfLsRequestEntry) {
-    nbr.ls_req.push(ls_req);
+/// Record an LSA we need from this neighbor. Stores the header it
+/// advertised, so the instance stays available for §13.3 step 1(b).
+fn ospf_ls_request_add(nbr: &mut Neighbor, advertised: &OspfLsaHeader) {
+    nbr.ls_req.push(advertised.clone());
 }
 
 fn ospf_db_desc_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, dd: &OspfDbDesc) {
@@ -651,8 +655,7 @@ fn ospf_db_desc_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, dd: &OspfDbDesc
     for lsah in dd.lsa_headers.iter() {
         let find = ospf_lsa_lookup(oi, lsah.ls_type, lsah.ls_id, lsah.adv_router);
         if find.is_none() {
-            let lsr = ospf_ls_rquest_new(lsah);
-            ospf_ls_request_add(nbr, lsr);
+            ospf_ls_request_add(nbr, lsah);
             ospf_nfsm_ls_req_timer_on(nbr, oi.retransmit_interval);
         }
     }

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1181,7 +1181,12 @@ pub fn ospfv3_ls_ack_recv(
 /// Returns `1` if `h1` is more recent than `h2`, `-1` if `h2` is
 /// more recent, `0` if same instance. Caller passes the dynamic
 /// current ages (database copies should compute `current_age`).
-fn ospfv3_lsa_more_recent(h1: &Ospfv3LsaHeader, age1: u16, h2: &Ospfv3LsaHeader, age2: u16) -> i32 {
+pub(super) fn ospfv3_lsa_more_recent(
+    h1: &Ospfv3LsaHeader,
+    age1: u16,
+    h2: &Ospfv3LsaHeader,
+    age2: u16,
+) -> i32 {
     use super::lsdb::OSPF_MAX_AGE;
     const OSPF_MAX_AGE_DIFF: u16 = 900;
 

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -753,12 +753,19 @@ fn ospfv3_db_desc_proc(
 ) {
     nbr.dd.recv = dd.clone();
 
-    // RFC 2328 §10.6 (reused by v3): for each header in the
-    // received DBD, if we don't already have the LSA, add it to
-    // the LS Request list and (re)arm the LS Request timer.
+    // RFC 2328 §10.6 (reused by v3): for each header in the received
+    // DBD, request the LSA when we hold no copy, or when the
+    // advertised instance is more recent than ours — testing only for
+    // absence leaves a stale copy in place until the originator's
+    // next refresh. See the v2 twin for why comparing the stored ages
+    // is sufficient here.
     let mut added = false;
     for h in dd.lsa_headers.iter() {
-        if ospfv3_lsa_lookup(oi, h).is_none() {
+        let need = match ospfv3_lsa_lookup(oi, h) {
+            None => true,
+            Some(current) => ospfv3_lsa_more_recent(h, h.ls_age, &current.h, current.h.ls_age) > 0,
+        };
+        if need {
             // Store the advertised header, not the wire request
             // record — §13.3 step 1(b) compares against this instance.
             nbr.ls_req.push(h.clone());

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -10,8 +10,8 @@ use ipnet::Ipv6Net;
 use ospf_macros::ospf_packet_handler;
 use ospf_packet::{
     OSPFV3_NSSA_LSA_TYPE, Ospfv3AuthTrailer, Ospfv3DbDesc, Ospfv3Hello, Ospfv3LsAck,
-    Ospfv3LsRequest, Ospfv3LsRequestEntry, Ospfv3LsUpdate, Ospfv3Lsa, Ospfv3LsaHeader,
-    Ospfv3Options, Ospfv3Packet, Ospfv3Payload,
+    Ospfv3LsRequest, Ospfv3LsUpdate, Ospfv3Lsa, Ospfv3LsaHeader, Ospfv3Options, Ospfv3Packet,
+    Ospfv3Payload,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -759,11 +759,9 @@ fn ospfv3_db_desc_proc(
     let mut added = false;
     for h in dd.lsa_headers.iter() {
         if ospfv3_lsa_lookup(oi, h).is_none() {
-            nbr.ls_req.push(Ospfv3LsRequestEntry::new(
-                h.ls_type,
-                h.link_state_id,
-                h.advertising_router,
-            ));
+            // Store the advertised header, not the wire request
+            // record — §13.3 step 1(b) compares against this instance.
+            nbr.ls_req.push(h.clone());
             added = true;
         }
     }
@@ -929,8 +927,8 @@ pub fn ospfv3_db_desc_recv(
 /// Pack the pending LS Request entries on `nbr.ls_req` into the
 /// outgoing packet. Mirrors v2's `ospf_packet_ls_req_set`.
 fn ospfv3_packet_ls_req_set(nbr: &Neighbor<Ospfv3>, ls_req: &mut Ospfv3LsRequest) {
-    for entry in nbr.ls_req.iter() {
-        ls_req.reqs.push(entry.clone());
+    for advertised in nbr.ls_req.iter() {
+        ls_req.reqs.push(Ospfv3::ls_request_entry(advertised));
     }
 }
 
@@ -1221,17 +1219,6 @@ fn ospfv3_lsa_more_recent(h1: &Ospfv3LsaHeader, age1: u16, h2: &Ospfv3LsaHeader,
         }
     }
     0
-}
-
-/// Position of a matching `Ospfv3LsRequestEntry` in `nbr.ls_req`
-/// for the LSA identified by `h`, or `None` if not on the list.
-/// Mirrors v2's `ospf_ls_request_lookup`.
-fn ospfv3_ls_request_lookup(nbr: &Neighbor<Ospfv3>, h: &Ospfv3LsaHeader) -> Option<usize> {
-    nbr.ls_req.iter().position(|req| {
-        req.ls_type == h.ls_type
-            && req.link_state_id == h.link_state_id
-            && req.advertising_router == h.advertising_router
-    })
 }
 
 /// True if `lsa` was advertised by us. v3 doesn't need the v2
@@ -1562,7 +1549,7 @@ fn ospfv3_ls_upd_proc(
         }
 
         // Drop matching entry from nbr.ls_req — request satisfied.
-        if let Some(idx) = ospfv3_ls_request_lookup(nbr, h) {
+        if let Some(idx) = super::flood::ospf_ls_request_lookup(nbr, h) {
             nbr.ls_req.remove(idx);
         }
 
@@ -1590,7 +1577,7 @@ fn ospfv3_ls_upd_proc(
     // instance, step 8 unicasts our newer copy back for an older
     // one. Genuine exchange corruption is still caught by the DD
     // sequence/option checks (SeqNumberMismatch).
-    if let Some(idx) = ospfv3_ls_request_lookup(nbr, h) {
+    if let Some(idx) = super::flood::ospf_ls_request_lookup(nbr, h) {
         nbr.ls_req.remove(idx);
     }
 

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -231,6 +231,14 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// when a request packet is built.
     fn ls_request_entry(h: &Self::LsaHeader) -> Self::LsRequestEntry;
 
+    /// RFC 2328 §13.1 instance comparison: sequence number, then
+    /// checksum, then the MaxAge / MaxAgeDiff age rules. Positive
+    /// means `h1` is the more recent instance, negative means `h2`
+    /// is, zero means the two are the same instance. Ages are passed
+    /// separately so a caller can supply a database copy's
+    /// dynamically-computed age instead of the stored header field.
+    fn lsa_more_recent(h1: &Self::LsaHeader, age1: u16, h2: &Self::LsaHeader, age2: u16) -> i32;
+
     /// Address by which a neighbor is uniquely identified on the
     /// local router, projected to a 32-bit value for storage in
     /// the v2-shaped `Message::Retransmit` / `Nfsm` channel
@@ -447,6 +455,9 @@ impl OspfVersion for Ospfv2 {
     fn ls_request_entry(h: &OspfLsaHeader) -> OspfLsRequestEntry {
         OspfLsRequestEntry::new(h.ls_type, h.ls_id, h.adv_router)
     }
+    fn lsa_more_recent(h1: &OspfLsaHeader, age1: u16, h2: &OspfLsaHeader, age2: u16) -> i32 {
+        super::packet::ospf_lsa_more_recent(h1, age1, h2, age2)
+    }
     fn length(h: &OspfLsaHeader) -> u16 {
         h.length
     }
@@ -585,6 +596,9 @@ impl OspfVersion for Ospfv3 {
     }
     fn ls_request_entry(h: &Ospfv3LsaHeader) -> Ospfv3LsRequestEntry {
         Ospfv3LsRequestEntry::new(h.ls_type, h.link_state_id, h.advertising_router)
+    }
+    fn lsa_more_recent(h1: &Ospfv3LsaHeader, age1: u16, h2: &Ospfv3LsaHeader, age2: u16) -> i32 {
+        super::packet_v3::ospfv3_lsa_more_recent(h1, age1, h2, age2)
     }
     fn adv_router(h: &Ospfv3LsaHeader) -> Ipv4Addr {
         h.advertising_router

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -223,6 +223,14 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// itself is 20 octets in both versions.
     fn length(h: &Self::LsaHeader) -> u16;
 
+    /// Build the on-the-wire LS Request record (§A.3.4) asking a
+    /// neighbor for the LSA this header describes. The request list
+    /// holds full headers (`Neighbor::ls_req`) so the instance the
+    /// neighbor advertised stays available for the RFC 2328 §13.3
+    /// step 1(b) comparison; the 12-octet wire form is derived only
+    /// when a request packet is built.
+    fn ls_request_entry(h: &Self::LsaHeader) -> Self::LsRequestEntry;
+
     /// Address by which a neighbor is uniquely identified on the
     /// local router, projected to a 32-bit value for storage in
     /// the v2-shaped `Message::Retransmit` / `Nfsm` channel
@@ -436,6 +444,9 @@ impl OspfVersion for Ospfv2 {
     fn ls_checksum(h: &OspfLsaHeader) -> u16 {
         h.ls_checksum
     }
+    fn ls_request_entry(h: &OspfLsaHeader) -> OspfLsRequestEntry {
+        OspfLsRequestEntry::new(h.ls_type, h.ls_id, h.adv_router)
+    }
     fn length(h: &OspfLsaHeader) -> u16 {
         h.length
     }
@@ -571,6 +582,9 @@ impl OspfVersion for Ospfv3 {
     }
     fn ls_id(h: &Ospfv3LsaHeader) -> u32 {
         h.link_state_id
+    }
+    fn ls_request_entry(h: &Ospfv3LsaHeader) -> Ospfv3LsRequestEntry {
+        Ospfv3LsRequestEntry::new(h.ls_type, h.link_state_id, h.advertising_router)
     }
     fn adv_router(h: &Ospfv3LsaHeader) -> Ipv4Addr {
         h.advertising_router


### PR DESCRIPTION
Follow-up to #2250. That fix made the **receive** side tolerate a Link State
Request satisfied by a parallel neighbour's serve. This implements the **flood**
side of the same rule — RFC 2328 §13.3 step 1(b) — which is what FRR relies on
to keep the collision from arising in the first place.

## Where we were

| Site | step 1(b) before this PR |
| --- | --- |
| v2 fan-out (`inst.rs`) | partial — removed the request entry on an identity match, with no instance comparison and no suppression, then flooded anyway |
| v3 fan-out (`inst.rs`) | **absent**; the omission was spelled out in its own doc comment |
| v2 sync install path (`flood.rs`) | source neighbour only — that is the §13 step-5 cleanup, not 1(b) |

The reason neither version could do it properly: `Neighbor::ls_req` stored
`V::LsRequestEntry`, the 12-octet on-the-wire record, which carries only the
identity triple. The instance a neighbour advertised in its Database
Description — sequence number, checksum, age — was parsed, used once for a
"do we have this LSA at all" test, then dropped. Step 1(b) compares a flooded
LSA against precisely that advertised instance, so it was not implementable.

## What changed

**1. Retain the advertised header** (`83d5e281`). `ls_req` becomes
`Vec<V::LsaHeader>`, mirroring the sibling list `db_sum`, which already stores
headers this way. The wire record is derived at send time through a new
`V::ls_request_entry`. The two request-list lookups — a public monomorphic v2
one and a private v3 twin — collapse into one generic
`ospf_ls_request_lookup<V>` built on the existing `V::ls_type` / `ls_id` /
`adv_router` accessors. Pure refactor, no behaviour change.

**2. Step 1(b) in both fan-outs** (`85e31b88`), as one shared
`ospf_flood_reconcile_ls_req` helper following the existing
`ospf_ls_retransmit_add` shape (a free function over `&mut Neighbor<V>` — both
flood loops hold `&mut OspfLink` across the iteration and cannot call any
`self` method):

- flooded LSA **less recent** — the neighbour's copy is newer and it still owes
  us that copy: keep the request, don't push our stale one at it
- **same instance** — the neighbour already holds exactly this LSA: request
  satisfied, and it needs no copy from us
- flooded LSA **more recent** — ours beats what it advertised: stop asking for
  theirs, and flood ours

Dropping a request can empty the list, so the Loading check runs in the helper.
Nothing called it from a fan-out before, which means v2's existing removal could
empty a request list without ever firing `LoadingDone`, stranding that neighbour
in Loading until its next LS Update — that latent bug goes away here too.

Step 1(b) now runs before the 1(c) source-neighbour skip, matching RFC order;
for the source neighbour it is a no-op, since its request was already reconciled
synchronously on the install path. Link-scope flooding is untouched: those LSAs
never appear in a DD summary (RFC 5340 §4.2.2), so they are never on a request
list.

**3. The §10.6 companion** (`6770f79d`). Both DD processors requested an LSA
only when it was entirely absent from the database. §10.6 also requires
requesting it when the advertised instance is more recent than the copy we hold
— otherwise a router that came up with an older instance keeps serving it until
the originator's next refresh, up to LSRefreshTime later. Same prerequisite,
same comparator.

## Verification

- `cargo fmt`; CI mirrored exactly with `RUSTFLAGS="-D warnings"` for both
  `clippy --workspace --all-targets` and `test --workspace --exclude bdd`.
  Every commit is independently green, so the series bisects cleanly.
- 10 new unit tests over `ospf_flood_reconcile_ls_req` covering all four
  decision branches plus the Full-neighbour and other-requests-untouched cases,
  on both v2 and v3.
- Targeted BDD, 3 runs each at `--concurrency=1`, all green: `@srv6_tilfa_v3`,
  `@ospfv3_tilfa`, `@ospfv2_tilfa`, `@ospfv2_virtual_link`.
- **The check that actually matters here.** Suppressing a flood is the one thing
  in this change that could silently starve a neighbour, and every ping in the
  suite would still pass if it did. So: bring up the eight-router RFC 9855
  topology, let it converge, and diff the area-scope LSDB across all eight
  nodes — `(ls_type, link_state_id, advertising_router)` sets must be identical.
  Result: **all 8 nodes hold the same 54 area-scope LSAs, union also 54, nobody
  missing anything.** This is the same technique that exposed the original hole
  in #2250, where `d` was missing exactly two LSAs.
- Full BDD suite at c=16: **281 ran, 278 passed**, no leaked namespaces,
  daemons or veths. All three failures are pre-existing and none is an OSPF
  flooding feature:
  - `ospf_ecmp_bfd_evict` — the documented ~50% intermittent in the BFD
    *eviction-recovery* path (the evicted nexthop not re-expanding into the
    ECMP set). Passes **2/2 solo** here.
  - `isis_bfd_ipv4_lan` — the BFD-Echo timing repeater; went fail/pass across
    two solo runs, i.e. still intermittent. Structurally unreachable from this
    change: the entire diff is confined to `zebra-rs/src/ospf/`, and this
    feature runs IS-IS with BFD and no OSPF daemon.
  - `bgp_allowas_in` — BGP Established assert after a fixed wait. Passes
    **2/2 solo**.

Not measured: the expected reduction in redundant LS Updates during initial
exchange. It needs an A/B packet capture against a pre-change build; the
correctness evidence above is what this PR stands on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
