### PR TITLE
bdd: poll the bring-up pings in ospfv2_bfd_frr

### DIFF
--- a/bdd/tests/features/ospfv2_bfd_frr.feature
+++ b/bdd/tests/features/ospfv2_bfd_frr.feature
@@ -62,8 +62,17 @@ Feature: OSPFv2 TI-LFA kernel-side fast-reroute on BFD failure
     Then kernel route "10.0.0.8" in namespace "s" should eventually contain "proto ospf"
     And bfd session in namespace "s" on interface "s-n1" should be up
     And show command "show ospf ti-lfa" in namespace "s" should contain "Adj-SID"
-    And ping from "s" to "10.0.0.8" should succeed
-    And ping from "d" to "10.0.0.1" should succeed
+    # These two poll. The gate above proves only that *s* installed its
+    # route; nothing there covers the ILMs on n1/r1-r3/d that the packet
+    # actually traverses, so at 30s the far end of an 8-node SR-MPLS ring
+    # can still be finishing. The single-shot form fired one 3-packet probe
+    # and failed a c=16 run here while the identical ping in the very next
+    # scenario succeeded seconds later on the same lab — a datapath that
+    # heals itself in that window was never wrong, just late.
+    # The later pings (post-switchover, post-restore) stay single-shot:
+    # convergence is already established by then.
+    And ping from "s" to "10.0.0.8" should eventually succeed
+    And ping from "d" to "10.0.0.1" should eventually succeed
 
   Scenario: BFD-down with the link up triggers the kernel-side switchover
     Given the test topology exists


### PR DESCRIPTION
## The failure

A c=16 suite run failed on line 65, `ping from "s" to "10.0.0.8" should succeed` — the last assert of the **bring-up** scenario, before any BFD-down is induced. Everything ahead of it passed:

```
kernel route 10.0.0.8 "proto ospf"      PASSED   (polling gate)
bfd session s-n1 up                     PASSED
show ospf ti-lfa contains "Adj-SID"     PASSED
ping s -> 10.0.0.8                      FAILED   <- forwarding
```

A control plane reporting converged while the datapath drops traffic is the signature of a **real** bug — a protection group pointing at a bad member, or a wrong label stack. This subsystem has had precisely that (#2144 / #2145, where zebra's RIB was correct and the kernel group was not). So this was investigated as a suspected forwarding bug, not assumed to be a flake.

## Why it is not one

**It self-heals in seconds.** When line 65 failed, cucumber skipped the rest of the scenario, and the *next* scenario re-pinged the same destination over the same path — and passed. No re-convergence, no config change, no intervention (`Given the test topology exists` is a bare existence check). A wrong nexthop group does not repair itself in that window.

**24 executions, zero reproductions:**

| condition | runs | failures |
|:--|:--|:--|
| solo, c=1 | 8 | 0 |
| solo + 14 busy threads (12 cores) | 10 | 0 |
| 15-feature batch at `--concurrency=16` | 6 rounds | 0 |

The batch peers were chosen for contention in this exact machinery: `isis_tilfa`, `ospfv2_tilfa`, `ospfv3_tilfa`, `isis_flex_srv6`, `isis_srv6_replace`, and both `*_ecmp_bfd_evict` features.

**Host-state poisoning ruled out** — the class that once made every PIM v4 payload assert fail while the control plane looked perfect (rp_filter inheritance, #2043). `netns::create` still zeroes `conf.{all,default}.rp_filter` at namespace creation, and no feature writes a host sysctl.

## What is actually fragile

```rust
netns::ping4(&scoped, &target, 3, 2)   // one 3-packet probe, no retry
```

Fired at a fixed 30 s mark across an **8-node SR-MPLS ring** — and the gate above it proves only that *s* installed its own route. Nothing there covers the ILMs on `n1`/`r1`–`r3`/`d` that the packet traverses, so the far end can still be finishing when the probe goes out.

## The change

Poll both bring-up pings. `should eventually succeed` exists for this, and its doc comment names the case — *"assertions that race protocol convergence — e.g. the reverse direction of a path right after topology bring-up"*. It retries 1 packet/second for 30 s and exits immediately on the common case, so it costs nothing when the lab is quick.

The post-switchover and post-restore pings (lines 70/82/88) **stay single-shot**: convergence is established by then, and those assert the switchover itself.

**If this recurs at c=16 with a 30 s polling ping, it is no longer a timing window and should be treated as a genuine forwarding bug.**

## Verification

Passes, and both converted steps were confirmed to *actually execute* — cucumber silently skips a step matching no definition, so a green run alone would not prove the edit landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)