### PR TITLE
config: expose running-config subscription over gRPC (zebra.config.v1)

### DIFF
--- a/proto/config.proto
+++ b/proto/config.proto
@@ -1,0 +1,81 @@
+// Copyright 2026 Zebra Project.
+
+syntax = "proto3";
+
+// Running-config change subscription — the gRPC face of the config
+// manager's in-process subscription mechanisms. External automation
+// (backup/audit tooling, out-of-process feature daemons, controllers)
+// subscribes to commits of the running configuration.
+//
+// This is deliberately a separate package from `vty`: vty.proto is the
+// interactive CLI session protocol (exec, completion, session RBAC),
+// while this is a machine-to-machine northbound API that a consumer
+// can vendor on its own and that versions independently (same model
+// as `cradle.v1`). It is served on the same gRPC endpoint as the vty
+// services.
+package zebra.config.v1;
+
+// Delivery format of a subscription, mirroring the two in-process
+// contracts: per-line command-path dispatch (`ConfigManager::
+// subscribe`, used by the protocol daemons) and whole-subtree JSON
+// batches (`ConfigManager::subscribe_json`, used by firewall/IPsec).
+enum Format {
+  // Every event carries the commit's changed lines as SET/DELETE
+  // path changes, in commit order.
+  PATH = 0;
+  // Every event carries the whole post-commit subtree at the
+  // subscribed path as one JSON document.
+  JSON = 1;
+}
+
+message SubscribeRequest {
+  Format format = 1;
+  // Config-tree prefix to watch, one segment per element — list keys
+  // count as segments (e.g. ["router", "bgp"] or
+  // ["interface", "eth0"]). Empty = the whole configuration.
+  repeated string path = 2;
+}
+
+enum Op {
+  SET = 0;
+  DELETE = 1;
+}
+
+// One changed config line (Format.PATH).
+message Change {
+  Op op = 1;
+  // Full path of the line, one segment per element, with list keys
+  // and leaf values inline: ["interface", "eth0", "mtu", "9000"].
+  // Joined with spaces it is exactly the `set`/`delete` command form
+  // accepted by the vty Apply service.
+  repeated string path = 2;
+}
+
+message ConfigEvent {
+  // True on the first event of every subscription: the current
+  // running config under the subscribed path, delivered as SET
+  // changes (PATH) or one JSON document (JSON). Later events are
+  // per-commit deltas. The snapshot is sent even when the subtree is
+  // empty (no changes / "{}") so the client knows it is in sync.
+  bool snapshot = 1;
+  // Format.PATH: this commit's changes under the subscribed prefix.
+  // Empty on JSON-format events.
+  repeated Change changes = 2;
+  // Format.JSON: the whole post-commit subtree at the subscribed
+  // path; "{}" when the subtree no longer exists. Empty on
+  // PATH-format events.
+  string json = 3;
+}
+
+// Running-config subscription service.
+//
+// Subscribe opens a snapshot-then-deltas stream: one snapshot event,
+// then one event per commit that changes config under the subscribed
+// path — commits that do not touch it produce no event. Delivery is
+// post-commit, so a reader that fetches state on an event sees the
+// committed tree. A subscriber that stops reading long enough to fill
+// its server-side buffer is disconnected; reconnect and resync from
+// the fresh snapshot.
+service ConfigService {
+  rpc Subscribe(SubscribeRequest) returns (stream ConfigEvent) {}
+}

--- a/vtyctl/build.rs
+++ b/vtyctl/build.rs
@@ -1,4 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::compile_protos("../proto/vty.proto")?;
+    // Running-config subscription API (`vtyctl watch`).
+    tonic_prost_build::compile_protos("../proto/config.proto")?;
     Ok(())
 }

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -9,6 +9,7 @@ pub mod clear;
 pub mod endpoint;
 pub mod mcp;
 pub mod show;
+pub mod watch;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -49,6 +50,21 @@ enum Commands {
         #[arg(help = "Show command to execute")]
         command: String,
     },
