### PR TITLE
config: default save format is CLI, even from the shipped conffile

### DIFF
--- a/book/src/ch-00-05-command-line-options.md
+++ b/book/src/ch-00-05-command-line-options.md
@@ -43,8 +43,10 @@ configuration representations is accepted:
   `show running-config formal` prints, with the `set` keyword restored).
 
 `save` writes the file back in the format it was loaded in, so the round
-trip preserves your choice. A file that was missing or empty at startup
-has no format to preserve, and saves in the **CLI** format. To convert a
+trip preserves your choice. A file that carried no configuration at
+startup — missing, empty, or comment-only like the shipped
+`zebra-rs.conf` — has no format to preserve, and saves in the **CLI**
+format. To convert a
 config file, name a format: `save { cli | formal | json | yaml }` writes
 that one and keeps the file in it from then on (see
 [Show Config Commands](ch-06-02-show-config-commands.md)).

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -200,8 +200,10 @@ system:
 The format is re-detected on every load — the startup load and the
 `load` command both — from the file's first meaningful line, the same
 sniffing `vtyctl apply -f` uses. Two cases fall back to the **CLI**
-block format: a config file that was missing or empty when the daemon
-started, and a daemon whose config only ever arrived over
+block format: a config file that carried no configuration when the
+daemon started (missing, empty, or comment-only — the shipped
+`/etc/zebra-rs/zebra-rs.conf` is comment-only, so a default install
+saves CLI), and a daemon whose config only ever arrived over
 `vtyctl apply`. Applying a document with `vtyctl apply` deliberately
 does *not* change the format `save` writes — an applied document is a
 config injection, not the on-disk file.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -220,9 +220,11 @@ pub struct ConfigManager {
     /// as YAML rather than being silently rewritten in the CLI brace
     /// format. Set by [`Self::load_config`] on every successful parse —
     /// both the startup load and the configure-mode `load` command — and
-    /// left at `Cli` when there was nothing to load (missing or empty
-    /// file), which keeps a first save on a fresh box in the format the
-    /// shipped `zebra-rs.conf` uses.
+    /// left at `Cli` when there was nothing to load: a missing file, an
+    /// empty one, or the comment-only conffile the .deb ships. (That
+    /// last case matters: comment-only used to reach the sniffer, whose
+    /// no-content fallback is YAML, so every default install saved its
+    /// first config as YAML instead of CLI.)
     ///
     /// Deliberately *not* driven by `vtyctl apply`: a streamed-in
     /// document is a config injection, not the on-disk file, so applying
@@ -992,17 +994,22 @@ impl ConfigManager {
         match std::fs::read_to_string(&self.config_path) {
             // An empty (or comment/whitespace-only) config file carries no
             // commands. Skip the format parsers entirely so the YAML
-            // default doesn't parse `""` into a spurious command. (Done
-            // here, not in `config_to_commands`, so the `vtyctl apply`
-            // path keeps its existing empty-document behavior — an empty
-            // apply must not clear+commit the running config.)
-            Ok(output) if output.trim().is_empty() => {
+            // default doesn't parse `""` into a spurious command — and,
+            // just as important, doesn't get *recorded*: the shipped
+            // `zebra-rs.conf` conffile is comment-only, and running it
+            // through the sniffer stamped `config_format` as YAML, so the
+            // first `save` on a default install came out YAML instead of
+            // the CLI default. (Done here, not in `config_to_commands`,
+            // so the `vtyctl apply` path keeps its existing
+            // empty-document behavior — an empty apply must not
+            // clear+commit the running config.)
+            Ok(output) if first_meaningful_line(&output).is_none() => {
                 // Unconditional, unlike the applied summary: the trace
                 // toggle rides in the config file, so a boot that lands
                 // here (or in the missing-file arm below) had nothing
                 // that could have enabled it.
                 tracing::info!(
-                    "startup config {} is empty; starting unconfigured",
+                    "startup config {} carries no commands; starting unconfigured",
                     self.config_path.display()
                 );
             }
@@ -1890,16 +1897,24 @@ impl ConfigFormat {
     }
 }
 
+/// First line of a config document that isn't blank or a `#` comment —
+/// `None` for a document that carries no configuration at all. This is
+/// both the line the format sniffer reads and [`ConfigManager::load_config`]'s
+/// "is there anything to load" test, so the two can't disagree on what
+/// counts as content.
+fn first_meaningful_line(config_str: &str) -> Option<&str> {
+    config_str
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+}
+
 pub fn config_format_type(config_str: &str) -> ConfigFormat {
     // Use the first *meaningful* line for format sniffing. Skip
     // blank lines and `#`-prefixed comments so leading whitespace
     // or commentary in a file or `-c` payload doesn't fall through
     // to the YAML default.
-    let first_line = config_str
-        .lines()
-        .map(str::trim)
-        .find(|l| !l.is_empty() && !l.starts_with('#'))
-        .unwrap_or("");
+    let first_line = first_meaningful_line(config_str).unwrap_or("");
     if first_line.starts_with('{') {
         ConfigFormat::Json
     } else if first_line.ends_with('{') || first_line.ends_with(';') {
@@ -2329,6 +2344,39 @@ mod save_config_tests {
         cm.save_config().expect("bare save");
         let saved = std::fs::read_to_string(&path).expect("config readable");
         assert_eq!(config_format_type(&saved), ConfigFormat::Yaml, "{saved:?}");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The .deb ships `/etc/zebra-rs/zebra-rs.conf` comment-only, and
+    /// that file must count as "nothing to load": it used to reach the
+    /// format sniffer, whose no-content fallback is YAML, so the first
+    /// `save` on every default install silently rewrote the conffile as
+    /// YAML. The default save format is CLI.
+    #[test]
+    fn comment_only_conffile_saves_as_cli() {
+        let path = temp_path("comment-only");
+        std::fs::write(
+            &path,
+            "# zebra-rs configuration file.\n#\n# It ships comment-only.\n\n",
+        )
+        .expect("seed config written");
+
+        let cm = manager_with_config(&path);
+        cm.load_config();
+        assert_eq!(*cm.config_format.borrow(), ConfigFormat::Cli);
+
+        // Give the running config content so the saved document has a
+        // format to sniff.
+        let mode = cm.modes.get("configure").expect("configure mode");
+        let (code, output, _) = cm.execute(mode, "set system hostname r1");
+        assert_eq!(code, ExecCode::Show, "set rejected: {output:?}");
+        cm.commit_config().expect("commit succeeds");
+
+        cm.save_config().expect("save succeeds");
+        let saved = std::fs::read_to_string(&path).expect("config readable");
+        assert_eq!(config_format_type(&saved), ConfigFormat::Cli, "{saved:?}");
+        assert!(saved.contains("hostname r1;"), "{saved:?}");
 
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
The default save format is CLI in intent — `config_format` is seeded `Cli` and bare `save` preserves the loaded format — but every **default install saved YAML**: the .deb ships `/etc/zebra-rs/zebra-rs.conf` comment-only, and `load_config` only skipped the format parsers for a byte-empty file. A comment-only document fell through to the sniffer, whose no-content fallback is YAML, so `config_format` was stamped YAML and the first `save` rewrote the conffile as a YAML document — dropping the shipped commentary and locking the box into YAML from then on.

## The fix

Treat "nothing to load" by the sniffer's own definition: the skip-blank-and-comment scan is hoisted into `first_meaningful_line` and used as `load_config`'s empty test, so a missing, empty, or comment-only file all leave `config_format` at the seeded CLI default.

Deliberately unchanged:
- A file with real YAML/JSON/set-delete content keeps saving in its own format (round-trip preserved).
- `save { cli | formal | json | yaml }` still converts and sticks.
- `vtyctl apply` still never flips the save format (an applied document is a config injection, not the on-disk file).

Book updated in the two places that describe the CLI fallback (`ch-00-05`, `ch-06-02`).

## Validation

- New regression test `comment_only_conffile_saves_as_cli`: seeds the shipped conffile's shape, configures a hostname, saves, asserts the file sniffs back as CLI. **A/B-proven** — with the old `output.trim().is_empty()` guard restored, the test fails (file comes out YAML).
- `config::manager` suite 114/114; workspace suite all 40 test binaries green; workspace clippy clean (cache-busted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
