### PR TITLE
config: external show providers + machine-peer access (zebra.show.v1)

### DIFF
--- a/proto/show.proto
+++ b/proto/show.proto
@@ -1,0 +1,61 @@
+// Copyright 2026 Zebra Project.
+
+syntax = "proto3";
+
+// External show-provider registration — the reverse of the vty `Show`
+// service. An out-of-process feature daemon (e.g. the insomnia
+// firewall/IPsec enforcement daemon) connects, names the show trees
+// it serves, and then answers the vty's show orders over the same
+// stream, so `show firewall …` typed at the CLI is rendered by the
+// external daemon exactly as an in-process handler would.
+//
+// Like zebra.config.v1 this is a machine-to-machine API, versioned
+// independently of the interactive `vty` package and served on the
+// same gRPC endpoint.
+package zebra.show.v1;
+
+// Client → server. The FIRST message on the stream must be
+// `register`; every later message is a `chunk` answering an order.
+message ProviderMessage {
+  oneof msg {
+    Register register = 1;
+    ShowChunk chunk = 2;
+  }
+}
+
+// The show trees this provider serves — the vty's routing keys, e.g.
+// "firewall" routes `show firewall …` and "ipsec" routes
+// `show vpn ipsec …`. Registration replaces any previous provider of
+// the same name; disconnecting withdraws it (the vty then falls back
+// to its "not configured or running" message).
+message Register {
+  repeated string name = 1;
+}
+
+// Server → client: one show command to answer. `path` is the
+// slash-joined command skeleton ("/show/firewall/ipv4/name") and
+// `args` the matched key/value tokens in command order — the same
+// (path, args) split the in-process handlers get from
+// `path_from_command`.
+message ShowOrder {
+  // Correlates the answer chunks; unique per stream.
+  uint64 id = 1;
+  string path = 2;
+  repeated string args = 3;
+  // Render JSON instead of the human table (`vtyctl show -j`).
+  bool json = 4;
+}
+
+// One piece of an order's output. Send any number of chunks followed
+// by one with `eof` set (its `text` may be empty or carry the final
+// piece). Always answer every order, even with a single empty eof
+// chunk — an unanswered order surfaces to the operator as an error.
+message ShowChunk {
+  uint64 id = 1;
+  string text = 2;
+  bool eof = 3;
+}
+
+service ShowProviderService {
+  rpc Provide(stream ProviderMessage) returns (stream ShowOrder) {}
+}

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -4,6 +4,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::compile_protos("../proto/vty.proto")?;
     // Running-config subscription API (zebra.config.v1).
     tonic_prost_build::compile_protos("../proto/config.proto")?;
+    // External show-provider API (zebra.show.v1).
+    tonic_prost_build::compile_protos("../proto/show.proto")?;
     // cradle eBPF data-plane control API (FibHandle tee target).
     tonic_prost_build::compile_protos("../proto/cradle.proto")?;
 

--- a/zebra-rs/src/config/api.rs
+++ b/zebra-rs/src/config/api.rs
@@ -188,6 +188,21 @@ pub enum Message {
     /// the snapshot event and keeps the sender until the client goes
     /// away.
     ConfigSubscribe(ConfigSubscribeRequest),
+    /// Register an external show provider (`zebra.show.v1`) under a
+    /// top-level show routing key ("firewall", "ipsec", …), replacing
+    /// any previous holder of that name.
+    SubscribeShow {
+        name: String,
+        tx: UnboundedSender<DisplayRequest>,
+    },
+    /// Withdraw an external show provider's name — but only while the
+    /// registry still points at that provider's channel
+    /// (`same_channel`), so a replaced provider's exit cannot remove
+    /// its successor.
+    UnsubscribeShow {
+        name: String,
+        tx: UnboundedSender<DisplayRequest>,
+    },
 }
 
 #[derive(Debug)]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1689,6 +1689,17 @@ impl ConfigManager {
             Message::UnsubscribeShowVrf { key } => {
                 self.show_vrf_clients.borrow_mut().remove(&key);
             }
