### PR TITLE
bdd: poll the convergence asserts in two OSPFv2 features

### DIFF
--- a/bdd/tests/features/ospfv2_spf_interval.feature
+++ b/bdd/tests/features/ospfv2_spf_interval.feature
@@ -29,9 +29,15 @@ Feature: OSPFv2 adaptive SPF throttle (spf-interval)
     # by `show ospf`, proving the config reached the instance.
     Then show command "show ospf" in namespace "a" should contain "SPF timers: initial 100 ms, secondary 300 ms, maximum 4000 ms"
     # Adjacency forms and routes converge under the adaptive scheduler.
-    And show command "show ospf neighbor" in namespace "a" should contain "Full"
-    And show command "show ospf neighbor" in namespace "b" should contain "Full"
-    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    # These poll: the 20s wait above is a fixed budget, and under suite load
+    # the Hello/DD exchange has finished right at that boundary — leaving the
+    # route assert inside the configured 100 ms `initial-wait` SPF window,
+    # with the LSA installed and SPF dispatched but not yet complete. The
+    # `show ospf` assert above stays bare on purpose: it reads back config,
+    # which is present the moment the instance exists and never converges.
+    And show command "show ospf neighbor" in namespace "a" should eventually contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should eventually contain "Full"
+    And show command "show ospf route" in namespace "a" should eventually contain "10.0.0.2/32"
     And ping from "a" to "10.0.0.2" should succeed
 
   Scenario: Teardown topology

--- a/bdd/tests/features/ospfv2_stub_base.feature
+++ b/bdd/tests/features/ospfv2_stub_base.feature
@@ -54,20 +54,29 @@ Feature: OSPFv2 stub area drops Type-5 AS-External while keeping inter-area rout
 
     # --- Adjacencies are Full (the stub link only comes up when the
     #     E-bit matches between a and c). ---
-    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    # `Full` polls: the 60s wait above is a fixed budget, and under suite
+    # load the stub link has been caught still in Loading/DROther with one
+    # LSA outstanding. The neighbor-ID checks stay bare — an ID is listed
+    # from the moment the neighbor exists, so they assert membership, not
+    # convergence, and the polling `Full` above is what gates the state.
+    Then show command "show ospf neighbor" in namespace "a" should eventually contain "Full"
     And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
     And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.3"
-    And show command "show ospf neighbor" in namespace "c" should contain "Full"
+    And show command "show ospf neighbor" in namespace "c" should eventually contain "Full"
     And show command "show ospf neighbor" in namespace "c" should contain "10.0.0.1"
 
     # --- The backbone router a installs the Type-5 external. ---
-    And show command "show ospf route" in namespace "a" should contain "192.168.1.0/24"
+    And show command "show ospf route" in namespace "a" should eventually contain "192.168.1.0/24"
 
     # --- The stub router c learns the backbone loopback as an inter-area
     #     Type-3 summary (stub still floods Type-3 inward). ---
-    And show command "show ospf route" in namespace "c" should contain "10.0.0.2/32"
+    And show command "show ospf route" in namespace "c" should eventually contain "10.0.0.2/32"
     # --- But c must NOT learn the Type-5 external: stub areas exclude
     #     AS-External, and externals are not re-advertised as Type-3. ---
+    # Deliberately a bare `should not contain`: this is a steady-state
+    # invariant, not a convergence event, and an `eventually not` would
+    # weaken it. It is meaningful here precisely because the polling
+    # assert above has already proven c converged.
     And show command "show ospf route" in namespace "c" should not contain "192.168.1.0/24"
 
     # --- Reachability across the area boundary works (Type-3); the ABR,


### PR DESCRIPTION
Two features whose asserts on convergence state had no retry, so they lost a race under c=16 suite load. Both are the pattern PRs #2181 / #2182 established: convert to the existing `should eventually contain` step (60 x 1s, exits immediately on the common case, so it costs nothing when the lab is quick).

## `ospfv2_stub_base`

Line 60, a bare `should contain "Full"`, caught the stub-link neighbour at `Loading/DROther` with `RqstL 1` — mid-Loading, one LSA still outstanding. The scenario's fixed `I wait 60 seconds` is its whole budget. Four asserts converted: both `Full` checks and the two positive route checks.

## `ospfv2_spf_interval`

This one was chased all the way down, because it looked like a daemon bug: both adjacencies **Full**, yet `a`'s route table held only its own connected routes — the signature of an SPF scheduling stall or a permanent LSDB hole, and this tree has had both (#2250, #2251).

It is neither. Reproduced under artificial load with `router ospf tracing` on:

```
18:18:30.132428  [LSDB install_lsa]  b's Router-LSA installed
18:18:30.132444  [NFSM:State]        Loading -> Full
18:18:30.233127  [SPF] Calculation dispatched      <- +100 ms
18:18:30.233625  SPF calculation complete (8 us)
```

SPF was scheduled and ran exactly `initial-wait: 100` ms after the install — precisely what this feature configures and asserts. `a`'s LSDB held b's Router-LSA (seq `0x80000001`, age 0), the SPF gates read `inflight=false, pending=false`, and a recheck 30 s later showed the route present. Nothing was wedged; **no daemon fix is needed.**

What the test caught is that the adjacency reaches Full right at the fixed `I wait 20 seconds` boundary under load, leaving the route assert inside that 100 ms SPF window — an assert with zero grace over the very delay the feature exists to configure. Three asserts converted.

## Deliberately left bare

Per the trap that bit the #2181 wave — a polling assert passes vacuously against pre-existing state:

* **`show ospf` … "SPF timers: initial 100 ms, …"** (spf_interval) — reads back config, present the moment the instance exists. Never converges.
* **The neighbour-ID checks** `10.0.0.2` / `10.0.0.3` / `10.0.0.1` (stub_base) — an ID is listed from the moment the neighbour exists, so they assert membership, not convergence; the polling `Full` above them gates the state.
* **`show ospf route` in "c" should not contain "192.168.1.0/24"** (stub_base) — the point of the whole feature: a stub area must never learn the Type-5. A steady-state invariant, which `eventually not` would weaken. It stays meaningful precisely because the polling assert above it has already proven c converged.

## Verification

* Both features pass solo, and **every converted step was confirmed to actually execute** — cucumber silently skips a step matching no definition, so a green run alone would not prove the edits landed.
* `ospfv2_stub_base` has since passed two full c=16 suite runs, where it previously failed.

A side benefit: the bare `should contain` step dumps only the failing output, while `should eventually contain` calls `route_failure_diagnostics`. The next genuine failure in either feature will arrive with the LSDB attached instead of needing a repro cycle to get it.

Companion to #2259 (the IS-IS BFD daemon fix), split out so the daemon change is reviewed on its own. Independent — different files, no ordering requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)