### PR TITLE
book: move the ST2 example's Direct segment to the N6 VRF

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -187,6 +187,17 @@ bgp_mup_interwork:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_interwork"
 
+# MUP Direct segment in the N6 VRF (the book ch-02-35 two-VRF example): the
+# ST2 originates from the RAN-facing N3 VRF (rd 65000:100), the DSD from
+# the internet-facing N6 VRF (rd 65000:200), and the interwork node (z2)
+# resolves the ST2 to the N6 Direct segment purely by the shared
+# Direct-segment id 1:2 — across VRFs and RDs, keeping post-decap uplink
+# lookups out of the RAN table. Needs `pfcp-inject` on the host PATH and
+# root netns (kernel VRF + seg6local).
+bgp_mup_direct_segment_n6:
+	mkdir -p allure-results
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_mup_direct_segment_n6"
+
 # MUP dual-ST: two VRFs (st1 downlink + st2 uplink) bind the same Network
 # Instance, so one PFCP session originates BOTH Session-Transformed routes
 # (Type-1 + Type-2), received by the peer. Needs `pfcp-inject` on the host

--- a/bdd/tests/configs/bgp_mup_direct_segment_n6/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_direct_segment_n6/z1.yaml
@@ -1,0 +1,97 @@
+# z1 — combined MUP UPF + Controller, the book ch-02-35 two-VRF example:
+#   * VRF N3 (rd 65000:100, `encapsulation srv6`) holds `route st2
+#     network-instance core mup-ext-comm 1:2` — a PFCP session on Network
+#     Instance `core` originates the ST2 under N3's RD, stamped with the
+#     Direct-segment id 1:2.
+#   * VRF N6 (rd 65000:200, `encapsulation srv6`) holds `segment direct
+#     mup-ext-comm 1:2` — originates the DSD (End.DT46 SID + id 1:2).
+# The Direct segment deliberately lives in the internet-facing N6 VRF, not
+# next to the ST2: the segment an ST2 resolves to selects the table its
+# uplink traffic is looked up in after decap, so keeping the DSD in N6
+# keeps internet-bound subscriber packets out of the RAN-facing N3 table.
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 (the interwork SRGW)
+# over loopbacks; z2 resolves the ST2 to the N6 Direct segment by the
+# shared id 1:2 — across VRFs and RDs.
+vrf:
+- name: N3
+  mup:
+    route-target:
+      export:
+      - "65000:100"
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65000:200"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N3
+      rd: "65000:100"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "1:2"
+    - name: N6
+      rd: "65000:200"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: direct
+            mup-ext-comm: "1:2"
+    mup-c:
+      enabled: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 127.0.0.1
+      srv6:
+        locator: S

--- a/bdd/tests/configs/bgp_mup_direct_segment_n6/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_direct_segment_n6/z2.yaml
@@ -1,0 +1,61 @@
+# z2 — MUP interwork node (SRGW). IS-IS L2 SRv6 underlay + iBGP (mup
+# afi-safi) to z1 over loopbacks. VRF N6 is `afi-safi mup segment
+# interwork`, which marks this node as an interwork (SRGW) node: it
+# receives z1's DSD (Direct segment from z1's N6 VRF, rd 65000:200,
+# End.DT46 + id `1:2`) and the ST2 (from z1's N3 VRF, rd 65000:100, id
+# `1:2`) into its global MUP Loc-RIB and resolves the ST2 to the Direct
+# segment by that id — across VRFs and RDs, so uplink GTP traffic forwards
+# into the N6 routing context, never the RAN-facing N3 table. (The
+# GTP-decap FIB itself, H.M.GTP4.D, is VPP/eBPF and out of scope here.)
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      afi-safi:
+        mup:
+          segment: interwork