+            Message::SubscribeShow { name, tx } => {
+                self.show_clients.borrow_mut().insert(name, tx);
+            }
+            Message::UnsubscribeShow { name, tx } => {
+                let mut clients = self.show_clients.borrow_mut();
+                if let Some(current) = clients.get(&name)
+                    && current.same_channel(&tx)
+                {
+                    clients.remove(&name);
+                }
+            }
             Message::ConfigSubscribe(req) => {
                 let sub = ConfigSubscriber {
                     format: req.format,

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -52,6 +52,7 @@ mod nsap;
 mod ospf;
 mod parse;
 mod pim;
+mod show_provider;
 mod stamp;
 mod subscribe;
 mod token;

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -19,6 +19,7 @@ use super::api::{
     ClearTxRequest, CompletionRequest, CompletionResponse, DisplayRequest, DisplayTxRequest,
     ExecuteRequest, ExecuteResponse, Message,
 };
+use super::show_provider::{ShowProviderBridge, ShowProviderServiceServer};
 use super::subscribe::{ConfigServiceServer, ConfigSubscribeService};
 use super::vty::apply_server::{Apply, ApplyServer};
 use super::vty::clear_server::{Clear, ClearServer};
@@ -627,23 +628,72 @@ struct VtyPeerInterceptor {
     sessions: Arc<SessionTable>,
 }
 
+/// Parse the `ZEBRA_VTY_ALLOW_UIDS` env allow-list shared by both
+/// interceptors. `None` when unset or empty (allow-list disabled).
+fn allow_uids_from_env() -> Option<Arc<HashSet<u32>>> {
+    std::env::var("ZEBRA_VTY_ALLOW_UIDS").ok().and_then(|raw| {
+        let set: HashSet<u32> = raw
+            .split(',')
+            .filter_map(|s| s.trim().parse::<u32>().ok())
+            .collect();
+        if set.is_empty() {
+            None
+        } else {
+            Some(Arc::new(set))
+        }
+    })
+}
+
 impl VtyPeerInterceptor {
     fn from_env(sessions: Arc<SessionTable>) -> Self {
-        let allow_uids = std::env::var("ZEBRA_VTY_ALLOW_UIDS").ok().and_then(|raw| {
-            let set: HashSet<u32> = raw
-                .split(',')
-                .filter_map(|s| s.trim().parse::<u32>().ok())
-                .collect();
-            if set.is_empty() {
-                None
-            } else {
-                Some(Arc::new(set))
-            }
-        });
         Self {
-            allow_uids,
+            allow_uids: allow_uids_from_env(),
             sessions,
         }
+    }
+}
+
+/// Per-RPC interceptor for the machine-facing APIs (`zebra.config.v1`
+/// subscription, `zebra.show.v1` show provider).
+///
+/// Enforces the same `ZEBRA_VTY_ALLOW_UIDS` allow-list from
+/// SO_PEERCRED as [`VtyPeerInterceptor`], but does NOT resolve a vty
+/// session: machine peers are typically daemons whose parent is init,
+/// which the session model rejects as orphan clients, and these RPCs
+/// carry no role-gated operations — they are read/serve surfaces at
+/// the same trust level as the session-less `Show` phase. TCP peers
+/// pass through untouched, matching the vty interceptor's posture.
+#[derive(Clone)]
+struct MachinePeerInterceptor {
+    allow_uids: Option<Arc<HashSet<u32>>>,
+}
+
+impl MachinePeerInterceptor {
+    fn from_env() -> Self {
+        Self {
+            allow_uids: allow_uids_from_env(),
+        }
+    }
+}
+
+impl tonic::service::Interceptor for MachinePeerInterceptor {
+    fn call(&mut self, req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        if let Some(info) = req
+            .extensions()
+            .get::<tonic::transport::server::UdsConnectInfo>()
+            && let Some(cred) = &info.peer_cred
+        {
+            let uid = cred.uid();
+            if let Some(allowed) = &self.allow_uids
+                && !allowed.contains(&uid)
+            {
+                tracing::warn!(uid, "machine rpc denied: uid not in allow-list");
+                return Err(tonic::Status::permission_denied(format!(
+                    "uid {uid} is not permitted to use this API"
+                )));
+            }
+        }
+        Ok(req)
     }
 }
 
@@ -747,9 +797,14 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
         tx: cli.tx.clone(),
         sessions: sessions.clone(),
     };
-    // Running-config subscription (zebra.config.v1). Read-only, so it
-    // rides at the same session level as Show — no admin gate.
+    // Machine-facing APIs: running-config subscription
+    // (zebra.config.v1) and the external show provider
+    // (zebra.show.v1). Both use the session-less machine interceptor
+    // so daemonized peers (init-parented) are not rejected as orphan
+    // clients.
     let config_service = ConfigSubscribeService { tx: cli.tx.clone() };
+    let show_provider = ShowProviderBridge { tx: cli.tx.clone() };
+    let machine_interceptor = MachinePeerInterceptor::from_env();
 
     let interceptor = VtyPeerInterceptor::from_env(sessions.clone());
     if let Some(set) = &interceptor.allow_uids {
@@ -789,7 +844,11 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
         ))
         .add_service(ConfigServiceServer::with_interceptor(
             config_service,
-            interceptor.clone(),
+            machine_interceptor.clone(),
+        ))
+        .add_service(ShowProviderServiceServer::with_interceptor(
+            show_provider,
+            machine_interceptor,
         ))
         .add_service(ClearServer::with_interceptor(clear_service, interceptor));
 