+    #[command(disable_help_flag = true)]
+    Watch {
+        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
+        host: String,
+
+        #[arg(
+            short,
+            long,
+            help = "Whole-subtree JSON per commit instead of set/delete lines"
+        )]
+        json: bool,
+
+        #[arg(help = "Config path to watch, e.g. 'router bgp' (omit for the whole config)")]
+        path: Vec<String>,
+    },
     /// Start MCP (Model Context Protocol) server for AI assistant integration
     Mcp {
         #[arg(short = 'H', long, default_value = "unix:zebra-rs/vty")]
@@ -74,6 +90,7 @@ fn print_help() {
     eprintln!("  apply       Apply configuration.");
     eprintln!("  clear       Clear commands.");
     eprintln!("  show        Show commands.");
+    eprintln!("  watch       Watch running-config commits.");
     eprintln!("  mcp         Start MCP server for AI assistant integration.");
 }
 
@@ -98,6 +115,9 @@ async fn main() -> Result<()> {
             command,
         }) => {
             show::show(host, command, *json).await?;
+        }
+        Some(Commands::Watch { host, json, path }) => {
+            watch::watch(host, *json, path.clone()).await?;
         }
         Some(Commands::Mcp { host, port, debug }) => {
             mcp::run(host, *port, *debug).await?;

--- a/vtyctl/src/watch.rs
+++ b/vtyctl/src/watch.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use std::io::Write;
+use std::process::exit;
+use tonic::Request;
+
+use pb::config_service_client::ConfigServiceClient;
+use pb::{ConfigEvent, Format, Op, SubscribeRequest};
+
+pub mod pb {
+    tonic::include_proto!("zebra.config.v1");
+}
+
+/// Render one PATH-format event as `set` / `delete` lines — the same
+/// form `vtyctl apply` accepts.
+fn format_event(event: &ConfigEvent) -> String {
+    let mut out = String::new();
+    for change in event.changes.iter() {
+        let op = if change.op == Op::Delete as i32 {
+            "delete"
+        } else {
+            "set"
+        };
+        out.push_str(op);
+        for seg in change.path.iter() {
+            out.push(' ');
+            out.push_str(seg);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+pub async fn watch(host: &str, json: bool, path: Vec<String>) -> Result<()> {
+    let uri = crate::endpoint::host_uri(host);
+    let channel = match crate::endpoint::connect(&uri).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Can't connect to {uri}: {e}");
+            exit(3);
+        }
+    };
+    let mut client = ConfigServiceClient::new(channel);
+
+    let request = SubscribeRequest {
+        format: if json { Format::Json } else { Format::Path } as i32,
+        path,
+    };
+    let mut stream = client.subscribe(Request::new(request)).await?.into_inner();
+
+    // First event is the snapshot of the current running config under
+    // the watched path; each later event is one commit.
+    while let Some(event) = stream.message().await? {
+        if json {
+            println!("{}", event.json);
+        } else {
+            print!("{}", format_event(&event));
+        }
+        std::io::stdout().flush()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_event_renders_set_and_delete_lines() {
+        let event = ConfigEvent {
+            snapshot: false,
+            changes: vec![
+                pb::Change {
+                    op: Op::Set as i32,
+                    path: vec!["system".into(), "hostname".into(), "r1".into()],
+                },
+                pb::Change {
+                    op: Op::Delete as i32,
+                    path: vec!["interface".into(), "eth0".into(), "mtu".into()],
+                },
+            ],
+            json: String::new(),
+        };
+        assert_eq!(
+            format_event(&event),
+            "set system hostname r1\ndelete interface eth0 mtu\n"
+        );
+    }
+}

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -2,6 +2,8 @@ use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::compile_protos("../proto/vty.proto")?;
+    // Running-config subscription API (zebra.config.v1).
+    tonic_prost_build::compile_protos("../proto/config.proto")?;
     // cradle eBPF data-plane control API (FibHandle tee target).
     tonic_prost_build::compile_protos("../proto/cradle.proto")?;
 

--- a/zebra-rs/src/config/api.rs
+++ b/zebra-rs/src/config/api.rs
@@ -1,3 +1,4 @@
+use super::subscribe::ConfigSubscribeRequest;
 use super::vty::CommandPath;
 use super::{ApplyCode, Completion, ExecCode};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -182,6 +183,11 @@ pub enum Message {
     UnsubscribeShowVrf {
         key: String,
     },
+    /// Register an external gRPC subscriber to running-config commits
+    /// (`zebra.config.v1.ConfigService/Subscribe`). The manager sends
+    /// the snapshot event and keeps the sender until the client goes
+    /// away.
+    ConfigSubscribe(ConfigSubscribeRequest),
 }
 
 #[derive(Debug)]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -17,6 +17,7 @@ use super::parse::parse;
 use super::paths::{path_try_trim, paths_str};
 use super::pim::{despawn_pim, spawn_pim};
 use super::stamp::{despawn_stamp, spawn_stamp};
+use super::subscribe::{ConfigSubscriber, path_has_prefix, pb as config_pb};
 use super::util::trim_first_line;
 use super::vrf_redirect_split;
 use super::vty::CommandPath;
@@ -246,6 +247,15 @@ pub struct ConfigManager {
     /// everything", unlike the per-line `cm_clients` broadcast that
     /// suits live-object protocol tasks.
     pub json_clients: RefCell<Vec<(Vec<String>, UnboundedSender<JsonConfigUpdate>)>>,
+    /// External gRPC subscribers to running-config commits
+    /// (`zebra.config.v1.ConfigService/Subscribe`). Unlike
+    /// `cm_clients` / `json_clients` these register at runtime (the
+    /// snapshot event replaces the startup-commit replay) and are
+    /// pruned instead of trusted: delivery is a bounded `try_send`,
+    /// and a subscriber whose channel is closed (client gone) or full
+    /// (client not reading) is dropped — the client resyncs by
+    /// resubscribing.
+    pub config_subscribers: RefCell<Vec<ConfigSubscriber>>,
     pub show_clients: RefCell<HashMap<String, UnboundedSender<DisplayRequest>>>,
     /// Per-instance show channels keyed `"<proto>:vrf:<name>"`. Populated
     /// at runtime as protocols spawn VRF tasks (via
@@ -397,6 +407,7 @@ impl ConfigManager {
             rx,
             cm_clients: RefCell::new(HashMap::new()),
             json_clients: RefCell::new(Vec::new()),
+            config_subscribers: RefCell::new(Vec::new()),
             show_clients: RefCell::new(HashMap::new()),
             show_vrf_clients: RefCell::new(HashMap::new()),
             bgp_tx: RefCell::new(None),
@@ -588,6 +599,86 @@ impl ConfigManager {
         let mut out = String::new();
         node.json(&mut out);
         out
+    }
+
+    /// The initial event of an external gRPC subscription: the
+    /// current running config under the subscriber's path, as SET
+    /// changes (PATH format) or one JSON document (JSON format).
+    /// Sent even when the subtree is empty so the client knows it is
+    /// in sync.
+    fn config_snapshot(&self, sub: &ConfigSubscriber) -> config_pb::ConfigEvent {
+        match sub.format {
+            config_pb::Format::Path => config_pb::ConfigEvent {
+                snapshot: true,
+                changes: self.running_changes(&sub.path),
+                json: String::new(),
+            },
+            config_pb::Format::Json => config_pb::ConfigEvent {
+                snapshot: true,
+                changes: Vec::new(),
+                json: self.subtree_json(&sub.path),
+            },
+        }
+    }
+
+    /// Render the running config under `prefix` as SET changes — the
+    /// PATH-format snapshot. Reuses the same `list()` rendering and
+    /// `paths()` parse that `commit_config`'s diff dispatch uses, so
+    /// snapshot and delta lines are segmented identically.
+    fn running_changes(&self, prefix: &[String]) -> Vec<config_pb::Change> {
+        let mut lines = String::new();
+        self.store.running.borrow().list(&mut lines);
+        let mut changes = Vec::new();
+        for line in lines.lines() {
+            let Some(paths) = self.paths(line.to_string()) else {
+                continue;
+            };
+            let path: Vec<String> = paths.iter().map(|p| p.name.clone()).collect();
+            if path_has_prefix(&path, prefix) {
+                changes.push(config_pb::Change {
+                    op: config_pb::Op::Set as i32,
+                    path,
+                });
+            }
+        }
+        changes
+    }
+
+    /// Deliver one commit's changes to the external gRPC subscribers:
+    /// post-commit (like the JSON batches), one event per touched
+    /// subscription — an untouched subscription gets nothing. A
+    /// subscriber whose channel is closed or full is dropped.
+    fn dispatch_config_subscribers(&self, changes: &[config_pb::Change]) {
+        self.config_subscribers.borrow_mut().retain(|sub| {
+            let event = match sub.format {
+                config_pb::Format::Path => {
+                    let matched: Vec<config_pb::Change> = changes
+                        .iter()
+                        .filter(|c| path_has_prefix(&c.path, &sub.path))
+                        .cloned()
+                        .collect();
+                    if matched.is_empty() {
+                        return true;
+                    }
+                    config_pb::ConfigEvent {
+                        snapshot: false,
+                        changes: matched,
+                        json: String::new(),
+                    }
+                }
+                config_pb::Format::Json => {
+                    if !changes.iter().any(|c| path_has_prefix(&c.path, &sub.path)) {
+                        return true;
+                    }
+                    config_pb::ConfigEvent {
+                        snapshot: false,
+                        changes: Vec::new(),
+                        json: self.subtree_json(&sub.path),
+                    }
+                }
+            };
+            sub.tx.try_send(event).is_ok()
+        });
     }
 
     fn paths(&self, input: String) -> Option<Vec<CommandPath>> {
@@ -826,6 +917,10 @@ impl ConfigManager {
             }
         }
         let mut json_touched = vec![false; self.json_clients.borrow().len()];
+        // This commit's changes in gRPC-subscriber form, accumulated
+        // here (pre-commit, in diff order) and delivered after
+        // `store.commit()` by `dispatch_config_subscribers`.
+        let mut subscriber_changes: Vec<config_pb::Change> = Vec::new();
         for line in diff.lines() {
             if !line.is_empty() {
                 let first_char = line.chars().next().unwrap();
@@ -840,6 +935,13 @@ impl ConfigManager {
                     continue;
                 }
                 let paths = paths.unwrap();
+                subscriber_changes.push(config_pb::Change {
+                    op: match op {
+                        ConfigOp::Set => config_pb::Op::Set as i32,
+                        _ => config_pb::Op::Delete as i32,
+                    },
+                    path: paths.iter().map(|p| p.name.clone()).collect(),
+                });
                 // JSON batch subscribers: only note that the prefix was
                 // touched — the single subtree delivery happens after
                 // the store commits, so it carries the post-commit
@@ -930,6 +1032,11 @@ impl ConfigManager {
                 let _ = tx.send(update);
             }
         }
+
+        // External gRPC subscribers — post-commit like the JSON
+        // batches, so a reader that fetches state on an event sees
+        // the committed tree.
+        self.dispatch_config_subscribers(&subscriber_changes);
         Ok(())
     }
 
@@ -1581,6 +1688,20 @@ impl ConfigManager {
             }
             Message::UnsubscribeShowVrf { key } => {
                 self.show_vrf_clients.borrow_mut().remove(&key);
+            }
+            Message::ConfigSubscribe(req) => {
+                let sub = ConfigSubscriber {
+                    format: req.format,
+                    path: req.path,
+                    tx: req.tx,
+                };
+                // The snapshot goes into a fresh bounded channel, so
+                // a failed send means the client is already gone —
+                // don't register it.
+                let snapshot = self.config_snapshot(&sub);
+                if sub.tx.try_send(snapshot).is_ok() {
+                    self.config_subscribers.borrow_mut().push(sub);
+                }
             }
         }
     }

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -53,6 +53,7 @@ mod ospf;
 mod parse;
 mod pim;
 mod stamp;
+mod subscribe;
 mod token;
 mod tracing;
 mod util;

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -19,6 +19,7 @@ use super::api::{
     ClearTxRequest, CompletionRequest, CompletionResponse, DisplayRequest, DisplayTxRequest,
     ExecuteRequest, ExecuteResponse, Message,
 };
+use super::subscribe::{ConfigServiceServer, ConfigSubscribeService};
 use super::vty::apply_server::{Apply, ApplyServer};
 use super::vty::clear_server::{Clear, ClearServer};
 use super::vty::exec_server::{Exec, ExecServer};
@@ -746,6 +747,9 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
         tx: cli.tx.clone(),
         sessions: sessions.clone(),
     };
+    // Running-config subscription (zebra.config.v1). Read-only, so it
+    // rides at the same session level as Show — no admin gate.
+    let config_service = ConfigSubscribeService { tx: cli.tx.clone() };
 
     let interceptor = VtyPeerInterceptor::from_env(sessions.clone());
     if let Some(set) = &interceptor.allow_uids {
@@ -781,6 +785,10 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
         ))
         .add_service(ApplyServer::with_interceptor(
             apply_service,
+            interceptor.clone(),
+        ))
+        .add_service(ConfigServiceServer::with_interceptor(
+            config_service,
             interceptor.clone(),
         ))
         .add_service(ClearServer::with_interceptor(clear_service, interceptor));

--- a/zebra-rs/src/config/subscribe.rs
+++ b/zebra-rs/src/config/subscribe.rs
@@ -1,0 +1,142 @@
+//! Running-config subscription over gRPC (`zebra.config.v1`).
+//!
+//! The gRPC face of the config manager's in-process subscription
+//! mechanisms: `Subscribe` opens a snapshot-then-deltas stream in
+//! either PATH format (per-commit batch of set/delete path changes,
+//! the `ConfigManager::subscribe` model) or JSON format (whole
+//! post-commit subtree per touching commit, the
+//! `ConfigManager::subscribe_json` model).
+//!
+//! The service handler only mints a per-subscriber channel and hands
+//! its sender to the manager's event loop
+//! ([`Message::ConfigSubscribe`]); registration, the snapshot, and all
+//! deliveries happen inside the manager (see
+//! `ConfigManager::dispatch_config_subscribers`), which prunes a
+//! subscriber whose channel is closed or full.
+
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Response;
+
+use super::api::Message;
+
+pub mod pb {
+    tonic::include_proto!("zebra.config.v1");
+}
+
+pub use pb::config_service_server::ConfigServiceServer;
+
+/// Per-subscriber buffer of undelivered events. Commits are rare and
+/// delivery is one event per commit, so this only fills when a client
+/// stops reading — at which point the manager drops the subscription
+/// rather than buffering without bound toward a dead peer.
+const EVENT_BUFFER: usize = 32;
+
+/// A subscribe registration in flight from the gRPC handler to the
+/// config manager's event loop.
+#[derive(Debug)]
+pub struct ConfigSubscribeRequest {
+    pub format: pb::Format,
+    /// Config-tree prefix to watch, one segment per element; empty
+    /// watches the whole configuration.
+    pub path: Vec<String>,
+    pub tx: mpsc::Sender<pb::ConfigEvent>,
+}
+
+/// One registered subscriber row in the manager.
+#[derive(Debug)]
+pub struct ConfigSubscriber {
+    pub format: pb::Format,
+    pub path: Vec<String>,
+    pub tx: mpsc::Sender<pb::ConfigEvent>,
+}
+
+/// Segment-wise prefix match, the same rule the in-process JSON batch
+/// subscriptions use: every `prefix` segment equals the corresponding
+/// leading `path` segment. An empty prefix matches everything.
+pub fn path_has_prefix(path: &[String], prefix: &[String]) -> bool {
+    path.len() >= prefix.len() && prefix.iter().zip(path.iter()).all(|(pre, seg)| pre == seg)
+}
+
+#[derive(Debug)]
+pub struct ConfigSubscribeService {
+    pub tx: mpsc::Sender<Message>,
+}
+
+#[tonic::async_trait]
+impl pb::config_service_server::ConfigService for ConfigSubscribeService {
+    type SubscribeStream = ReceiverStream<Result<pb::ConfigEvent, tonic::Status>>;
+
+    async fn subscribe(
+        &self,
+        request: tonic::Request<pb::SubscribeRequest>,
+    ) -> Result<Response<Self::SubscribeStream>, tonic::Status> {
+        let request = request.into_inner();
+        let format = pb::Format::try_from(request.format).map_err(|_| {
+            tonic::Status::invalid_argument(format!("unknown format {}", request.format))
+        })?;
+
+        let (bus_tx, mut bus_rx) = mpsc::channel::<pb::ConfigEvent>(EVENT_BUFFER);
+        let register = ConfigSubscribeRequest {
+            format,
+            path: request.path,
+            tx: bus_tx,
+        };
+        self.tx
+            .send(Message::ConfigSubscribe(register))
+            .await
+            .map_err(|_| tonic::Status::unavailable("config manager unavailable"))?;
+
+        // Forward manager deliveries to the response stream. The
+        // `closed()` arm tears the bus down promptly when the client
+        // disconnects, so the manager notices (try_send error) on its
+        // next delivery instead of buffering toward a dead peer.
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    event = bus_rx.recv() => match event {
+                        Some(event) => {
+                            if tx.send(Ok(event)).await.is_err() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    },
+                    _ = tx.closed() => break,
+                }
+            }
+        });
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segs(s: &[&str]) -> Vec<String> {
+        s.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_prefix_matches_everything() {
+        assert!(path_has_prefix(&segs(&["router", "bgp"]), &[]));
+        assert!(path_has_prefix(&[], &[]));
+    }
+
+    #[test]
+    fn prefix_matches_by_leading_segments() {
+        let path = segs(&["interface", "eth0", "mtu", "9000"]);
+        assert!(path_has_prefix(&path, &segs(&["interface"])));
+        assert!(path_has_prefix(&path, &segs(&["interface", "eth0"])));
+        assert!(!path_has_prefix(&path, &segs(&["interface", "eth1"])));
+        assert!(!path_has_prefix(&path, &segs(&["router"])));
+    }
+
+    #[test]
+    fn prefix_longer_than_path_does_not_match() {
+        let path = segs(&["router", "bgp"]);
+        assert!(!path_has_prefix(&path, &segs(&["router", "bgp", "65001"])));
+    }
+}


