### PR TITLE
isis: re-key BFD from the adjacency instead of the NFSM Up edge

### DIFF
--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use tokio::sync::mpsc::UnboundedSender;
 
+use crate::bfd::session::SessionKey;
 use crate::config::Args;
 use crate::context::Timer;
 use crate::isis::srv6::{ElibPool, function_addr, lib_addr};
@@ -53,6 +54,25 @@ pub struct Neighbor {
     //
     pub hold_time: u16,
     pub hold_timer: Option<Timer>,
+
+    /// The BFD `SessionKey` this adjacency is currently subscribed with,
+    /// or `None` while no session has been asked for.
+    ///
+    /// The subscribe used to be a pure edge action on the NFSM Up
+    /// transition, which silently did nothing when the key could not be
+    /// built yet — `bfd_session_key` needs BOTH our own interface address
+    /// (netlink `AddrAdd`) and the peer's (its IIH), and either can land
+    /// after the adjacency is already Up. Nothing retried, so the session
+    /// stayed absent for the life of the adjacency: `show bfd peers` empty
+    /// while the neighbour sat Up, recovering only on a link bounce.
+    ///
+    /// Tracking the key here turns the subscribe into a diff: every Hello
+    /// recomputes the desired key and dispatches when it differs from what
+    /// we hold, so a late address is picked up on the next IIH. It also
+    /// covers renumbering (`Some(old)` → `Some(new)`), which the edge
+    /// version left pinned to the stale session. Dropped with the
+    /// neighbour row in `nbr_hold_timer_expire`, so it cannot go stale.
+    pub bfd_key: Option<SessionKey>,
 
     /// Allocated End.X (adjacency) SID. Pair carries the ELIB function
     /// bits (so we can release them on neighbor down) and the full SID
@@ -118,6 +138,7 @@ impl Neighbor {
             mac,
             proto: None,
             hold_timer: None,
+            bfd_key: None,
             is_dis: false,
             circuit_id: None,
             hold_time: 0,

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -82,11 +82,28 @@ pub(super) fn bfd_session_key(
 /// `nfsm::nbr_hold_timer_expire(release_bfd=true)`, which fires only
 /// when the hold timer expires for a neighbour that *was* Up, and by
 /// `bfd_reconcile_all` on a config-change disable.
+/// **Why a diff and not the Up edge?** `bfd_session_key` needs a usable
+/// address *pair* — our own interface address (learned from netlink
+/// `AddrAdd`) and the peer's (learned from its IIH) — and either can
+/// arrive after the adjacency is already Up. The edge-triggered version
+/// returned early in that case and never ran again, so the session was
+/// never created at all: `show bfd peers` stayed empty under a neighbour
+/// sitting Up, recovering only when a link bounce re-fired the edge. It
+/// reproduced deterministically by bringing the adjacency up with no
+/// address on the link and adding one afterwards, and intermittently in
+/// CI, where netlink can lag adjacency formation under load.
+///
+/// Comparing against the key we actually subscribed with fixes both that
+/// and renumbering: this runs per-Hello, both address sources are
+/// refreshed by the caller before we are called, and a no-change Hello
+/// (the overwhelmingly common case) costs one comparison and sends
+/// nothing.
 fn bfd_nfsm_dispatch(
-    link: &super::link::LinkTop<'_>,
+    link: &mut super::link::LinkTop<'_>,
+    level: Level,
+    sys_id: &IsisSysId,
     peer_v4: Option<Ipv4Addr>,
     peer_v6ll: Option<Ipv6Addr>,
-    was_up: bool,
     state: NfsmState,
 ) {
     // Effective enable = per-interface `bfd {}` merged over the instance-level
@@ -94,12 +111,30 @@ fn bfd_nfsm_dispatch(
     if !link.config.bfd.resolve(&link.up_config.bfd).enable {
         return;
     }
-    let Some(key) = bfd_session_key(link, peer_v4, peer_v6ll) else {
+    // Only an Up adjacency wants a session. Deliberately no teardown on the
+    // other states — see the doc comment above on why Up→Init must leave the
+    // session probing.
+    if state != NfsmState::Up {
+        return;
+    }
+    // Computed before the `nbrs` borrow: `bfd_session_key` reads
+    // `link.state.v4addr` / `v6laddr` through a shared borrow of `link`.
+    let Some(desired) = bfd_session_key(link, peer_v4, peer_v6ll) else {
         return;
     };
-    if !was_up && state == NfsmState::Up {
-        let _ = link.tx.send(Message::BfdSubscribe(key));
+    let Some(nbr) = link.state.nbrs.get_mut(&level).get_mut(sys_id) else {
+        return;
+    };
+    if nbr.bfd_key.as_ref() == Some(&desired) {
+        return;
     }
+    // Renumbering: release the session keyed on the old address pair before
+    // asking for the new one, or the stale session keeps probing forever.
+    let stale = nbr.bfd_key.replace(desired);
+    if let Some(stale) = stale {
+        let _ = link.tx.send(Message::BfdUnsubscribe(stale));
+    }
+    let _ = link.tx.send(Message::BfdSubscribe(desired));
 }
 
 /// Kick the STAMP measurement reconcile on any NFSM transition that
@@ -598,7 +633,14 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
 
     // RFC 5882 §5 BFD attachment, post-FSM. nbr has been dropped so
     // we can read link.state.v4addr / link.config.bfd freely.
-    bfd_nfsm_dispatch(link, bfd_peer_v4, bfd_peer_v6ll, was_up, state);
+    bfd_nfsm_dispatch(
+        link,
+        level,
+        &pdu.source_id,
+        bfd_peer_v4,
+        bfd_peer_v6ll,
+        state,
+    );
     stamp_nfsm_dispatch(link, was_up, state);
 
     // CSNP + SRM kick on first RR. Deferred to here so we can take
@@ -825,7 +867,14 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // the LAN handler — defer until after the `nbr` mutable
         // borrow is gone so we can read link.state / link.config
         // freely.
-        bfd_nfsm_dispatch(link, bfd_peer_v4, bfd_peer_v6ll, was_up, state);
+        bfd_nfsm_dispatch(
+            link,
+            level,
+            &pdu.source_id,
+            bfd_peer_v4,
+            bfd_peer_v6ll,
+            state,
+        );
         stamp_nfsm_dispatch(link, was_up, state);
 
         // CSNP+SRM kick on first RR. P2P always wins the


### PR DESCRIPTION
## The bug

`bfd_nfsm_dispatch` subscribed only on the `!was_up && Up` transition, and returned early when `bfd_session_key` could not be built:

```rust
let Some(key) = bfd_session_key(link, peer_v4, peer_v6ll) else {
    return;                       // no subscribe — and the Up edge never fires again
};
```

That key needs a usable address **pair**: our own interface address (netlink `AddrAdd`) and the peer's (its IIH). IS-IS forms adjacencies at **L2**, so neither is a precondition for reaching Up, and either can land afterwards. When one was late the subscribe was silently skipped and **nothing retried** — the Up edge had already fired, and `addr_update` (the `AddrAdd` path) re-originates Hello and LSP but never touches BFD.

Result: the session did not exist for the life of the adjacency. `show bfd peers` empty under a neighbour sitting Up, recovering only when a link bounce re-fired the edge.

## The fix

Track the key we actually subscribed with on the neighbour (`Neighbor::bfd_key`) and dispatch on the diff. The caller already refreshes both address sources on every IIH, so a late address is picked up on the next Hello. A no-change Hello — the overwhelmingly common case — costs one comparison and sends nothing.

The same diff fixes **renumbering**: `Some(old)` → `Some(new)` now unsubscribes the stale session first, where the edge version left it pinned and probing forever.

Teardown semantics are unchanged: still no unsubscribe off the Up state, so the Up→Init 3-way case keeps its session probing to detect the peer's Down (the rationale already documented on this function).

## Why IS-IS only

This is the reconcile pattern **BGP** (`peer.bfd_session_key`, PR #1391) and **OSPF** (`Neighbor::bfd_session_key` + `bfd_reconcile_nbr`) already use. IS-IS was the last protocol on the edge trigger — and the only one where the BFD key and the adjacency have *independent* preconditions, which is why it was the only one that could lose the subscribe:

* OSPFv2 sources Hellos from the interface's IPv4 address and takes the neighbour's from the packet — no address, no neighbour to subscribe for.
* OSPFv3 keys on the link-local pair, present from the moment the link is up.
* OSPF also already calls `bfd_reconcile_link` from `addr_add`/`addr_del` (both families).

No OSPF or BGP change is needed; verified by reading those paths.

## How it was found

Two of three full BDD runs on one unchanged commit failed with an **empty peer list** in two *different* features (`isis_bfd_ipv4_p2p`, `isis_bfd_ipv4_lan`) — a family-level repeater, not the roaming load-margin floor. The assert already polls 60x1s (PR #2182), so a longer budget was never the fix.

## Verification

**Deterministic repro, no load needed** — bring an L2 p2p adjacency up with no address on the link, then add addresses at runtime:

| stage | before | after |
|:--|:--|:--|
| adjacency Up, no address | *No BFD sessions* | *No BFD sessions* |
| 40s after adding addresses | **still *No BFD sessions*** | **session `up`** |
| after a link bounce | session up | session up |

**Full BDD suite at c=16: 281 ran, 280 passed**, no leaks. All nine BFD-related features pass — `isis_bfd_ipv4_{p2p,lan}`, `isis_bfd_ipv6_{p2p,lan}`, `isis_tilfa_bfd`, `ospfv2_bfd_frr`, `ospfv3_bfd_frr`, `ecmp_bfd_evict`, `ospf_ecmp_bfd_evict` — and the `no Up BFD session … []` signature appears in no per-feature log. The single failure (`ospfv2_spf_interval`) is an unrelated bare-assert load flake this suite has produced before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)