### PR TITLE
playset: point --config-file at the lab's own YAML so saves persist

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -37,20 +37,20 @@ Linux tooling works inside the namespaces too — `ip route`, `tcpdump`,
 
 The daemon and CLI binaries are resolved from `target/debug/` when built,
 falling back to the installed ones on `PATH`. Each playset writes its
-runtime state (`*.log`, `*.pid`, and the config file each daemon actually
-loads) into `/tmp/zebra-rs-playset/<playset-name>/` (override with
-`PLAYSET_RUN_DIR`), so the labs also run from a read-only install location
-such as `/usr/share/zebra-rs/playset`.
+runtime state (`*.log`, `*.pid`) into `/tmp/zebra-rs-playset/<playset-name>/`
+(override with `PLAYSET_RUN_DIR`), so a run leaves nothing behind but the
+config each node was given.
 
 ## Changing a node's configuration
 
 The config is yours to edit — every node boots from a real startup config
-file rather than having one injected after the fact. There are two ways in,
-and they meet in the same place:
+file rather than having one injected after the fact, and that file is the
+lab's own `<playset>/<node>.yaml`. There are two ways in, and they meet in
+the same place:
 
-* **Before bring-up**, edit `<playset>/<node>.yaml`. `up.sh` copies each
-  one into the runtime directory and hands it to that node's daemon as
-  `--config-file`, so the next `./up.sh` comes up on your version.
+* **Before bring-up**, edit `<playset>/<node>.yaml`. `up.sh` hands it to
+  that node's daemon as `--config-file`, so the lab comes up on your
+  version.
 * **On a running lab**, configure it live and write it back:
 
   ``` shell
@@ -59,18 +59,23 @@ and they meet in the same place:
   s#set router isis interface s-n1 metric 50
   s#commit
   s#save
-  Configuration saved to /tmp/zebra-rs-playset/isis-srmpls/s.yaml (yaml)
+  Configuration saved to /usr/share/zebra-rs/playset/isis-srmpls/s.yaml (yaml)
   ```
 
-  `save` targets the same `--config-file` the node booted from and keeps it
-  in the format it was loaded in — YAML stays YAML. (`save cli`, `save json`
-  and `save formal` convert it if you would rather read one of the others.)
+  `save` targets the same `--config-file` the node booted from — the lab's
+  own YAML — and keeps it in the format it was loaded in, so YAML stays
+  YAML. (`save cli`, `save json` and `save formal` convert it if you would
+  rather read one of the others.)
 
-The runtime copy is re-seeded from `<playset>/<node>.yaml` on every
-`./up.sh`, so a lab always comes up as its README documents it. To keep a
-run's `save`d edits across a bring-up, set `PLAYSET_KEEP_CONFIG=1`. Note
-that the daemon runs as root, so a file it has saved over is root-owned —
-edit it through the vty, or with `sudo`.
+Either way the change is **persistent**: it is in the lab's file, so the
+next `./up.sh` comes up on it. Two things follow from the daemon being the
+one that writes it. It runs as root, so a node's YAML is root-owned once
+saved — edit it through the vty, or with `sudo`. And the running config is
+re-serialized rather than textually patched, so a saved file comes back
+normalized (leaf-lists as sequences, keys in schema order) even where
+nothing changed; in a git checkout that shows up as a modified file. To put
+a lab back the way it shipped, restore its YAML — `git checkout --
+<playset>/` in a checkout, or reinstall the package.
 
 > **One at a time**: the TI-LFA playsets share the same topology and
 > namespace names (`s`, `n1`..`n3`, `r1`..`r3`, `d`, `e1`, `e2`), so bring

--- a/playset/bgp-evpn-mpls/README.md
+++ b/playset/bgp-evpn-mpls/README.md
@@ -35,8 +35,6 @@ loopbacks, pops it, exposing the service label to the egress PE.
 ```shell
 $ ./up.sh
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-mpls6/README.md
+++ b/playset/bgp-evpn-mpls6/README.md
@@ -39,8 +39,6 @@ loopback, the P's eBPF stage pops it, pe2's stack receives it plain.
 ```shell
 $ ./up.sh
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-srv6/README.md
+++ b/playset/bgp-evpn-srv6/README.md
@@ -29,8 +29,6 @@ kernel path stays inert.
 ```shell
 $ ./up.sh
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vpws-mpls/README.md
+++ b/playset/bgp-evpn-vpws-mpls/README.md
@@ -36,8 +36,6 @@ reach it, and the data plane composes the two.
 ```shell
 $ ./up.sh
 ...
