### PR TITLE
bgp: pace the OpenSent redial with the idle-hold timer

### DIFF
--- a/bdd/tests/configs/bgp_opensent_redial/z1.yaml
+++ b/bdd/tests/configs/bgp_opensent_redial/z1.yaml
@@ -1,0 +1,25 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.40.1
+    neighbor:
+    # The DUT dials the scripted listener on h1 (which DOES listen on
+    # 179, unlike bgp_mp_reach_send.py), so no passive-mode here — we
+    # want this peer to be the active side that ends up in OpenSent.
+    #
+    # connect-retry-time is pinned high ON PURPOSE. The whole point of
+    # this feature is which timer paces the redial after a connection
+    # dies in OpenSent: the short idle-hold pacer (5s by default) or the
+    # ConnectRetryTimer. Pinning the latter to 120s puts the two an order
+    # of magnitude apart, so the assertion cannot be satisfied by the
+    # wrong one — and it keeps the test independent of whatever the
+    # ConnectRetryTime *default* happens to be.
+    - remote-address: 192.168.40.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 120

--- a/bdd/tests/features/bgp_opensent_redial.feature
+++ b/bdd/tests/features/bgp_opensent_redial.feature
@@ -1,0 +1,78 @@
+@serial
+@bgp_opensent_redial
+Feature: A BGP connection lost in OpenSent redials on the idle-hold pacer
+  As a network operator
+  I want a peer whose TCP connection dies after it has sent its OPEN to
+  redial on the short idle-hold pacer rather than the ConnectRetryTimer,
+  so a transient failure costs seconds instead of minutes.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   h1    │
+           │ zebra-rs│     │ scripted│
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │ 40.1/24 │     │ 40.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  `fsm_conn_fail`'s OpenSent arm used to restart the full
+  ConnectRetryTimer, while its Connect-state sibling `fsm_dial_fail` uses
+  the idle-hold pacer. A peer that lost its TCP after sending OPEN
+  therefore sat in Active for up to a ConnectRetryTime — two minutes on
+  the old 120s default — before trying again. In the wild that window is
+  reached by an RFC 4271 §6.8 collision, where the loser's connection dies
+  precisely after it has sent its OPEN.
+
+  h1 runs tests/scripts/bgp_opensent_reset.py, which makes that
+  non-deterministic case deterministic: it accepts the DUT's first
+  connection, waits for the OPEN so the DUT is provably in OpenSent, then
+  aborts with RST; every later connection it serves as a normal speaker.
+  So the time from reset to Established is exactly the redial pacer.
+
+  z1.yaml pins connect-retry-time to 120s, an order of magnitude above the
+  5s idle-hold default, so the 30s polling assert below can only be
+  satisfied by the idle-hold pacer — and the test does not depend on what
+  the ConnectRetryTime default happens to be.
+
+  Scenario: The session establishes after a reset taken in OpenSent
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.40.1/24" on bridge "br0"
+    And I create namespace "h1" with IP "192.168.40.2/24" on bridge "br0"
+    # The listener must be up before the DUT dials: a refused connect
+    # fails in Connect and takes the already-correct `fsm_dial_fail`
+    # path, which would let this pass regardless of the OpenSent arm.
+    And I spawn "timeout 300 python3 tests/scripts/bgp_opensent_reset.py 65002 192.168.40.2 192.168.40.2 /tmp/bgp_opensent_redial.state" in namespace "h1"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+    # The peer came back on the short pacer. With the ConnectRetryTimer
+    # pacing it instead, this is still ~90s away when the poll gives up.
+    Then BGP session in "z1" to "192.168.40.2" should eventually be "Established"
+    # ...and it came back *from OpenSent*. The script logs this line only
+    # after reading the DUT's OPEN, i.e. once the DUT has provably left
+    # Connect, and it only serves a session on the second connection — so
+    # reaching Established already implies the first was reset. Without
+    # this check a green run could mean the reset landed in Connect and
+    # the arm under test was never exercised. `I execute` fails the step
+    # on a non-zero exit, so grep is the assertion; no retry is needed
+    # because the Established poll above has already ordered it.
+    #
+    # Written `When`, not `And`: an `And` here would inherit the previous
+    # `Then` keyword, and `I execute` is registered only as a `when` step
+    # — the step would resolve to nothing at all.
+    When I execute "grep -q reset-in-opensent /tmp/bgp_opensent_redial.state" in namespace "h1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I execute "rm -f /tmp/bgp_opensent_redial.state" in namespace "h1"
+    And I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete namespace "h1"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/scripts/bgp_opensent_reset.py
+++ b/bdd/tests/scripts/bgp_opensent_reset.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Scripted BGP listener that fails the DUT's first connection *in OpenSent*.
+
+Regression harness for the OpenSent redial pacer. `fsm_conn_fail`'s
+OpenSent arm used to restart the full ConnectRetryTimer (120s by default,
+30s now) instead of the short idle-hold pacer its Connect-state sibling
+`fsm_dial_fail` uses, so a peer whose TCP died after it had sent its OPEN
+sat in Active for up to two minutes before redialling.
+
+Reproducing that state router-to-router is not deterministic — it needs a
+connection to die in the window between "TCP is up, OPEN sent" and "peer's
+OPEN received", which in the wild is a §6.8 collision. This script makes it
+deterministic:
+
+  connection 1  accept, wait for the DUT's OPEN so it is provably in
+                OpenSent, then abort with RST (SO_LINGER 0). The DUT takes
+                TcpConnectionFails *in OpenSent* — the arm under test.
+  connection 2+ behave as a real speaker: OPEN, then KEEPALIVE, and keep
+                answering, so the session establishes.
+
+So the time from the reset to Established is exactly the redial pacer.
+With the idle-hold pacer that is ~5s; with the ConnectRetryTimer it is 30s
+(or 120s before the default changed). The feature asserts Established
+inside a window between the two — see bgp_opensent_redial.feature, where
+the *fixed wait is the assertion* and must not be turned into a polling
+step.
+
+The DUT dials us, so this script listens on 179 and the neighbor needs no
+passive-mode (unlike bgp_mp_reach_send.py, which connects out).
+
+Usage: bgp_opensent_reset.py <local-as> <router-id> [listen-addr] [state-file]
+"""
+
+import os
+import socket
+import struct
+import sys
+import time
+
+MARKER = b"\xff" * 16
+MSG_OPEN, MSG_UPDATE, MSG_NOTIFICATION, MSG_KEEPALIVE = 1, 2, 3, 4
+CAP_MP, CAP_AS4 = 1, 65
+AFI_IP, SAFI_UNICAST = 1, 1
+HOLDTIME = 90
+
+
+def bgp_msg(msg_type, body):
+    return MARKER + struct.pack("!HB", 19 + len(body), msg_type) + body
+
+
+def open_msg(local_as, router_id):
+    caps = bytes([CAP_MP, 4]) + struct.pack("!HBB", AFI_IP, 0, SAFI_UNICAST)
+    caps += bytes([CAP_AS4, 4]) + struct.pack("!I", local_as)
+    opt = bytes([2, len(caps)]) + caps
+    my_as2 = local_as if local_as < 65536 else 23456  # AS_TRANS
+    body = struct.pack(
+        "!BHH4sB", 4, my_as2, HOLDTIME, socket.inet_aton(router_id), len(opt)
+    ) + opt
+    return bgp_msg(MSG_OPEN, body)
+
+
+def recv_exact(sock, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def read_msg(sock):
+    hdr = recv_exact(sock, 19)
+    if hdr is None:
+        return None
+    length, msg_type = struct.unpack("!HB", hdr[16:19])
+    body = recv_exact(sock, length - 19) if length > 19 else b""
+    if length > 19 and body is None:
+        return None
+    return msg_type, body
+
+
+def note(state_file, text):
+    """Append a progress line the feature (or a human) can read."""
+    print(text, flush=True)
+    if state_file:
+        with open(state_file, "a") as fh:
+            fh.write("%.3f %s\n" % (time.time(), text))
+
+
+def abort_connection(conn):
+    """Close with RST rather than FIN.
+
+    A graceful FIN is also a TcpConnectionFails for the DUT, but RST
+    removes any doubt about half-open lingering and gets the event to the
+    FSM immediately.
+    """
+    conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+    conn.close()
+
+
+def serve_session(conn, local_as, router_id, state_file):
+    """Full speaker: OPEN, KEEPALIVE, then answer keepalives forever."""
+    conn.sendall(open_msg(local_as, router_id))
+    conn.sendall(bgp_msg(MSG_KEEPALIVE, b""))
+    conn.settimeout(HOLDTIME)
+    while True:
+        msg = read_msg(conn)
+        if msg is None:
+            note(state_file, "peer closed the established connection")
+            return
+        msg_type, _body = msg
+        if msg_type == MSG_OPEN:
+            conn.sendall(bgp_msg(MSG_KEEPALIVE, b""))
+        elif msg_type == MSG_KEEPALIVE:
+            conn.sendall(bgp_msg(MSG_KEEPALIVE, b""))
+        elif msg_type == MSG_NOTIFICATION:
+            note(state_file, "peer sent NOTIFICATION; connection over")
+            return
+
+
+def main():
+    local_as = int(sys.argv[1])
+    router_id = sys.argv[2]
+    listen_addr = sys.argv[3] if len(sys.argv) > 3 else "0.0.0.0"
+    state_file = sys.argv[4] if len(sys.argv) > 4 else None
+    if state_file and os.path.exists(state_file):
+        os.remove(state_file)
+
+    lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    lsock.bind((listen_addr, 179))
+    lsock.listen(5)
+    note(state_file, "listening on %s:179" % listen_addr)
+
+    first = True
+    while True:
+        conn, peer = lsock.accept()
+        if first:
+            # Wait for the DUT's OPEN before resetting: that is the proof
+            # it has left Connect and is sitting in OpenSent, which is the
+            # state whose failure arm this exercises. Without this wait the
+            # reset could land while it is still in Connect and take the
+            # already-correct `fsm_dial_fail` path instead — the test would
+            # then pass no matter what OpenSent does.
+            conn.settimeout(30)
+            try:
+                msg = read_msg(conn)
+            except socket.timeout:
+                msg = None
+            if msg is not None and msg[0] == MSG_OPEN:
+                note(state_file, "reset-in-opensent %s" % (peer,))
+            else:
+                note(state_file, "no OPEN before reset (got %r) from %s" % (msg, peer))
+            abort_connection(conn)
+            first = False
+            continue
+        note(state_file, "accepting-session %s" % (peer,))
+        try:
+            serve_session(conn, local_as, router_id, state_file)
+        except (OSError, socket.timeout) as exc:
+            note(state_file, "session ended: %s" % exc)
+        finally:
+            conn.close()
+        # Exit once the served session ends rather than looping back to
+        # accept(). The feature only needs one session, and a listener
+        # that outlives its scenario keeps port 179 in a namespace that
+        # is about to be deleted — the next run's instance then dies on
+        # bind *after* clearing the state file, which reads as "the
+        # reset never happened". Deleting a namespace does not kill the
+        # processes inside it, so self-terminating is the reliable fix.
+        note(state_file, "listener exiting")
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2574,12 +2574,25 @@ pub fn fsm_conn_fail(peer: &mut Peer, conn: ConnTag) -> State {
     // connection succeeds — what differs is the pacer and whether we
     // keep accepting inbound connects in the meantime.
     match peer.state {
-        // OpenSent: restart the ConnectRetryTimer, keep listening,
-        // go to Active; the timer's Event::Start redials. Passive
-        // peers don't redial — they park in Active listening.
+        // OpenSent: keep listening and go to Active, with the redial
+        // paced by the idle-hold timer rather than the full
+        // ConnectRetryTime. RFC 4271 §8.2.2 says "restart the
+        // ConnectRetryTimer" here, and taking that literally left this
+        // path on the 120s default while its sibling — a dial that
+        // fails in Connect (`fsm_dial_fail`) — was already moved onto
+        // the 5s pacer by the crossed-SYN fix. OpenSent is if anything
+        // the more common half: in a collision the loser's connection
+        // dies *after* it sent an OPEN, so the peer that backs off is
+        // usually this one, and it then sat out up to two minutes
+        // before redialling while the winner waited. Observed as a
+        // BDD failure with the session Active, `uptime: never` and
+        // `connect_retry_timer_rem: 99`.
+        //
+        // Passive peers still don't redial — they park in Active
+        // listening.
         State::OpenSent => {
             if !peer.is_passive() {
-                peer.timer.connect_retry = Some(timer::start_connect_retry_timer(peer));
+                peer.timer.connect_retry = Some(timer::start_dial_retry_timer(peer));
             }
             State::Active
         }
@@ -3785,19 +3798,37 @@ mod fsm_idle_hold_tests {
         assert!(peer.timer.idle_hold_timer.is_some());
     }
 
-    /// RFC 4271 OpenSent TcpConnectionFails: restart the
-    /// ConnectRetryTimer, keep listening, go to Active — the timer's
-    /// Event::Start paces the redial.
+    /// RFC 4271 OpenSent TcpConnectionFails: keep listening and go to
+    /// Active with a redial pacer armed. The pacer is the *idle-hold*
+    /// interval, not the full ConnectRetryTime — asserted on the
+    /// remaining seconds, because arming the wrong one still leaves
+    /// the timer `is_some()` and would slip through a presence-only
+    /// check (which is exactly how this path stayed on 120s while its
+    /// `fsm_dial_fail` sibling moved to the short pacer).
     #[tokio::test]
-    async fn opensent_tcp_failure_goes_active_with_connect_retry() {
+    async fn opensent_tcp_failure_goes_active_with_short_redial_pacer() {
         let mut peer = test_peer(false);
         peer.state = State::OpenSent;
+        let idle_hold = peer.config.timer.idle_hold_time();
+        let connect_retry = peer.config.timer.connect_retry_time();
+        assert!(
+            idle_hold < connect_retry,
+            "test is meaningless unless the two intervals differ"
+        );
 
         let next = fsm_conn_fail(&mut peer, ConnTag::Primary);
         assert_eq!(next, State::Active);
+        let rem = peer
+            .timer
+            .connect_retry
+            .as_ref()
+            .expect("a redial pacer must be armed")
+            .rem_sec();
         assert!(
-            peer.timer.connect_retry.is_some(),
-            "ConnectRetryTimer must be restarted to pace the redial"
+            rem <= idle_hold,
+            "redial must be paced by the idle-hold interval ({idle_hold}s), got {rem}s \
+             (ConnectRetryTime is {connect_retry}s — arming that strands a collision \
+             loser in Active for minutes)"
         );
 
         peer.state = next;

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -53,11 +53,17 @@ impl Default for AdvInterval {
 impl Config {
     const DEFAULT_IDLE_HOLD_TIME: u64 = 5;
     const DEFAULT_HOLD_TIME: u64 = 180;
-    /// RFC 4271 §10 suggested default. This paces the Connect⇄Active
-    /// redial loop after a connection failure; set `timers
-    /// connect-retry-time` on the neighbor when a faster redial
-    /// cadence is wanted.
-    const DEFAULT_CONNECT_RETRY_TIME: u64 = 120;
+    /// Paces the Connect⇄Active redial loop after a connection
+    /// failure; set `timers connect-retry-time` on the neighbor to
+    /// override.
+    ///
+    /// RFC 4271 §10 suggests 120s. We use 30s, matching FRR's
+    /// `BGP_DEFAULT_CONNECT_RETRY` — two minutes is a long outage for
+    /// a session that is merely waiting to redial, and every other
+    /// redial path here is already paced by the much shorter
+    /// idle-hold timer. The RFC value is a suggestion, not a
+    /// conformance requirement.
+    const DEFAULT_CONNECT_RETRY_TIME: u64 = 30;
 
     pub fn idle_hold_time(&self) -> u64 {
         if let Some(idle_hold_time) = self.idle_hold_time {

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -1573,11 +1573,12 @@ mod tests {
         assert_eq!(peer.config.timer.idle_hold_time(), 1);
 
         // A neighbor with no `timers` block is untouched: all three fall
-        // through to the documented defaults (RFC 4271 §10 suggests 120s
-        // ConnectRetry; hold-time 180s; idle-hold 5s).
+        // through to the documented defaults (ConnectRetry 30s, matching
+        // FRR rather than the 120s RFC 4271 §10 suggests; hold-time 180s;
+        // idle-hold 5s).
         let peer = vrf.peers.get(&bare).expect("bare peer inserted");
         assert!(peer.config.timer.connect_retry_time.is_none());
-        assert_eq!(peer.config.timer.connect_retry_time(), 120);
+        assert_eq!(peer.config.timer.connect_retry_time(), 30);
         assert_eq!(peer.config.timer.hold_time(), 180);
         assert_eq!(peer.config.timer.idle_hold_time(), 5);
     }

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -238,8 +238,10 @@ module zebra-bgp-vrf {
           units "seconds";
           description
             "Time interval for the ConnectRetryTimer, pacing the
-             Connect/Active redial loop. Defaults to 120s (RFC 4271
-             §8.2.2) when unset.";
+             Connect/Active redial loop. Defaults to 30s when unset —
+             RFC 4271 §10 suggests 120s, but that is a suggestion and
+             two minutes is a long outage for a session that is only
+             waiting to redial; 30s matches FRR.";
           reference
             "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
              Section 8.2.2.";


### PR DESCRIPTION
## The bug

A TCP failure in **OpenSent** left the peer in `Active` behind the full ConnectRetryTime, while its sibling — a dial that fails in `Connect` (`fsm_dial_fail`) — has used the 5 s idle-hold pacer since the crossed-SYN fix (#1910). Every other state already falls through to `Idle`, which re-arms that same pacer, so OpenSent was the last path on the slow timer.

Found by triaging a `bgp_remove_private_as` failure in a full BDD run. The captured neighbor state is unambiguous:

```json
"state": "Active",  "uptime": "never",
"connect_retry_timer_rem": 99,     ← 99s left of 120
"idle_hold_timer_next": 5          ← the pacer, unused
```

The session had never come up and would not retry for another 99 seconds; the feature asserts at 20 s. Reproduced ~1 run in 16 under load.

OpenSent is if anything the *more* common half of the pair: in an RFC 4271 §6.8 collision the loser's connection dies **after** it has sent its OPEN, so the peer that backs off is usually this one.

## Checked against FRR rather than assumed

FRR's OpenSent + `TCP_connection_closed` is `{bgp_stop, Active}`, and its `Active` case arms `t_connect` with `v_connect` — the same shape as the code being changed, so the old behaviour was not unreasonable. Two details make it wrong for us anyway:

* **`BGP_DEFAULT_CONNECT_RETRY` is 30 in FRR**, not the RFC's 120 that zebra-rs used — FRR's worst case here was already 4× better.
* **FRR keeps the collision winner**: it NOTIFIEs the losing connection and lets the survivor reach Established, so it rarely needs this redial. `fsm_conn_fail` deliberately does the opposite — it closes the parked collision conn rather than promoting it — and justifies that in its own comment as costing *"one reconnect round-trip"*. A 120 s timer is not a round-trip. **This change makes the code match its own stated intent.**

RFC 4271 §8.2.2 does say "restart the ConnectRetryTimer" here, so the old code was conformant; the timer slot is unchanged and only the interval moves. Passive peers are untouched — they still park in Active listening with no pacer.

## Second commit: default ConnectRetryTime 120s → 30s

Matching FRR. The RFC value is a suggestion, and two minutes is a long outage for a session that is only waiting to redial.

Verified which default is actually **live**, because `ietf-bgp-common@2023-07-05.yang` declares `default "120"` on the same leaf and `config.yang` pulls that tree in via `uses "ietf-bgp:bgp"` — a YANG-applied default would have made the Rust constant dead code. Blackholing the SYN so the timer runs in `Connect`:

```
BGP state = Connect, up for never
Next connect retry timer fires in 26 seconds     (sampled ~4s in ⇒ armed at 30)
```

> **Reviewer note:** this half changes behaviour for every peer that does not override `connect-retry-time` — 128 of 149 BGP config dirs. Happy to split it out if you would rather it land separately from the FSM fix.

## New BDD: `bgp_opensent_redial`

The bug's natural trigger is a §6.8 collision, which a two-router topology will not produce on demand. `tests/scripts/bgp_opensent_reset.py` (stdlib only) makes it deterministic: accept the DUT's first connection, **wait for the OPEN** so the DUT is provably in OpenSent rather than Connect, then abort with RST; serve every later connection normally. The reset→Established interval is therefore exactly the redial pacer, and the script's own log shows it:

```
146.006 reset-in-opensent
151.009 accepting-session      ← 5.003s
```

`z1.yaml` pins `connect-retry-time: 120` on purpose — an order of magnitude above the 5 s idle-hold — so the assertion can only be satisfied by the correct timer, and the feature does not depend on whatever the default happens to be.

## Test plan

* **Unit, controlled both ways.** The existing test asserted only `connect_retry.is_some()` — exactly how this path stayed on 120 s while its sibling moved, since arming the wrong timer still satisfies presence. It now asserts `rem_sec()` against `idle_hold_time()`, and was verified non-vacuous by reinstating the old call (fails) and restoring the fix (passes).
* **BDD, controlled both ways.** Reinstating `start_connect_retry_timer` makes `bgp_opensent_redial` fail with the session stuck `Active`; restoring the fix passes 3/3, no leaks.
* **Full workspace suite: 2790 passed, 0 failed.** `materialize_peers_applies_configured_timers` pinned the old 120 and caught the default change — it reads the effective value through the accessor, which is why it fired. Updated.
* `cargo fmt` clean, workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)