--- a/zebra-rs/src/config/show_provider.rs
+++ b/zebra-rs/src/config/show_provider.rs
@@ -1,0 +1,166 @@
+//! External show providers over gRPC (`zebra.show.v1`).
+//!
+//! The reverse of the vty `Show` service: an out-of-process feature
+//! daemon opens `Provide`, names the show trees it serves (the same
+//! keys in-process daemons pass to `ConfigManager::subscribe_show`,
+//! e.g. `"firewall"` / `"ipsec"`), and answers the vty's orders over
+//! the stream. The bridge task below is the provider's in-process
+//! stand-in: it owns a `DisplayRequest` channel registered in the
+//! manager's show registry and translates requests into `ShowOrder`s
+//! and chunks back into per-request responses.
+//!
+//! Lifecycle: registration replaces any previous provider of the same
+//! name; when the stream ends the names are withdrawn (guarded by a
+//! `same_channel` check so a replaced provider's exit cannot remove
+//! its successor) and outstanding orders' response buses are dropped,
+//! which the vty surfaces as an unanswered command instead of a hang.
+
+use std::collections::HashMap;
+
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Response;
+
+use super::api::{DisplayRequest, Message};
+use super::paths::path_from_command;
+
+pub mod pb {
+    tonic::include_proto!("zebra.show.v1");
+}
+
+pub use pb::show_provider_service_server::ShowProviderServiceServer;
+
+/// Undelivered-order buffer toward one provider. Show traffic is
+/// human-driven; this only fills when the provider stops reading.
+const ORDER_BUFFER: usize = 16;
+
+#[derive(Debug)]
+pub struct ShowProviderBridge {
+    pub tx: mpsc::Sender<Message>,
+}
+
+#[tonic::async_trait]
+impl pb::show_provider_service_server::ShowProviderService for ShowProviderBridge {
+    type ProvideStream = ReceiverStream<Result<pb::ShowOrder, tonic::Status>>;
+
+    async fn provide(
+        &self,
+        request: tonic::Request<tonic::Streaming<pb::ProviderMessage>>,
+    ) -> Result<Response<Self::ProvideStream>, tonic::Status> {
+        let mut inbound = request.into_inner();
+
+        // The stream must open with a Register naming the show trees.
+        let names = match inbound.message().await? {
+            Some(pb::ProviderMessage {
+                msg: Some(pb::provider_message::Msg::Register(register)),
+            }) => register.name,
+            _ => {
+                return Err(tonic::Status::invalid_argument(
+                    "first provider message must be Register",
+                ));
+            }
+        };
+        if names.is_empty() {
+            return Err(tonic::Status::invalid_argument(
+                "Register must name at least one show tree",
+            ));
+        }
+
+        let (display_tx, display_rx) = mpsc::unbounded_channel::<DisplayRequest>();
+        for name in names.iter() {
+            self.tx
+                .send(Message::SubscribeShow {
+                    name: name.clone(),
+                    tx: display_tx.clone(),
+                })
+                .await
+                .map_err(|_| tonic::Status::unavailable("config manager unavailable"))?;
+        }
+        tracing::info!(names = ?names, "show provider registered");
+
+        let (orders_tx, orders_rx) = mpsc::channel(ORDER_BUFFER);
+        tokio::spawn(bridge(
+            display_rx,
+            display_tx,
+            inbound,
+            orders_tx,
+            names,
+            self.tx.clone(),
+        ));
+        Ok(Response::new(ReceiverStream::new(orders_rx)))
+    }
+}
+
+/// Per-provider pump: vty `DisplayRequest`s out as orders, provider
+/// chunks back into the per-request response buses. Runs until the
+/// provider stream ends (disconnect, error, or a protocol violation),
+/// then withdraws the registrations.
+async fn bridge(
+    mut display_rx: mpsc::UnboundedReceiver<DisplayRequest>,
+    display_tx: mpsc::UnboundedSender<DisplayRequest>,
+    mut inbound: tonic::Streaming<pb::ProviderMessage>,
+    orders_tx: mpsc::Sender<Result<pb::ShowOrder, tonic::Status>>,
+    names: Vec<String>,
+    manager_tx: mpsc::Sender<Message>,
+) {
+    let mut next_id: u64 = 0;
+    // Response bus of each outstanding order. Dropping an entry closes
+    // that request's stream; dropping the whole map at exit is what
+    // turns provider death into per-command errors instead of hangs.
+    let mut pending: HashMap<u64, mpsc::Sender<String>> = HashMap::new();
+    loop {
+        tokio::select! {
+            req = display_rx.recv() => {
+                // Unreachable in practice (we hold `display_tx`), but
+                // a closed channel would make recv() a busy loop.
+                let Some(req) = req else { break };
+                next_id += 1;
+                let (path, args) = path_from_command(&req.paths);
+                pending.insert(next_id, req.resp);
+                let order = pb::ShowOrder {
+                    id: next_id,
+                    path,
+                    args: args.0.into(),
+                    json: req.json,
+                };
+                if orders_tx.send(Ok(order)).await.is_err() {
+                    break;
+                }
+            }
+            msg = inbound.message() => {
+                match msg {
+                    Ok(Some(pb::ProviderMessage {
+                        msg: Some(pb::provider_message::Msg::Chunk(chunk)),
+                    })) => {
+                        if let Some(resp) = pending.get(&chunk.id) {
+                            let _ = resp.send(chunk.text).await;
+                        }
+                        if chunk.eof {
+                            pending.remove(&chunk.id);
+                        }
+                    }
+                    Ok(Some(pb::ProviderMessage {
+                        msg: Some(pb::provider_message::Msg::Register(_)),
+                    })) => {
+                        tracing::warn!(
+                            names = ?names,
+                            "show provider sent a second Register; closing stream"
+                        );
+                        break;
+                    }
+                    Ok(Some(pb::ProviderMessage { msg: None })) => {}
+                    Ok(None) | Err(_) => break,
+                }
+            }
+        }
+    }
+    for name in names.iter() {
+        let _ = manager_tx
+            .send(Message::UnsubscribeShow {
+                name: name.clone(),
+                tx: display_tx.clone(),
+            })
+            .await;
+    }
+    tracing::info!(names = ?names, "show provider withdrawn");
+}


