### PR TITLE
config: a failed `save` must not take the daemon down

### DIFF
--- a/book/src/ch-00-05-command-line-options.md
+++ b/book/src/ch-00-05-command-line-options.md
@@ -40,7 +40,10 @@ configuration representations is accepted:
 - **JSON** — a JSON document of the configuration tree.
 - **YAML** — a YAML document of the configuration tree.
 - **set/delete** — a flat list of `set …` / `delete …` statements (the
-  `formal` format that `load` and `save` consume).
+  `formal` format `show running-config formal` prints).
+
+Reading accepts all four; `save` always writes back the **CLI** format,
+whatever format the file was loaded in.
 
 The four formats are interchangeable; see
 [Show Config Commands](ch-06-02-show-config-commands.md) for examples of

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -27,8 +27,9 @@ All eight display commands work identically from both `exec` mode and
 
 The bare form (no trailing keyword) renders the **CLI** view — the
 indented block format familiar from Cisco IOS, suitable for reading
-on a terminal. The `formal` keyword names the canonical set/delete
-form, the same format `load` and `save` consume. The `json` and
+on a terminal — and the format `save` writes to disk. The `formal`
+keyword names the canonical set/delete form, one of the four formats
+`load` accepts (see below). The `json` and
 `yaml` keywords are the equivalent serializations of the same
 configuration tree.
 
@@ -126,7 +127,28 @@ under the top level of `configure` mode (not under `show`):
 | `commit` | Validate the candidate, apply diffs to subscribers, then promote candidate → running |
 | `discard` | Revert candidate back to running (drops uncommitted edits) |
 | `load` | Re-load the on-disk config file into the candidate, then commit |
