### PR TITLE
ai: 3D traffic path visualizer over MCP (zebra-topology)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "zebra-rs",
   "vtyctl",
+  "ai/topology",
   "vtyhelper",
   "vtypam",
   "crates/bgp-packet",

--- a/ai/topology/Cargo.toml
+++ b/ai/topology/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "zebra-topology"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+tokio.workspace = true
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+
+[lints]
+workspace = true

--- a/ai/topology/README.md
+++ b/ai/topology/README.md
@@ -1,0 +1,98 @@
+# zebra-topology — 3D Traffic Path Visualizer
+
+A 3D globe visualizer for the [`playset/isis-flexalgo`](../../playset/isis-flexalgo)
+lab: eleven zebra-rs routers across the US, Europe and Asia-Pacific running
+IS-IS Flexible Algorithm (RFC 9350). Pick a source router, a destination and
+an algorithm, and watch the SPF paths arc across the globe — algorithm 0
+crosses the Pacific directly, algorithm 128 (`exclude-any: trans-pacific`)
+sends the same traffic the long way round through Asia and Europe.
+
+There is no TE telemetry (latency/jitter/loss) in this lab; the viewer shows
+what the routers actually know: connectivity, IGP metrics, and per-algorithm
+SPF paths.
+
+## How it gets its data — MCP only
+
+The backend never scrapes `vty`/`vtyctl` CLI output. Every query is a
+[Model Context Protocol](https://modelcontextprotocol.io) `tools/call`
+(2026-07-28 stateless revision) against `vtyctl mcp`, spawned inside the
+router's network namespace — the daemon's VTY endpoint is a Linux abstract
+Unix socket (`@zebra-rs/vty`), which is network-namespaced, so the MCP
+server must run inside the namespace to reach it:
+
+```
+browser ── HTTP ── zebra-topology ── stdio/JSON-RPC ── ip netns exec <rtr> vtyctl mcp ── gRPC ── zebra-rs
+```
+
+Tools used (any MCP client, an AI assistant included, can call the same
+ones):
+
+| tool                 | arguments            | backs                       |
+|----------------------|----------------------|-----------------------------|
+| `get-isis-flex-algo` | —                    | the Algorithm dropdown      |
+| `get-isis-graph`     | `level`, `algorithm` | connectivity arcs           |
+| `get-isis-spf`       | `algorithm`          | the colored path arcs       |
+
+Router locations come from the playset's
+[`ontology.json`](../../playset/isis-flexalgo/ontology.json) (name, city,
+region), joined with a built-in city → latitude/longitude gazetteer.
+
+## Usage
+
+```shell
+# 1. Bring up the eleven-node lab (root required)
+cd playset/isis-flexalgo && ./up.sh && cd -
+
+# 2. Build the daemon tooling and the viewer
+cargo build -p zebra-rs -p vtyctl -p zebra-topology
+
+# 3. Run the viewer from the repository root (root required for
+#    `ip netns exec`; a non-root run falls back to `sudo -n`)
+sudo ./target/debug/zebra-topology
+
+# 4. Browse
+open http://localhost:8080
+```
+
+The globe needs internet access in the browser (three.js, globe.gl and the
+earth textures load from unpkg.com, integrity-pinned).
+
+### Things to try
+
+* Source `tk`, destination `se`: flip Algorithm between `0` and `128` and
+  watch the two ECMP paths jump from the direct Pacific crossing to
+  `tk → sg → fr → {ln,va} → ch → se`. The grey connectivity mesh changes
+  too — algorithm 128's graph genuinely does not contain the three
+  trans-Pacific links.
+* `sudo ip netns exec fr ip link set fr-sg down`, then Refresh: algorithm
+  128 partitions (Tokyo can only reach AP), while algorithm 0 still spans
+  the world. `... set fr-sg up` and Refresh to heal it.
+* Click a path arc (or its legend chip) for the hop-by-hop table with link
+  and cumulative metrics.
+
+### Flags
+
+| flag         | default                                | meaning                        |
+|--------------|----------------------------------------|--------------------------------|
+| `--port`     | `8080`                                 | HTTP listen port               |
+| `--ontology` | `playset/isis-flexalgo/ontology.json`  | router ontology                |
+| `--vtyctl`   | auto (sibling → `target/debug` → PATH) | vtyctl binary for `vtyctl mcp` |
+| `--mcp-host` | `unix:zebra-rs/vty`                    | daemon endpoint inside each ns |
+| `--timeout`  | `15`                                   | per-MCP-call timeout (seconds) |
+
+## HTTP API
+
+* `GET /api/routers` — the ontology with coordinates.
+* `GET /api/algorithms?source=<rtr>` — algorithm 0 plus every
+  Flex-Algorithm the source runs, labeled with its constraints.
+* `GET /api/topology?source=<rtr>&algorithm=<0|128-255>&destination=<rtr|__all__>`
+  — nodes (with `active` = present in the IS-IS graph), undirected
+  connectivity edges of *that algorithm's* graph, and the SPF paths as
+  complete hop lists with cost and egress interface.
+
+## Provenance
+
+Ported from the Graphiant `graphiant-topology` viewer (Go + globe.gl,
+driven by the Graphiant NaaS assurance API). This version swaps the data
+plane for MCP against local zebra-rs routers and drops the TE-specific UI
+(time slider, latency/jitter/loss columns) that has no data source here.

--- a/ai/topology/src/api.rs
+++ b/ai/topology/src/api.rs
@@ -1,0 +1,438 @@
+//! The three JSON APIs behind the viewer, assembled from MCP tool calls
+//! against the selected source router:
+//!
+//! - `/api/routers`    — the ontology (no MCP).
+//! - `/api/algorithms` — `get-isis-flex-algo` → algorithm choices.
+//! - `/api/topology`   — `get-isis-graph` + `get-isis-spf` → nodes,
+//!   connectivity edges, and hop-by-hop paths from the source router.
+
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+use serde_json::{Value, json};
+
+use crate::mcp::McpLauncher;
+use crate::ontology::Router;
+
+pub struct App {
+    pub routers: Vec<Router>,
+    pub launcher: McpLauncher,
+}
+
+impl App {
+    pub fn router(&self, name: &str) -> Option<&Router> {
+        self.routers.iter().find(|r| r.name == name)
+    }
+
+    pub fn api_routers(&self) -> Value {
+        json!({ "routers": self.routers })
+    }
+
+    /// Algorithm choices for the source router: algorithm 0 always, plus
+    /// every locally configured Flex-Algorithm with a human label built
+    /// from its constraints.
+    pub async fn api_algorithms(&self, source: &str) -> Result<Value> {
+        let flex = self
+            .launcher
+            .call_tool(source, "get-isis-flex-algo", json!({}))
+            .await?;
+        Ok(json!({ "algorithms": algorithm_choices(&flex) }))
+    }
+
+    /// The graph and SPF view from `source`, optionally constrained to
+    /// one Flex-Algorithm and filtered to one destination.
+    pub async fn api_topology(
+        &self,
+        source: &str,
+        algorithm: u8,
+        destination: Option<&str>,
+    ) -> Result<Value> {
+        let mut graph_args = json!({ "level": "both" });
+        let mut spf_args = json!({});
+        if algorithm != 0 {
+            graph_args["algorithm"] = json!(algorithm);
+            spf_args["algorithm"] = json!(algorithm);
+        }
+
+        let (graph, spf) = tokio::try_join!(
+            self.launcher
+                .call_tool(source, "get-isis-graph", graph_args),
+            self.launcher.call_tool(source, "get-isis-spf", spf_args),
+        )?;
+
+        let active = graph_node_names(&graph);
+        let edges = graph_edges(&graph);
+        let paths = spf_paths(&spf, source, destination);
+
+        // Every ontology router, marked active when the graph knows it —
+        // plus any graph node the ontology does not know (no coordinates,
+        // so the frontend lists it without plotting it).
+        let mut nodes: Vec<Value> = Vec::new();
+        for r in &self.routers {
+            let mut n = serde_json::to_value(r)?;
+            n["active"] = json!(active.contains(&r.name));
+            nodes.push(n);
+        }
+        for name in &active {
+            if self.router(name).is_none() {
+                nodes.push(json!({
+                    "name": name,
+                    "fullName": name,
+                    "region": "unknown",
+                    "active": true,
+                }));
+            }
+        }
+
+        Ok(json!({
+            "source": source,
+            "algorithm": algorithm,
+            "nodes": nodes,
+            "edges": edges,
+            "paths": paths,
+        }))
+    }
+}
+
+/// Flatten `get-isis-flex-algo` output into dropdown choices. Algorithm 0
+/// is always present — it is IS-IS's unconstrained SPF, not a FAD.
+fn algorithm_choices(flex: &Value) -> Vec<Value> {
+    let mut choices = vec![json!({
+        "algo": 0,
+        "label": "0 — shortest path (unconstrained SPF)",
+    })];
+    let Some(locals) = flex.get("local_algorithms").and_then(Value::as_array) else {
+        return choices;
+    };
+    for entry in locals {
+        let Some(algo) = entry.get("algorithm").and_then(Value::as_u64) else {
+            continue;
+        };
+        let mut constraints = Vec::new();
+        for key in ["exclude_any", "include_any", "include_all"] {
+            if let Some(list) = entry.get(key).and_then(Value::as_array)
+                && !list.is_empty()
+            {
+                let names: Vec<&str> = list.iter().filter_map(Value::as_str).collect();
+                constraints.push(format!("{}: {}", key.replace('_', "-"), names.join(", ")));
+            }
+        }
+        let label = if constraints.is_empty() {
+            format!("{} — flex-algo", algo)
+        } else {
+            format!("{} — {}", algo, constraints.join("; "))
+        };
+        choices.push(json!({ "algo": algo, "label": label }));
+    }
+    choices
+}
+
+/// All node names present in a `get-isis-graph` result (any level).
+fn graph_node_names(graph: &Value) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for level in graph.as_array().into_iter().flatten() {
+        for node in level
+            .get("nodes")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(name) = node.get("name").and_then(Value::as_str) {
+                names.insert(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// Undirected connectivity edges from a `get-isis-graph` result: each
+/// node's outgoing links, deduplicated so `a->b` and `b->a` (and the
+/// same pair on another level) become one edge.
+fn graph_edges(graph: &Value) -> Vec<Value> {
+    let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut edges = Vec::new();
+    for level in graph.as_array().into_iter().flatten() {
+        for node in level
+            .get("nodes")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let Some(from) = node.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            for link in node
+                .get("olinks")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let Some(to) = link.get("name").and_then(Value::as_str) else {
+                    continue;
+                };
+                if from == to {
+                    continue;
+                }
+                let key = if from < to {
+                    (from.to_string(), to.to_string())
+                } else {
+                    (to.to_string(), from.to_string())
+                };
+                if !seen.insert(key) {
+                    continue;
+                }
+                edges.push(json!({
+                    "source": from,
+                    "target": to,
+                    "cost": link.get("cost").and_then(Value::as_u64).unwrap_or(0),
+                }));
+            }
+        }
+    }
+    edges
+}
+
+/// Hop-by-hop paths from a `get-isis-spf` result. The daemon's path
+/// vertex lists start at the first hop, so the source is prepended to
+/// make each path a complete node walk. Paths are deduplicated across
+/// topologies (e.g. MT0 and MT2 computing the identical path).
+fn spf_paths(spf: &Value, source: &str, destination: Option<&str>) -> Vec<Value> {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut paths = Vec::new();
+    let Some(topologies) = spf.get("topologies").and_then(Value::as_object) else {
+        return paths;
+    };
+    for topology in topologies.values() {
+        let destinations = topology.get("destinations").and_then(Value::as_array);
+        for dest in destinations.into_iter().flatten() {
+            let Some(dest_name) = dest.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            if dest_name == source {
+                continue;
+            }
+            if let Some(filter) = destination
+                && dest_name != filter
+            {
+                continue;
+            }
+            let cost = dest.get("cost").and_then(Value::as_u64).unwrap_or(0);
+            for path in dest
+                .get("paths")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let mut hops = vec![source.to_string()];
+                for vertex in path.as_array().into_iter().flatten() {
+                    if let Some(name) = vertex.get("name").and_then(Value::as_str) {
+                        hops.push(name.to_string());
+                    }
+                }
+                if hops.len() < 2 {
+                    continue;
+                }
+                let key = hops.join(">");
+                if !seen.insert(key) {
+                    continue;
+                }
+                // The outgoing interface for this path is the one toward
+                // its first hop.
+                let interface = dest
+                    .get("nexthops")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .find(|nh| nh.get("name").and_then(Value::as_str) == Some(&hops[1]))
+                    .and_then(|nh| nh.get("interface").and_then(Value::as_str))
+                    .unwrap_or("");
+                paths.push(json!({
+                    "index": paths.len(),
+                    "destination": dest_name,
+                    "cost": cost,
+                    "hops": hops,
+                    "interface": interface,
+                }));
+            }
+        }
+    }
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A two-level slice of `get-isis-graph` output shaped like the
+    /// daemon's `GraphJson` (see zebra-rs/src/isis/show.rs).
+    fn graph_fixture() -> Value {
+        json!([
+            {
+                "level": "L2",
+                "nodes": [
+                    {
+                        "id": 0,
+                        "name": "se",
+                        "sys_id": "0000.0000.0001",
+                        "olinks": [
+                            {"id": 1, "name": "sj", "cost": 10},
+                            {"id": 2, "name": "sg", "cost": 10},
+                        ],
+                        "ilinks": [
+                            {"id": 1, "name": "sj", "cost": 10},
+                        ],
+                    },
+                    {
+                        "id": 1,
+                        "name": "sj",
+                        "sys_id": "0000.0000.0002",
+                        "olinks": [
+                            {"id": 0, "name": "se", "cost": 10},
+                        ],
+                        "ilinks": [],
+                    },
+                ],
+            }
+        ])
+    }
+
+    /// A slice of `get-isis-spf` output shaped like the daemon's
+    /// `SpfResultJson`, from source `tk`.
+    fn spf_fixture() -> Value {
+        json!({
+            "ti_lfa_enabled": false,
+            "sr_mpls_enabled": true,
+            "sr_srv6_enabled": false,
+            "detail": false,
+            "topologies": {
+                "L2 (algorithm 128)": {
+                    "destinations": [
+                        {
+                            "vertex_id": 0,
+                            "name": "tk",
+                            "cost": 0,
+                            "nexthops": [],
+                            "paths": [],
+                        },
+                        {
+                            "vertex_id": 1,
+                            "name": "se",
+                            "cost": 60,
+                            "nexthops": [
+                                {"vertex_id": 9, "name": "sg", "interface": "tk-sg"},
+                            ],
+                            "paths": [
+                                [
+                                    {"vertex_id": 9, "name": "sg"},
+                                    {"vertex_id": 8, "name": "fr"},
+                                    {"vertex_id": 7, "name": "ln"},
+                                    {"vertex_id": 3, "name": "ch"},
+                                    {"vertex_id": 1, "name": "se"},
+                                ],
+                            ],
+                        },
+                        {
+                            "vertex_id": 4,
+                            "name": "da",
+                            "cost": 60,
+                            "nexthops": [
+                                {"vertex_id": 9, "name": "sg", "interface": "tk-sg"},
+                            ],
+                            "paths": [
+                                [
+                                    {"vertex_id": 9, "name": "sg"},
+                                    {"vertex_id": 4, "name": "da"},
+                                ],
+                                [
+                                    {"vertex_id": 9, "name": "sg"},
+                                    {"vertex_id": 4, "name": "da"},
+                                ],
+                            ],
+                        },
+                    ],
+                },
+            },
+        })
+    }
+
+    #[test]
+    fn node_names_cover_all_levels() {
+        let names = graph_node_names(&graph_fixture());
+        assert_eq!(
+            names.into_iter().collect::<Vec<_>>(),
+            vec!["se".to_string(), "sj".to_string()]
+        );
+    }
+
+    #[test]
+    fn edges_are_undirected_and_deduplicated() {
+        let edges = graph_edges(&graph_fixture());
+        // se->sj and sj->se collapse; se->sg survives even though sg has
+        // no node entry of its own in this slice.
+        assert_eq!(edges.len(), 2);
+        assert_eq!(edges[0]["source"], "se");
+        assert_eq!(edges[0]["cost"], 10);
+        let pairs: Vec<(String, String)> = edges
+            .iter()
+            .map(|e| {
+                (
+                    e["source"].as_str().unwrap().to_string(),
+                    e["target"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+        assert!(pairs.contains(&("se".to_string(), "sj".to_string())));
+        assert!(pairs.contains(&("se".to_string(), "sg".to_string())));
+    }
+
+    #[test]
+    fn paths_prepend_source_skip_self_and_dedup() {
+        let paths = spf_paths(&spf_fixture(), "tk", None);
+        // 1 path to se + 1 to da (the duplicate ECMP entry dedups).
+        assert_eq!(paths.len(), 2);
+        let se = &paths[0];
+        assert_eq!(se["destination"], "se");
+        assert_eq!(se["cost"], 60);
+        assert_eq!(se["interface"], "tk-sg");
+        let hops: Vec<&str> = se["hops"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|h| h.as_str().unwrap())
+            .collect();
+        assert_eq!(hops, vec!["tk", "sg", "fr", "ln", "ch", "se"]);
+    }
+
+    #[test]
+    fn paths_filter_by_destination() {
+        let paths = spf_paths(&spf_fixture(), "tk", Some("da"));
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0]["destination"], "da");
+    }
+
+    #[test]
+    fn algorithm_choices_always_include_zero() {
+        let flex = json!({
+            "area": "49.0000",
+            "local_algorithms": [
+                {
+                    "algorithm": 128,
+                    "metric_type": "igp",
+                    "advertise_definition": false,
+                    "include_any": [],
+                    "include_all": [],
+                    "exclude_any": ["trans-pacific"],
+                    "srlg_exclude": [],
+                },
+            ],
+        });
+        let choices = algorithm_choices(&flex);
+        assert_eq!(choices.len(), 2);
+        assert_eq!(choices[0]["algo"], 0);
+        assert_eq!(choices[1]["algo"], 128);
+        assert_eq!(choices[1]["label"], "128 — exclude-any: trans-pacific");
+
+        // No flex-algo configured still offers algorithm 0.
+        assert_eq!(algorithm_choices(&json!({})).len(), 1);
+    }
+}

--- a/ai/topology/src/main.rs
+++ b/ai/topology/src/main.rs
@@ -1,0 +1,253 @@
+//! zebra-topology — 3D traffic path visualizer for the zebra-rs
+//! `playset/isis-flexalgo` lab.
+//!
+//! Serves an embedded globe.gl frontend and three JSON APIs. All router
+//! state is obtained through the MCP framework (`vtyctl mcp`, one
+//! stateless session per call, per router namespace) — never by scraping
+//! vty/vtyctl CLI output.
+
+mod api;
+mod mcp;
+mod ontology;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+
+use api::App;
+use mcp::McpLauncher;
+
+const INDEX_HTML: &str = include_str!("../static/index.html");
+const APP_JS: &str = include_str!("../static/app.js");
+const STYLE_CSS: &str = include_str!("../static/style.css");
+
+#[derive(Parser)]
+#[command(
+    name = "zebra-topology",
+    about = "3D traffic path visualizer for the isis-flexalgo playset (MCP-backed)"
+)]
+struct Cli {
+    /// HTTP server port.
+    #[arg(long, default_value_t = 8080)]
+    port: u16,
+
+    /// Path to the playset ontology (router names, cities, regions).
+    #[arg(long, default_value = "playset/isis-flexalgo/ontology.json")]
+    ontology: PathBuf,
+
+    /// vtyctl binary providing `vtyctl mcp`. Defaults to $VTYCTL_BIN,
+    /// then a vtyctl next to this executable, then target/debug/vtyctl,
+    /// then plain `vtyctl` from PATH.
+    #[arg(long)]
+    vtyctl: Option<String>,
+
+    /// VTY gRPC endpoint passed to `vtyctl mcp -H` (as seen from inside
+    /// each router's namespace).
+    #[arg(long, default_value = "unix:zebra-rs/vty")]
+    mcp_host: String,
+
+    /// Per-MCP-call timeout in seconds.
+    #[arg(long, default_value_t = 15)]
+    timeout: u64,
+}
+
+/// Resolve the vtyctl binary the same way the playset scripts do, plus an
+/// executable-sibling fallback so `sudo ./target/debug/zebra-topology`
+/// works from any directory.
+fn resolve_vtyctl(explicit: Option<String>) -> String {
+    if let Some(path) = explicit {
+        return path;
+    }
+    if let Ok(path) = std::env::var("VTYCTL_BIN")
+        && !path.is_empty()
+    {
+        return path;
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        let sibling = dir.join("vtyctl");
+        if sibling.is_file() {
+            return sibling.to_string_lossy().into_owned();
+        }
+    }
+    let built = PathBuf::from("target/debug/vtyctl");
+    if built.is_file() {
+        return built.to_string_lossy().into_owned();
+    }
+    "vtyctl".to_string()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let routers = ontology::load(&cli.ontology)?;
+    let vtyctl = resolve_vtyctl(cli.vtyctl);
+    let app = Arc::new(App {
+        routers,
+        launcher: McpLauncher {
+            vtyctl: vtyctl.clone(),
+            host: cli.mcp_host.clone(),
+            timeout: Duration::from_secs(cli.timeout),
+        },
+    });
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], cli.port));
+    let listener = TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind {addr}"))?;
+
+    println!("zebra-topology: http://localhost:{}", cli.port);
+    println!(
+        "  ontology : {} ({} routers)",
+        cli.ontology.display(),
+        app.routers.len()
+    );
+    println!("  vtyctl   : {vtyctl}");
+    println!("  mcp host : {}", cli.mcp_host);
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let app = app.clone();
+        tokio::spawn(async move {
+            let service = service_fn(move |req| handle(req, app.clone()));
+            if let Err(e) = http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await
+            {
+                eprintln!("connection error: {e}");
+            }
+        });
+    }
+}
+
+fn query_params(req: &Request<Incoming>) -> HashMap<String, String> {
+    req.uri()
+        .query()
+        .unwrap_or("")
+        .split('&')
+        .filter_map(|kv| kv.split_once('='))
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+fn respond(
+    status: StatusCode,
+    content_type: &str,
+    body: impl Into<Bytes>,
+) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header("content-type", content_type)
+        .body(Full::new(body.into()))
+        .expect("static response parts are valid")
+}
+
+fn json_ok(value: serde_json::Value) -> Response<Full<Bytes>> {
+    respond(StatusCode::OK, "application/json", value.to_string())
+}
+
+fn json_error(status: StatusCode, message: &str) -> Response<Full<Bytes>> {
+    respond(
+        status,
+        "application/json",
+        serde_json::json!({ "error": message }).to_string(),
+    )
+}
+
+async fn handle(
+    req: Request<Incoming>,
+    app: Arc<App>,
+) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    if req.method() != Method::GET {
+        return Ok(json_error(StatusCode::METHOD_NOT_ALLOWED, "GET only"));
+    }
+
+    let path = req.uri().path().to_string();
+    let response = match path.as_str() {
+        "/" => respond(StatusCode::OK, "text/html; charset=utf-8", INDEX_HTML),
+        "/static/app.js" => respond(StatusCode::OK, "application/javascript", APP_JS),
+        "/static/style.css" => respond(StatusCode::OK, "text/css", STYLE_CSS),
+        "/api/routers" => json_ok(app.api_routers()),
+        "/api/algorithms" => api_algorithms(&req, &app).await,
+        "/api/topology" => api_topology(&req, &app).await,
+        _ => json_error(StatusCode::NOT_FOUND, "not found"),
+    };
+    Ok(response)
+}
+
+/// Validate a `source`/`destination` query value: it must be a router the
+/// ontology knows. Since the router name doubles as the network namespace
+/// in the spawned `ip netns exec` argv, unknown names are rejected rather
+/// than passed through.
+fn known_router<'a>(app: &App, params: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    params
+        .get(key)
+        .map(String::as_str)
+        .filter(|name| app.router(name).is_some())
+}
+
+async fn api_algorithms(req: &Request<Incoming>, app: &App) -> Response<Full<Bytes>> {
+    let params = query_params(req);
+    let Some(source) = known_router(app, &params, "source") else {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "unknown or missing 'source' router",
+        );
+    };
+    match app.api_algorithms(source).await {
+        Ok(v) => json_ok(v),
+        Err(e) => json_error(StatusCode::BAD_GATEWAY, &format!("{e:#}")),
+    }
+}
+
+async fn api_topology(req: &Request<Incoming>, app: &App) -> Response<Full<Bytes>> {
+    let params = query_params(req);
+    let Some(source) = known_router(app, &params, "source") else {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "unknown or missing 'source' router",
+        );
+    };
+
+    let algorithm = match params.get("algorithm").map(String::as_str) {
+        None | Some("") | Some("0") => 0u8,
+        Some(text) => match text.parse::<u8>() {
+            Ok(n) if (128..=255).contains(&n) => n,
+            _ => {
+                return json_error(
+                    StatusCode::BAD_REQUEST,
+                    "'algorithm' must be 0 or a Flex-Algorithm number 128-255",
+                );
+            }
+        },
+    };
+
+    let destination = match params.get("destination").map(String::as_str) {
+        None | Some("") | Some("__all__") => None,
+        Some(_) => match known_router(app, &params, "destination") {
+            Some(name) => Some(name),
+            None => {
+                return json_error(StatusCode::BAD_REQUEST, "unknown 'destination' router");
+            }
+        },
+    };
+
+    match app.api_topology(source, algorithm, destination).await {
+        Ok(v) => json_ok(v),
+        Err(e) => json_error(StatusCode::BAD_GATEWAY, &format!("{e:#}")),
+    }
+}