--- a/bdd/tests/features/bgp_mup_direct_segment_n6.feature
+++ b/bdd/tests/features/bgp_mup_direct_segment_n6.feature
@@ -1,0 +1,77 @@
+@serial
+@bgp_mup_direct_segment_n6
+Feature: BGP MUP Direct segment in the N6 VRF, ST2 in the N3 VRF
+  As a network operator
+  I want the `mup-ext-comm` correlation to work across VRFs — a Type-2
+  Session-Transformed (ST2) route originated by the RAN-facing N3 VRF
+  resolving to the Direct Segment Discovery (DSD) route originated by the
+  internet-facing N6 VRF — because the segment an ST2 resolves to selects
+  the table its uplink traffic is looked up in after GTP decap: the Direct
+  segment must live in the N6 routing context so internet-bound subscriber
+  packets never route through the RAN-facing N3 table. This is the two-VRF
+  example in the BGP MUP book chapter (ch-02-35).
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ UPF +    │   iBGP (mup)    │ interwork│
+       │ MUP-C    │                 │  (SRGW)  │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1 is a combined UPF + controller with the book's two-VRF split: VRF N3
+  (rd 65000:100, `encapsulation srv6`) holds `route st2 network-instance
+  core mup-ext-comm 1:2`; VRF N6 (rd 65000:200, `encapsulation srv6`)
+  holds `segment direct mup-ext-comm 1:2`. One `pfcp-inject` session on
+  Network Instance `core` originates the ST2 under N3's RD; the DSD
+  originates under N6's RD. z2 (`afi-safi mup segment interwork`) receives
+  both and resolves the ST2 to the N6 Direct segment purely by the shared
+  Direct-segment id 1:2 — across VRFs and RDs.
+
+  NOTE: needs `pfcp-inject` on the BDD host PATH (cargo build --release -p
+  pfcp-inject; copy to /usr/bin) and root netns (kernel VRF + seg6local).
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8::2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: One PFCP session originates the ST2 under N3's RD, the DSD under N6's
+    Given the test topology exists
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.0.0.1 --core-teid 0x12345678 --network-instance core" in namespace "z1"
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "[DSD][65000:200][10.0.0.1]"
+    And show command "show bgp mup" in namespace "z1" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    # The split holds per VRF: the ST2 belongs to N3, the DSD to N6.
+    And show command "show bgp vrf N3 mup" in namespace "z1" should contain "[ST2]"
+    And show command "show bgp vrf N6 mup" in namespace "z1" should contain "[DSD]"
+    # z1 declares direct, not interwork, so it shows no resolution.
+    And show command "show bgp mup" in namespace "z1" should not contain "resolved mup:1:2"
+
+  Scenario: z2 (interwork) resolves the N3 ST2 to the N6 Direct segment across RDs
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    And show command "show bgp mup" in namespace "z2" should contain "[DSD][65000:200][10.0.0.1]"
+    # The ST2's Direct-segment id (1:2) — not its VRF or RD — picks the
+    # segment: uplink traffic decaps into the N6 routing context.
+    And show command "show bgp mup" in namespace "z2" should eventually contain "resolved mup:1:2 -> End.DT46"
+    And show command "show bgp mup" in namespace "z2" should contain "(via [DSD][65000:200][10.0.0.1])"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -190,8 +190,8 @@ whether the two directions live on two VRFs (one entry each) or on one
 dual-direction VRF (both entries), one session originates both the
 Type-1 and the Type-2 ST.
 
-For example, an uplink VRF that also originates the Direct segment it
-resolves to:
+For example, an uplink (N3) VRF whose ST2 routes resolve to the Direct
+segment originated by the internet-facing (N6) VRF:
 
 ```
 vrf N3 {
@@ -202,12 +202,27 @@ vrf N3 {
       network-instance core;   # originate an ST2 for PFCP sessions on NI "core"
       mup-ext-comm 1:2;        # the Direct segment id it resolves to
     }
+  }
+}
+vrf N6 {
+  rd 65000:200;
+  encapsulation srv6;
+  afi-safi mup {
     segment direct {
       mup-ext-comm 1:2;        # originate the End.DT46 DSD with the same id
     }
   }
 }
 ```
+
+The Direct segment deliberately lives in the **N6** VRF, not next to the
+ST2: the segment an ST2 resolves to selects the table its uplink traffic is
+looked up in after GTP decap, so declaring `segment direct` in the N3 VRF
+would send internet-bound subscriber packets through the RAN-facing routing
+table. Keeping the DSD in the internet-facing VRF keeps the two routing
+contexts apart — the mapping the
+[interwork/direct split](#the-faithful-interworkdirect-split--n3-in-a-vrf-dataplane-gtp)
+below formalizes.
 
 ### Selecting the forwarding plane (`dataplane`)
 

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -222,7 +222,9 @@ would send internet-bound subscriber packets through the RAN-facing routing
 table. Keeping the DSD in the internet-facing VRF keeps the two routing
 contexts apart — the mapping the
 [interwork/direct split](#the-faithful-interworkdirect-split--n3-in-a-vrf-dataplane-gtp)
-below formalizes.
+below formalizes. This exact configuration — and an interwork peer
+resolving the N3 ST2 to the N6 Direct segment across the two RDs — is
+regression-tested by the `bgp_mup_direct_segment_n6` BDD.
 
 ### Selecting the forwarding plane (`dataplane`)
 


### PR DESCRIPTION
The `mup-ext-comm` example in ch-02-35 configured `segment direct` in the same N3 VRF as the `route st2` it resolves. That teaches an anti-pattern: the segment an ST2 resolves to selects the table its uplink traffic is looked up in after GTP decap (see the resolution table in "The faithful interwork/direct split"), so a Direct segment declared in the N3 VRF sends internet-bound subscriber packets through the RAN-facing routing table.

**Book**: rewritten as the two-VRF form — `route st2` + `mup-ext-comm 1:2` in vrf N3 (rd 65000:100), `segment direct { mup-ext-comm 1:2 }` in vrf N6 (rd 65000:200) — with a paragraph explaining why the DSD belongs in the internet-facing VRF, linking to the interwork/direct-split section that formalizes the mapping. `mdbook build` clean; the in-page anchor verified against the generated HTML.

**BDD**: new `@bgp_mup_direct_segment_n6` feature regression-testing that exact configuration. z1 (UPF + MUP-C) originates the ST2 under N3's RD and the DSD under N6's RD from one `pfcp-inject` session on NI `core`; per-VRF views assert the split; the interwork peer z2 resolves the ST2 to the N6 Direct segment purely by the shared Direct-segment id — across VRFs and RDs (`resolved mup:1:2 -> End.DT46 (via [DSD][65000:200][10.0.0.1])`). Passed live 4/4 scenarios with clean teardown (staged debug toolchain, root netns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)