### PR TITLE
isis: no identity, no wire — gate Hello TX on a configured NET

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -258,6 +258,13 @@ isis_lan_dis_reelection:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@isis_lan_dis_reelection"
 
+# "No identity, no wire": an enabled circuit without a configured NET
+# must stay Hello-silent (no 0000.0000.0000 impostor neighbor on the
+# peer) and come up promptly once the NET lands.
+isis_no_net_gate:
+	mkdir -p allure-results
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_no_net_gate"
+
 # A DIS that loses its circuit must purge the pseudonode LSP it originated
 # rather than leave it to age out over MaxAge (~20 min). Slow by nature:
 # the purged copy has to outlive ZeroAgeLifetime (60s) before eviction.

--- a/bdd/tests/configs/isis_no_net_gate/z1-1.yaml
+++ b/bdd/tests/configs/isis_no_net_gate/z1-1.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enabled: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_no_net_gate/z2-1.yaml
+++ b/bdd/tests/configs/isis_no_net_gate/z2-1.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enabled: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enabled: true

--- a/bdd/tests/features/isis_no_net_gate.feature
+++ b/bdd/tests/features/isis_no_net_gate.feature
@@ -1,0 +1,70 @@
+@isis_no_net_gate
+@isis
+Feature: IS-IS no-NET hello gate (no identity, no wire)
+  As a network operator
+  I want an IS-IS instance without a configured NET to stay silent on
+  the wire — an enabled circuit must not emit Hellos under the default
+  all-zero system-id (0000.0000.0000), which peers would key a phantom
+  neighbor under — and to come up promptly once the NET is configured.
+
+  Test Topology:
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+   lo: 2001:db8:0:ffff::1   lo: 2001:db8:0:ffff::2
+              /128                  /128
+  ```
+
+  Config files:
+  - z1-1.yaml: IS-IS L2 with IPv6 on lo + vz1ns, but NO net configured.
+  - z2-1.yaml: full IS-IS L2 config with net 49.0001.0000.0000.0002.00.
+
+  Scenario: Setup topology with z1 enabled but identity-less
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then ping from "z1" to "2001:db8:1::2" should succeed
+    And ping from "z2" to "2001:db8:1::1" should succeed
+
+  Scenario: An identity-less z1 sends no Hellos, so z2 learns no neighbor
+    Given the test topology exists
+    # Without the gate, z1's enable-instant and periodic Hellos carry
+    # source-id 0000.0000.0000, z2 keys a phantom neighbor under it and
+    # the 3-way handshake completes — the control run on the pre-fix
+    # binary showed the impostor reaching Up (displayed under z1's
+    # hostname once its zero-keyed LSP delivers the hostname TLV).
+    Then show command "show isis neighbor" in namespace "z2" should not contain "0000.0000.0000"
+    And show command "show isis neighbor" in namespace "z2" should not contain "z1"
+    And show command "show isis neighbor" in namespace "z2" should not contain "Up"
+    And show command "show isis neighbor" in namespace "z2" should not contain "Init"
+
+  Scenario: Configuring the NET brings the adjacency up promptly
+    Given the test topology exists
+    When I apply command "set router isis net 49.0001.0000.0000.0001.00" in namespace "z1"
+    Then show command "show isis neighbor" in namespace "z2" should eventually contain "Up"
+    And show command "show isis neighbor" in namespace "z1" should eventually contain "Up"
+    And show command "show isis neighbor" in namespace "z2" should not contain "0000.0000.0000"
+    And ping from "z1" to "2001:db8:0:ffff::2" should eventually succeed
+    And ping from "z2" to "2001:db8:0:ffff::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -927,12 +927,35 @@ impl IsisConfig {
 fn config_net(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let nsap = args.string()?.parse::<Nsap>().unwrap();
 
+    let prev = isis.config.net.sys_id();
     if op.is_set() {
         isis.lsp_map.get_mut(&Level::L1).get_sys(&nsap.sys_id());
         isis.lsp_map.get_mut(&Level::L2).get_sys(&nsap.sys_id());
         isis.config.net = nsap;
     } else {
         isis.config.net = Nsap::default();
+    }
+
+    // No identity, no wire: `hello_send` stays silent while the sys-id
+    // is empty (pre-NET), and an already-armed hello timer only fires
+    // into that gate. When the identity lands (or changes), kick an
+    // immediate Hello on every enabled circuit so peers learn the real
+    // system-id without waiting out a hello interval. Deliberately not
+    // `kick_hello_all_links`: that helper covers every kernel link, and
+    // `hello_originate` would arm periodic timers on circuits that are
+    // not IS-IS-enabled. A NET delete sends nothing — the gate goes
+    // silent and peers age the adjacency out via their hold timers.
+    let curr = isis.config.net.sys_id();
+    if curr != prev && !curr.is_empty() {
+        for (ifindex, link) in isis.links.iter() {
+            if link.config.enabled() {
+                let _ = isis.tx.send(Message::Ifsm(
+                    super::ifsm::IfsmEvent::HelloOriginate,
+                    *ifindex,
+                    None,
+                ));
+            }
+        }
     }
 
     Some(())

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -344,6 +344,20 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
         return Ok(());
     }
 
+    // No identity, no wire (FRR parity, mirroring OSPF's unspecified
+    // Router-ID gate): until the NET is configured the instance has no
+    // system-id, and a Hello would go out as 0000.0000.0000 — peers
+    // key a neighbor under that impostor identity and carry it in
+    // their IIH neighbor lists, poisoning the 3-way handshake. Within
+    // one commit `net` applies first (`ext:sort "1"`), so the exposed
+    // window is a config sequence that enables circuits in an earlier
+    // commit than the NET — or deletes the NET while circuits are up.
+    // The armed timer only fires into this gate; `config_net` kicks an
+    // immediate Hello on every enabled circuit once the identity lands.
+    if link.up_config.net.sys_id().is_empty() {
+        return Ok(());
+    }
+
     let hello = if link.config.network_type() == NetworkType::P2p {
         IsisPdu::P2pHello(hello_p2p_generate(link, level))
     } else {


### PR DESCRIPTION
Closes the IS-IS identity gap flagged during the commit-gate work (#2273): **an enabled circuit on an instance without a NET emitted Hellos under the default all-zero system-id**.

## The impostor is not cosmetic

The control run on the pre-fix binary showed the peer keying a neighbor under `0000.0000.0000` and completing the full 3-way handshake to **Up** — after which the zero-keyed LSP (carrying the real hostname) lands in the peer's LSDB. Within one commit `net` applies first (`ext:sort "1"`), so the exposed window is enabling circuits in an earlier commit than the NET — or deleting the NET while circuits are up.

## The fix

**No identity, no wire** — FRR parity, and the IS-IS analog of OSPF's unspecified-Router-ID gate (#2272):

- `hello_send` — the single choke point for Hello TX, covering both the enable-instant send and the periodic timer path — bails while the system-id is empty.
- `config_net` kicks an immediate `HelloOriginate` on every IS-IS-enabled circuit when the identity lands or changes, so peers learn the real system-id without waiting out a hello interval. Deliberately not `kick_hello_all_links`: that walks every kernel link, and `hello_originate` would arm periodic timers on circuits that are not IS-IS-enabled.
- A NET delete sends nothing — the gate goes silent and peers age the adjacency out via their hold timers.

## Validation

- New BDD feature `isis_no_net_gate`: an identity-less z1 must stay Hello-silent (peer neighbor table empty), and applying `set router isis net …` live must bring the adjacency Up and loopback pings through. **A/B proven**: fails on the pre-fix binary (impostor reaches Up), passes on the fix.
- Full IS-IS BDD sweep: **37 features, 37 passed, 0 failed** (concurrency 20, installed fix binary)
- Workspace suite: 40 test binaries, zero failures; workspace clippy clean (cache-busted)

Still open in this area (noted in project memory): pseudonode `DisOriginate` bypasses the lsp-gen throttle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