### PR DESCRIPTION
## Summary

Exposes the config manager's subscription functionality to external gRPC clients.

* **New `proto/config.proto`, package `zebra.config.v1`** — deliberately a separate, versioned package rather than an addition to `vty.proto`: that file already carries the dead openconfigd-legacy `Config`/`Register`/`ExecModule` services (never served, no clients), and its live services are the human CLI-session protocol, while this is a machine northbound API consumers can vendor standalone (same model as `cradle.v1`). Cleaning the dead vty.proto services out is a follow-up.
* **`ConfigService/Subscribe`** opens a snapshot-then-deltas stream of running-config commits, mirroring both in-process contracts: `PATH` format (per-commit batch of set/delete path changes — the `ConfigManager::subscribe` model) and `JSON` format (whole post-commit subtree per touching commit, `"{}"` when deleted — the `subscribe_json` model), with a segment-wise path-prefix filter.
* Served on the existing vty endpoint through the same peer interceptor, at the same session level as `Show` (read-only, no admin gate).
* External subscribers are a **prunable registry** in the manager: delivery is a bounded `try_send` after `store.commit()`; a closed or full channel drops the subscription (the client resyncs by resubscribing) instead of panicking the manager the way the internal `cm_clients` unwrap would.
* **`vtyctl watch [-j] [PATH…]`** reference client; PATH output is `vtyctl apply`-compatible `set`/`delete` lines.

## Test plan

* `cargo test --workspace --exclude bdd` green; fmt + workspace clippy clean.
* Unit tests: prefix matching (`config::subscribe`), event rendering (`vtyctl watch`).
* Live-proven against a throwaway root daemon: correct snapshots (`{}`/empty), set/delete delivery across commits in both formats, prefix filtering (`router` watcher stayed silent), late subscriber received the accumulated config as its snapshot, and killing a subscriber mid-stream left the daemon and remaining subscribers healthy.

Generated with [Claude Code](https://claude.com/claude-code)