### PR TITLE
config: `save { cli | formal | json | yaml }` converts the config file

### DIFF
--- a/book/src/ch-00-05-command-line-options.md
+++ b/book/src/ch-00-05-command-line-options.md
@@ -44,7 +44,10 @@ configuration representations is accepted:
 
 `save` writes the file back in the format it was loaded in, so the round
 trip preserves your choice. A file that was missing or empty at startup
-has no format to preserve, and saves in the **CLI** format.
+has no format to preserve, and saves in the **CLI** format. To convert a
+config file, name a format: `save { cli | formal | json | yaml }` writes
+that one and keeps the file in it from then on (see
+[Show Config Commands](ch-06-02-show-config-commands.md)).
 
 The four formats are interchangeable; see
 [Show Config Commands](ch-06-02-show-config-commands.md) for examples of

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -133,22 +133,23 @@ under the top level of `configure` mode (not under `show`):
 | `commit` | Validate the candidate, apply diffs to subscribers, then promote candidate → running |
 | `discard` | Revert candidate back to running (drops uncommitted edits) |
 | `load` | Re-load the on-disk config file into the candidate, then commit |
-| `save` | Write the running config to the on-disk file, and print the path written |
+| `save` | Write the running config to the on-disk file in its current format |
+| `save { cli \| formal \| json \| yaml }` | Write it in that format instead, and keep the file in that format from then on |
 
 Both `load` and `save` operate on the file named by `--config-file`, or
 on the resolved default when the flag is absent (see
 [Command Line Options](ch-00-05-command-line-options.md)). `save` names
-that file in its reply:
+that file, and the format it wrote, in its reply:
 
 ```
 host(config)# save
-Configuration saved to /etc/zebra-rs/zebra-rs.conf
+Configuration saved to /etc/zebra-rs/zebra-rs.conf (cli)
 ```
 
 ### The format `save` writes
 
