### PR TITLE
ospf: no identity, no wire — stop defaulting the Router-ID to 10.0.0.1

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -61,7 +61,16 @@ pub type ShowCallback<V = Ospfv2> = fn(&Ospf<V>, Args, bool) -> Result<String, s
 /// Constructor-default Router ID, used until a configured or
 /// RIB-derived value arrives (and as the fallback when a configured
 /// one is deleted on an instance that never received a RIB value).
-pub const DEFAULT_ROUTER_ID: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+///
+/// UNSPECIFIED, deliberately: an instance with no identity yet must
+/// stay off the wire (the hello send paths gate on it), because any
+/// concrete placeholder is an identity collision waiting to happen —
+/// the previous value, 10.0.0.1, meant every not-yet-configured router
+/// in a v6-only topology (nothing to derive a Router-ID from)
+/// impersonated whichever real router legitimately owned 10.0.0.1,
+/// planting ghost neighbors keyed under a colliding identity. FRR
+/// behaves the same way: no Router-ID, no OSPF.
+pub const DEFAULT_ROUTER_ID: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 
 /// OSPF protocol instance.
 ///
@@ -7225,6 +7234,16 @@ impl Ospf<Ospfv3> {
             let _ = self
                 .tx
                 .send(Message::Ifsm(addr.ifindex, IfsmEvent::InterfaceUp));
+        } else if link.enabled && changed && prefix.addr().is_unicast_link_local() {
+            // The link came Up on a GLOBAL address alone (config commit)
+            // and the kernel's link-local landed afterwards. The hello
+            // timer is already armed, so `ifsm_hello_start`'s
+            // is-none guard won't re-fire — but every hello sent so far
+            // was silently skipped by `ospfv3_hello_send`'s no-LL bail,
+            // and the next periodic tick is up to a HelloInterval away.
+            // Send one now that a source exists; traced runs put the
+            // adjacency at enable+10s without this.
+            let _ = self.tx.send(Message::HelloTimer(addr.ifindex));
         }
 
         // A prefix the address list didn't hold yet must reach the

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -360,6 +360,19 @@ pub fn ospf_hello_recv(
         return;
     }
 
+    // A hello claiming OUR identity is either our own packet reflected
+    // back or a peer wearing a colliding (mis)configured Router-ID.
+    // Processing it would fabricate a self-neighbor and poison our own
+    // hello neighbor lists — drop it.
+    if packet.router_id == *router_id {
+        ospf_pdu_trace!(
+            tracing,
+            "[Hello:Recv] dropping hello claiming our own Router-ID {}",
+            router_id
+        );
+        return;
+    }
+
     ospf_pdu_trace!(tracing, "[Hello:Recv] on {}", oi.index);
 
     let Ospfv2Payload::Hello(ref hello) = packet.payload else {
@@ -519,6 +532,13 @@ pub fn ospf_hello_send(
     tracing: &OspfTracing,
 ) {
     if oi.is_passive() {
+        return;
+    }
+    // No identity yet (constructor default, before the Router-ID
+    // config or a RIB-derived value lands): stay off the wire. When
+    // the identity arrives, router_id_update fires immediate hellos
+    // on every up link, so nothing is lost by skipping here.
+    if oi.ident.router_id.is_unspecified() {
         return;
     }
     ospf_pdu_trace!(tracing, "[Hello:Send] on {}", oi.name);

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -302,6 +302,10 @@ pub fn ospfv3_hello_send(
     if link.is_passive() {
         return;
     }
+    // No identity yet: stay off the wire — see the v2 twin's comment.
+    if link.ident.router_id.is_unspecified() {
+        return;
+    }
     ospf_pdu_trace!(tracing, "[Hello:Send] on {}", link.name);
     let Some(src) = link_local_src(link) else {
         tracing::debug!(
@@ -375,6 +379,19 @@ pub fn ospfv3_hello_recv(
     tracing: &OspfTracing,
 ) {
     if oi.is_passive() {
+        return;
+    }
+
+    // Same guard as the v2 twin: a hello claiming OUR identity is a
+    // reflection or a colliding Router-ID — processing it fabricates a
+    // self-neighbor (keyed by rid in v3) that poisons our own hello
+    // neighbor lists.
+    if packet.router_id == *our_router_id {
+        ospf_pdu_trace!(
+            tracing,
+            "[v3 Hello:Recv] dropping hello claiming our own Router-ID {}",
+            our_router_id
+        );
         return;
     }
 


### PR DESCRIPTION
Resolves the OSPFv3 load-profile sensitivity flagged in #2271 — which turned out to be an identity-collision bug hiding behind a hardcoded default: **`DEFAULT_ROUTER_ID` was `10.0.0.1`**, a real address that real routers (and these test topologies) legitimately configure.

## The mechanism (traced, `bdd/logs/ospfv3_srv6_z*.log`)

In a v6-only topology there is no IPv4 address to derive a Router-ID from, so until the `router-id` callback lands mid-commit, an enabling instance wore `10.0.0.1` — impersonating whichever router actually owns it. z1's LSDB grew a ghost neighbor keyed `10.0.0.1` (z2 wearing the default), the collision wedged the LSDB exchange, and the v3 features failed **5/6** when run at `--concurrency=8` (the full suite at 16 straddled the boundary, which is why it flickered between runs).

Two companion holes surfaced by the same traces:

* **`ospfv3_hello_send` silently skips without a link-local source**, and the kernel's link-local can land after the config commit — at which point `ifsm_hello_start`'s is-none guard sees the hello timer already armed and never re-fires. The first effective hello waited a full HelloInterval: adjacency at enable+10 s, then Down→Full in 1.7 ms once anything arrived. A link-local arriving on an enabled link now sends the hello that was skipped.
* **Neither OSPF version dropped a received hello claiming our own Router-ID** — processing one fabricates a self-neighbor (keyed by rid in v3) that poisons our own hello neighbor lists. Both receive paths now drop it with a trace.

## The fix

`DEFAULT_ROUTER_ID` becomes UNSPECIFIED and the hello send paths gate on it: **no identity, no wire** — exactly FRR's behavior. When the identity lands (same commit), `router_id_update`'s immediate hellos — parked until CommitEnd by #2270's machinery — bring everything up under the real name. The whole provisional/default-identity disease class is now closed at the root for both versions: derived-identity transitions are commit-gated (#2270), abandoned identities are flushed when echoed (#2271), and no-identity instances stay silent (this PR).

## Validation

- The reproducer: 5/6 v3 features failing on `main` → **6/6 passing, twice**, on the staged fix binary
- **Full BDD suite: 284/284** — the first fully clean run across this whole investigation arc
- Full zebra-rs suite (2036 tests), workspace clippy clean (cache-busted)

A test-infrastructure lesson from the hunt is recorded in the project notes: direct `cargo test --test cucumber` runs the last-staged binary — only `make -C bdd` targets restage — which briefly made this fix look ineffective and invalidated several checkout-based baseline runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
