### PR TITLE
vty: keep the exit-time commit prompt inside 80 columns

### DIFF
--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -157,13 +157,13 @@ asks:
 
 ```
 host# exit
-You have uncommitted changes. Commit? [y=commit, n=discard, other=leave pending]
+You have uncommitted changes. Commit? [y=commit n=discard other=keep]
 ```
 
-`y` commits, `n` discards, and anything else (including just pressing
-Enter, or waiting for the 30-second timeout) leaves the edits in the
-candidate for the next session. The shell exits in every case — the
-answer never cancels the exit.
+`y` commits, `n` discards, and anything else — `keep`, including just
+pressing Enter or waiting out the 30-second timeout — leaves the edits
+in the candidate for the next session. The shell exits in every case;
+the answer never cancels the exit.
 
 Three cases stay silent: a session that never entered configure mode, a
 session with no terminal to ask on (a script piping commands in), and a

--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -585,8 +585,10 @@ _cli_exit_hook ()
       # shell that has already decided to die — and further Ctrl-D
       # cannot break it. CLI_EXIT_PROMPT_TIMEOUT exists so the tests
       # don't have to wait out the default.
+      # Kept to 70 columns so an 80-column terminal has room for the
+      # answer instead of wrapping the question.
       read -t "${CLI_EXIT_PROMPT_TIMEOUT:-30}" -r -p \
-        "You have uncommitted changes. Commit? [y=commit, n=discard, other=leave pending] " ans
+        "You have uncommitted changes. Commit? [y=commit n=discard other=keep] " ans
       if [[ $? -gt 128 ]]; then
         # Timed out: leave the candidate alone and close the prompt line.
         echo >&2

--- a/vty/tests/exit-hook/run.py
+++ b/vty/tests/exit-hook/run.py
@@ -17,6 +17,7 @@ Usage: vty/tests/exit-hook/run.py [-v]
 import fcntl
 import os
 import pty
+import re
 import select
 import signal
 import subprocess
@@ -262,6 +263,17 @@ def case_no_tty():
     check("no tty skips the query", not r.called("-u"), str(r.calls))
 
 
+def case_prompt_width():
+    """80 columns is the floor to design for — the question is asked on
+    whatever terminal the operator happens to be leaving from, and a
+    prompt that wraps pushes the answer onto its own line."""
+    match = re.search(r'-r -p \\\n\s*"([^"]+)"', VTY_SH.read_text())
+    check("prompt string is findable", match is not None)
+    if match:
+        width = len(match.group(1))
+        check(f"prompt fits 80 columns (is {width})", width <= 80)
+
+
 def case_sighup():
     r = run(
         [ENTER_CONFIGURE],
@@ -287,6 +299,7 @@ def main():
         case_commit_denied,
         case_commit_validation_error,
         case_no_tty,
+        case_prompt_width,
         case_sighup,
     ):
         fn()


### PR DESCRIPTION
## Summary

The prompt added in #2255 was **81 characters** — one over the width every
terminal is guaranteed to have — so it wrapped and pushed the operator's answer
onto a line of its own:

```
-You have uncommitted changes. Commit? [y=commit, n=discard, other=leave pending]
+You have uncommitted changes. Commit? [y=commit n=discard other=keep]
```

Dropping the commas and shortening `other=leave pending` → `other=keep` takes
it to 70, leaving room for the reply. `n=discard` stays spelled out: that was
the point of the explicit legend, so nobody reads `n` as "leave my changes
alone" and loses them.

The exit-hook harness gained a width check that greps the string out of
`vty.sh` and fails over 80 columns, so this cannot drift back unnoticed.

## Test plan

* `vty/tests/exit-hook/run.py` — 27 checks green, including the new
  `prompt fits 80 columns (is 70)`. Confirmed non-vacuous: padding the string
  to 102 characters turns that check red.
* `bash -n vty/additions/vty.sh` clean.
* Docs updated to show the new prompt.

Follow-up to #2255.

Generated with [Claude Code](https://claude.com/claude-code)