### PR TITLE
ospfv3: re-run SPF when a neighbour's link-local moves

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -10220,6 +10220,35 @@ impl Ospf<Ospfv3> {
                 // configured.
                 self.bfd_reconcile_nbr(ifindex, nbr_router_id);
                 self.reconcile_endx_sid(ifindex, nbr_router_id);
+                // The RIB is a consumer too, and was the one missing
+                // here. `collect_v3_nexthops` reads the next hop from
+                // `nbr.ident.prefix`, so every installed route through
+                // this neighbor is keyed on the address that just
+                // moved — but only an SPF re-derives them.
+                //
+                // Nothing else reliably schedules that. The peer's
+                // Link-LSA change floods immediately and does trigger
+                // an SPF, while `ident.prefix` is not corrected until a
+                // Hello arrives from the new source, up to a
+                // HelloInterval later. Win that race and the routes are
+                // right; lose it and the LSA-driven SPF bakes in the
+                // dead address and no further SPF ever runs — the RIB
+                // and the kernel FIB keep pointing at an address the
+                // peer has deleted, indefinitely. Blackhole, not a
+                // cosmetic stale entry.
+                //
+                // Scheduling here closes the race from the other end:
+                // the address is already updated above, so the SPF this
+                // arms cannot observe the old value. It is the throttled
+                // scheduler, so a burst of renumbers coalesces, and
+                // `apply_routing_updates_v3` diffs the result — an SPF
+                // that changes nothing costs one comparison and emits no
+                // RIB message.
+                if let Some(area_id) = self.links.get(&ifindex).map(|link| link.area)
+                    && let Some(area) = self.areas.get_mut(area_id)
+                {
+                    Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
+                }
             }
             Message::DdRetransmit(ifindex, router_id) => {
                 self.process_dd_retransmit(ifindex, router_id);


### PR DESCRIPTION
## The bug

A peer deleting a link-local leaves us with **the dead address installed as the route next hop — in the RIB *and* the kernel FIB — permanently**:

```
O  *> 2001:db8:2::/64 [110/10] via fe80::1:1               ← deleted address, SELECTED
L2    2001:db8:2::/64 [115/20] via fe80::84ff:cfff:fe16:411 ← IS-IS recovered correctly
# kernel: 2001:db8:2::/64 nhid 2 via fe80::1:1 dev vz2ns proto ospf
```

That is a blackhole, not a cosmetic stale entry — and IS-IS on the same link recovers, which is what makes it OSPFv3-specific.

## Mechanism

`collect_v3_nexthops` reads the next hop from **`nbr.ident.prefix`** — the neighbour struct, not the LSDB. That field is corrected only when a Hello arrives from the peer's new source, and `NbrSourceChanged` re-keyed the BFD session and the End.X SID while **scheduling no SPF**. The RIB is a consumer of that address too, and was the one missing.

So the delete races:

| | |
|:--|:--|
| Link-LSA floods **immediately** | triggers an SPF — but `ident.prefix` is still the old address, so the dead link-local is baked into every route through that neighbour |
| Hello from the new source, **up to a HelloInterval later** | corrects `ident.prefix` — and nothing re-runs SPF |

Win the race and the routes are right (~6–7 s, the common case); lose it and they are wrong forever.

## The fix

Schedule the area's SPF from `NbrSourceChanged`. The address is already updated by the time we get there, so the SPF this arms **cannot observe the old value** — it closes the race from the other end. It uses the throttled scheduler, so a burst of renumbers coalesces, and `apply_routing_updates_v3` diffs the result, so an SPF that changes nothing emits no RIB message.

## Ruled out first, in order

* **z1 re-originates correctly** — its own Link-LSA carries the surviving EUI-64 address after the delete.
* **Flooding is fine** — z2's copy is byte-identical.
* **Not a missing SPF trigger in the flooding path** — with `router ospfv3 tracing spf lsdb`, z2 shows `[LSDB install_lsa] type=0x0008` followed **202 ms later** by `[v3 SPF] Calculation dispatched` + `complete`. SPF ran; it just had the wrong input.

## Test plan

Found triaging `multi_ipv6_address` from a full BDD run. The feature runs the add/delete cycle **once per invocation**, so 8 runs under load passed 8/8 and told me nothing. Driving the cycle directly — lab up once, repeat only add/delete, time the withdrawal — reproduces on **cycle 2 of 12**, repeatably, and turns a rare binary failure into a latency distribution.

| | before | after |
|:--|:--|:--|
| outcome | permanent wedge, >70 s (4 separate reproductions) | every cycle withdraws |
| worst case | ∞ | **16 s** |

16 s is the correct bound: one HelloInterval (the Hello is what corrects the address) plus the SPF delay — and well inside the feature's 60 s poll.

* `multi_ipv6_address` passes 3/3, no leaks.
* Workspace suite: **2790 passed, 0 failed**. `cargo fmt` clean, workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)