--- a/ai/topology/src/mcp.rs
+++ b/ai/topology/src/mcp.rs
@@ -1,0 +1,159 @@
+//! Minimal MCP (Model Context Protocol) client for `vtyctl mcp`.
+//!
+//! Each router in the playset runs zebra-rs inside its own network
+//! namespace, listening on the abstract Unix socket `@zebra-rs/vty` —
+//! which is network-namespaced, so the daemon is only reachable from
+//! inside its namespace. This client therefore spawns
+//! `ip netns exec <router> vtyctl mcp` per call and speaks the MCP
+//! 2026-07-28 stateless revision over stdio: one `tools/call` request
+//! line out, one response line back, no handshake.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+const PROTOCOL_VERSION: &str = "2026-07-28";
+const META_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
+const META_CLIENT_CAPABILITIES: &str = "io.modelcontextprotocol/clientCapabilities";
+
+/// How the MCP server process is launched for a given router.
+#[derive(Clone, Debug)]
+pub struct McpLauncher {
+    /// Path to the vtyctl binary that provides `vtyctl mcp`.
+    pub vtyctl: String,
+    /// `--host` passed through to `vtyctl mcp` (the daemon's VTY gRPC
+    /// endpoint as seen from inside the namespace).
+    pub host: String,
+    /// Per-call timeout.
+    pub timeout: Duration,
+}
+
+impl McpLauncher {
+    /// Build the command that runs `vtyctl mcp` inside `netns`. When not
+    /// running as root, go through `sudo -n` — the same convention as the
+    /// playset scripts, but non-interactive so a misconfigured sudo fails
+    /// fast instead of hanging the HTTP request on a password prompt.
+    fn command(&self, netns: &str) -> Command {
+        let mut argv: Vec<&str> = Vec::new();
+        if !is_root() {
+            argv.extend(["sudo", "-n"]);
+        }
+        argv.extend(["ip", "netns", "exec", netns]);
+        argv.push(&self.vtyctl);
+        argv.extend(["mcp", "-H", &self.host]);
+
+        let mut cmd = Command::new(argv[0]);
+        cmd.args(&argv[1..]);
+        cmd
+    }
+
+    /// Call one MCP tool on the router in `netns` and return the tool's
+    /// text content parsed as JSON.
+    pub async fn call_tool(&self, netns: &str, tool: &str, arguments: Value) -> Result<Value> {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool,
+                "arguments": arguments,
+                "_meta": {
+                    META_PROTOCOL_VERSION: PROTOCOL_VERSION,
+                    META_CLIENT_CAPABILITIES: {},
+                },
+            },
+        });
+
+        let response = tokio::time::timeout(self.timeout, self.roundtrip(netns, &request))
+            .await
+            .map_err(|_| anyhow!("MCP call '{tool}' on '{netns}' timed out"))??;
+
+        if let Some(error) = response.get("error") {
+            bail!("MCP error from '{netns}': {error}");
+        }
+        let result = response
+            .get("result")
+            .ok_or_else(|| anyhow!("MCP response from '{netns}' has no result"))?;
+        let text = result
+            .pointer("/content/0/text")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("MCP result from '{netns}' has no text content"))?;
+        if result.get("isError").and_then(Value::as_bool) == Some(true) {
+            bail!("MCP tool '{tool}' failed on '{netns}': {text}");
+        }
+        serde_json::from_str(text)
+            .with_context(|| format!("MCP tool '{tool}' on '{netns}' returned non-JSON output"))
+    }
+
+    /// One stateless request/response exchange with a freshly spawned
+    /// `vtyctl mcp` in `netns`.
+    async fn roundtrip(&self, netns: &str, request: &Value) -> Result<Value> {
+        let mut child = self
+            .command(netns)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| format!("failed to spawn vtyctl mcp for '{netns}'"))?;
+
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut stderr = child.stderr.take().expect("piped stderr");
+
+        let mut line = serde_json::to_string(request)?;
+        line.push('\n');
+        stdin.write_all(line.as_bytes()).await?;
+        // Closing stdin lets the server exit after answering, so the
+        // process reaps itself once we have read the response.
+        drop(stdin);
+
+        let mut lines = BufReader::new(stdout).lines();
+        let response = loop {
+            match lines.next_line().await? {
+                // Skip anything that is not a JSON object (stray log noise).
+                Some(l) => match serde_json::from_str::<Value>(&l) {
+                    Ok(v) if v.is_object() => break Some(v),
+                    _ => continue,
+                },
+                None => break None,
+            }
+        };
+
+        match response {
+            Some(v) => {
+                let _ = child.wait().await;
+                Ok(v)
+            }
+            None => {
+                // Server exited without answering — surface its stderr,
+                // which is where sudo and connection errors land.
+                let mut err = String::new();
+                let _ = stderr.read_to_string(&mut err).await;
+                let status = child.wait().await?;
+                bail!(
+                    "vtyctl mcp for '{netns}' exited ({status}) without a response: {}",
+                    err.trim()
+                );
+            }
+        }
+    }
+}
+
+fn is_root() -> bool {
+    // SAFETY: geteuid is always safe to call.
+    unsafe { libc_geteuid() == 0 }
+}
+
+unsafe fn libc_geteuid() -> u32 {
+    // Avoid a libc dependency for one syscall wrapper: geteuid is
+    // exported by glibc/musl under this exact name and signature.
+    unsafe extern "C" {
+        fn geteuid() -> u32;
+    }
+    unsafe { geteuid() }
+}