### PR DESCRIPTION
## Summary

Second piece of the firewall/IPsec extraction (after #2280): lets an out-of-process enforcement daemon keep the vty show surface alive.

* **New `proto/show.proto` (`zebra.show.v1`)** — `ShowProviderService/Provide` is the reverse of the in-process `subscribe_show` registry: the external daemon registers show routing keys ("firewall", "ipsec") and answers the vty's orders over the same bidi stream. Orders carry the identical `(path, args, json)` split the in-process handlers got from `path_from_command`, so handlers move without behavior change.
* Registration **replaces** a previous holder of a name; disconnect **withdraws** it behind a `same_channel` guard (a replaced provider's exit can't remove its successor). Outstanding orders' response buses are dropped on provider death, so the vty reports an unanswered command instead of hanging.
* **`MachinePeerInterceptor`** for both machine-facing APIs (`zebra.config.v1`, `zebra.show.v1`): keeps the `ZEBRA_VTY_ALLOW_UIDS` SO_PEERCRED allow-list, drops vty session resolution — the orphan-client guard would reject daemonized (init-parented) peers, which is exactly what an external enforcement daemon is, and these RPCs carry no role-gated operations.

## Test plan

* `cargo test --workspace --exclude bdd` green; fmt + workspace clippy clean.
* Live E2E against the insomnia daemon (the extracted firewall/IPsec backends): firewall commit → JSON subscription → real nftables ruleset; `show firewall ipv4 name WEB-IN` (args flow) and `-j` JSON answered by the provider with live counters; provider kill → vty falls back to "not configured or running"; provider restart and zebra-rs restart both re-register and resync from the snapshot, including full ruleset teardown on an emptied config.

Generated with [Claude Code](https://claude.com/claude-code)