-`save` writes the file back in the format it was **loaded** in, so a
-`--config-file` handed to the daemon as YAML stays YAML, JSON stays
+A bare `save` writes the file back in the format it was **loaded** in,
+so a `--config-file` handed to the daemon as YAML stays YAML, JSON stays
 JSON, and a `set`/`delete` document stays `set`/`delete`:
 
 ```
@@ -156,7 +157,7 @@ $ zebra-rs --config-file /etc/zebra-rs/config.yaml
 host(config)# set system hostname r2
 host(config)# commit
 host(config)# save
-Configuration saved to /etc/zebra-rs/config.yaml
+Configuration saved to /etc/zebra-rs/config.yaml (yaml)
 
 $ cat /etc/zebra-rs/config.yaml
 system:
@@ -171,6 +172,24 @@ started, and a daemon whose config only ever arrived over
 `vtyctl apply`. Applying a document with `vtyctl apply` deliberately
 does *not* change the format `save` writes — an applied document is a
 config injection, not the on-disk file.
+
+### Converting the config file
+
+Name a format to convert the file. The keywords are the ones
+`show running-config` uses — `cli`, `formal`, `json`, `yaml` — and the
+choice sticks, so every later bare `save` keeps writing it:
+
+```
+host(config)# save yaml
+Configuration saved to /etc/zebra-rs/zebra-rs.conf (yaml)
+host(config)# save
+Configuration saved to /etc/zebra-rs/zebra-rs.conf (yaml)
+```
+
+The file is a whole config document in the new format — the daemon
+reads any of the four at startup, so a converted file boots unchanged.
+A conversion that fails to write leaves both the file and the
+remembered format alone.
 
 The write is atomic — the config is serialized to a sibling temp file
 and renamed into place, so an interrupted save leaves the previous file

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -1,9 +1,10 @@
 use super::ExecCode;
-use super::manager::ConfigManager;
+use super::manager::{ConfigFormat, ConfigManager};
 use super::util::trim_first_line;
 use libyang::Entry;
 use similar::TextDiff;
 use std::collections::HashMap;
+use std::path::Path;
 use std::rc::Rc;
 
 type FuncMap = HashMap<String, fn(&ConfigManager) -> (ExecCode, String)>;
@@ -49,6 +50,10 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     mode.install_func(String::from("/discard"), discard);
     mode.install_func(String::from("/load"), load);
     mode.install_func(String::from("/save"), save);
+    mode.install_func(String::from("/save/cli"), save_cli);
+    mode.install_func(String::from("/save/formal"), save_formal);
+    mode.install_func(String::from("/save/json"), save_json);
+    mode.install_func(String::from("/save/yaml"), save_yaml);
     mode.install_func(String::from("/clear/isis/spf"), clear_isis_spf);
     // Same operator command as exec mode, so the output format can be
     // switched without leaving the configure prompt.
@@ -257,15 +262,26 @@ fn load(config: &ConfigManager) -> (ExecCode, String) {
     (ExecCode::Show, String::from(""))
 }
 
+// === save [ cli | formal | json | yaml ] ===
+//
+// Bare `save` keeps the config file in whatever format it already is;
+// a format keyword writes that format and makes it the file's format
+// from then on (`ConfigManager::save_config_as`). One handler per
+// keyword because `FuncMap` holds plain fn pointers, not closures.
+
 /// `save` used to answer with an empty string, so the operator had no
 /// way to tell which file was written — the target is the resolved
 /// `--config-file` (or the default `zebra-rs.conf`), and nothing on the
-/// prompt named it. Report the path on success and the io error on
-/// failure; a failed save is no longer fatal to the daemon (see
-/// `ConfigManager::save_config`).
-fn save(config: &ConfigManager) -> (ExecCode, String) {
-    let output = match config.save_config() {
-        Ok(path) => format!("Configuration saved to {}\n", path.display()),
+/// prompt named it. Report the path and the format on success and the
+/// io error on failure; a failed save is no longer fatal to the daemon
+/// (see `ConfigManager::save_config`).
+fn save_reply(config: &ConfigManager, saved: std::io::Result<&Path>) -> (ExecCode, String) {
+    let output = match saved {
+        Ok(path) => format!(
+            "Configuration saved to {} ({})\n",
+            path.display(),
+            config.config_format.borrow().keyword()
+        ),
         Err(e) => format!(
             "Failed to save configuration to {}: {}\n",
             config.config_path.display(),
@@ -273,6 +289,26 @@ fn save(config: &ConfigManager) -> (ExecCode, String) {
         ),
     };
     (ExecCode::Show, output)
+}
+
+fn save(config: &ConfigManager) -> (ExecCode, String) {
+    save_reply(config, config.save_config())
+}
+
+fn save_cli(config: &ConfigManager) -> (ExecCode, String) {
+    save_reply(config, config.save_config_as(ConfigFormat::Cli))
+}
+
+fn save_formal(config: &ConfigManager) -> (ExecCode, String) {
+    save_reply(config, config.save_config_as(ConfigFormat::SetDelete))
+}
+
+fn save_json(config: &ConfigManager) -> (ExecCode, String) {
+    save_reply(config, config.save_config_as(ConfigFormat::Json))
+}
+
+fn save_yaml(config: &ConfigManager) -> (ExecCode, String) {
+    save_reply(config, config.save_config_as(ConfigFormat::Yaml))
 }
 
 fn clear_isis_spf(_config: &ConfigManager) -> (ExecCode, String) {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1117,9 +1117,24 @@ impl ConfigManager {
     ///
     /// The serialization is [`Self::config_format`] — the format the
     /// file was loaded in — so the round trip preserves the operator's
-    /// choice instead of rewriting every config file as CLI.
+    /// choice instead of rewriting every config file as CLI. The bare
+    /// `save` command lands here; `save { cli | formal | json | yaml }`
+    /// goes through [`Self::save_config_as`] to convert the file.
     pub fn save_config(&self) -> std::io::Result<&Path> {
-        let output = self.serialize_running(*self.config_format.borrow());
+        // Copy the format out before the call: `save_config_as` takes
+        // `config_format` mutably on success, and a live `Ref` held
+        // across the call would make that a `BorrowMutError` panic.
+        let format = *self.config_format.borrow();
+        self.save_config_as(format)
+    }
+
+    /// Write the running config in `format`, and on success adopt it as
+    /// [`Self::config_format`] so later bare `save`s keep the operator's
+    /// new choice. Adopted only on success: while the write is failing
+    /// the file on disk is still in its old format, and the remembered
+    /// format is supposed to describe that file.
+    pub fn save_config_as(&self, format: ConfigFormat) -> std::io::Result<&Path> {
+        let output = self.serialize_running(format);
 
         let mut tmp = self.config_path.clone().into_os_string();
         tmp.push(".tmp");
@@ -1138,7 +1153,10 @@ impl ConfigManager {
         });
 
         match write {
-            Ok(()) => Ok(&self.config_path),
+            Ok(()) => {
+                *self.config_format.borrow_mut() = format;
+                Ok(&self.config_path)
+            }
             Err(e) => {
                 // Don't leave the half-written sibling behind for the
                 // operator to trip over on the next `ls`.
@@ -1857,6 +1875,21 @@ pub enum ConfigFormat {
     SetDelete,
 }
 
+impl ConfigFormat {
+    /// CLI spelling of the format: the keyword `save <format>` takes and
+    /// the name the `save` reply reports back. `SetDelete` is spelled
+    /// `formal`, matching `show running-config formal` — the operator
+    /// never sees the internal name.
+    pub fn keyword(self) -> &'static str {
+        match self {
+            ConfigFormat::Cli => "cli",
+            ConfigFormat::Json => "json",
+            ConfigFormat::Yaml => "yaml",
+            ConfigFormat::SetDelete => "formal",
+        }
+    }
+}
+
 pub fn config_format_type(config_str: &str) -> ConfigFormat {
     // Use the first *meaningful* line for format sniffing. Skip
     // blank lines and `#`-prefixed comments so leading whitespace