-seed config: c2
-...
 start zebra-rs: c2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vpws-mpls6/README.md
+++ b/playset/bgp-evpn-vpws-mpls6/README.md
@@ -35,8 +35,6 @@ straight through the wire.
 ```shell
 $ ./up.sh
 ...
-seed config: c2
-...
 start zebra-rs: c2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vpws-srv6/README.md
+++ b/playset/bgp-evpn-vpws-srv6/README.md
@@ -30,8 +30,6 @@ address and no bridge — they are pure attachment circuits.
 ```shell
 $ ./up.sh
 ...
-seed config: c2
-...
 start zebra-rs: c2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vpws-vxlan/README.md
+++ b/playset/bgp-evpn-vpws-vxlan/README.md
@@ -33,8 +33,6 @@ over the tee.
 ```shell
 $ ./up.sh
 ...
-seed config: c2
-...
 start zebra-rs: c2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan4-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-ebpf/README.md
@@ -35,8 +35,6 @@ Two deliberate differences from the kernel twin:
 ```shell
 $ ./up.sh
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan4-multi-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan4-multi-ebpf/README.md
@@ -32,8 +32,6 @@ only where it exists, so neither VTEP ever learns the other's routes.
 ```shell
 $ ./up.sh
 ...
-seed config: h4
-...
 start zebra-rs: h4
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan4-multi/README.md
+++ b/playset/bgp-evpn-vxlan4-multi/README.md
@@ -21,8 +21,6 @@ flood domain.
 $ ./up.sh
 bring up
 ...
-seed config: h4
-...
 start zebra-rs: h4
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan4/README.md
+++ b/playset/bgp-evpn-vxlan4/README.md
@@ -23,8 +23,6 @@ plumbing (VLAN-aware bridge, per-port tunnel mapping) plus every FDB entry
 $ ./up.sh
 bring up
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan6-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan6-ebpf/README.md
@@ -33,8 +33,6 @@ Same two deliberate differences from the kernel twin as
 ```shell
 $ ./up.sh
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan6-multi-ebpf/README.md
+++ b/playset/bgp-evpn-vxlan6-multi-ebpf/README.md
@@ -33,8 +33,6 @@ only where it exists, so neither VTEP ever learns the other's routes.
 ```shell
 $ ./up.sh
 ...
-seed config: h4
-...
 start zebra-rs: h4
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan6-multi/README.md
+++ b/playset/bgp-evpn-vxlan6-multi/README.md
@@ -23,8 +23,6 @@ from the VNI and its route-target, not from the underlay's address family
 $ ./up.sh
 bring up
 ...
-seed config: h4
-...
 start zebra-rs: h4
 sleep 3sec
 ```

--- a/playset/bgp-evpn-vxlan6/README.md
+++ b/playset/bgp-evpn-vxlan6/README.md
@@ -21,8 +21,6 @@ underlay's address family.
 $ ./up.sh
 bring up
 ...
-seed config: h2
-...
 start zebra-rs: h2
 sleep 3sec
 ```

--- a/playset/interas-option-a/README.md
+++ b/playset/interas-option-a/README.md
@@ -48,8 +48,6 @@ identical: a labeled path between the PE and ASBR loopbacks).
 $ ./up.sh
 bring up
 ...
-seed config: ce6
-...
 start zebra-rs: ce6
 sleep 3sec
 ```

--- a/playset/interas-option-ab/README.md
+++ b/playset/interas-option-ab/README.md
@@ -47,8 +47,6 @@ restored at both borders.
 $ ./up.sh
 bring up
 ...