-| `save` | Write the running config to the on-disk file |
+| `save` | Write the running config to the on-disk file, and print the path written |
+
+Both `load` and `save` operate on the file named by `--config-file`, or
+on the resolved default when the flag is absent (see
+[Command Line Options](ch-00-05-command-line-options.md)). `save` names
+that file in its reply:
+
+```
+host(config)# save
+Configuration saved to /etc/zebra-rs/zebra-rs.conf
+```
+
+The write is atomic — the config is serialized to a sibling temp file
+and renamed into place, so an interrupted save leaves the previous file
+intact. A save that fails (read-only filesystem, missing parent
+directory, a file the daemon's user cannot write) reports the error and
+leaves the daemon running:
+
+```
+host(config)# save
+Failed to save configuration to /etc/zebra-rs/zebra-rs.conf: Permission denied (os error 13)
+```
 
 ## Reorganization notes (history)
 

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -257,9 +257,22 @@ fn load(config: &ConfigManager) -> (ExecCode, String) {
     (ExecCode::Show, String::from(""))
 }
 
+/// `save` used to answer with an empty string, so the operator had no
+/// way to tell which file was written — the target is the resolved
+/// `--config-file` (or the default `zebra-rs.conf`), and nothing on the
+/// prompt named it. Report the path on success and the io error on
+/// failure; a failed save is no longer fatal to the daemon (see
+/// `ConfigManager::save_config`).
 fn save(config: &ConfigManager) -> (ExecCode, String) {
-    config.save_config();
-    (ExecCode::Show, String::from(""))
+    let output = match config.save_config() {
+        Ok(path) => format!("Configuration saved to {}\n", path.display()),
+        Err(e) => format!(
+            "Failed to save configuration to {}: {}\n",
+            config.config_path.display(),
+            e
+        ),
+    };
+    (ExecCode::Show, output)
 }
 
 fn clear_isis_spf(_config: &ConfigManager) -> (ExecCode, String) {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1066,10 +1066,62 @@ impl ConfigManager {
         }
     }
 
-    pub fn save_config(&self) {
+    /// Write the running config to [`Self::config_path`] — the file
+    /// named by `--config-file`, or the resolved default when the flag
+    /// is absent. Returns the path written on success.
+    ///
+    /// Two properties the previous one-liner lacked:
+    ///
+    /// * **No panic.** `save` is an operator command, and the write can
+    ///   fail for ordinary reasons — a read-only filesystem, a missing
+    ///   parent directory, a `--config-file` the daemon's uid can't
+    ///   write. The old `expect` took the whole daemon down (and the
+    ///   config-loop panic cascaded into the vty server's
+    ///   `rx.await.unwrap()`), so a mistyped path cost the operator the
+    ///   router. The error now travels back to the caller as command
+    ///   output instead.
+    /// * **Atomic replace.** Serialize into a sibling temp file and
+    ///   `rename` it into place, so a failure part-way through (ENOSPC,
+    ///   a crash) leaves the previous config intact rather than a
+    ///   truncated file the next boot would half-load. The temp file
+    ///   must be a sibling: `rename(2)` is only atomic within one
+    ///   filesystem.
+    ///
+    /// Replacing rather than rewriting in place means the save needs
+    /// write permission on the *directory*, and the config file comes
+    /// back owned by the daemon's uid — visible only when the daemon
+    /// doesn't already own the file it saves. The file's mode is carried
+    /// over explicitly (below) so that part of the in-place behavior is
+    /// preserved.
+    pub fn save_config(&self) -> std::io::Result<&Path> {
         let mut output = String::new();
         self.store.running.borrow().format(&mut output);
-        std::fs::write(&self.config_path, output).expect("Unable to write file");
+
+        let mut tmp = self.config_path.clone().into_os_string();
+        tmp.push(".tmp");
+        let tmp = PathBuf::from(tmp);
+
+        let write = std::fs::write(&tmp, output).and_then(|()| {
+            // `fs::write` on the existing file used to keep its mode;
+            // a fresh temp file gets 0666 & !umask instead, which would
+            // silently widen a config the operator had locked down. Carry
+            // the current mode over before the rename. A missing target
+            // (first save) just keeps the default.
+            if let Ok(meta) = std::fs::metadata(&self.config_path) {
+                std::fs::set_permissions(&tmp, meta.permissions())?;
+            }
+            std::fs::rename(&tmp, &self.config_path)
+        });
+
+        match write {
+            Ok(()) => Ok(&self.config_path),
+            Err(e) => {
+                // Don't leave the half-written sibling behind for the
+                // operator to trip over on the next `ls`.
+                let _ = std::fs::remove_file(&tmp);
+                Err(e)
+            }
+        }
     }
 
     pub fn clear(&self, paths: &[CommandPath]) {
@@ -2040,6 +2092,103 @@ mod startup_load_tests {
             message,
             "startup config /etc/zebra-rs/zebra-rs.conf: 1 command(s) rejected:\n  set no such command"
         );
+    }
+}
+
+#[cfg(test)]
+mod save_config_tests {
+    use super::*;
+
+    /// Build a `ConfigManager` on the shipped `yang/` tree whose
+    /// `--config-file` is `path`. Same constraints as the startup-load
+    /// helper: the configs used here stay inside `system`, so no
+    /// protocol task is ever spawned and this needs no tokio runtime.
+    fn manager_with_config(path: &Path) -> ConfigManager {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _rib_inbound_rx) = mpsc::unbounded_channel();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        ConfigManager::new(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/yang").to_string(),
+            Vec::new(),
+            Some(path.to_string_lossy().into_owned()),
+            rib_tx,
+            rib_inbound_tx,
+            policy_tx,
+        )
+        .expect("manager builds")
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("zebra-rs-save-{}-{}", name, std::process::id()))
+    }
+
+    /// The core contract: `save` writes the running config to the file
+    /// named by `--config-file`, not to the default `zebra-rs.conf`.
+    #[test]
+    fn save_writes_to_the_config_file_path() {
+        let path = temp_path("target");
+        std::fs::write(&path, "set system hostname r1\n").expect("seed config written");
+
+        let cm = manager_with_config(&path);
+        cm.load_config();
+        let saved = cm.save_config().expect("save succeeds");
+        assert_eq!(saved, path.as_path());
+
+        let on_disk = std::fs::read_to_string(&path).expect("config readable");
+        assert!(
+            on_disk.contains("hostname r1;"),
+            "saved config: {on_disk:?}"
+        );
+        // The atomic-replace temp sibling must not survive the save.
+        assert!(
+            !path.with_extension("tmp").exists(),
+            "temp sibling left behind"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// An unwritable target must come back as an `Err` the `save`
+    /// handler can print. Before this it was an `expect` that killed
+    /// the daemon.
+    #[test]
+    fn save_reports_write_failure_instead_of_panicking() {
+        // Parent directory does not exist, so both the temp write and
+        // the rename fail.
+        let dir = temp_path("nodir");
+        let path = dir.join("zebra-rs.conf");
+
+        let cm = manager_with_config(&path);
+        let err = cm.save_config().expect_err("save fails");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert!(!dir.exists(), "save must not create the parent directory");
+    }
+
+    /// The temp-file + rename dance must not widen the config's mode:
+    /// a fresh temp file is created 0666 & !umask, so the previous
+    /// file's permissions are carried over before the rename.
+    #[cfg(unix)]
+    #[test]
+    fn save_preserves_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("perms");
+        std::fs::write(&path, "set system hostname r1\n").expect("seed config written");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("mode 0600 set");
+
+        let cm = manager_with_config(&path);
+        cm.load_config();
+        cm.save_config().expect("save succeeds");
+
+        let mode = std::fs::metadata(&path)
+            .expect("config readable")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "save widened the config file mode");
+
+        let _ = std::fs::remove_file(&path);
     }
 }
 