--- a/ai/topology/src/ontology.rs
+++ b/ai/topology/src/ontology.rs
@@ -1,0 +1,106 @@
+//! Router ontology: the playset's `ontology.json` (name, full name,
+//! region per router) joined with a built-in city gazetteer that supplies
+//! the coordinates the 3D globe needs. `ontology.json` is the source of
+//! truth for which routers exist and where they are; the gazetteer only
+//! turns its city names into latitude/longitude.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct OntologyEntry {
+    name: String,
+    #[serde(rename = "full-name")]
+    full_name: String,
+    region: String,
+}
+
+/// One router as served to the frontend.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Router {
+    /// Short name — the IS-IS hostname and the network namespace name.
+    pub name: String,
+    pub full_name: String,
+    pub region: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lat: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lng: Option<f64>,
+}
+
+/// City-name → (lat, lng) gazetteer for the ontology's `full-name`
+/// values. A city missing here still renders in lists; it just cannot be
+/// placed on the globe.
+const CITY_GEO: &[(&str, f64, f64)] = &[
+    ("Seattle", 47.6062, -122.3321),
+    ("San Jose", 37.3382, -121.8863),
+    ("Chicago", 41.8781, -87.6298),
+    ("Dallas", 32.7767, -96.7970),
+    // The ontology's "Virginia" is the Ashburn, VA datacenter corridor.
+    ("Virginia", 39.0438, -77.4874),
+    ("Atlanta", 33.7490, -84.3880),
+    ("London", 51.5074, -0.1278),
+    ("Frankfurt", 50.1109, 8.6821),
+    ("Singapore", 1.3521, 103.8198),
+    ("Sydney", -33.8688, 151.2093),
+    ("Tokyo", 35.6762, 139.6503),
+];
+
+fn geocode(full_name: &str) -> Option<(f64, f64)> {
+    CITY_GEO
+        .iter()
+        .find(|(city, _, _)| city.eq_ignore_ascii_case(full_name))
+        .map(|(_, lat, lng)| (*lat, *lng))
+}
+
+/// Load `ontology.json` and geocode each entry.
+pub fn load(path: &Path) -> Result<Vec<Router>> {
+    let data = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read ontology {}", path.display()))?;
+    let entries: Vec<OntologyEntry> = serde_json::from_str(&data)
+        .with_context(|| format!("failed to parse ontology {}", path.display()))?;
+    Ok(entries
+        .into_iter()
+        .map(|e| {
+            let geo = geocode(&e.full_name);
+            Router {
+                name: e.name,
+                full_name: e.full_name,
+                region: e.region,
+                lat: geo.map(|(lat, _)| lat),
+                lng: geo.map(|(_, lng)| lng),
+            }
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_the_playset_ontology() {
+        // The playset file this app is built around; keep the test
+        // hermetic against layout changes by resolving from the crate.
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../playset/isis-flexalgo/ontology.json");
+        let routers = load(&path).expect("ontology loads");
+        assert_eq!(routers.len(), 11);
+        assert!(
+            routers.iter().all(|r| r.lat.is_some() && r.lng.is_some()),
+            "every playset city must geocode"
+        );
+        let tk = routers.iter().find(|r| r.name == "tk").expect("tk exists");
+        assert_eq!(tk.full_name, "Tokyo");
+        assert_eq!(tk.region, "AP");
+    }
+
+    #[test]
+    fn geocode_is_case_insensitive_and_total_for_known_cities() {
+        assert!(geocode("tokyo").is_some());
+        assert!(geocode("Nowhere City").is_none());
+    }
+}

--- a/ai/topology/static/app.js
+++ b/ai/topology/static/app.js
@@ -1,0 +1,457 @@
+// zebra-rs Traffic Path Visualizer — Frontend (3D Globe)
+//
+// Ported from the Graphiant topology viewer. Data comes from the local
+// backend, which queries each router over MCP (vtyctl mcp). There is no
+// TE telemetry here — the lab carries connectivity, IGP metrics, and
+// per-algorithm SPF paths, so that is what the globe shows.
+
+const COLORS = ['#e6194b', '#3cb44b', '#4363d8', '#f58231', '#911eb4', '#42d4f4', '#f032e6', '#bfef45'];
+
+const REGION_COLORS = {
+    US: '#3b82f6',
+    EU: '#2ecc71',
+    AP: '#f59e0b',
+};
+
+const BASE_ARC_COLOR = 'rgba(170, 180, 200, 0.35)';
+const INACTIVE_COLOR = '#95a5a6';
+
+let map;
+
+// Rendered state
+let renderedPaths = [];
+let allArcs = [];        // base connectivity arcs + path arcs
+let allPoints = [];
+let visiblePathIdx = new Set();
+let currentNodeMap = {};
+let currentEdgeCost = {};
+let currentAlgorithm = 0;
+
+function initMap() {
+    const container = document.getElementById('map');
+    map = Globe()(container)
+        .globeImageUrl('//unpkg.com/three-globe/example/img/earth-blue-marble.jpg')
+        .bumpImageUrl('//unpkg.com/three-globe/example/img/earth-topology.png')
+        .backgroundImageUrl('//unpkg.com/three-globe/example/img/night-sky.png')
+        .atmosphereColor('#3b82f6')
+        .atmosphereAltitude(0.18)
+        .arcColor('color')
+        .arcStroke(d => d.base ? 0.22 : 0.5)
+        .arcAltitudeAutoScale(d => d.base ? 0.25 : 0.4)
+        .arcDashLength(d => d.base ? 1 : 0.4)
+        .arcDashGap(d => d.base ? 0 : 0.15)
+        .arcDashAnimateTime(d => d.base ? 0 : 2500)
+        .arcLabel('tooltip')
+        .onArcClick(d => { if (d && !d.base) populatePathDetail(d.pathIdx); })
+        .pointLat('lat')
+        .pointLng('lng')
+        .pointColor('color')
+        .pointAltitude(0.01)
+        .pointRadius(0.4)
+        .pointLabel('label')
+        .pointOfView({ lat: 30, lng: -30, altitude: 2.5 });
+
+    // Auto-rotate gently until the user interacts
+    const controls = map.controls();
+    controls.autoRotate = true;
+    controls.autoRotateSpeed = 0.3;
+    map.onGlobeClick(() => { controls.autoRotate = false; });
+
+    // Keep canvas sized to its container on viewport changes
+    const resize = () => map.width(container.clientWidth).height(container.clientHeight);
+    window.addEventListener('resize', resize);
+    resize();
+
+    const panel = document.getElementById('pathDetail');
+    if (panel) {
+        panel.querySelector('.path-detail-close').addEventListener('click', () => {
+            panel.style.display = 'none';
+        });
+    }
+}
+
+function clearMap() {
+    if (map) {
+        map.arcsData([]).pointsData([]);
+    }
+    document.getElementById('legend').innerHTML = '';
+
+    renderedPaths = [];
+    allArcs = [];
+    allPoints = [];
+    visiblePathIdx = new Set();
+    currentNodeMap = {};
+    currentEdgeCost = {};
+
+    const panel = document.getElementById('pathDetail');
+    if (panel) panel.style.display = 'none';
+}
+
+function setStatus(msg, isError) {
+    const el = document.getElementById('status');
+    el.textContent = msg;
+    el.className = isError ? 'status-bar error' : 'status-bar';
+}
+
+async function apiFetch(url) {
+    const resp = await fetch(url);
+    const body = await resp.text();
+    if (!resp.ok) {
+        let msg = body;
+        try { msg = JSON.parse(body).error || body; } catch (e) { /* raw body */ }
+        throw new Error(`API error ${resp.status}: ${msg}`);
+    }
+    return JSON.parse(body);
+}
+
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+    })[c]);
+}
+
+// --- Dropdown logic ---
+
+async function loadRouters() {
+    try {
+        setStatus('Loading routers...');
+        const data = await apiFetch('/api/routers');
+        const routers = data.routers || [];
+
+        const srcSel = document.getElementById('source');
+        srcSel.innerHTML = '';
+        routers.forEach(r => {
+            const opt = document.createElement('option');
+            opt.value = r.name;
+            opt.textContent = `${r.name} — ${r.fullName} (${r.region})`;
+            srcSel.appendChild(opt);
+        });
+
+        const dstSel = document.getElementById('destination');
+        dstSel.innerHTML = '<option value="__all__">All destinations</option>';
+        routers.forEach(r => {
+            const opt = document.createElement('option');
+            opt.value = r.name;
+            opt.textContent = `${r.name} — ${r.fullName} (${r.region})`;
+            dstSel.appendChild(opt);
+        });
+        dstSel.disabled = false;
+
+        // Tokyo makes the flex-algo detour the most dramatic; default to
+        // it when present, otherwise the first router.
+        if (routers.some(r => r.name === 'tk')) {
+            srcSel.value = 'tk';
+        }
+
+        setStatus(`${routers.length} routers loaded.`);
+        if (routers.length > 0) {
+            await loadAlgorithms(srcSel.value);
+            await loadTopology();
+        }
+    } catch (e) {
+        setStatus('Failed to load routers: ' + e.message, true);
+    }
+}
+
+async function loadAlgorithms(source) {
+    const algoSel = document.getElementById('algorithm');
+    const previous = algoSel.value;
+    try {
+        setStatus('Loading algorithms...');
+        const data = await apiFetch('/api/algorithms?source=' + encodeURIComponent(source));
+        const algorithms = data.algorithms || [];
+        algoSel.innerHTML = '';
+        algorithms.forEach(a => {
+            const opt = document.createElement('option');
+            opt.value = String(a.algo);
+            opt.textContent = a.label;
+            algoSel.appendChild(opt);
+        });
+        // Keep the previous selection when the new source also runs it.
+        if ([...algoSel.options].some(o => o.value === previous)) {
+            algoSel.value = previous;
+        }
+        algoSel.disabled = false;
+        setStatus(`${algorithms.length} algorithm(s) available.`);
+    } catch (e) {
+        algoSel.innerHTML = '<option value="0">0 — shortest path (unconstrained SPF)</option>';
+        algoSel.disabled = false;
+        setStatus('Failed to load algorithms (showing algorithm 0 only): ' + e.message, true);
+    }
+}
+
+async function loadTopology() {
+    const source = document.getElementById('source').value;
+    const destination = document.getElementById('destination').value;
+    const algorithm = document.getElementById('algorithm').value || '0';
+
+    if (!source) return;
+
+    clearMap();
+    setStatus('Querying ' + source + ' over MCP...');
+
+    try {
+        const url = '/api/topology?source=' + encodeURIComponent(source) +
+            '&algorithm=' + encodeURIComponent(algorithm) +
+            '&destination=' + encodeURIComponent(destination);
+        const data = await apiFetch(url);
+        renderTopology(data);
+    } catch (e) {
+        setStatus('Failed to load topology: ' + e.message, true);
+    }
+}
+
+// --- Map rendering ---
+
+function nodeLabel(n) {
+    const region = n.region && REGION_COLORS[n.region] ? n.region : (n.region || 'unknown');
+    return `<b>${escapeHtml(n.fullName || n.name)}</b> (${escapeHtml(n.name)})<br>` +
+        `Region: ${escapeHtml(region)}<br>` +
+        `IS-IS: ${n.active ? 'up' : 'not in topology'}`;
+}
+
+function renderTopology(data) {
+    clearMap();
+
+    currentAlgorithm = data.algorithm || 0;
+
+    if (!data.nodes || data.nodes.length === 0) {
+        setStatus('No topology data returned.');
+        return;
+    }
+
+    const nodeMap = {};
+    data.nodes.forEach(n => { nodeMap[n.name] = n; });
+    currentNodeMap = nodeMap;
+
+    const edges = data.edges || [];
+    const edgeCost = {};
+    edges.forEach(e => {
+        edgeCost[e.source + '|' + e.target] = e.cost;
+        edgeCost[e.target + '|' + e.source] = e.cost;
+    });
+    currentEdgeCost = edgeCost;
+
+    // Base connectivity arcs (the algorithm's own view of the graph —
+    // links pruned by a flex-algo constraint are genuinely absent here).
+    let plottedEdges = 0;
+    edges.forEach(e => {
+        const a = nodeMap[e.source];
+        const b = nodeMap[e.target];
+        if (!a || !b || a.lat == null || b.lat == null) return;
+        plottedEdges++;
+        allArcs.push({
+            base: true,
+            startLat: a.lat, startLng: a.lng,
+            endLat: b.lat, endLng: b.lng,
+            color: BASE_ARC_COLOR,
+            pathIdx: -1,
+            tooltip: `<b>${escapeHtml(e.source)} &harr; ${escapeHtml(e.target)}</b><br>metric ${e.cost}`
+        });
+    });
+
+    // Path arcs, one color per path, with a legend toggle each.
+    const paths = data.paths || [];
+    const legendEl = document.getElementById('legend');
+    legendEl.innerHTML = '';
+    let allPathBtn = null;
+
+    paths.forEach(path => {
+        const idx = path.index;
+        const color = COLORS[idx % COLORS.length];
+        const hops = (path.hops || []).filter(h => {
+            const n = nodeMap[h];
+            return n && n.lat != null && n.lng != null;
+        });
+        if (hops.length < 2) return;
+
+        const title = `${path.hops[0]} → ${path.destination}`;
+        for (let i = 0; i < hops.length - 1; i++) {
+            const a = nodeMap[hops[i]];
+            const b = nodeMap[hops[i + 1]];
+            const cost = edgeCost[hops[i] + '|' + hops[i + 1]];
+            allArcs.push({
+                base: false,
+                startLat: a.lat, startLng: a.lng,
+                endLat: b.lat, endLng: b.lng,
+                color,
+                pathIdx: idx,
+                tooltip: `<b>${escapeHtml(hops[i])} → ${escapeHtml(hops[i + 1])}</b><br>` +
+                    `Path ${idx + 1}: ${escapeHtml(title)}<br>` +
+                    `Algorithm ${currentAlgorithm}, path cost ${path.cost}` +
+                    (cost != null ? `<br>link metric ${cost}` : '')
+            });
+        }
+
+        visiblePathIdx.add(idx);
+
+        const btn = document.createElement('button');
+        btn.className = 'path-toggle active';
+        btn.innerHTML = `<span class="swatch" style="background:${color}"></span>` +
+            escapeHtml(`${title} #${idx + 1}`);
+        btn.addEventListener('click', () => {
+            if (visiblePathIdx.has(idx)) {
+                visiblePathIdx.delete(idx);
+                btn.classList.remove('active');
+            } else {
+                visiblePathIdx.add(idx);
+                btn.classList.add('active');
+                populatePathDetail(idx);
+            }
+            refreshArcs();
+            if (allPathBtn) {
+                const allVisible = renderedPaths.every(p => visiblePathIdx.has(p.idx));
+                allPathBtn.classList.toggle('active', allVisible);
+            }
+        });
+        legendEl.appendChild(btn);
+
+        renderedPaths.push({ idx, color, path, button: btn });
+    });
+
+    if (renderedPaths.length > 1) {
+        allPathBtn = document.createElement('button');
+        allPathBtn.className = 'path-toggle active';
+        allPathBtn.textContent = 'All paths';
+        allPathBtn.addEventListener('click', () => {
+            const anyHidden = renderedPaths.some(p => !visiblePathIdx.has(p.idx));
+            if (anyHidden) {
+                renderedPaths.forEach(p => {
+                    visiblePathIdx.add(p.idx);
+                    p.button.classList.add('active');
+                });
+                allPathBtn.classList.add('active');
+            } else {
+                renderedPaths.forEach(p => {
+                    visiblePathIdx.delete(p.idx);
+                    p.button.classList.remove('active');
+                });
+                allPathBtn.classList.remove('active');
+            }
+            refreshArcs();
+        });
+        legendEl.insertBefore(allPathBtn, legendEl.firstChild);
+    }
+
+    // Node points, colored by region, grey when not in the IS-IS topology.
+    data.nodes.forEach(n => {
+        if (n.lat == null || n.lng == null) return;
+        const color = n.active ? (REGION_COLORS[n.region] || INACTIVE_COLOR) : INACTIVE_COLOR;
+        allPoints.push({
+            lat: n.lat,
+            lng: n.lng,
+            color,
+            label: nodeLabel(n)
+        });
+    });
+
+    map.pointsData(allPoints);
+    refreshArcs();
+
+    if (allPoints.length > 0) {
+        focusCamera(allPoints);
+    }
+
+    const unplotted = data.nodes.filter(n => n.lat == null || n.lng == null).map(n => n.name);
+    const extra = unplotted.length > 0 ? ` (${unplotted.length} node(s) without coordinates: ${unplotted.join(', ')})` : '';
+    setStatus(`Algorithm ${currentAlgorithm} from ${data.source}: ` +
+        `${paths.length} path(s), ${data.nodes.length} node(s), ${plottedEdges} link(s)${extra}.`);
+}
+
+function refreshArcs() {
+    if (!map) return;
+    map.arcsData(allArcs.filter(a => a.base || visiblePathIdx.has(a.pathIdx)));
+}
+
+function focusCamera(points) {
+    let minLat = 90, maxLat = -90, minLng = 180, maxLng = -180;
+    points.forEach(p => {
+        if (p.lat < minLat) minLat = p.lat;
+        if (p.lat > maxLat) maxLat = p.lat;
+        if (p.lng < minLng) minLng = p.lng;
+        if (p.lng > maxLng) maxLng = p.lng;
+    });
+    const lat = (minLat + maxLat) / 2;
+    const lng = (minLng + maxLng) / 2;
+    const span = Math.max(maxLat - minLat, maxLng - minLng);
+    // Altitude: small span = close zoom, large span = far view
+    const altitude = Math.max(0.6, Math.min(2.5, span / 25 + 0.6));
+    map.pointOfView({ lat, lng, altitude }, 800);
+}
+
+// --- Path detail table ---
+
+function populatePathDetail(idx) {
+    const panel = document.getElementById('pathDetail');
+    if (!panel) return;
+    const entry = renderedPaths.find(p => p.idx === idx);
+    if (!entry) return;
+    const path = entry.path;
+
+    panel.style.display = '';
+
+    const titleEl = panel.querySelector('.path-detail-title');
+    if (titleEl) {
+        titleEl.innerHTML = `<span class="swatch" style="background:${entry.color}"></span>` +
+            escapeHtml(`Path ${idx + 1}: ${path.hops[0]} → ${path.destination}`);
+    }
+
+    const subEl = document.getElementById('pathDetailSub');
+    if (subEl) {
+        const iface = path.interface ? `egress ${path.interface} · ` : '';
+        subEl.textContent = `algorithm ${currentAlgorithm} · ${iface}total cost ${path.cost} · ${path.hops.length - 1} hop(s)`;
+    }
+
+    const tbody = panel.querySelector('tbody');
+    tbody.innerHTML = '';
+
+    let cumulative = 0;
+    path.hops.forEach((name, i) => {
+        const node = currentNodeMap[name];
+        const fullName = node ? node.fullName : name;
+        const region = node ? node.region : '—';
+
+        let link = '—';
+        if (i > 0) {
+            const cost = currentEdgeCost[path.hops[i - 1] + '|' + name];
+            if (cost != null) {
+                cumulative += cost;
+                link = String(cost);
+            } else {
+                link = '?';
+            }
+        }
+
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td class="metric">${i}</td>
+            <td>${escapeHtml(name)} — ${escapeHtml(fullName)}</td>
+            <td>${escapeHtml(region)}</td>
+            <td class="metric">${escapeHtml(link)}</td>
+            <td class="metric">${i === 0 ? '0' : String(cumulative)}</td>
+        `;
+        tbody.appendChild(tr);
+    });
+}
+
+// --- Event listeners ---
+
+document.addEventListener('DOMContentLoaded', () => {
+    initMap();
+    loadRouters();
+
+    document.getElementById('source').addEventListener('change', async (e) => {
+        if (e.target.value) {
+            await loadAlgorithms(e.target.value);
+            loadTopology();
+        }
+    });
+
+    document.getElementById('destination').addEventListener('change', () => loadTopology());
+    document.getElementById('algorithm').addEventListener('change', () => loadTopology());
+    document.getElementById('refresh').addEventListener('click', () => loadTopology());
+});

--- a/ai/topology/static/index.html
+++ b/ai/topology/static/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>zebra-rs Traffic Path Visualizer</title>
+    <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+    <div class="header">zebra-rs Traffic Path Visualizer</div>
+
+    <div class="controls">
+        <label>
+            Source
+            <select id="source">
+                <option value="">Loading...</option>
+            </select>
+        </label>
+        <label>
+            Destination
+            <select id="destination" disabled>
+                <option value="__all__">All destinations</option>
+            </select>
+        </label>
+        <label>
+            Algorithm
+            <select id="algorithm" disabled>
+                <option value="0">0 — shortest path (unconstrained SPF)</option>
+            </select>
+        </label>
+        <label>
+            &nbsp;
+            <button id="refresh" class="refresh-btn" title="Re-query the routers">Refresh</button>
+        </label>
+        <div class="path-legend" id="legend"></div>
+    </div>
+
+    <div class="main-content">
+        <div class="map-area">
+            <div class="map-stage">
+                <div id="map"></div>
+                <div class="path-detail" id="pathDetail" style="display:none">
+                    <div class="path-detail-header">
+                        <span class="path-detail-title"></span>
+                        <button class="path-detail-close" title="Close">&times;</button>
+                    </div>
+                    <div class="path-detail-sub" id="pathDetailSub"></div>
+                    <div class="path-detail-body">
+                        <table class="path-detail-table">
+                            <thead>
+                                <tr>
+                                    <th>Hop</th>
+                                    <th>Node</th>
+                                    <th>Region</th>
+                                    <th>Link metric</th>
+                                    <th>Cumulative</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="status-bar" id="status">Initializing...</div>
+
+    <script src="https://unpkg.com/three@0.160.0/build/three.min.js"
+            integrity="sha384-qOkzR5Ke/XkQxuGVJ9hpFEpDlcoLtWwVYhnJf06cLIZa2vaIptSqaubivErzmD5O"
+            crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/globe.gl@2.32.0/dist/globe.gl.min.js"
+            integrity="sha384-Plx/0mhoQXLzFNQEcp4kULf6wOFgVaNISmr+3cNLjGb4U8Nq7d7/96ydYtbT0Wb6"
+            crossorigin="anonymous"></script>
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/ai/topology/static/style.css
+++ b/ai/topology/static/style.css
@@ -1,0 +1,245 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    color: #333;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    background: #1a1a2e;
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.controls {
+    display: flex;
+    gap: 12px;
+    padding: 10px 16px;
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.controls label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #555;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.controls select {
+    padding: 6px 8px;
+    min-width: 200px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 13px;
+    background: #fff;
+}
+
+.controls select:disabled {
+    background: #eee;
+    color: #999;
+}
+
+.refresh-btn {
+    padding: 6px 14px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.refresh-btn:hover {
+    background: #f0f0f0;
+    border-color: #999;
+}
+
+.main-content {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+.map-area {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.map-stage {
+    flex: 1;
+    position: relative;
+    min-width: 0;
+    min-height: 0;
+}
+
+#map {
+    position: absolute;
+    inset: 0;
+    background: #000;
+    overflow: hidden;
+}
+
+#map canvas {
+    display: block;
+}
+
+.status-bar {
+    padding: 4px 16px;
+    font-size: 12px;
+    color: #666;
+    background: #fafafa;
+    border-top: 1px solid #eee;
+}
+
+.status-bar.error {
+    color: #c0392b;
+    background: #fdecea;
+}
+
+.path-legend {
+    display: flex;
+    gap: 10px;
+    margin-left: auto;
+    font-size: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.path-legend .swatch {
+    display: inline-block;
+    width: 20px;
+    height: 3px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 3px;
+}
+
+.path-toggle {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    font-size: 12px;
+    cursor: pointer;
+    opacity: 0.5;
+}
+
+.path-toggle.active {
+    opacity: 1;
+    border-color: #666;
+    background: #f0f0f0;
+}
+
+.path-detail {
+    position: absolute;
+    bottom: 12px;
+    right: 12px;
+    z-index: 1000;
+    pointer-events: auto;
+    background: rgba(255, 255, 255, 0.97);
+    border: 1px solid #bbb;
+    border-radius: 6px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    font-size: 12px;
+    min-width: 480px;
+    max-width: 720px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.path-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    background: #1a1a2e;
+    color: #fff;
+    font-weight: 600;
+}
+
+.path-detail-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.path-detail-title .swatch {
+    display: inline-block;
+    width: 18px;
+    height: 3px;
+    border-radius: 2px;
+}
+
+.path-detail-close {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+}
+
+.path-detail-close:hover {
+    opacity: 0.7;
+}
+
+.path-detail-sub {
+    padding: 6px 12px;
+    background: #f0f2f7;
+    color: #555;
+    border-bottom: 1px solid #ddd;
+    font-variant-numeric: tabular-nums;
+}
+
+.path-detail-body {
+    overflow-y: auto;
+    max-height: 300px;
+}
+
+.path-detail-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+}
+
+.path-detail-table th,
+.path-detail-table td {
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+    white-space: nowrap;
+}
+
+.path-detail-table th {
+    background: #f5f5f5;
+    font-weight: 600;
+    color: #555;
+    position: sticky;
+    top: 0;
+}
+
+.path-detail-table tbody tr:hover {
+    background: #f9f9f9;
+}
+
+.path-detail-table td.metric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -5,7 +5,7 @@ use tracing::{debug, error};
 
 use crate::vty::exec_client::ExecClient;
 use crate::vty::show_client::ShowClient;
-use crate::vty::{CommandPath, ExecRequest, ExecType, ShowRequest, YangMatch};
+use crate::vty::{ExecCode, ExecRequest, ExecType, ShowRequest};
 
 /// A single completion candidate for the token following a command line,
 /// parsed from the daemon's completion engine output.
@@ -51,52 +51,67 @@ impl ZebraClient {
         }
     }
 
-    /// Execute a show command and return the result as JSON
+    /// Execute a show command and return its output.
+    ///
+    /// Two-phase, like `vtyctl show`: the daemon's parser first resolves
+    /// the command line into `CommandPath`s (which is what handles value
+    /// arguments such as `flex-algo 128`), then the Show RPC runs those
+    /// resolved paths. Building paths client-side from whitespace tokens
+    /// only ever worked for pure-keyword commands.
     pub async fn show_command(&self, command: &str, json: bool) -> Result<String> {
         let endpoint = self.endpoint();
         debug!("Connecting to zebra-rs at {}", endpoint);
 
         let channel = crate::endpoint::connect(&endpoint).await?;
-        let mut client = ShowClient::new(channel);
 
-        let mut paths = Vec::new();
-        let cmds: Vec<&str> = command.split_whitespace().collect();
-        let len = cmds.len();
-        for (pos, cmd) in cmds.iter().enumerate() {
-            let ymatch = if pos != len - 1 {
-                YangMatch::Dir
-            } else {
-                YangMatch::Leaf
-            };
-            let path = CommandPath {
-                name: cmd.to_string(),
-                key: "".to_string(),
-                ymatch: ymatch.into(),
-                ..Default::default()
-            };
-            paths.push(path);
+        // Phase 1: parse the line through the daemon's command grammar.
+        let mut exec_client = ExecClient::new(channel.clone());
+        let exec_request = Request::new(ExecRequest {
+            r#type: ExecType::Exec as i32,
+            mode: String::from("exec"),
+            privilege: 15,
+            line: command.to_string(),
+            args: Vec::new(),
+            ..Default::default()
+        });
+        let reply = exec_client.do_exec(exec_request).await?.into_inner();
+        if let Some(msg) = exec_parse_error(reply.code, &reply.lines) {
+            return Err(anyhow::anyhow!("{msg}"));
         }
 
+        // Phase 2: run the resolved paths.
+        let mut client = ShowClient::new(channel);
         let request = Request::new(ShowRequest {
             json,
             line: command.to_string(),
-            paths,
+            paths: reply.paths,
         });
 
         debug!("Executing show command: {}", command);
         let mut stream = client.show(request).await?.into_inner();
 
         let mut result = String::new();
-        while let Some(reply) = stream.next().await {
-            match reply {
+        let mut got_any = false;
+        while let Some(item) = stream.next().await {
+            match item {
                 Ok(response) => {
+                    got_any = true;
                     result.push_str(&response.str);
                 }
                 Err(e) => {
+                    // Commands answered entirely in the exec phase (fmap
+                    // commands like `show help`) stream nothing; their
+                    // output already sits in the phase-1 `lines`.
+                    if !got_any && reply.code == ExecCode::Show as i32 && !reply.lines.is_empty() {
+                        return Ok(reply.lines);
+                    }
                     error!("Error receiving response: {}", e);
                     return Err(anyhow::anyhow!("gRPC error: {}", e));
                 }
             }
+        }
+        if !got_any && reply.code == ExecCode::Show as i32 && !reply.lines.is_empty() {
+            return Ok(reply.lines);
         }
 
         debug!("Show command completed, received {} bytes", result.len());
@@ -146,6 +161,31 @@ impl ZebraClient {
                 Err(e)
             }
         }
+    }
+}
+
+/// Inspect the phase-1 ExecReply of a show command. Parse failures (and
+/// codes we don't know) must stop here: running the Show RPC with
+/// unresolved paths ends in a NotFound from the daemon at best.
+fn exec_parse_error(code: i32, lines: &str) -> Option<String> {
+    match ExecCode::try_from(code) {
+        Ok(ExecCode::Success | ExecCode::Show | ExecCode::Redirect | ExecCode::RedirectShow) => {
+            None
+        }
+        Ok(ExecCode::Nomatch | ExecCode::Incomplete | ExecCode::Ambiguous) => {
+            let reason = lines.trim();
+            let reason = if reason.is_empty() {
+                match ExecCode::try_from(code) {
+                    Ok(ExecCode::Incomplete) => "Incomplete",
+                    Ok(ExecCode::Ambiguous) => "Ambiguous",
+                    _ => "NoMatch",
+                }
+            } else {
+                reason
+            };
+            Some(format!("command rejected: {reason}"))
+        }
+        Err(_) => Some(format!("unexpected exec code {code} from daemon")),
     }
 }
 
@@ -216,5 +256,26 @@ mod tests {
     fn nomatch_yields_no_candidates() {
         assert!(parse_completion_lines("NoMatch\n").is_empty());
         assert!(parse_completion_lines("").is_empty());
+    }
+
+    #[test]
+    fn exec_parse_error_stops_on_parse_failures() {
+        let msg = exec_parse_error(ExecCode::Nomatch as i32, "NoMatch\n").unwrap();
+        assert_eq!(msg, "command rejected: NoMatch");
+        let msg = exec_parse_error(ExecCode::Incomplete as i32, "").unwrap();
+        assert_eq!(msg, "command rejected: Incomplete");
+        assert!(exec_parse_error(99, "").unwrap().contains("99"));
+    }
+
+    #[test]
+    fn exec_parse_error_passes_showable_codes() {
+        for code in [
+            ExecCode::Success,
+            ExecCode::Show,
+            ExecCode::Redirect,
+            ExecCode::RedirectShow,
+        ] {
+            assert_eq!(exec_parse_error(code as i32, ""), None);
+        }
     }
 }

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -275,7 +275,7 @@ impl ZmcpServer {
                 },
                 {
                     "name": "get-isis-graph",
-                    "description": "Get IS-IS topology graph data for network visualization and analysis",
+                    "description": "Get IS-IS topology graph data for network visualization and analysis. Without 'algorithm' this is the unpruned LSDB graph; with a Flex-Algorithm number (128-255) it is that algorithm's constraint-pruned graph.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -283,8 +283,39 @@ impl ZmcpServer {
                                 "type": "string",
                                 "enum": ["L1", "L2", "both"],
                                 "description": "IS-IS level to retrieve (L1, L2, or both)"
+                            },
+                            "algorithm": {
+                                "type": "integer",
+                                "minimum": 128,
+                                "maximum": 255,
+                                "description": "Flex-Algorithm number (128-255). Omit for the plain algorithm-0 graph."
                             }
                         },
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "name": "get-isis-spf",
+                    "description": "Get IS-IS SPF (shortest path first) results as JSON: per-destination cost, nexthops, and the full hop-by-hop paths from this router. Without 'algorithm' this is the plain algorithm-0 SPF; with a Flex-Algorithm number (128-255) it is that algorithm's constrained SPF.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "algorithm": {
+                                "type": "integer",
+                                "minimum": 128,
+                                "maximum": 255,
+                                "description": "Flex-Algorithm number (128-255). Omit for the plain algorithm-0 SPF."
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "name": "get-isis-flex-algo",
+                    "description": "Get IS-IS Flexible Algorithm (RFC 9350) state as JSON: locally configured algorithms with their constraints, and per-level peer FAD advertisements and algorithm participation.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {},
                         "additionalProperties": false
                     }
                 }
@@ -312,6 +343,8 @@ impl ZmcpServer {
             "list-show-commands" => self.commands_tool.list_show_commands().await,
             "show" => self.show_tool.run(arguments).await,
             "get-isis-graph" => self.isis_tools.get_isis_graph(arguments).await,
+            "get-isis-spf" => self.isis_tools.get_isis_spf(arguments).await,
+            "get-isis-flex-algo" => self.isis_tools.get_isis_flex_algo(arguments).await,
             _ => {
                 warn!("Unknown tool requested: {}", tool_name);
                 return tool_result(format!("Unknown tool: {}", tool_name), true);
@@ -396,7 +429,13 @@ mod tests {
             .iter()
             .filter_map(|t| t["name"].as_str())
             .collect();
-        for expected in ["list-show-commands", "show", "get-isis-graph"] {
+        for expected in [
+            "list-show-commands",
+            "show",
+            "get-isis-graph",
+            "get-isis-spf",
+            "get-isis-flex-algo",
+        ] {
             assert!(
                 names.contains(&expected),
                 "missing {expected}; tools: {names:?}"
@@ -465,7 +504,7 @@ mod tests {
             .await
             .expect("response");
         let result = &resp["result"];
-        assert!(result["tools"].as_array().is_some_and(|t| t.len() == 3));
+        assert!(result["tools"].as_array().is_some_and(|t| t.len() == 5));
         assert_eq!(result["resultType"], json!("complete"));
         assert_eq!(result["cacheScope"], json!("private"));
         assert!(result["ttlMs"].is_u64());

--- a/vtyctl/src/mcp/tools/isis.rs
+++ b/vtyctl/src/mcp/tools/isis.rs
@@ -11,12 +11,69 @@ pub struct IsisTools {
     client: ZebraClient,
 }
 
+/// Parse and validate the optional `algorithm` argument shared by the
+/// IS-IS tools. Absent means algorithm 0 — the plain SPF topology;
+/// present it must be a Flex-Algorithm number (RFC 9350: 128-255).
+fn algorithm_arg(args: &HashMap<String, Value>) -> Result<Option<u8>> {
+    let Some(value) = args.get("algorithm") else {
+        return Ok(None);
+    };
+    let algo = value
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("'algorithm' must be an integer (128-255)"))?;
+    if !(128..=255).contains(&algo) {
+        return Err(anyhow::anyhow!(
+            "Invalid algorithm {}. Flex-Algorithm numbers are 128-255",
+            algo
+        ));
+    }
+    Ok(Some(algo as u8))
+}
+
 impl IsisTools {
     pub fn new(client: ZebraClient) -> Self {
         Self { client }
     }
 
-    /// Get ISIS topology graph data
+    /// Run an IS-IS show subcommand in JSON mode, validating that the
+    /// output parses. `empty` is returned for a daemon with no data
+    /// (protocol not configured yet), so callers always get valid JSON.
+    async fn show_json(&self, subcommand: &str, empty: &str) -> Result<String> {
+        match self.client.show_isis_command(subcommand, true).await {
+            Ok(output) => {
+                debug!(
+                    "Received data for 'show isis {}': {} bytes",
+                    subcommand,
+                    output.len()
+                );
+                if output.trim().is_empty() {
+                    warn!("'show isis {}' returned empty output", subcommand);
+                    return Ok(empty.to_string());
+                }
+                match serde_json::from_str::<Value>(&output) {
+                    Ok(parsed) => Ok(serde_json::to_string_pretty(&parsed)?),
+                    Err(e) => {
+                        error!("Failed to parse 'show isis {}' JSON: {}", subcommand, e);
+                        // If parsing fails but we have data, it might be
+                        // text format — return it rather than losing it.
+                        warn!(
+                            "'show isis {}' data is not JSON, returning as-is",
+                            subcommand
+                        );
+                        Ok(output)
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to run 'show isis {}': {}", subcommand, e);
+                Err(anyhow::anyhow!("Error retrieving IS-IS data: {}", e))
+            }
+        }
+    }
+
+    /// Get ISIS topology graph data. Without `algorithm` this is the
+    /// unpruned LSDB graph; with a Flex-Algorithm number it is that
+    /// algorithm's constraint-pruned graph.
     pub async fn get_isis_graph(&self, args: HashMap<String, Value>) -> Result<String> {
         debug!("Getting ISIS graph with args: {:?}", args);
 
@@ -32,50 +89,52 @@ impl IsisTools {
             ));
         }
 
-        // Execute the show isis graph command
-        match self.client.show_isis_command("graph", true).await {
-            Ok(json_output) => {
-                debug!("Received ISIS graph data: {} bytes", json_output.len());
+        let subcommand = match algorithm_arg(&args)? {
+            Some(algo) => format!("flex-algo {} graph", algo),
+            None => "graph".to_string(),
+        };
 
-                // Handle empty response (ISIS not configured or no data)
-                if json_output.trim().is_empty() {
-                    warn!("ISIS graph command returned empty output");
-                    return Ok("[]".to_string()); // Return empty JSON array
-                }
+        let output = self.show_json(&subcommand, "[]").await?;
 
-                // Parse the JSON to validate it
-                match serde_json::from_str::<Value>(&json_output) {
-                    Ok(parsed_json) => {
-                        // Filter by level if requested
-                        let filtered_data = self.filter_graph_by_level(&parsed_json, level)?;
-
-                        // Return the graph data as pretty-printed JSON
-                        Ok(serde_json::to_string_pretty(&filtered_data)?)
-                    }
-                    Err(e) => {
-                        error!("Failed to parse ISIS graph JSON: {}", e);
-                        // If parsing fails but we have data, it might be text format
-                        if !json_output.trim().is_empty() {
-                            warn!("ISIS graph data is not JSON format, returning as-is");
-                            Ok(json_output)
-                        } else {
-                            Err(anyhow::anyhow!("Error parsing ISIS graph data: {}", e))
-                        }
-                    }
-                }
+        // Filter by level if requested (tolerate non-JSON text output).
+        match serde_json::from_str::<Value>(&output) {
+            Ok(parsed) => {
+                let filtered = self.filter_graph_by_level(&parsed, level)?;
+                Ok(serde_json::to_string_pretty(&filtered)?)
             }
-            Err(e) => {
-                error!("Failed to get ISIS graph: {}", e);
-                Err(anyhow::anyhow!("Error retrieving ISIS graph: {}", e))
-            }
+            Err(_) => Ok(output),
         }
     }
 
-    /// Filter graph data by IS-IS level
+    /// Get ISIS SPF results: per-destination cost, nexthops, and the
+    /// full hop-by-hop paths, computed from this router's LSDB. Without
+    /// `algorithm` this is the algorithm-0 SPF; with a Flex-Algorithm
+    /// number it is that algorithm's constrained SPF.
+    pub async fn get_isis_spf(&self, args: HashMap<String, Value>) -> Result<String> {
+        debug!("Getting ISIS SPF with args: {:?}", args);
+        let subcommand = match algorithm_arg(&args)? {
+            Some(algo) => format!("flex-algo {} spf", algo),
+            None => "spf".to_string(),
+        };
+        self.show_json(&subcommand, "{}").await
+    }
+
+    /// Get ISIS Flexible Algorithm state: locally configured algorithms
+    /// with their constraints, and per-level peer FADs / participation.
+    pub async fn get_isis_flex_algo(&self, args: HashMap<String, Value>) -> Result<String> {
+        debug!("Getting ISIS flex-algo state with args: {:?}", args);
+        self.show_json("flex-algo", "{}").await
+    }
+
+    /// Filter graph data by IS-IS level. Graph objects label their level
+    /// as `L1`/`L2` (plain graph) or `L1 algo 128`-style (per-algorithm
+    /// graph), so match on the leading level token.
     pub fn filter_graph_by_level(&self, data: &Value, level: &str) -> Result<Value> {
         if level == "both" {
             return Ok(data.clone());
         }
+
+        let level_matches = |l: &str| l == level || l.starts_with(&format!("{} ", level));
 
         // If data is an array of graph objects, filter by level
         if let Value::Array(graphs) = data {
@@ -85,7 +144,7 @@ impl IsisTools {
                     graph
                         .get("level")
                         .and_then(|l| l.as_str())
-                        .map(|l| l == level)
+                        .map(level_matches)
                         .unwrap_or(false)
                 })
                 .cloned()
@@ -95,7 +154,7 @@ impl IsisTools {
         } else {
             // If it's a single graph object, check if it matches the level
             if let Some(graph_level) = data.get("level").and_then(|l| l.as_str()) {
-                if graph_level == level {
+                if level_matches(graph_level) {
                     Ok(data.clone())
                 } else {
                     Ok(json!([]))
@@ -105,5 +164,83 @@ impl IsisTools {
                 Ok(data.clone())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools() -> IsisTools {
+        IsisTools::new(ZebraClient::new("127.0.0.1".to_string(), 2650))
+    }
+
+    fn args(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn algorithm_arg_absent_is_none() {
+        assert_eq!(algorithm_arg(&args(&[])).unwrap(), None);
+    }
+
+    #[test]
+    fn algorithm_arg_accepts_flex_algo_range() {
+        for algo in [128u64, 200, 255] {
+            assert_eq!(
+                algorithm_arg(&args(&[("algorithm", json!(algo))])).unwrap(),
+                Some(algo as u8)
+            );
+        }
+    }
+
+    #[test]
+    fn algorithm_arg_rejects_out_of_range_and_non_integer() {
+        for bad in [json!(0), json!(127), json!(256), json!("128"), json!(-1)] {
+            assert!(
+                algorithm_arg(&args(&[("algorithm", bad.clone())])).is_err(),
+                "expected error for {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn level_filter_matches_plain_and_algo_labels() {
+        let data = json!([
+            {"level": "L1", "nodes": []},
+            {"level": "L2", "nodes": []},
+            {"level": "L2 algo 128", "nodes": []},
+        ]);
+        let filtered = tools().filter_graph_by_level(&data, "L2").unwrap();
+        let levels: Vec<&str> = filtered
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|g| g["level"].as_str().unwrap())
+            .collect();
+        assert_eq!(levels, vec!["L2", "L2 algo 128"]);
+    }
+
+    #[tokio::test]
+    async fn graph_rejects_invalid_algorithm() {
+        let err = tools()
+            .get_isis_graph(args(&[("algorithm", json!(1))]))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("128-255"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn spf_rejects_invalid_algorithm() {
+        let err = tools()
+            .get_isis_spf(args(&[("algorithm", json!("igp"))]))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("integer"), "{err}");
     }
 }


### PR DESCRIPTION
## Summary

Ports the Graphiant 3D globe topology viewer onto zebra-rs as `ai/topology` (new workspace member, bin `zebra-topology`), visualizing the `playset/isis-flexalgo` lab: connectivity, IGP metrics, and per-algorithm SPF paths on a globe.gl globe. No TE telemetry exists in the lab, so the TE-era UI (time slider, latency/jitter/loss) is dropped.

**Data plane is MCP only** — every router query is a stateless MCP 2026-07-28 `tools/call` against `vtyctl mcp` spawned inside the router's netns (the daemon's `@zebra-rs/vty` abstract socket is network-namespaced). No vty/vtyctl CLI scraping.

### vtyctl MCP framework

- Fix: the MCP `show` path built `CommandPath`s from whitespace tokens, so value-carrying commands (`show isis flex-algo 128 spf`) failed with "no show handler produced output". `ZebraClient::show_command` now parses the line through the daemon (Exec RPC) and runs the resolved paths (Show RPC), same as `vtyctl show`, incl. the fmap fallback.
- New tools: `get-isis-spf` (per-destination cost/nexthops/full hop-by-hop paths, optional `algorithm` 128-255), `get-isis-flex-algo` (FADs, constraints, participation); `get-isis-graph` gains an `algorithm` argument (pruned graph) and a level filter that matches per-algo labels.

### Viewer

- Source / Destination / Algorithm selectors; grey connectivity arcs draw the selected algorithm's own graph (pruned links visibly vanish); colored animated arcs per SPF path with legend toggles and a hop-by-hop metric table.
- Geo = `ontology.json` × built-in city gazetteer; nodes color by region, grey when absent from the IS-IS graph.
- Source/destination validated against the ontology before reaching `ip netns exec` argv; CDN scripts SRI-pinned; frontend interpolations HTML-escaped.

## Test plan

- `cargo test -p vtyctl -p zebra-topology` (27 + 7 pass), workspace clippy + fmt clean.
- Live on the 11-node playset: tk→se flips from the Pacific crossing (cost 20) to `sg→fr→{ln,va}→ch→se` (cost 50) on algorithm 0→128 with edges 17→14; downing `fr-sg` partitions algorithm 128 to AP while algorithm 0 keeps working; APIs, static serving, and error paths curl-verified.

Generated with [Claude Code](https://claude.com/claude-code)