-seed config: ce6
-...
 start zebra-rs: ce6
 sleep 3sec
 ```

--- a/playset/interas-option-b/README.md
+++ b/playset/interas-option-b/README.md
@@ -43,8 +43,6 @@ diff cleanly:
 $ ./up.sh
 bring up
 ...
-seed config: ce6
-...
 start zebra-rs: ce6
 sleep 3sec
 ```

--- a/playset/interas-option-c-rr/README.md
+++ b/playset/interas-option-c-rr/README.md
@@ -43,8 +43,6 @@ walkthrough proves both halves.
 $ ./up.sh
 bring up
 ...
-seed config: ce6
-...
 start zebra-rs: ce6
 sleep 3sec
 ```

--- a/playset/interas-option-c/README.md
+++ b/playset/interas-option-c/README.md
@@ -38,8 +38,6 @@ Deliberate choices carried over from A and B:
 $ ./up.sh
 bring up
 ...
-seed config: ce4
-...
 start zebra-rs: ce4
 sleep 3sec
 ```

--- a/playset/isis-flexalgo/README.md
+++ b/playset/isis-flexalgo/README.md
@@ -47,8 +47,8 @@ after. Every link has metric 10, and the full link list is in the appendix.
 
 ## Bring up all nodes
 
-`./up.sh` sets up all namespaces, seeds each node's config file, and starts
-the zebra-rs routing daemon in each of them on its own `--config-file`.
+`./up.sh` sets up all namespaces and starts the zebra-rs routing daemon in
+each of them on that node's own `<node>.yaml` as `--config-file`.
 
 ``` shell
 $ ./up.sh
@@ -58,10 +58,7 @@ teardown: stop zebra-rs
 teardown: delete namespace se
 teardown: delete namespace sj
 ...
-cleanup run dir
-seed config: se
-seed config: sj
-...
+cleanup logs
 create namespace: sg
 create namespace: sy
 create namespace: tk

--- a/playset/isis-srmpls/README.md
+++ b/playset/isis-srmpls/README.md
@@ -13,8 +13,8 @@ its own `<node>.yaml` at startup via the `--config-file` argument.
 
 ## Bring up all nodes
 
-`./up.sh` sets up all namespaces, seeds each node's config file, and starts
-the zebra-rs routing daemon in each of them on its own `--config-file`.
+`./up.sh` sets up all namespaces and starts the zebra-rs routing daemon in
+each of them on that node's own `<node>.yaml` as `--config-file`.
 
 ``` shell
 $ ./up.sh
@@ -23,8 +23,6 @@ teardown: stop zebra-rs
 teardown: delete namespace e1
 teardown: delete namespace e2
 teardown: delete namespace s
-...
-seed config: d
 ...
 start zebra-rs: d
 sleep 3sec

--- a/playset/isis-srv6-classic/README.md
+++ b/playset/isis-srv6-classic/README.md
@@ -32,8 +32,6 @@ playsets — bring up one of them at a time.
 $ ./up.sh
 bring up
 ...
