### PR TITLE
config: show ... formal prints set-prefixed statements

### DIFF
--- a/book/src/ch-00-05-command-line-options.md
+++ b/book/src/ch-00-05-command-line-options.md
@@ -39,8 +39,8 @@ configuration representations is accepted:
 - **CLI** — the Cisco-style indented block format (`show running-config`).
 - **JSON** — a JSON document of the configuration tree.
 - **YAML** — a YAML document of the configuration tree.
-- **set/delete** — a flat list of `set …` / `delete …` statements (what
-  `show running-config formal` prints, with the `set` keyword restored).
+- **set/delete** — a flat list of `set …` / `delete …` statements
+  (exactly what `show running-config formal` prints).
 
 `save` writes the file back in the format it was loaded in, so the round
 trip preserves your choice. A file that carried no configuration at

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -60,22 +60,22 @@ router {
 
 ### `formal`
 
-A flat listing, one configuration leaf per line, handy for diffing in
-plain text or grepping for a single leaf.
+A flat listing, one `set` statement per configuration leaf, handy for
+diffing in plain text, grepping for a single leaf, or pasting straight
+into another router's configure mode.
 
 ```
 host(config)# show candidate-config formal
-system hostname r1
-router bgp global as 65000
-router bgp global router-id 10.0.0.1
-router bgp neighbor 10.0.0.2 remote-as 65001
+set system hostname r1
+set router bgp global as 65000
+set router bgp global router-id 10.0.0.1
+set router bgp neighbor 10.0.0.2 remote-as 65001
 ```
 
-The display drops the leading `set` keyword. A *file* in this format
-keeps it — `set system hostname r1` — which is what `save` writes and
-what the set/delete loader reads; a file of bare lines is sniffed as
-YAML and won't load. So paste from `show … formal` into a config file
-only with the `set` prefix restored.
+This is exactly the document `save formal` writes and the set/delete
+loader reads, so the output also works as a config file as-is — the
+`set` prefix is what makes it sniff as the set/delete format rather
+than falling through to YAML.
 
 ### `json`
 

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -330,10 +330,12 @@ const UNCOMMITTED_UNKNOWN: i32 = 2;
 ///
 /// The predicate is a string comparison of `show running-config formal`
 /// against `show candidate-config formal`. Both render through
-/// `Config::list()` — the same rendering `commit_config` diffs — so this
-/// answers "would a commit do anything?" rather than the weaker "do the
-/// two trees look different"; the configure-mode `show` command
-/// compares the other (`format()`) rendering and the two can disagree.
+/// `Config::formal()` — a `set `-prefixed spelling of the `list()`
+/// rendering `commit_config` diffs, with the prefix applied uniformly
+/// to both sides — so this answers "would a commit do anything?" rather
+/// than the weaker "do the two trees look different"; the
+/// configure-mode `show` command compares the other (`format()`)
+/// rendering and the two can disagree.
 /// Both commands live in exec mode and are not admin-gated, so a View
 /// session can ask.
 ///

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -179,7 +179,7 @@ fn show(config: &ConfigManager) -> (ExecCode, String) {
 // === show {candidate,running}-config [ formal | json | yaml ] ===
 //
 // `Config::format()` renders the CLI / Cisco-style indented block view;
-// `Config::list()` renders the flat set-statement form ("formal");
+// `Config::formal()` renders the flat `set`-statement form ("formal");
 // `Config::json()` / `Config::yaml()` are the serialized equivalents.
 
 fn show_candidate_cli(config: &ConfigManager) -> (ExecCode, String) {
@@ -196,7 +196,7 @@ fn show_running_cli(config: &ConfigManager) -> (ExecCode, String) {
 
 fn show_candidate_formal(config: &ConfigManager) -> (ExecCode, String) {
     let mut output = String::new();
-    config.store.candidate.borrow().list(&mut output);
+    config.store.candidate.borrow().formal(&mut output);
     (ExecCode::Show, output)
 }
 
@@ -214,7 +214,7 @@ fn show_candidate_yaml(config: &ConfigManager) -> (ExecCode, String) {
 
 fn show_running_formal(config: &ConfigManager) -> (ExecCode, String) {
     let mut output = String::new();
-    config.store.running.borrow().list(&mut output);
+    config.store.running.borrow().formal(&mut output);
     (ExecCode::Show, output)
 }
 

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -510,6 +510,23 @@ impl Config {
         }
     }
 
+    /// The operator-facing spelling of [`Self::list`]: every line
+    /// carries the `set` keyword, so the output pastes straight into
+    /// another vty's configure mode and, written to a file, sniffs as
+    /// the set/delete format instead of falling through to YAML. This
+    /// is what `show {running,candidate}-config formal` prints and what
+    /// `save formal` writes; `list` stays bare because the commit
+    /// text-diff and the config-tree parsers work on command bodies.
+    pub fn formal(&self, output: &mut String) {
+        let mut list = String::new();
+        self.list(&mut list);
+        for line in list.lines() {
+            output.push_str("set ");
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+
     fn has_mandatory(&self, mandatory: &String) -> bool {
         for config in self.configs.borrow().iter() {
             if config.name == *mandatory {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1175,14 +1175,12 @@ impl ConfigManager {
 
     /// Render the running config in `format`, as a document
     /// [`Self::load_config`] can read back — the four serializations are
-    /// exactly the four `config_format_type` sniffs.
-    ///
-    /// `SetDelete` is the one that needs assembling: `Config::list`
-    /// renders the bare command bodies (`system hostname r1`), which is
-    /// what `show running-config formal` prints, but a *file* of those
-    /// lines sniffs as YAML — no `{`, no trailing `;`, no `set` — and
-    /// would be unreadable on the next boot. Prefix each line with `set`
-    /// so the document round-trips.
+    /// exactly the four `config_format_type` sniffs. `SetDelete` uses
+    /// `Config::formal` (the `set`-prefixed spelling `show
+    /// running-config formal` also prints), not the bare `Config::list`:
+    /// a file of bare command bodies sniffs as YAML — no `{`, no
+    /// trailing `;`, no `set` — and would be unreadable on the next
+    /// boot.
     fn serialize_running(&self, format: ConfigFormat) -> String {
         let running = self.store.running.borrow();
         let mut output = String::new();
@@ -1194,15 +1192,7 @@ impl ConfigManager {
                 running.json(&mut compact);
                 output = prettify_json(compact);
             }
-            ConfigFormat::SetDelete => {
-                let mut list = String::new();
-                running.list(&mut list);
-                for line in list.lines() {
-                    output.push_str("set ");
-                    output.push_str(line);
-                    output.push('\n');
-                }
-            }
+            ConfigFormat::SetDelete => running.formal(&mut output),
         }
         output
     }
@@ -1455,7 +1445,7 @@ impl ConfigManager {
                     };
                     let text = if req.paths.iter().any(|p| p.name == "formal") {
                         let mut out = String::new();
-                        running().list(&mut out);
+                        running().formal(&mut out);
                         out
                     } else if req.paths.iter().any(|p| p.name == "yaml") {
                         let mut out = String::new();
@@ -1485,7 +1475,7 @@ impl ConfigManager {
                     };
                     let text = if req.paths.iter().any(|p| p.name == "formal") {
                         let mut out = String::new();
-                        candidate().list(&mut out);
+                        candidate().formal(&mut out);
                         out
                     } else if req.paths.iter().any(|p| p.name == "yaml") {
                         let mut out = String::new();
@@ -2348,6 +2338,31 @@ mod save_config_tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// `show … formal` and `save formal` share one rendering
+    /// (`Config::formal`): every line carries the `set` keyword, so the
+    /// display pastes straight into another vty's configure mode and
+    /// doubles as a loadable set/delete document. It used to print the
+    /// bare `Config::list` bodies, which sniffed as YAML when saved.
+    #[test]
+    fn formal_lines_carry_the_set_keyword() {
+        let path = temp_path("formal");
+        std::fs::write(&path, "system {\n  hostname r1;\n}\n").expect("seed config written");
+
+        let cm = manager_with_config(&path);
+        cm.load_config();
+
+        let mut formal = String::new();
+        cm.store.running.borrow().formal(&mut formal);
+        assert!(
+            formal.lines().any(|l| l == "set system hostname r1"),
+            "{formal:?}"
+        );
+        assert!(formal.lines().all(|l| l.starts_with("set ")), "{formal:?}");
+        assert_eq!(config_format_type(&formal), ConfigFormat::SetDelete);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
     /// The .deb ships `/etc/zebra-rs/zebra-rs.conf` comment-only, and
     /// that file must count as "nothing to load": it used to reach the
     /// format sniffer, whose no-content fallback is YAML, so the first
@@ -2517,15 +2532,19 @@ mod uncommitted_predicate_tests {
         exec_show(cm, "show running-config formal") != exec_show(cm, "show candidate-config formal")
     }
 
+    /// The formal show is `Config::formal()` — the `list()` rendering
+    /// `commit_config` diffs, with the `set` prefix applied uniformly to
+    /// both sides, so equality of the two shows still means equality of
+    /// the two diffed renderings.
     #[test]
     fn formal_show_is_the_rendering_commit_diffs() {
         let cm = manager();
         edit(&cm, "set system hostname r1");
 
         let mut running = String::new();
-        cm.store.running.borrow().list(&mut running);
+        cm.store.running.borrow().formal(&mut running);
         let mut candidate = String::new();
-        cm.store.candidate.borrow().list(&mut candidate);
+        cm.store.candidate.borrow().formal(&mut candidate);
 
         assert_eq!(exec_show(&cm, "show running-config formal"), running);
         assert_eq!(exec_show(&cm, "show candidate-config formal"), candidate);


### PR DESCRIPTION
`show {running,candidate}-config formal` rendered bare command bodies (`system hostname r1`), so the output could not be pasted into another vty's configure mode — or saved as a config file — without restoring the `set` keyword by hand (a file of bare lines sniffs as YAML and does not load).

## The change

The prefixing `serialize_running`'s SetDelete arm already did is hoisted into a new `Config::formal()` renderer, used everywhere the formal view is presented:

- the exec-mode `show {running,candidate}-config formal` handlers,
- the `vtyctl show` / MCP running- and candidate-config arms,
- `save formal`.

The show output, the saved file, and the set/delete loader now all speak the same document, so `show … formal` output copy-pastes into another vty **and** works as a config file as-is.

Deliberately unchanged:
- `Config::list()` stays bare — the commit text-diff and the config-tree parsers work on command bodies.
- `vtyhelper -u` (exit-hook dirty check) compares the two formal outputs for equality; both sides gain the prefix uniformly.
- BDD assertions over formal output are substring matches and still hold.

Book updated: `ch-00-05` set/delete bullet, `ch-06-02` formal section (example now shows `set` lines and documents the copy-paste use).

## Validation

- New unit test `formal_lines_carry_the_set_keyword`: every line `set `-prefixed and the document sniffs as `SetDelete`.
- `formal_show_is_the_rendering_commit_diffs` updated to pin the new shared rendering (prefix uniform on both sides of the vtyhelper predicate).
- Config suite 382/382; workspace suite all 40 test binaries green; workspace clippy clean (cache-busted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
