### PR TITLE
fpm-tap review follow-ups: connected-route tee, walk stall, diagnostics

### DIFF
--- a/tools/fpm-tap/src/capture.rs
+++ b/tools/fpm-tap/src/capture.rs
@@ -142,8 +142,29 @@ pub fn read(path: &Path) -> Result<Vec<Record>> {
         let dir = Dir::from_u8(hdr[0])?;
         let usec = u64::from_le_bytes(hdr[4..12].try_into().unwrap());
         let len = u32::from_le_bytes(hdr[12..16].try_into().unwrap()) as usize;
-        let mut bytes = vec![0u8; len];
-        if r.read_exact(&mut bytes).is_err() {
+        // A record cannot legitimately exceed the FPM frame limit; a
+        // larger value is a corrupt or hostile length field, and
+        // allocating whatever a mangled u32 asks for (up to 4 GiB)
+        // turns one flipped bit into an OOM.
+        if len > crate::frame::FPM_MAX_MSG_LEN {
+            bail!(
+                "corrupt capture: record claims {len} bytes (FPM max is {}); \
+                 {} complete records read before it",
+                crate::frame::FPM_MAX_MSG_LEN,
+                records.len()
+            );
+        }
+        // `take + read_to_end` rather than `read_exact` into a
+        // pre-zeroed buffer: on a truncated tail this reports how many
+        // bytes actually arrived — read_exact left the buffer at its
+        // full pre-allocated size, so the diagnostic always claimed
+        // "len of len bytes".
+        let mut bytes = Vec::with_capacity(len);
+        (&mut r)
+            .take(len as u64)
+            .read_to_end(&mut bytes)
+            .context("reading capture record payload")?;
+        if bytes.len() < len {
             eprintln!(
                 "warning: capture ends with a truncated record ({} of {len} bytes); \
                  keeping the {} complete records before it",
@@ -160,6 +181,52 @@ pub fn read(path: &Path) -> Result<Vec<Record>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A corrupt length field must fail loudly, not allocate what a
+    /// mangled u32 asks for.
+    #[test]
+    fn oversized_length_field_bails_instead_of_allocating() {
+        let dir = std::env::temp_dir().join(format!("fpm-tap-test-len-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("bad-len.fpm");
+
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&MAGIC);
+        let mut hdr = [0u8; REC_HDR_LEN];
+        hdr[0] = 0; // dir
+        hdr[12..16].copy_from_slice(&u32::MAX.to_le_bytes());
+        raw.extend_from_slice(&hdr);
+        std::fs::write(&path, raw).unwrap();
+
+        let err = match read(&path) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("a corrupt length field must not parse"),
+        };
+        assert!(err.contains("corrupt capture"), "got: {err}");
+    }
+
+    /// A rig killed mid-write leaves a truncated tail; the complete
+    /// records before it survive.
+    #[test]
+    fn truncated_tail_keeps_complete_records() {
+        let dir = std::env::temp_dir().join(format!("fpm-tap-test-trunc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("trunc.fpm");
+
+        let mut w = Writer::create(&path).unwrap();
+        w.write(Dir::ToFpm, 0, &[1, 2, 3, 4]).unwrap();
+        w.write(Dir::ToFpm, 1, &[5, 6, 7, 8]).unwrap();
+        w.flush().unwrap();
+        drop(w);
+
+        // Chop the last two payload bytes off the second record.
+        let full = std::fs::read(&path).unwrap();
+        std::fs::write(&path, &full[..full.len() - 2]).unwrap();
+
+        let recs = read(&path).unwrap();
+        assert_eq!(recs.len(), 1, "only the complete record survives");
+        assert_eq!(recs[0].bytes, vec![1, 2, 3, 4]);
+    }
 
     #[test]
     fn round_trips_through_a_file() {

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -3162,14 +3162,6 @@ pub(super) fn peer_policy_ident_decode(ident: usize) -> (usize, Option<AfiSafi>)
     (peer_idx, afi_safi)
 }
 
-/// `router bgp afi-safi <af> table-map <policy>`
-/// (zebra-bgp-table-map.yang). Stores the binding on
-/// `local_rib.table_map`, (un)registers the policy watch via
-/// [`policy_attach_msgs`], and reconciles the FIB. Set defers the
-/// resync to the `PolicyRx` reply — always sent for
-/// `PolicyType::TableMap`, even when the name doesn't resolve — so
-/// the FIB flips exactly once, on the definitive answer. Delete
-/// resyncs immediately (nothing will reply).
 /// `set/delete router bgp suppress-fib-pending <bool>`.
 ///
 /// Turning it OFF must flush the pending set and advertise everything in
@@ -3333,6 +3325,14 @@ fn config_multipath_relax(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
     Some(())
 }
 
+/// `router bgp afi-safi <af> table-map <policy>`
+/// (zebra-bgp-table-map.yang). Stores the binding on
+/// `local_rib.table_map`, (un)registers the policy watch via
+/// [`policy_attach_msgs`], and reconciles the FIB. Set defers the
+/// resync to the `PolicyRx` reply — always sent for
+/// `PolicyType::TableMap`, even when the name doesn't resolve — so
+/// the FIB flips exactly once, on the definitive answer. Delete
+/// resyncs immediately (nothing will reply).
 pub(super) fn config_table_map(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     if !table_map_afi_valid(&afi_safi) {

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7964,6 +7964,48 @@ mod neighbor_group_wiring_tests {
         assert!(!member_ttl_security(&bgp));
     }
 
+    /// A group `add-path` opinion for `mup` must land on BOTH MUP
+    /// families, exactly as the `enabled` knob fans out — storing under
+    /// the raw key alone left it on IPv4-MUP only, so the group's
+    /// opinion never reached the IPv6-MUP capability.
+    #[tokio::test]
+    async fn group_add_path_mup_fans_out_to_both_afis() {
+        use super::super::neighbor_group::config_neighbor_group_afi_safi_add_path;
+        use bgp_packet::{Afi, Safi};
+
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_afi_safi_add_path(
+            &mut bgp,
+            arg_words(&["G", "mup", "send-receive"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+
+        let group = bgp.neighbor_groups.get("G").unwrap();
+        for afi in [Afi::Ip, Afi::Ip6] {
+            let entry = group.afi_safi.get(&AfiSafi::new(afi, Safi::Mup));
+            assert!(
+                entry.is_some_and(|e| e.add_path.is_some()),
+                "{afi:?}-MUP must carry the group's add-path opinion"
+            );
+        }
+
+        config_neighbor_group_afi_safi_add_path(
+            &mut bgp,
+            arg_words(&["G", "mup", "send-receive"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        let group = bgp.neighbor_groups.get("G").unwrap();
+        for afi in [Afi::Ip, Afi::Ip6] {
+            let entry = group.afi_safi.get(&AfiSafi::new(afi, Safi::Mup));
+            assert!(
+                entry.is_none_or(|e| e.add_path.is_none()),
+                "{afi:?}-MUP delete must clear both"
+            );
+        }
+    }
+
     /// Per-family next-hop-self inherits through the group's afi-safi
     /// entry with explicit-wins semantics.
     #[tokio::test]

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -437,23 +437,36 @@ pub fn config_neighbor_group_afi_safi_add_path(
     let name = args.string()?;
     let family: AfiSafi = args.afi_safi()?;
     let group = bgp.neighbor_groups.entry(name.clone()).or_default();
+    // `mup` fans out to both MUP AFIs, exactly as the `enabled` knob
+    // above does — storing under the raw key alone left the opinion on
+    // IPv4-MUP only, so a group's `add-path` never reached the
+    // IPv6-MUP capability.
+    let families = mp_family_expand(family);
     match op {
         ConfigOp::Set => {
             let mode: AddPathSendReceive = args.string()?.parse().ok()?;
-            group.afi_safi.entry(family).or_default().add_path = Some(mode);
+            for fam in &families {
+                group.afi_safi.entry(*fam).or_default().add_path = Some(mode);
+            }
         }
         ConfigOp::Delete => {
-            if let Some(entry) = group.afi_safi.get_mut(&family) {
-                entry.add_path = None;
+            for fam in &families {
+                if let Some(entry) = group.afi_safi.get_mut(fam) {
+                    entry.add_path = None;
+                }
             }
         }
         _ => return Some(()),
     }
     sweep_members(bgp, &name, |groups, peer| {
-        let before = peer.config.addpath.get(&family).map(|v| v.send_receive);
-        apply_resolved_add_path(groups, &mut peer.config, family);
-        let after = peer.config.addpath.get(&family).map(|v| v.send_receive);
-        before != after && matches!(peer.state, State::Established)
+        let mut changed = false;
+        for fam in &families {
+            let before = peer.config.addpath.get(fam).map(|v| v.send_receive);
+            apply_resolved_add_path(groups, &mut peer.config, *fam);
+            let after = peer.config.addpath.get(fam).map(|v| v.send_receive);
+            changed |= before != after;
+        }
+        changed && matches!(peer.state, State::Established)
     });
     Some(())
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -351,6 +351,19 @@ fn write_summary_section<V: BgpShowView>(
     )?;
     writeln!(buf, "RIB entries {}", rib_entries)?;
     writeln!(buf, "Peers {}", peers.len())?;
+    // Instance-wide, but rendered per section like FRR renders its
+    // instance header lines. The timeout counter is the operator's
+    // signal that the forwarding plane is not acknowledging installs
+    // in time — a number climbing here means every affected prefix
+    // was advertised a full hold interval late.
+    if bgp.local_rib().suppress_fib_pending {
+        writeln!(
+            buf,
+            "FIB-pending suppression: enabled, {} held, {} released by timeout",
+            bgp.local_rib().fib_pending.len(),
+            bgp.local_rib().fib_pending_timeouts
+        )?;
+    }
     writeln!(buf)?;
 
     if peers.is_empty() {
@@ -495,7 +508,30 @@ fn srv6_behavior_name(behavior: u16) -> String {
 struct BgpSummaryJson {
     router_id: String,
     local_as: u32,
+    /// Present only while `suppress-fib-pending` is enabled: how many
+    /// prefixes are currently held awaiting a forwarding-plane ack,
+    /// and how many were ever released by the timeout instead of an
+    /// ack — the counter that makes a lagging ASIC visible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suppress_fib_pending: Option<BgpFibPendingJson>,
     afi_safis: Vec<BgpAfiSafiSummaryJson>,
+}
+
+#[derive(Serialize)]
+struct BgpFibPendingJson {
+    held: usize,
+    timeout_releases: u64,
+}
+
+/// The instance's `suppress-fib-pending` state for the summary JSON,
+/// `None` while the feature is off.
+fn summary_fib_pending<V: BgpShowView>(bgp: &V) -> Option<BgpFibPendingJson> {
+    bgp.local_rib()
+        .suppress_fib_pending
+        .then(|| BgpFibPendingJson {
+            held: bgp.local_rib().fib_pending.len(),
+            timeout_releases: bgp.local_rib().fib_pending_timeouts,
+        })
 }
 
 /// One AFI/SAFI section of `show bgp summary --json`, mirroring the
@@ -2401,6 +2437,7 @@ fn summary_all<V: BgpShowView>(
         let summary = BgpSummaryJson {
             router_id: summary_router_id(bgp),
             local_as: bgp.asn(),
+            suppress_fib_pending: summary_fib_pending(bgp),
             afi_safis: configured_afi_safis(bgp)
                 .into_iter()
                 .map(|afi_safi| summary_section_json(bgp, afi_safi, counts))
@@ -2464,6 +2501,7 @@ fn summary_one<V: BgpShowView>(
         let summary = BgpSummaryJson {
             router_id: summary_router_id(bgp),
             local_as: bgp.asn(),
+            suppress_fib_pending: summary_fib_pending(bgp),
             afi_safis: vec![summary_section_json(bgp, afi_safi, counts)],
         };
         return Ok(summary_json_render(&summary));
@@ -2959,6 +2997,7 @@ fn show_bgp_mup_summary(
         let summary = BgpSummaryJson {
             router_id: summary_router_id(bgp),
             local_as: bgp.asn(),
+            suppress_fib_pending: summary_fib_pending(bgp),
             afi_safis: families
                 .iter()
                 .map(|af| summary_section_json(bgp, *af, None))

--- a/zebra-rs/src/fib/fpm/client.rs
+++ b/zebra-rs/src/fib/fpm/client.rs
@@ -321,7 +321,7 @@ impl FpmFib {
                     if self.shutdown.load(Ordering::Relaxed) {
                         return;
                     }
-                    if let Err(e) = wr.write_all(msg).await {
+                    if let Err(e) = wr.write_all(msg.as_slice()).await {
                         tracing::warn!("fib: FPM replay failed ({e})");
                         failed = true;
                         break;
@@ -341,16 +341,20 @@ impl FpmFib {
             // makes the handoff lossless: a concurrent route_add/del
             // either lands before the drain (and is included here) or
             // observes `connected` and sends through the live channel.
-            let settle: Vec<Vec<u8>> = {
+            let settle: Vec<std::sync::Arc<Vec<u8>>> = {
                 let mut mirror = self.mirror.lock().await;
-                let mut msgs = mirror.take_dels();
+                let mut msgs: Vec<std::sync::Arc<Vec<u8>>> = mirror
+                    .take_dels()
+                    .into_iter()
+                    .map(std::sync::Arc::new)
+                    .collect();
                 msgs.extend(mirror.changed_since(&snapshot));
                 self.connected.store(true, Ordering::Relaxed);
                 msgs
             };
             let mut failed = false;
             for msg in &settle {
-                if let Err(e) = wr.write_all(msg).await {
+                if let Err(e) = wr.write_all(msg.as_slice()).await {
                     tracing::warn!("fib: FPM settle write failed ({e})");
                     failed = true;
                     break;

--- a/zebra-rs/src/fib/fpm/encode.rs
+++ b/zebra-rs/src/fib/fpm/encode.rs
@@ -274,8 +274,21 @@ pub fn encode_route(
     entry: &RibEntry,
     vrf_ifindex: u32,
 ) -> Option<Vec<u8>> {
-    let legs = legs(&entry.nexthop);
+    let mut legs = legs(&entry.nexthop);
     let blackhole = matches!(entry.nexthop, Nexthop::Blackhole(_));
+
+    // A connected route carries no nexthop object — its "leg" is the
+    // interface itself, which FRR encodes as RTA_OIF with no gateway.
+    // Without this the encoder refused every connected route and the
+    // switch's APPL_DB never learned the subnet routes it needs to
+    // deliver to directly-attached hosts.
+    if legs.is_empty() && entry.rtype == RibType::Connected && entry.ifindex != 0 {
+        legs.push(Leg {
+            gateway: None,
+            ifindex: entry.ifindex,
+            weight: 1,
+        });
+    }
 
     // A delete carries no nexthops at all, so it is fine without legs.
     // An add without them is not: it would install an unusable route.
@@ -468,6 +481,32 @@ mod tests {
         let mut e = RibEntry::new(rtype);
         e.nexthop = nexthop;
         e
+    }
+
+    /// A connected route has no nexthop object — the encoder must
+    /// synthesize its interface leg (RTA_OIF, no gateway) rather than
+    /// refuse it, or APPL_DB never learns the subnet routes FRR sends.
+    #[test]
+    fn connected_route_encodes_as_interface_leg() {
+        let mut e = RibEntry::new(RibType::Connected);
+        e.ifindex = 4;
+        let msg = encode_route(RouteOp::Add, &"10.100.1.0/24".parse().unwrap(), &e, 0)
+            .expect("a connected route must encode");
+        // protocol byte: connected folds into RTPROT_KERNEL (2), at
+        // FPM hdr (4) + nlmsg hdr (16) + rtmsg offset 5.
+        assert_eq!(msg[4 + 16 + 5], RTPROT_KERNEL);
+        // RTA_OIF with ifindex 4, and no gateway attribute at all.
+        let oif = [8u8, 0, 4, 0, 4, 0, 0, 0];
+        assert!(
+            msg.windows(oif.len()).any(|w| w == oif),
+            "no RTA_OIF(4) in the encoded message"
+        );
+        for gw in [[8u8, 0, 5, 0], [20u8, 0, 5, 0]] {
+            assert!(
+                !msg.windows(gw.len()).any(|w| w == gw),
+                "a connected route must carry no RTA_GATEWAY"
+            );
+        }
     }
 
     /// RFC 5549: a v4 prefix reached over a v6 next-hop (BGP

--- a/zebra-rs/src/fib/fpm/mirror.rs
+++ b/zebra-rs/src/fib/fpm/mirror.rs
@@ -20,6 +20,7 @@
 //! differently.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use ipnet::IpNet;
 
@@ -29,7 +30,12 @@ type Key = (IpNet, u32);
 
 #[derive(Default)]
 pub struct Mirror {
-    routes: HashMap<Key, Vec<u8>>,
+    /// `Arc` around each message so a reconnect snapshot is a map of
+    /// pointer bumps, not a deep copy of the whole table's bytes taken
+    /// while holding the mirror lock — with a full table, that clone
+    /// stalled every route_add/del (and the RIB loop behind them) for
+    /// the duration.
+    routes: HashMap<Key, Arc<Vec<u8>>>,
     /// Deletes that could not be sent — the peer was down, or the
     /// reconnect replay was still in flight. An add's replay row covers
     /// a dropped ADD, but a delete has no replay row to ride: without
@@ -53,10 +59,10 @@ impl Mirror {
         // A re-add cancels any pending delete for the key: sending the
         // stale DEL after the ADD would remove the resurrected route.
         self.dels.remove(&key);
-        if self.routes.get(&key).is_some_and(|prev| *prev == msg) {
+        if self.routes.get(&key).is_some_and(|prev| **prev == msg) {
             return false;
         }
-        self.routes.insert(key, msg);
+        self.routes.insert(key, Arc::new(msg));
         true
     }
 
@@ -79,10 +85,10 @@ impl Mirror {
         self.dels.drain().map(|(_, msg)| msg).collect()
     }
 
-    /// The current desired state, cloned — the reconnect replay works
-    /// from this snapshot so the mirror stays unlocked during the
-    /// (potentially large) socket writes.
-    pub fn snapshot(&self) -> HashMap<Key, Vec<u8>> {
+    /// The current desired state — `Arc` bumps, not byte copies — so
+    /// the reconnect replay works from this snapshot with the mirror
+    /// unlocked during the (potentially large) socket writes.
+    pub fn snapshot(&self) -> HashMap<Key, Arc<Vec<u8>>> {
         self.routes.clone()
     }
 
@@ -91,10 +97,16 @@ impl Mirror {
     /// it was in flight was recorded here but dropped by the
     /// not-yet-connected send gate, so the settle step sends the
     /// difference or the peer diverges until the next reconnect.
-    pub fn changed_since(&self, snapshot: &HashMap<Key, Vec<u8>>) -> Vec<Vec<u8>> {
+    pub fn changed_since(&self, snapshot: &HashMap<Key, Arc<Vec<u8>>>) -> Vec<Arc<Vec<u8>>> {
         self.routes
             .iter()
-            .filter(|(key, msg)| snapshot.get(*key) != Some(*msg))
+            // `insert` replaces the Arc only when the bytes changed, so
+            // pointer identity IS "unchanged since the snapshot".
+            .filter(|(key, msg)| {
+                !snapshot
+                    .get(*key)
+                    .is_some_and(|prev| Arc::ptr_eq(prev, msg))
+            })
             .map(|(_, msg)| msg.clone())
             .collect()
     }
@@ -110,6 +122,9 @@ impl Mirror {
             .collect();
         keys.into_iter()
             .filter_map(|key| self.routes.remove(&key))
+            // The caller mutates these into DELROUTEs; unwrap the Arc
+            // (cloning only if a snapshot still shares it).
+            .map(|arc| Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone()))
             .collect()
     }
 
@@ -149,7 +164,7 @@ mod tests {
     }
 
     fn replay(m: &Mirror) -> Vec<Vec<u8>> {
-        m.snapshot().into_values().collect()
+        m.snapshot().into_values().map(|a| (*a).clone()).collect()
     }
 
     #[test]
@@ -216,7 +231,11 @@ mod tests {
 
         m.insert(net("10.1.0.0/24"), 0, vec![3]); // changed
         m.insert(net("10.2.0.0/24"), 0, vec![4]); // new
-        let mut delta = m.changed_since(&snap);
+        let mut delta: Vec<Vec<u8>> = m
+            .changed_since(&snap)
+            .into_iter()
+            .map(|a| (*a).clone())
+            .collect();
         delta.sort();
         assert_eq!(delta, vec![vec![3], vec![4]]);
         assert!(

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -622,6 +622,16 @@ impl FibHandle {
         }
     }
 
+    /// Tee-only add for a route the kernel owns: a connected route
+    /// needs no netlink install (the kernel creates the prefix route
+    /// with the address), but SONiC's APPL_DB still needs it — FRR
+    /// sends subnet routes over FPM, and without them the ASIC cannot
+    /// deliver to directly-attached hosts. A no-op when the tee is off
+    /// or the entry is not tee-able (`fpm_prepare` gates).
+    pub async fn fpm_tee_add(&self, prefix: ipnet::IpNet, entry: &RibEntry, table_id: u32) {
+        self.fpm_tee(RouteOp::Add, prefix, entry, table_id).await;
+    }
+
     /// Tee one route to SONiC's FPM southbound.
     ///
     /// Connected routes ride along with protocol routes: the kernel

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -622,12 +622,6 @@ impl FibHandle {
         }
     }
 
-    /// Re-tee one already-installed route (the enable-after-routes walk).
-    /// A no-op when the tee is off.
-    pub async fn fpm_route_resync(&self, prefix: ipnet::IpNet, entry: &RibEntry, table_id: u32) {
-        self.fpm_tee(RouteOp::Add, prefix, entry, table_id).await;
-    }
-
     /// Tee one route to SONiC's FPM southbound.
     ///
     /// Connected routes ride along with protocol routes: the kernel
@@ -636,11 +630,33 @@ impl FibHandle {
     /// the cradle tee. Kernel-learned routes stay out; they would echo
     /// back what SONiC itself installed.
     async fn fpm_tee(&self, op: RouteOp, prefix: ipnet::IpNet, entry: &RibEntry, table_id: u32) {
-        let Some(fpm) = &self.fpm else {
+        if self.fpm.is_none() {
+            return;
+        }
+        let Some((vrf_ifindex, msg)) = self.fpm_prepare(op, prefix, entry, table_id) else {
             return;
         };
+        let fpm = self.fpm.as_ref().expect("checked above");
+        match op {
+            RouteOp::Add => fpm.route_add(prefix, vrf_ifindex, msg).await,
+            RouteOp::Del => fpm.route_del(&prefix, vrf_ifindex, msg).await,
+        }
+    }
+
+    /// The gating + encoding half of [`fpm_tee`](Self::fpm_tee),
+    /// synchronous and side-effect free, so the enable-time reseed walk
+    /// can prepare its whole batch inline and hand the sends to a
+    /// spawned task instead of stalling the RIB event loop on one
+    /// mirror-lock round trip per route.
+    pub fn fpm_prepare(
+        &self,
+        op: RouteOp,
+        prefix: ipnet::IpNet,
+        entry: &RibEntry,
+        table_id: u32,
+    ) -> Option<(u32, Vec<u8>)> {
         if !entry.is_protocol() && !matches!(entry.rtype, RibType::Connected) {
-            return;
+            return None;
         }
 
         // FPM's table field is a VRF *device ifindex*, not a kernel
@@ -662,18 +678,13 @@ impl FibHandle {
                     tracing::debug!(
                         "fib: FPM tee skipping {prefix} in table {other} (no VRF ifindex known)"
                     );
-                    return;
+                    return None;
                 }
             },
         };
 
-        let Some(msg) = encode_route(op, &prefix, entry, vrf_ifindex) else {
-            return;
-        };
-        match op {
-            RouteOp::Add => fpm.route_add(prefix, vrf_ifindex, msg).await,
-            RouteOp::Del => fpm.route_del(&prefix, vrf_ifindex, msg).await,
-        }
+        let msg = encode_route(op, &prefix, entry, vrf_ifindex)?;
+        Some((vrf_ifindex, msg))
     }
 
     /// Push the RFC 3443 MPLS TTL model (`set mpls ttl propagate`) into the

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -414,12 +414,23 @@ pub fn resolve_calls(config: &mut BTreeMap<String, PolicyList>) -> Vec<String> {
                         stack.push((next.clone(), 0));
                     }
                     Colour::Grey => {
-                        // Back edge: everything currently grey on the
-                        // path from `next` onward is on a cycle. Marking
-                        // both endpoints is enough for the fail-closed
-                        // behaviour and keeps this linear.
+                        // Back edge: every node on the current path from
+                        // `next` through `node` is a member of the
+                        // cycle, and ALL of them must be marked. Marking
+                        // only the two endpoints — the previous
+                        // behaviour — left the intermediate members of a
+                        // 4+-policy cycle resolving their calls against
+                        // a chain that denies at runtime through the
+                        // broken link, while `show` reported
+                        // `call_resolved: true` for them. The stack IS
+                        // the grey path (a frame is pushed on entry and
+                        // popped only at finish), so the segment from
+                        // `next` onward is exactly the cycle.
+                        let from = stack.iter().position(|(n, _)| n == next).unwrap_or(0);
+                        for (member, _) in &stack[from..] {
+                            on_cycle.insert(member.clone());
+                        }
                         on_cycle.insert(next.clone());
-                        on_cycle.insert(node.clone());
                     }
                     Colour::Black => {}
                 }
@@ -2101,6 +2112,53 @@ mod call_tests {
         assert!(unresolved.contains(&"B".to_string()));
         assert!(call_policy_of(&cfg, "A").is_none());
         assert!(call_policy_of(&cfg, "B").is_none());
+    }
+
+    /// Every member of a longer cycle must be rejected, not just the
+    /// two endpoints of the back edge. With only {A, D} marked in
+    /// A→B→C→D→A, B and C resolved their calls against a chain that
+    /// denies at runtime through the broken D→A link while reporting
+    /// `call_resolved: true`.
+    #[test]
+    fn every_member_of_a_long_cycle_is_rejected() {
+        let mut cfg = config(&[
+            ("A", Some("B")),
+            ("B", Some("C")),
+            ("C", Some("D")),
+            ("D", Some("A")),
+        ]);
+        let unresolved = resolve_calls(&mut cfg);
+        for name in ["A", "B", "C", "D"] {
+            assert!(
+                unresolved.contains(&name.to_string()),
+                "{name} must report unresolved"
+            );
+            assert!(
+                call_policy_of(&cfg, name).is_none(),
+                "{name}'s call must stay None so the entry denies"
+            );
+        }
+    }
+
+    /// The wider marking must not swallow the rest of the graph: a
+    /// caller INTO the cycle is fail-closed too (its call can never
+    /// work), but an unrelated chain resolves untouched.
+    #[test]
+    fn cycle_marking_does_not_leak_to_unrelated_policies() {
+        let mut cfg = config(&[
+            ("X", Some("A")), // calls into the cycle: denied
+            ("A", Some("B")),
+            ("B", Some("A")), // the cycle {A, B}
+            ("Y", Some("Z")), // unrelated chain: resolves
+            ("Z", None),
+        ]);
+        let unresolved = resolve_calls(&mut cfg);
+        for name in ["A", "B", "X"] {
+            assert!(unresolved.contains(&name.to_string()), "{name}");
+            assert!(call_policy_of(&cfg, name).is_none(), "{name}");
+        }
+        assert!(!unresolved.contains(&"Y".to_string()));
+        assert!(call_policy_of(&cfg, "Y").is_some(), "Y→Z must resolve");
     }
 
     /// The property the design exists to guarantee: chain length is not

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -4664,25 +4664,36 @@ impl Rib {
     }
 
     /// Re-tee every selected, installed route to the FPM tee.
+    ///
+    /// The encoding runs inline (synchronous, no locks), but the sends
+    /// go to a spawned task: at a full table's scale, one mirror-lock
+    /// round trip per route on this event loop stalled every netlink
+    /// and route message behind the walk.
     #[cfg(target_os = "linux")]
     async fn fpm_rib_walk(&self) {
+        use crate::fib::fpm::RouteOp;
         use ipnet::IpNet;
 
-        let mut count = 0usize;
+        let Some(fpm) = self.fib_handle.fpm.clone() else {
+            return;
+        };
+        let mut batch: Vec<(IpNet, u32, Vec<u8>)> = Vec::new();
+        let mut prepare = |prefix: IpNet, entry: &crate::rib::entry::RibEntry, table_id: u32| {
+            if let Some((vrf_ifindex, msg)) =
+                self.fib_handle
+                    .fpm_prepare(RouteOp::Add, prefix, entry, table_id)
+            {
+                batch.push((prefix, vrf_ifindex, msg));
+            }
+        };
         for (prefix, entries) in self.table.iter() {
             for entry in entries.iter().filter(|e| e.is_selected() && e.is_fib()) {
-                self.fib_handle
-                    .fpm_route_resync(IpNet::V4(prefix), entry, RT_TABLE_MAIN)
-                    .await;
-                count += 1;
+                prepare(IpNet::V4(prefix), entry, RT_TABLE_MAIN);
             }
         }
         for (prefix, entries) in self.table_v6.iter() {
             for entry in entries.iter().filter(|e| e.is_selected() && e.is_fib()) {
-                self.fib_handle
-                    .fpm_route_resync(IpNet::V6(prefix), entry, RT_TABLE_MAIN)
-                    .await;
-                count += 1;
+                prepare(IpNet::V6(prefix), entry, RT_TABLE_MAIN);
             }
         }
         // VRF tables as well: the tee resolves each table id to its VRF
@@ -4691,24 +4702,25 @@ impl Rib {
         for (table_id, tables) in self.vrf_tables.iter() {
             for (prefix, entries) in tables.table.iter() {
                 for entry in entries.iter().filter(|e| e.is_selected() && e.is_fib()) {
-                    self.fib_handle
-                        .fpm_route_resync(IpNet::V4(prefix), entry, *table_id)
-                        .await;
-                    count += 1;
+                    prepare(IpNet::V4(prefix), entry, *table_id);
                 }
             }
             for (prefix, entries) in tables.table_v6.iter() {
                 for entry in entries.iter().filter(|e| e.is_selected() && e.is_fib()) {
-                    self.fib_handle
-                        .fpm_route_resync(IpNet::V6(prefix), entry, *table_id)
-                        .await;
-                    count += 1;
+                    prepare(IpNet::V6(prefix), entry, *table_id);
                 }
             }
         }
-        if count > 0 {
-            tracing::info!("rib: reseeded {count} routes into the FPM tee");
+        if batch.is_empty() {
+            return;
         }
+        tokio::spawn(async move {
+            let count = batch.len();
+            for (prefix, vrf_ifindex, msg) in batch {
+                fpm.route_add(prefix, vrf_ifindex, msg).await;
+            }
+            tracing::info!("rib: reseeded {count} routes into the FPM tee");
+        });
     }
 
     fn cradle_apply(&mut self) {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1745,6 +1745,14 @@ async fn ipv4_entry_selection(
                 retry = true;
             }
         } else {
+            // Connected / kernel routes need no netlink install — the
+            // kernel owns their FIB entries — but the FPM tee still
+            // wants the connected ones: FRR sends subnet routes to
+            // APPL_DB, and without them the ASIC cannot deliver to
+            // directly-attached hosts (`fpm_prepare` keeps
+            // kernel-learned routes out).
+            fib.fpm_tee_add(ipnet::IpNet::V4(*prefix), next, table_id)
+                .await;
             next.set_fib(true);
         }
     }
@@ -2414,6 +2422,10 @@ async fn ipv6_entry_selection(
                 retry = true;
             }
         } else {
+            // Same as the v4 twin: no netlink install, but connected
+            // routes ride the FPM tee to APPL_DB.
+            fib.fpm_tee_add(ipnet::IpNet::V6(*prefix), next, table_id)
+                .await;
             next.set_fib(true);
         }
     }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -471,6 +471,14 @@ pub fn rib_entry_show(
 
     let offset = buf.len();
     let uptime = format_uptime(e.time.elapsed());
+    // The forwarding plane's acknowledgement (the FPM offload ack that
+    // sets RibEntry.offloaded) rides the line's tail — without this the
+    // flag was recorded and never visible anywhere.
+    let uptime = if e.offloaded {
+        format!("{uptime}, offloaded")
+    } else {
+        uptime
+    };
 
     if e.is_connected() {
         writeln!(
@@ -568,6 +576,14 @@ pub fn rib_entry_show_v6(
 
     let offset = buf.len();
     let uptime = format_uptime(e.time.elapsed());
+    // The forwarding plane's acknowledgement (the FPM offload ack that
+    // sets RibEntry.offloaded) rides the line's tail — without this the
+    // flag was recorded and never visible anywhere.
+    let uptime = if e.offloaded {
+        format!("{uptime}, offloaded")
+    } else {
+        uptime
+    };
 
     if e.is_connected() {
         writeln!(
@@ -1067,6 +1083,12 @@ pub fn rib_entry_show_detail(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> Strin
         subtype_tag
     );
     let _ = writeln!(buf, "  Last update {} ago", format_uptime(e.time.elapsed()));
+    if e.offloaded {
+        let _ = writeln!(
+            buf,
+            "  Offloaded to the forwarding plane (FPM ack received)"
+        );
+    }
 
     if e.is_connected() {
         let _ = writeln!(buf, "  Directly connected via {}", rib.link_name(e.ifindex));
@@ -1104,6 +1126,12 @@ pub fn rib_entry_show_v6_detail(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> St
         subtype_tag
     );
     let _ = writeln!(buf, "  Last update {} ago", format_uptime(e.time.elapsed()));
+    if e.offloaded {
+        let _ = writeln!(
+            buf,
+            "  Offloaded to the forwarding plane (FPM ack received)"
+        );
+    }
 
     if e.is_connected() {
         let _ = writeln!(buf, "  Directly connected via {}", rib.link_name(e.ifindex));


### PR DESCRIPTION
The below-the-cut findings from the fpm-tap branch review (#2267) — everything the blocking-fix pass deferred, six commits, one per finding.

**`policy: mark every member of a call cycle`** — the three-colour DFS recorded only the back edge's endpoints, so intermediate members of a 4+-policy cycle resolved their calls against a chain that denies at runtime while `show` reported `call_resolved: true`. The iterative DFS stack is exactly the grey path, so the back edge now marks the whole segment. New tests pin a four-member cycle and that unrelated chains still resolve.

**`bgp: fan a neighbor-group mup add-path opinion to both MUP families`** — every other per-family group knob runs through `mp_family_expand`; the add-path handler stored the raw key alone, so a group's `mup` opinion never reached IPv6-MUP.

**`fpm-tap: bound record allocation`** — the capture reader allocated whatever the record header's u32 asked for (one flipped bit from a 4 GiB buffer), and its truncation warning always printed "len of len bytes" because `read_exact` leaves a pre-sized buffer full-length. Lengths above `FPM_MAX_MSG_LEN` now bail as corrupt; `take + read_to_end` reports the real count.

**`bgp/rib: surface the fib-pending counters and the offloaded flag`** — `fib_pending_timeouts` and `RibEntry.offloaded` were written and never read. `show bgp summary` (text and JSON) now reports the suppress-fib-pending state — prefixes currently held, and how many were ever released by timeout instead of an ack, the counter that makes a lagging ASIC visible. `show ip route` appends `offloaded` to acknowledged routes. Also un-fuses the table-map doc comment that had landed on `config_suppress_fib_pending`.

**`fib: keep the FPM reseed walk off the RIB event loop`** — the enable-time walk awaited one mirror-lock round trip per route on the RIB's own loop; it now encodes its batch inline (`fpm_prepare`, the synchronous half of `fpm_tee`) and hands the sends to a spawned task. The mirror's messages moved behind `Arc`s, so the reconnect replay's snapshot is a map of pointer bumps instead of a deep byte copy taken under the lock — and `changed_since` gets pointer identity as its unchanged test for free.

**`fib: tee connected routes to FPM, as FRR does`** — the biggest one: FRR sends subnet routes over FPM and the ASIC needs them to deliver to directly-attached hosts, but zebra-rs never teed them (the selection path installs only protocol routes, and the encoder refused a leg-less connected entry anyway). The encoder now synthesizes the interface leg (RTA_OIF, no gateway, protocol `RTPROT_KERNEL` — FRR's own form), and the selection path's non-protocol arm tees connected routes without a netlink install. This also closes the SET/DEL asymmetry the review flagged: the withdrawal path already teed DELs, which the mirror-membership guard had been suppressing as orphans.

Validation: workspace clippy clean (cache-busted), full workspace suite green, `bgp_multipath` and `bgp_basic_ebgp` BDD features green on the rebuilt binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