@@ -2273,6 +2306,55 @@ mod save_config_tests {
 
             let _ = std::fs::remove_file(&path);
         }
+    }
+
+    /// `save <format>` converts the file *and* sticks: the next bare
+    /// `save` must keep writing the format the operator picked, not
+    /// revert to the one the file was loaded in.
+    #[test]
+    fn save_as_converts_the_file_and_sticks() {
+        let path = temp_path("convert");
+        std::fs::write(&path, "system {\n  hostname r1;\n}\n").expect("seed config written");
+
+        let cm = manager_with_config(&path);
+        cm.load_config();
+        assert_eq!(*cm.config_format.borrow(), ConfigFormat::Cli);
+
+        cm.save_config_as(ConfigFormat::Yaml).expect("save yaml");
+        let saved = std::fs::read_to_string(&path).expect("config readable");
+        assert_eq!(config_format_type(&saved), ConfigFormat::Yaml, "{saved:?}");
+        assert_eq!(*cm.config_format.borrow(), ConfigFormat::Yaml);
+
+        // Bare `save` now keeps YAML.
+        cm.save_config().expect("bare save");
+        let saved = std::fs::read_to_string(&path).expect("config readable");
+        assert_eq!(config_format_type(&saved), ConfigFormat::Yaml, "{saved:?}");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A `save <format>` that never reached disk must not switch the
+    /// remembered format: the file is still in its old format, and the
+    /// next bare `save` has to match the file, not the failed attempt.
+    #[test]
+    fn failed_save_as_keeps_the_previous_format() {
+        let path = temp_path("noconvert").join("zebra-rs.conf");
+
+        let cm = manager_with_config(&path);
+        cm.save_config_as(ConfigFormat::Yaml)
+            .expect_err("save fails");
+        assert_eq!(*cm.config_format.borrow(), ConfigFormat::Cli);
+    }
+
+    /// The `save` keyword for `SetDelete` is `formal`, matching
+    /// `show running-config formal` — the internal name never leaks to
+    /// the operator.
+    #[test]
+    fn format_keywords_are_the_cli_spellings() {
+        assert_eq!(ConfigFormat::Cli.keyword(), "cli");
+        assert_eq!(ConfigFormat::Json.keyword(), "json");
+        assert_eq!(ConfigFormat::Yaml.keyword(), "yaml");
+        assert_eq!(ConfigFormat::SetDelete.keyword(), "formal");
     }
 
     /// Nothing to load — a first boot on a box with no config file —

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -87,9 +87,31 @@ module configure {
     type empty;
   }
 
-  leaf save {
-    ext:help "Save config from file";
-    type empty;
+  // `save` alone writes the running config in whatever format the
+  // config file is already in (see `ConfigManager::config_format`); a
+  // format keyword writes that format instead and makes it the file's
+  // format from then on. Modeled as a presence container — the same
+  // shape `show running-config { formal | json | yaml }` uses in
+  // exec.yang — so the bare command stays a valid terminal.
+  container save {
+    ext:help "Save config to file";
+    presence "Save in the config file's current format";
+    leaf cli {
+      ext:help "Cisco-style indented block format";
+      type empty;
+    }
+    leaf formal {
+      ext:help "Set-style flat statement listing";
+      type empty;
+    }
+    leaf json {
+      ext:help "Pretty-printed JSON";
+      type empty;
+    }
+    leaf yaml {
+      ext:help "YAML";
+      type empty;
+    }
   }
 
   container clear {


### PR DESCRIPTION
## Summary

`save` could only write the format the config file already had (#2253),
so moving a router's config from the CLI brace format to YAML — or to
JSON for a tool that consumes it — meant editing the file behind the
daemon's back and reloading. The four formats are now keywords on the
command.

* `save <format>` writes that serialization and, **on success**, adopts it
  as the file's format, so every later bare `save` keeps it — the
  conversion is a one-time act, not something to repeat.
* Adoption is gated on the write succeeding: while a save is failing the
  file on disk is still in its old format, and the remembered format is
  supposed to describe that file.
* A bare `save` is unchanged — it keeps the current format.
* The keywords are the ones `show running-config` already uses, so
  `ConfigFormat::SetDelete` is spelled `formal` and the internal name never
  reaches the operator.
* In YANG this is the `show running-config` shape exactly — a presence
  container with four empty leaves — which keeps the bare `save` a valid
  terminal and gets `save <TAB>` listing the four plus `<cr>` for free.
* The reply names the format alongside the path, which also answers "what
  format is my config file in?" for a bare `save`.

## Test plan

New unit tests (`save_config_tests` is 8 cases now): a `save <format>`
converts the file *and* sticks for the next bare `save`; a failed
`save <format>` leaves the remembered format alone; the keyword mapping
pins `SetDelete` → `formal`.

Live daemon, every keyword:

```
host(config)# save              file stays CLI              ... (cli)
host(config)# save yaml         file converted to YAML      ... (yaml)
host(config)# save              still YAML                  ... (yaml)   <- sticks
host(config)# save json         { "system": { ... } }       ... (json)
host(config)# save formal       set system hostname r1      ... (formal)
host(config)# save cli          system { hostname r1; }     ... (cli)

host(config)# save <TAB>
cli       Cisco-style indented block format
formal    Set-style flat statement listing
json      Pretty-printed JSON
yaml      YAML
<cr>
```

A daemon restarted on a file converted to JSON came up with the identical
running config.

`cargo fmt --all --check` clean, workspace clippy clean,
`cargo test --workspace --exclude bdd` green (1950 in zebra-rs, 0 failures).

Follow-up to #2252 and #2253 (same `save` path).

Generated with [Claude Code](https://claude.com/claude-code)