### PR TITLE
playset: each node boots on its own --config-file, not vtyctl injection

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -3,9 +3,9 @@
 Playsets are self-contained demo labs for zebra-rs — a simple, easy way to
 experience cutting-edge routing technology. Each one builds a small network out
 of Linux network namespaces connected by veth pairs, runs a zebra-rs daemon in
-every node, injects per-node YAML configuration with `vtyctl apply -f
-<node>.yaml`, and walks through a feature in its README with real command output
-captured from a live run.
+every node with that node's `<node>.yaml` as its startup config
+(`zebra-rs --config-file`), and walks through a feature in its README with real
+command output captured from a live run.
 
 Sixteen walkthroughs in three series — [SR-MPLS & SRv6 with TI-LFA
 fast-reroute](#sr-mpls--srv6-with-ti-lfa-fast-reroute) (seven labs, one
@@ -19,7 +19,7 @@ against each other.
 
 ``` shell
 $ cd <playset-directory>
-$ ./up.sh        # create namespaces + links, start zebra-rs, apply configs
+$ ./up.sh        # create namespaces + links, start zebra-rs on each node's config
 $ ./down.sh      # stop the daemons and delete the namespaces
 ```
 
@@ -37,9 +37,40 @@ Linux tooling works inside the namespaces too — `ip route`, `tcpdump`,
 
 The daemon and CLI binaries are resolved from `target/debug/` when built,
 falling back to the installed ones on `PATH`. Each playset writes its
-runtime state (`*.log`, `*.pid`) into `/tmp/zebra-rs-playset/<playset-name>/`
-(override with `PLAYSET_RUN_DIR`), so the labs also run from a read-only
-install location such as `/usr/share/zebra-rs/playset`.
+runtime state (`*.log`, `*.pid`, and the config file each daemon actually
+loads) into `/tmp/zebra-rs-playset/<playset-name>/` (override with
+`PLAYSET_RUN_DIR`), so the labs also run from a read-only install location
+such as `/usr/share/zebra-rs/playset`.
+
+## Changing a node's configuration
+
+The config is yours to edit — every node boots from a real startup config
+file rather than having one injected after the fact. There are two ways in,
+and they meet in the same place:
+
+* **Before bring-up**, edit `<playset>/<node>.yaml`. `up.sh` copies each
+  one into the runtime directory and hands it to that node's daemon as
+  `--config-file`, so the next `./up.sh` comes up on your version.
+* **On a running lab**, configure it live and write it back:
+
+  ``` shell
+  $ sudo ip netns exec s vty
+  s>configure
+  s#set router isis interface s-n1 metric 50
+  s#commit
+  s#save
+  Configuration saved to /tmp/zebra-rs-playset/isis-srmpls/s.yaml (yaml)
+  ```
+
+  `save` targets the same `--config-file` the node booted from and keeps it
+  in the format it was loaded in — YAML stays YAML. (`save cli`, `save json`
+  and `save formal` convert it if you would rather read one of the others.)
+
+The runtime copy is re-seeded from `<playset>/<node>.yaml` on every
+`./up.sh`, so a lab always comes up as its README documents it. To keep a
+run's `save`d edits across a bring-up, set `PLAYSET_KEEP_CONFIG=1`. Note
+that the daemon runs as root, so a file it has saved over is root-owned —
+edit it through the vty, or with `sudo`.
 
 > **One at a time**: the TI-LFA playsets share the same topology and
 > namespace names (`s`, `n1`..`n3`, `r1`..`r3`, `d`, `e1`, `e2`), so bring

--- a/playset/bgp-evpn-mpls/README.md
+++ b/playset/bgp-evpn-mpls/README.md
@@ -35,8 +35,10 @@ loopbacks, pops it, exposing the service label to the egress PE.
 ```shell
 $ ./up.sh
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 (`up.sh` also turns kernel forwarding off on pe1/p/pe2 and computes TCP

--- a/playset/bgp-evpn-mpls6/README.md
+++ b/playset/bgp-evpn-mpls6/README.md
@@ -39,8 +39,10 @@ loopback, the P's eBPF stage pops it, pe2's stack receives it plain.
 ```shell
 $ ./up.sh
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 (`up.sh` also turns kernel forwarding off — both families — on pe1/p/pe2,

--- a/playset/bgp-evpn-srv6/README.md
+++ b/playset/bgp-evpn-srv6/README.md
@@ -29,8 +29,10 @@ kernel path stays inert.
 ```shell
 $ ./up.sh
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 ## Take a look at the YAML configuration

--- a/playset/bgp-evpn-vpws-mpls/README.md
+++ b/playset/bgp-evpn-vpws-mpls/README.md
@@ -36,8 +36,10 @@ reach it, and the data plane composes the two.
 ```shell
 $ ./up.sh
 ...
-apply config: c2
-applied
+seed config: c2
+...
+start zebra-rs: c2
+sleep 3sec
 ```
 
 (`up.sh` also turns kernel forwarding off on pe1/p/pe2 and computes TCP

--- a/playset/bgp-evpn-vpws-mpls6/README.md
+++ b/playset/bgp-evpn-vpws-mpls6/README.md
@@ -35,8 +35,10 @@ straight through the wire.
 ```shell
 $ ./up.sh
 ...
-apply config: c2
-applied
+seed config: c2
+...
+start zebra-rs: c2
+sleep 3sec
 ```
 
 ## Ping through the wire, then read the service back

--- a/playset/bgp-evpn-vpws-srv6/README.md
+++ b/playset/bgp-evpn-vpws-srv6/README.md
@@ -30,8 +30,10 @@ address and no bridge — they are pure attachment circuits.
 ```shell
 $ ./up.sh
 ...
-apply config: c2
-applied
+seed config: c2
+...
+start zebra-rs: c2
+sleep 3sec
 ```
 
 ## Take a look at the YAML configuration

--- a/playset/bgp-evpn-vpws-vxlan/README.md
+++ b/playset/bgp-evpn-vpws-vxlan/README.md
@@ -33,8 +33,10 @@ over the tee.
 ```shell
 $ ./up.sh
 ...
-apply config: c2
-applied
+seed config: c2
+...
+start zebra-rs: c2
+sleep 3sec
 ```
 
 ## Take a look at the YAML configuration

--- a/playset/bgp-evpn-vxlan4-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-ebpf/README.md
@@ -35,8 +35,10 @@ Two deliberate differences from the kernel twin:
 ```shell
 $ ./up.sh
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 ## Take a look at the YAML configuration

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/README.md
@@ -32,8 +32,10 @@ only where it exists, so neither VTEP ever learns the other's routes.
 ```shell
 $ ./up.sh
 ...
-apply config: h4
-applied
+seed config: h4
+...
+start zebra-rs: h4
+sleep 3sec
 ```
 
 ## Both tenants forward, and never into each other

--- a/playset/bgp-evpn-vxlan4-multi/README.md
+++ b/playset/bgp-evpn-vxlan4-multi/README.md
@@ -21,10 +21,10 @@ flood domain.
 $ ./up.sh
 bring up
 ...
-apply config: h3
-applied
-apply config: h4
-applied
+seed config: h4
+...
+start zebra-rs: h4
+sleep 3sec
 ```
 
 ## The multi-tenant VTEP configuration

--- a/playset/bgp-evpn-vxlan4/README.md
+++ b/playset/bgp-evpn-vxlan4/README.md
@@ -23,8 +23,10 @@ plumbing (VLAN-aware bridge, per-port tunnel mapping) plus every FDB entry
 $ ./up.sh
 bring up
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 ## Take a look at the YAML configuration

--- a/playset/bgp-evpn-vxlan6-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan6-ebpf/README.md
@@ -33,8 +33,10 @@ Same two deliberate differences from the kernel twin as
 ```shell
 $ ./up.sh
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 ## Ping, then look at what the engine built

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/README.md
@@ -33,8 +33,10 @@ only where it exists, so neither VTEP ever learns the other's routes.
 ```shell
 $ ./up.sh
 ...
-apply config: h4
-applied
+seed config: h4
+...
+start zebra-rs: h4
+sleep 3sec
 ```
 
 ## Both tenants forward, and never into each other

--- a/playset/bgp-evpn-vxlan6-multi/README.md
+++ b/playset/bgp-evpn-vxlan6-multi/README.md
@@ -23,10 +23,10 @@ from the VNI and its route-target, not from the underlay's address family
 $ ./up.sh
 bring up
 ...
-apply config: h3
-applied
-apply config: h4
-applied
+seed config: h4
+...
+start zebra-rs: h4
+sleep 3sec
 ```
 
 ## The multi-tenant VTEP over two IPv6 links

--- a/playset/bgp-evpn-vxlan6/README.md
+++ b/playset/bgp-evpn-vxlan6/README.md
@@ -21,8 +21,10 @@ underlay's address family.
 $ ./up.sh
 bring up
 ...
-apply config: h2
-applied
+seed config: h2
+...
+start zebra-rs: h2
+sleep 3sec
 ```
 
 ## What makes this the IPv6 version

--- a/playset/interas-option-a/README.md
+++ b/playset/interas-option-a/README.md
@@ -48,10 +48,10 @@ identical: a labeled path between the PE and ASBR loopbacks).
 $ ./up.sh
 bring up
 ...
-apply config: ce5
-applied
-apply config: ce6
-applied
+seed config: ce6
+...
+start zebra-rs: ce6
+sleep 3sec
 ```
 
 Thirteen namespaces: `ce1 ce2 ce3 pe1 pe2 p1 asbr1` + `asbr2 p2 pe3 ce4

--- a/playset/interas-option-ab/README.md
+++ b/playset/interas-option-ab/README.md
@@ -47,10 +47,10 @@ restored at both borders.
 $ ./up.sh
 bring up
 ...
-apply config: ce5
-applied
-apply config: ce6
-applied
+seed config: ce6
+...
+start zebra-rs: ce6
+sleep 3sec
 ```
 
 Same thirteen namespaces as the A/B labs — bring up only one Inter-AS

--- a/playset/interas-option-b/README.md
+++ b/playset/interas-option-b/README.md
@@ -43,10 +43,10 @@ diff cleanly:
 $ ./up.sh
 bring up
 ...
-apply config: ce5
-applied
-apply config: ce6
-applied
+seed config: ce6
+...
+start zebra-rs: ce6
+sleep 3sec
 ```
 
 Same thirteen namespaces as Option A (`ce1 ce2 ce3 pe1 pe2 p1 asbr1` +

--- a/playset/interas-option-c-rr/README.md
+++ b/playset/interas-option-c-rr/README.md
@@ -43,10 +43,10 @@ walkthrough proves both halves.
 $ ./up.sh
 bring up
 ...
-apply config: ce5
-applied
-apply config: ce6
-applied
+seed config: ce6
+...
+start zebra-rs: ce6
+sleep 3sec
 ```
 
 Fifteen namespaces — the thirteen from the Option A/B labs plus `rr1` and

--- a/playset/interas-option-c/README.md
+++ b/playset/interas-option-c/README.md
@@ -38,10 +38,10 @@ Deliberate choices carried over from A and B:
 $ ./up.sh
 bring up
 ...
-apply config: ce3
-applied
-apply config: ce4
-applied
+seed config: ce4
+...
+start zebra-rs: ce4
+sleep 3sec
 ```
 
 Same ten namespaces as Options A and B — bring up only one Inter-AS lab

--- a/playset/isis-flexalgo/README.md
+++ b/playset/isis-flexalgo/README.md
@@ -8,8 +8,8 @@ link, so traffic between Tokyo and the United States is forced the long way
 round — through Asia and Europe — while algorithm 0 keeps using the direct
 Pacific crossing.
 
-Each node runs zebra-rs in its own network namespace, and its YAML
-configuration is injected with the `vtyctl apply` command.
+Each node runs zebra-rs in its own network namespace, and loads its own
+`<node>.yaml` at startup via the `--config-file` argument.
 
 ## Topology
 

--- a/playset/isis-flexalgo/README.md
+++ b/playset/isis-flexalgo/README.md
@@ -47,8 +47,8 @@ after. Every link has metric 10, and the full link list is in the appendix.
 
 ## Bring up all nodes
 
-`./up.sh` sets up all namespaces, starts the zebra-rs routing daemon in each
-of them, and injects the initial configuration.
+`./up.sh` sets up all namespaces, seeds each node's config file, and starts
+the zebra-rs routing daemon in each of them on its own `--config-file`.
 
 ``` shell
 $ ./up.sh
@@ -57,6 +57,10 @@ runtime dir: /tmp/zebra-rs-playset/isis-flexalgo
 teardown: stop zebra-rs
 teardown: delete namespace se
 teardown: delete namespace sj
+...
+cleanup run dir
+seed config: se
+seed config: sj
 ...
 create namespace: sg
 create namespace: sy
@@ -69,10 +73,8 @@ create link: sj-sy (sj) <-> sy-sj (sy)
 start zebra-rs: ch
 start zebra-rs: da
 ...
-apply config: sy
-applied
-apply config: tk
-applied
+start zebra-rs: tk
+sleep 3sec
 ```
 
 You can then list the namespaces:

--- a/playset/isis-srmpls/README.md
+++ b/playset/isis-srmpls/README.md
@@ -13,8 +13,8 @@ its own `<node>.yaml` at startup via the `--config-file` argument.
 
 ## Bring up all nodes
 
-`./up.sh` sets up all namespaces, starts the zebra-rs routing daemon in each
-of them, and injects the initial configuration.
+`./up.sh` sets up all namespaces, seeds each node's config file, and starts
+the zebra-rs routing daemon in each of them on its own `--config-file`.
 
 ``` shell
 $ ./up.sh
@@ -24,10 +24,10 @@ teardown: delete namespace e1
 teardown: delete namespace e2
 teardown: delete namespace s
 ...
-apply config: r3
-applied
-apply config: d
-applied
+seed config: d
+...
+start zebra-rs: d
+sleep 3sec
 ```
 
 You can then list the namespaces:

--- a/playset/isis-srmpls/README.md
+++ b/playset/isis-srmpls/README.md
@@ -4,8 +4,8 @@ This playset demonstrates IS-IS SR-MPLS with TI-LFA fast reroute. Every core
 node has a loopback address with a Prefix-SID index, so every node can reach
 every other node's loopback over an SR-MPLS label-switched path. The topology
 follows the example in the TI-LFA specification (RFC 9855). All core and edge
-nodes run in separate network namespaces. Each node runs zebra-rs, and its
-YAML configuration is injected with the `vtyctl apply` command.
+nodes run in separate network namespaces. Each node runs zebra-rs, and loads
+its own `<node>.yaml` at startup via the `--config-file` argument.
 
 ## Topology
 
@@ -152,10 +152,17 @@ hop, so it pops the label and delivers a plain IP packet to `d`).
 
 ## Take a look at the YAML configuration
 
-Node `s`'s configuration is in `s.yaml`. After zebra-rs for namespace `s` has
-been launched, the YAML configuration below is applied to it with `vtyctl
-apply -f s.yaml`. If you are familiar with Kubernetes, this is exactly the
-same idea as `kubectl apply -f config.yaml`.
+Node `s`'s configuration is in `s.yaml`, and zebra-rs for namespace `s` is
+launched with it: `zebra-rs --config-file s.yaml`. It is an ordinary startup
+config — the daemon loads it at boot, and `save` in the vty writes the
+running config straight back to it, still as YAML. Edit it and re-run
+`./up.sh` to bring the lab up your way.
+
+(The same document can also be streamed into a *running* daemon with
+`vtyctl apply -f s.yaml` — if you are familiar with Kubernetes, that is
+exactly the same idea as `kubectl apply -f config.yaml`. That is config
+injection rather than the node's own config file, so it deliberately does
+not change what `save` writes.)
 
 ``` yaml
 interface:

--- a/playset/isis-srv6-classic/README.md
+++ b/playset/isis-srv6-classic/README.md
@@ -32,10 +32,10 @@ playsets — bring up one of them at a time.
 $ ./up.sh
 bring up
 ...
-apply config: r3
-applied
-apply config: d
-applied
+seed config: d
+...
+start zebra-rs: d
+sleep 3sec
 ```
 
 ## Examine routes on node `s`

--- a/playset/isis-srv6-classic/README.md
+++ b/playset/isis-srv6-classic/README.md
@@ -15,7 +15,7 @@ There are no labels anywhere: steady-state core forwarding is plain IPv6,
 service traffic is IPv6-in-IPv6 (H.Encaps), and the TI-LFA repair is an SRH
 (Segment Routing Header) *inserted* into the packet in flight. All core and
 edge nodes run in separate network namespaces; each node runs zebra-rs and
-its YAML configuration is injected with `vtyctl apply`.
+loads its own `<node>.yaml` at startup via `--config-file`.
 
 ## Topology
 
@@ -118,7 +118,8 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
 
 ## Take a look at the YAML configuration
 
-Node `s`'s configuration (`s.yaml`), applied with `vtyctl apply -f s.yaml`:
+Node `s`'s configuration (`s.yaml`), loaded at startup with
+`zebra-rs --config-file s.yaml`:
 
 ``` yaml
 system:

--- a/playset/lib/common.sh
+++ b/playset/lib/common.sh
@@ -7,9 +7,10 @@ set -euo pipefail
 
 PLAYSET_ROOT="$(cd "${PLAYSET_DEMO_DIR}/.." && pwd)"
 
-# Runtime state (*.pid, *.log) lives outside the demo directory so the labs
-# also run from a read-only install location such as
-# /usr/share/zebra-rs/playset. Override with PLAYSET_RUN_DIR.
+# Runtime state (*.pid, *.log, and each router's startup config) lives
+# outside the demo directory so the labs also run from a read-only install
+# location such as /usr/share/zebra-rs/playset. Override with
+# PLAYSET_RUN_DIR.
 : "${PLAYSET_RUN_DIR:=/tmp/zebra-rs-playset/$(basename "${PLAYSET_DEMO_DIR}")}"
 mkdir -p "${PLAYSET_RUN_DIR}"
 
@@ -23,6 +24,14 @@ run_in_netns() {
     run ip netns exec "$netns" "$@"
 }
 
-playset_cleanup_logs() {
+# Wipe the previous run's state. The seeded startup configs go with it:
+# `up.sh` re-seeds them from the demo directory, so the lab always comes up
+# as its README documents it and a `save` made during the last run is
+# deliberately not carried over. Set PLAYSET_KEEP_CONFIG=1 to keep the
+# copies (and the edits saved into them) across a bring-up.
+playset_cleanup_run_dir() {
     rm -f "${PLAYSET_RUN_DIR}"/*.log "${PLAYSET_RUN_DIR}"/*.pid "${PLAYSET_RUN_DIR}"/nohup.out
+    if [[ "${PLAYSET_KEEP_CONFIG:-0}" != 1 ]]; then
+        rm -f "${PLAYSET_RUN_DIR}"/*.yaml
+    fi
 }

--- a/playset/lib/topology.sh
+++ b/playset/lib/topology.sh
@@ -37,11 +37,11 @@ playset_start_daemons() {
     done
 }
 
-playset_apply_configs() {
+playset_seed_configs() {
     local netns
     for netns in "${PLAYSET_ROUTERS[@]}"; do
-        echo "apply config: ${netns}"
-        playset_apply_config "$netns" "${PLAYSET_DEMO_DIR}/${netns}.yaml"
+        echo "seed config: ${netns}"
+        playset_seed_config "$netns"
     done
 }
 
@@ -49,12 +49,18 @@ playset_up() {
     echo "bring up"
     echo "runtime dir: ${PLAYSET_RUN_DIR}"
     playset_teardown
-    echo "cleanup logs"
-    playset_cleanup_logs
+    echo "cleanup run dir"
+    playset_cleanup_run_dir
+    # Seeded before the daemons start: each one loads its own config file
+    # at boot, so there is no injection step after they are up.
+    playset_seed_configs
     playset_create_namespaces
     playset_create_links
     playset_start_daemons
+    # Nothing left in the bring-up waits on this, but the labs that add
+    # steps after `playset_up` (kernel forwarding off, ethtool, ND warm-up
+    # pings) used to run a full config-apply cycle after the daemons came
+    # up. Keep the settle so their timing is unchanged.
     echo "sleep 3sec"
     sleep 3
-    playset_apply_configs
 }

--- a/playset/lib/zebra-rs.sh
+++ b/playset/lib/zebra-rs.sh
@@ -58,6 +58,48 @@ playset_pid_file() {
     echo "${PLAYSET_RUN_DIR}/${netns}.pid"
 }
 
+# The startup config the daemon in `netns` loads at boot — and the file
+# its `save` writes back to, since `--config-file` names both. It is a
+# copy under PLAYSET_RUN_DIR, never the demo directory's own <netns>.yaml:
+# the daemon runs as root and `save` replaces the file (create + rename),
+# and the demo directory may be the packaged, read-only
+# /usr/share/zebra-rs/playset tree. So the lab's YAML stays the pristine
+# source and this copy is what the running daemon owns.
+playset_config_file() {
+    local netns=$1
+    echo "${PLAYSET_RUN_DIR}/${netns}.yaml"
+}
+
+# Seed that copy from the demo directory. Plain `cp`, not `run cp`: the
+# file starts out owned by the invoking user, so it can be hand-edited
+# before the daemon has ever saved over it. A node with no YAML in the
+# demo directory is left without a config file and boots unconfigured.
+playset_seed_config() {
+    local netns=$1
+    local src="${PLAYSET_DEMO_DIR}/${netns}.yaml"
+    local dst
+    dst="$(playset_config_file "$netns")"
+    if [[ "${PLAYSET_KEEP_CONFIG:-0}" == 1 && -f "$dst" ]]; then
+        return 0
+    fi
+    if [[ -f "$src" ]]; then
+        cp "$src" "$dst"
+    fi
+}
+
+# `--config-file` for the daemon in `netns`, or nothing when the node has
+# no seeded config — an unconfigured daemon, which is what every node got
+# before the config file was handed to the daemon directly. Emitted as an
+# arg so `playset_start_zebra` can splice it in like the yang path.
+playset_zebra_rs_config_args() {
+    local netns=$1
+    local config
+    config="$(playset_config_file "$netns")"
+    if [[ -f "$config" ]]; then
+        echo "--config-file=${config}"
+    fi
+}
+
 playset_stop_zebra_daemon() {
     local pid_file=$1
     if [[ ! -f "$pid_file" ]]; then
@@ -84,16 +126,22 @@ playset_start_zebra() {
     local log_file pid_file
     log_file="${PLAYSET_RUN_DIR}/${netns}.log"
     pid_file="$(playset_pid_file "$netns")"
-    # shellcheck disable=SC2046 — the yang args are zero-or-one flag,
-    # deliberately word-split.
+    # shellcheck disable=SC2046 — the yang and config args are each a
+    # zero-or-one flag, deliberately word-split.
     run_in_netns "$netns" "$(playset_zebra_rs_bin)" \
         $(playset_zebra_rs_yang_args) \
+        $(playset_zebra_rs_config_args "$netns") \
         --daemon \
         --log-output=file \
         --log-file="$log_file" \
         --pid-file="$pid_file"
 }
 
+# Stream a config document into a running daemon. Bring-up no longer uses
+# this — each node loads its own `--config-file` at boot — but it stays the
+# way to inject a config mid-walkthrough, and the READMEs teach it.
+# Deliberately not the same thing as the startup config: `vtyctl apply` does
+# not change the file `save` writes to.
 playset_apply_config() {
     local netns=$1
     local config=$2

--- a/playset/ospfv2-srmpls/README.md
+++ b/playset/ospfv2-srmpls/README.md
@@ -8,8 +8,8 @@ RFC 8665's Extended Prefix / Extended Link Opaque LSAs instead of IS-IS
 sub-TLVs). Every core node advertises a Prefix-SID for its loopback, so any
 node can reach every other node's loopback over an SR-MPLS label-switched
 path. All core and edge nodes run in separate network namespaces. Each node
-runs zebra-rs, and its YAML configuration is injected with the `vtyctl
-apply` command.
+runs zebra-rs, and loads its own `<node>.yaml` at startup via the
+`--config-file` argument.
 
 ## Topology
 
@@ -17,18 +17,19 @@ apply` command.
 
 ## Bring up all nodes
 
-`./up.sh` sets up all namespaces, starts the zebra-rs routing daemon in each
-of them, and injects the initial configuration. Note that this playset and
-the IS-IS one use the same namespace names — bring up one of them at a time.
+`./up.sh` sets up all namespaces, seeds each node's config file, and starts
+the zebra-rs routing daemon in each of them on its own `--config-file`. Note
+that this playset and the IS-IS one use the same namespace names — bring up
+one of them at a time.
 
 ``` shell
 $ ./up.sh
 bring up
 ...
-apply config: r3
-applied
-apply config: d
-applied
+seed config: d
+...
+start zebra-rs: d
+sleep 3sec
 ```
 
 ## Examine routes on node `s`
@@ -90,10 +91,9 @@ full explanation of the recursive static.
 
 Node `s`'s configuration is in `s.yaml`, which its daemon loads at startup
 (`zebra-rs --config-file s.yaml`). The interface addressing, `system
-hostname`, and the recursive
-static route are identical to the IS-IS playset; only the `router` section
-differs — a single OSPF area 0, with every core link declared
-point-to-point and carrying an explicit `cost`:
+hostname`, and the recursive static route are identical to the IS-IS
+playset; only the `router` section differs — a single OSPF area 0, with
+every core link declared point-to-point and carrying an explicit `cost`:
 
 ``` yaml
 system:

--- a/playset/ospfv2-srmpls/README.md
+++ b/playset/ospfv2-srmpls/README.md
@@ -88,8 +88,9 @@ full explanation of the recursive static.
 
 ## Take a look at the YAML configuration
 
-Node `s`'s configuration is in `s.yaml` and is applied with `vtyctl apply -f
-s.yaml`. The interface addressing, `system hostname`, and the recursive
+Node `s`'s configuration is in `s.yaml`, which its daemon loads at startup
+(`zebra-rs --config-file s.yaml`). The interface addressing, `system
+hostname`, and the recursive
 static route are identical to the IS-IS playset; only the `router` section
 differs — a single OSPF area 0, with every core link declared
 point-to-point and carrying an explicit `cost`:

--- a/playset/ospfv3-srmpls/README.md
+++ b/playset/ospfv3-srmpls/README.md
@@ -11,7 +11,7 @@ label-switched paths. The edge story mirrors the
 *recursive IPv6 static route* whose nexthop is the remote loopback
 resolves through the SR-MPLS route and inherits its label stack. All core
 and edge nodes run in separate network namespaces; each node runs zebra-rs
-and its YAML configuration is injected with `vtyctl apply`.
+and loads its own `<node>.yaml` at startup via `--config-file`.
 
 ## Topology
 

--- a/playset/ospfv3-srmpls/README.md
+++ b/playset/ospfv3-srmpls/README.md
@@ -29,8 +29,10 @@ playsets — bring up one of them at a time.
 $ ./up.sh
 bring up
 ...
-apply config: d
-applied
+seed config: d
+...
+start zebra-rs: d
+sleep 3sec
 ```
 
 OSPFv3 full-mesh convergence takes a little longer than the v2/IS-IS labs;

--- a/playset/ospfv3-srv6-classic/README.md
+++ b/playset/ospfv3-srv6-classic/README.md
@@ -12,7 +12,7 @@ SID per adjacency, and — on the edge routers — an **End.DT6** service SID.
 The edge LANs are carried by iBGP between `s` and `d` as an SRv6
 IPv6-unicast service (RFC 9252); the core carries no edge state. All core
 and edge nodes run in separate network namespaces; each node runs zebra-rs
-and its YAML configuration is injected with `vtyctl apply`.
+and loads its own `<node>.yaml` at startup via `--config-file`.
 
 ## Topology
 

--- a/playset/ospfv3-srv6-classic/README.md
+++ b/playset/ospfv3-srv6-classic/README.md
@@ -29,10 +29,10 @@ names with the other SR playsets — bring up one of them at a time.
 $ ./up.sh
 bring up
 ...
-apply config: r3
-applied
-apply config: d
-applied
+seed config: d
+...
+start zebra-rs: d
+sleep 3sec
 ```
 
 OSPFv3 full-mesh convergence plus the iBGP session take a little while —


### PR DESCRIPTION
## What

`playset_up` started every daemon bare, slept three seconds, then pushed each node's YAML in with `vtyctl apply -f <node>.yaml`. That made the config something done *to* the lab from outside: the running daemon had no config file of its own, so `save` in the vty wrote to the default `/etc` path — nowhere near the YAML the operator had just been reading — and the only way to change a node was to edit the demo file and re-run the whole bring-up.

Hand each daemon the file instead. `--config-file` names both the startup load and the `save` target, and since the format is now remembered across a save (04a05350), a YAML lab stays YAML through a round trip. The injection step disappears from `playset_up`; the config lands in one commit at boot, before the three-second settle rather than after it.

## Where the file lives

The file the daemon gets is a copy under `PLAYSET_RUN_DIR`, never the demo directory's own `<node>.yaml`. `save` replaces the file as root, and the demo directory may be the packaged, read-only `/usr/share/zebra-rs/playset` tree — so the lab's YAML stays the pristine source and the copy is what the running daemon owns.

* Seeded with a plain `cp` (not `sudo`), so it starts out editable by the invoking user.
* Re-seeded on every `up.sh`, so a lab always comes up as its README documents it. `PLAYSET_KEEP_CONFIG=1` keeps a run's saved edits instead.
* `playset_cleanup_logs` clears the copies too, hence the rename to `playset_cleanup_run_dir`.

## Scope

`playset/lib/` only. All 28 labs keep their `topology.sh`, `up.sh`, `down.sh` and 221 node YAMLs byte for byte. `playset_apply_config` stays in the harness — bring-up no longer calls it, but it is still how a document is streamed into a running daemon mid-walkthrough, and `vtyctl apply` deliberately does not change what `save` writes.

Docs: `playset/README.md` gains a *Changing a node's configuration* section (edit-then-`up.sh`, or configure live and `save`); the 9 `vtyctl apply` mentions across 6 lab READMEs now describe the startup config. One stays on purpose — `isis-srmpls`'s `kubectl apply` analogy, rewritten to frame it as mid-lab injection.

## Verified live

The risk going in was config landing at boot before the RIB enumerates links — BDD only ever exercises `vtyctl apply`, so this is the first real test of `--config-file` carrying full interface config. It did not materialize.

* **isis-srmpls** — routing table matches the README line for line (prefix-SID labels, recursive static inheriting 16800), IS-IS neighbors up, e1→e2 ping passes.
* **Round trip** — `set router isis interface s-n1 metric 50` + `commit` re-runs SPF (paths shift off `s-n1`); `save` reports `…/s.yaml (yaml)` and writes `metric: 50` back as YAML, which then boots identically under `PLAYSET_KEEP_CONFIG=1`.
* **bgp-evpn-vxlan4-ebpf** — h1→h2 ping passes with `ip_forward=0` on both VTEPs and two cradle engines up; cradle now spawns at boot rather than 3s in.
* **interas-option-c-rr** (15 daemons) — converges across both ASes, ce1 and ce2 reach their site-B peers.
* `make -C packaging playset` (the CI `playset-assets` lane) passes; namespaces and daemons clean after every teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)