-seed config: d
-...
 start zebra-rs: d
 sleep 3sec
 ```

--- a/playset/lib/common.sh
+++ b/playset/lib/common.sh
@@ -7,10 +7,9 @@ set -euo pipefail
 
 PLAYSET_ROOT="$(cd "${PLAYSET_DEMO_DIR}/.." && pwd)"
 
-# Runtime state (*.pid, *.log, and each router's startup config) lives
-# outside the demo directory so the labs also run from a read-only install
-# location such as /usr/share/zebra-rs/playset. Override with
-# PLAYSET_RUN_DIR.
+# Runtime state (*.pid, *.log) lives outside the demo directory so a lab
+# run leaves nothing behind but the config each node was given. Override
+# with PLAYSET_RUN_DIR.
 : "${PLAYSET_RUN_DIR:=/tmp/zebra-rs-playset/$(basename "${PLAYSET_DEMO_DIR}")}"
 mkdir -p "${PLAYSET_RUN_DIR}"
 
@@ -24,14 +23,9 @@ run_in_netns() {
     run ip netns exec "$netns" "$@"
 }
 
-# Wipe the previous run's state. The seeded startup configs go with it:
-# `up.sh` re-seeds them from the demo directory, so the lab always comes up
-# as its README documents it and a `save` made during the last run is
-# deliberately not carried over. Set PLAYSET_KEEP_CONFIG=1 to keep the
-# copies (and the edits saved into them) across a bring-up.
-playset_cleanup_run_dir() {
+# Wipe the previous run's logs and pid files. The node configs are not in
+# here — they are the lab's own <node>.yaml, edited in place — so a config
+# saved from the vty survives every bring-up.
+playset_cleanup_logs() {
     rm -f "${PLAYSET_RUN_DIR}"/*.log "${PLAYSET_RUN_DIR}"/*.pid "${PLAYSET_RUN_DIR}"/nohup.out
-    if [[ "${PLAYSET_KEEP_CONFIG:-0}" != 1 ]]; then
-        rm -f "${PLAYSET_RUN_DIR}"/*.yaml
-    fi
 }

--- a/playset/lib/topology.sh
+++ b/playset/lib/topology.sh
@@ -37,23 +37,12 @@ playset_start_daemons() {
     done
 }
 
-playset_seed_configs() {
-    local netns
-    for netns in "${PLAYSET_ROUTERS[@]}"; do
-        echo "seed config: ${netns}"
-        playset_seed_config "$netns"
-    done
-}
-
 playset_up() {
     echo "bring up"
     echo "runtime dir: ${PLAYSET_RUN_DIR}"
     playset_teardown
-    echo "cleanup run dir"
-    playset_cleanup_run_dir
-    # Seeded before the daemons start: each one loads its own config file
-    # at boot, so there is no injection step after they are up.
-    playset_seed_configs
+    echo "cleanup logs"
+    playset_cleanup_logs
     playset_create_namespaces
     playset_create_links
     playset_start_daemons

--- a/playset/lib/zebra-rs.sh
+++ b/playset/lib/zebra-rs.sh
@@ -58,39 +58,25 @@ playset_pid_file() {
     echo "${PLAYSET_RUN_DIR}/${netns}.pid"
 }
 
-# The startup config the daemon in `netns` loads at boot — and the file
-# its `save` writes back to, since `--config-file` names both. It is a
-# copy under PLAYSET_RUN_DIR, never the demo directory's own <netns>.yaml:
-# the daemon runs as root and `save` replaces the file (create + rename),
-# and the demo directory may be the packaged, read-only
-# /usr/share/zebra-rs/playset tree. So the lab's YAML stays the pristine
-# source and this copy is what the running daemon owns.
+# The startup config the daemon in `netns` loads at boot — and the file its
+# `save` writes back to, since `--config-file` names both. It is the lab's
+# own <netns>.yaml, in place: a config saved from the vty has to still be
+# there on the next `./up.sh`, and only the original file survives that.
+#
+# The daemon runs as root and `save` replaces the file (write sibling temp,
+# then rename), so a node that has been saved leaves its YAML owned by root
+# — and, in a git checkout, showing as modified, since the serializer
+# normalizes leaf-lists and key order. That is the cost of persistence; see
+# the "Changing a node's configuration" section in ../README.md.
 playset_config_file() {
     local netns=$1
-    echo "${PLAYSET_RUN_DIR}/${netns}.yaml"
+    echo "${PLAYSET_DEMO_DIR}/${netns}.yaml"
 }
 
-# Seed that copy from the demo directory. Plain `cp`, not `run cp`: the
-# file starts out owned by the invoking user, so it can be hand-edited
-# before the daemon has ever saved over it. A node with no YAML in the
-# demo directory is left without a config file and boots unconfigured.
-playset_seed_config() {
-    local netns=$1
-    local src="${PLAYSET_DEMO_DIR}/${netns}.yaml"
-    local dst
-    dst="$(playset_config_file "$netns")"
-    if [[ "${PLAYSET_KEEP_CONFIG:-0}" == 1 && -f "$dst" ]]; then
-        return 0
-    fi
-    if [[ -f "$src" ]]; then
-        cp "$src" "$dst"
-    fi
-}
-
-# `--config-file` for the daemon in `netns`, or nothing when the node has
-# no seeded config — an unconfigured daemon, which is what every node got
-# before the config file was handed to the daemon directly. Emitted as an
-# arg so `playset_start_zebra` can splice it in like the yang path.
+# `--config-file` for the daemon in `netns`, or nothing when the node has no
+# YAML — an unconfigured daemon, which is what every node got before the
+# config file was handed to the daemon directly. Emitted as an arg so
+# `playset_start_zebra` can splice it in like the yang path.
 playset_zebra_rs_config_args() {
     local netns=$1
     local config

--- a/playset/ospfv2-srmpls/README.md
+++ b/playset/ospfv2-srmpls/README.md
@@ -17,16 +17,14 @@ runs zebra-rs, and loads its own `<node>.yaml` at startup via the
 
 ## Bring up all nodes
 
-`./up.sh` sets up all namespaces, seeds each node's config file, and starts
-the zebra-rs routing daemon in each of them on its own `--config-file`. Note
+`./up.sh` sets up all namespaces and starts the zebra-rs routing daemon in
+each of them on that node's own `<node>.yaml` as `--config-file`. Note
 that this playset and the IS-IS one use the same namespace names — bring up
 one of them at a time.
 
 ``` shell
 $ ./up.sh
 bring up