### PR DESCRIPTION
## Summary

`save` in configure mode wrote the running config with
`fs::write(&self.config_path, output).expect("Unable to write file")`.
Any ordinary write failure panicked the config loop, and that panic
cascaded into the vty server's `rx.await.unwrap()` — the whole daemon
died. Reproduced live: a `--config-file` the daemon's uid can't write
(read-only fs, missing parent directory, an `/etc` path under a
non-root daemon) is enough.

```
thread 'main' panicked at zebra-rs/src/config/manager.rs:1072:51:
Unable to write file: Os { code: 13, kind: PermissionDenied }
thread 'tokio-rt-worker' panicked at zebra-rs/src/config/serve.rs:104:18:
called `Result::unwrap()` on an `Err` value: RecvError(())
```

Three changes, all in the `save` path:

* **No panic.** `ConfigManager::save_config` returns `io::Result<&Path>`;
  the `save` handler renders the error as command output.
* **Atomic replace.** Serialize into a sibling `<config>.tmp` and
  `rename` it into place, so an interrupted save leaves the previous
  config intact rather than a truncated file the next boot would
  half-load. The existing file's mode is carried across the rename — a
  fresh temp file is created `0666 & !umask` and would otherwise widen a
  config the operator had locked down. The temp file is removed on any
  failure.
* **Report the path.** `save` used to answer with an empty string, so an
  operator saving to a file other than the one they assumed had no way
  to tell. It now names the resolved `--config-file`.

The `--config-file` target itself already worked for both `load` and
`save` (`manager.rs` resolves one `config_path` used by both); this PR
does not change which file is written.

## Test plan

* New `save_config_tests` (3): save lands on the `--config-file` path
  with no leftover `.tmp`; a write failure returns `Err` instead of
  panicking; mode 0600 survives the save.
* Live daemon, success path — `Configuration saved to .../start2.conf`,
  and the file holds the freshly applied config.
* Live daemon, failure path — `--config-file` in a missing directory:
  `Failed to save configuration to .../no-such-dir/zebra-rs.conf: No such
  file or directory (os error 2)`, daemon still alive and answering
  `show running-config`. The same case killed the daemon before.
* `cargo fmt --all --check` clean, workspace clippy clean,
  `cargo test --workspace --exclude bdd` green (1945 in zebra-rs, 0
  failures).

Docs: `book/src/ch-06-02-show-config-commands.md` gains the save-reply
examples and the atomicity note; two places claiming `save` emits the
`formal` set/delete format were corrected (it writes the CLI brace
format).

Generated with [Claude Code](https://claude.com/claude-code)