-...
-seed config: d
 ...
 start zebra-rs: d
 sleep 3sec

--- a/playset/ospfv3-srmpls/README.md
+++ b/playset/ospfv3-srmpls/README.md
@@ -29,8 +29,6 @@ playsets — bring up one of them at a time.
 $ ./up.sh
 bring up
 ...
-seed config: d
-...
 start zebra-rs: d
 sleep 3sec
 ```

--- a/playset/ospfv3-srv6-classic/README.md
+++ b/playset/ospfv3-srv6-classic/README.md
@@ -29,8 +29,6 @@ names with the other SR playsets — bring up one of them at a time.
 $ ./up.sh
 bring up
 ...
-seed config: d
-...
 start zebra-rs: d
 sleep 3sec
 ```


### PR DESCRIPTION
## What

#2257 gave each node a real startup config but handed the daemon a **copy** under `PLAYSET_RUN_DIR`, deliberately re-seeded from the lab directory on every bring-up. That kept the shipped labs pristine at the cost of the thing the config file is for: a config saved from the vty lived in `/tmp` and was thrown away by the next `./up.sh`.

Name the lab's own `<playset>/<node>.yaml` instead. It is the file the README already tells you to read, `save` writes the running config back to it, and the next bring-up loads what you saved — the config is yours and it persists.

The seeding step, `PLAYSET_KEEP_CONFIG`, and the run-dir YAML sweep all go away with it. `PLAYSET_RUN_DIR` is back to just logs and pid files, and `playset_cleanup_run_dir` reverts to `playset_cleanup_logs`.

## Consequences, documented rather than worked around

Both follow from the daemon being the one that writes the file, and both are spelled out in `playset/README.md`:

* It runs as **root** and `save` replaces the file (temp + rename), so a saved node's YAML ends up root-owned.
* The running config is **re-serialized**, not textually patched, so a saved file comes back normalized (leaf-lists as sequences, keys in schema order) — in a git checkout that shows as a modified file even where nothing changed.

`git checkout -- <playset>/` puts a lab back the way it shipped, and works despite the root ownership since the directory is the user's (verified).

## READMEs

The `seed config:` lines added to 26 captured `up.sh` transcripts are gone again, `isis-flexalgo`'s is back to `cleanup logs`, and the three labs that described the harness in prose no longer mention seeding.

## Verified live

On `isis-srmpls` with a current build:

* the daemon boots on `--config-file=<repo>/playset/isis-srmpls/s.yaml`;
* `set router isis interface s-n1 metric 50` + `commit` + `save` reports that path and rewrites it **as YAML**;
* a full `./up.sh` cycle comes back up on the saved metric — every path via `s-n2`, `10.0.0.2/32` at cost 13 instead of 11.

Caught in passing: `target/debug` had been cleaned mid-session, so the first attempt silently ran the Aug-5 `bdd/.stage` binary, which predates 04a05350 and converted the YAML to brace format. The fallback chain worked as designed; the binary was just stale.

`make -C packaging playset` passes; namespaces and daemons clean after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)