### PR TITLE
mcp: OSPFv2/v3 tools mirroring the IS-IS family, plus book docs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -162,6 +162,7 @@
 ## AI Native
 
 - [Native MCP Server](ch-13-00-mcp-server.md)
+  - [3D Traffic Path Visualizer](ch-13-01-topology-viewer.md)
 
 ## Logging and Monitoring
 

--- a/book/src/ch-13-00-mcp-server.md
+++ b/book/src/ch-13-00-mcp-server.md
@@ -41,6 +41,29 @@ to any MCP client and your assistant can reach the router straight away:
 }
 ```
 
+## The tools
+
+The server is read-only by contract: every tool answers from the daemon's
+live state, and none of them mutate it. Two tools cover the whole `show`
+surface, and a small typed family serves the data that topology-aware
+agents ask for most:
+
+| tool | arguments | returns |
+|:-----|:----------|:--------|
+| `list-show-commands` | — | every runnable `show` command with one-line help, generated live from the daemon's command grammar. Call it first to discover what `show` can do. |
+| `show` | `command`, `json` | the output of any operational `show` command — value arguments included (`show isis flex-algo 128 spf`, `show bgp summary`). `json: true` returns structured output where the command supports it. |
+| `get-isis-graph` | `level`, `algorithm` | the IS-IS topology graph: nodes with hostnames and system-ids, links with costs. With `algorithm` (128–255) it is that Flex-Algorithm's constraint-pruned graph. |
+| `get-isis-spf` | `algorithm` | the IS-IS SPF result: per-destination cost, nexthops, and the full hop-by-hop paths from this router — plain SPF, or a Flex-Algorithm's constrained SPF. |
+| `get-isis-flex-algo` | — | Flexible Algorithm (RFC 9350) state: local FADs with their constraints, peer FAD advertisements, and per-level algorithm participation. |
+| `get-ospf-graph` | `version` | the OSPF area graph with router names and link costs. `version` selects OSPFv2 (2, the default) or OSPFv3 (3). |
+| `get-ospf-spf` | `version` | the OSPF SPF tree: per-vertex cost and first hops. OSPF's SPF does not retain hop-by-hop vertex chains, so join vertex ids against `get-ospf-graph` for names and links. |
+| `get-ospf-flex-algo` | `version` | OSPF Flexible Algorithm state: each configured algorithm's definition and constraints, its per-algorithm SPF status, and per-algorithm routes. |
+
+The typed `get-*` tools return validated JSON, so an agent — or an ordinary
+program using MCP as its API — can consume them without scraping CLI text.
+The [3D Traffic Path Visualizer](ch-13-01-topology-viewer.md) is exactly
+that: a web application whose only data plane is these tools.
+
 ## Current protocol, older clients welcome
 
 The server speaks the stateless [MCP 2026-07-28

--- a/book/src/ch-13-01-topology-viewer.md
+++ b/book/src/ch-13-01-topology-viewer.md
@@ -1,0 +1,94 @@
+# 3D Traffic Path Visualizer
+
+The routers' own view of the network, on a globe. `zebra-topology` renders
+live connectivity and per-algorithm SPF paths from a running zebra-rs lab —
+and every byte of routing state it draws arrives through the
+[MCP server](ch-13-00-mcp-server.md), not through CLI scraping. The same
+tools an AI assistant calls in conversation turn out to be a perfectly good
+API for an ordinary web application: MCP is the router's API surface, and
+this viewer is the proof.
+
+The viewer ships in the repository under `ai/topology` and is built for the
+`playset/isis-flexalgo` lab: eleven routers named after cities across the
+US, Europe and Asia-Pacific, running plain IS-IS (algorithm 0) and a
+Flexible Algorithm 128 defined as `exclude-any: trans-pacific` over the
+same links. Pick Tokyo as the source and flip the algorithm selector:
+algorithm 0 crosses the Pacific in one hop, algorithm 128 sends the same
+traffic the long way round — Singapore, Frankfurt, and onward — exactly as
+RFC 9350 promises. There is no TE telemetry in the lab, so the globe shows
+what the routers actually know: connectivity, IGP metrics, and paths.
+
+## How it is put together
+
+```
+browser ── HTTP ── zebra-topology ── stdio/JSON-RPC ── ip netns exec <rtr> vtyctl mcp ── gRPC ── zebra-rs
+```
+
+- The backend is a single Rust binary serving an embedded
+  [globe.gl](https://globe.gl) frontend and three JSON APIs
+  (`/api/routers`, `/api/algorithms`, `/api/topology`).
+- Every router query is a stateless MCP 2026-07-28 `tools/call` against
+  `vtyctl mcp`, spawned inside that router's network namespace. The
+  daemon's VTY endpoint (`unix:zebra-rs/vty`) is a Linux *abstract* Unix
+  socket, and abstract sockets are network-namespaced — which is why each
+  of the eleven daemons can bind the same name, and why the MCP server
+  must run inside the namespace to reach one.
+- Three tools carry everything: `get-isis-flex-algo` fills the Algorithm
+  dropdown, `get-isis-graph` draws the connectivity arcs, and
+  `get-isis-spf` draws the paths.
+- Router geography comes from the playset's `ontology.json` (name, city,
+  region per router) joined with a small built-in city gazetteer for
+  coordinates.
+
+## Run it
+
+```shell
+# 1. Bring up the eleven-node lab (root required)
+cd playset/isis-flexalgo && ./up.sh && cd -
+
+# 2. Build the daemon tooling and the viewer
+cargo build -p zebra-rs -p vtyctl -p zebra-topology
+
+# 3. Run the viewer from the repository root (root required for
+#    `ip netns exec`; a non-root run falls back to `sudo -n`)
+sudo ./target/debug/zebra-topology
+
+# 4. Browse
+open http://localhost:8080
+```
+
+The globe itself needs internet access in the browser — three.js, globe.gl
+and the earth textures load from unpkg.com, integrity-pinned.
+
+## Reading the globe
+
+- **Points** are routers, colored by region (US, EU, AP) and grey when a
+  router is absent from the IS-IS topology.
+- **Grey arcs** are the connectivity mesh of the *selected algorithm's own
+  graph*. Switch to algorithm 128 and the three trans-Pacific links do not
+  dim — they vanish, because the FAD pruned them before SPF ran.
+- **Colored, animated arcs** are the SPF paths from the selected source —
+  one color per path, ECMP included, with a legend chip per path to toggle
+  it. Selecting a single destination narrows the view; "All destinations"
+  shows the source's entire SPF fan-out.
+- **Click a path arc** (or its legend chip) for the hop-by-hop table: each
+  hop's router, region, link metric, and the cumulative cost, plus the
+  egress interface.
+
+## Things to try
+
+- Source `tk`, destination `se`, algorithm 0 → 128: cost 20 across the
+  Pacific becomes cost 50 through `sg → fr → {ln,va} → ch`, and the edge
+  count visibly drops as the pruned links disappear.
+- Partition an algorithm without touching the other:
+  `sudo ip netns exec fr ip link set fr-sg down`, then Refresh. Algorithm
+  128 loses everything outside Asia-Pacific — Tokyo can still reach only
+  Singapore and Sydney — while algorithm 0 keeps spanning the world.
+  `... set fr-sg up` and Refresh heals it.
+- Change the source router: SPF is computed from the source's LSDB, so
+  Seattle's algorithm-128 view heads *east* through Chicago, the mirror
+  image of Tokyo's.
+
+`ai/topology/README.md` documents the command-line flags and the HTTP API;
+the [playset README](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-flexalgo)
+tells the full Flex-Algorithm story the viewer animates.

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -124,6 +124,34 @@ impl ZebraClient {
         self.show_command(&command, json).await
     }
 
+    /// Run a show command in JSON mode, validating that the output
+    /// parses. `empty` is returned for a daemon with no data (protocol
+    /// not configured yet), so callers always get valid JSON.
+    pub async fn show_json(&self, command: &str, empty: &str) -> Result<String> {
+        match self.show_command(command, true).await {
+            Ok(output) => {
+                debug!("Received data for '{}': {} bytes", command, output.len());
+                if output.trim().is_empty() {
+                    debug!("'{}' returned empty output", command);
+                    return Ok(empty.to_string());
+                }
+                match serde_json::from_str::<serde_json::Value>(&output) {
+                    Ok(parsed) => Ok(serde_json::to_string_pretty(&parsed)?),
+                    Err(e) => {
+                        error!("Failed to parse '{}' JSON: {}", command, e);
+                        // If parsing fails but we have data, it might be
+                        // text format — return it rather than losing it.
+                        Ok(output)
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to run '{}': {}", command, e);
+                Err(anyhow::anyhow!("Error retrieving data: {}", e))
+            }
+        }
+    }
+
     /// Return the completion candidates for the token *after* `line`, using
     /// the daemon's completion engine (the same one that backs CLI `?`/TAB).
     /// Completion is not admin-gated, so a View session can enumerate the

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -7,6 +7,7 @@ use tracing::{debug, error, warn};
 use super::client::ZebraClient;
 use super::tools::commands::CommandsTool;
 use super::tools::isis::IsisTools;
+use super::tools::ospf::OspfTools;
 use super::tools::show::ShowTool;
 
 /// Handshake revisions the legacy `initialize` path can negotiate, newest
@@ -82,6 +83,7 @@ fn tool_result(text: String, is_error: bool) -> Value {
 pub struct ZmcpServer {
     zebra_client: ZebraClient,
     isis_tools: IsisTools,
+    ospf_tools: OspfTools,
     show_tool: ShowTool,
     commands_tool: CommandsTool,
 }
@@ -90,12 +92,14 @@ impl ZmcpServer {
     pub fn new(base_url: String, port: u32) -> Self {
         let zebra_client = ZebraClient::new(base_url, port);
         let isis_tools = IsisTools::new(zebra_client.clone());
+        let ospf_tools = OspfTools::new(zebra_client.clone());
         let show_tool = ShowTool::new(zebra_client.clone());
         let commands_tool = CommandsTool::new(zebra_client.clone());
 
         Self {
             zebra_client,
             isis_tools,
+            ospf_tools,
             show_tool,
             commands_tool,
         }
@@ -318,6 +322,51 @@ impl ZmcpServer {
                         "properties": {},
                         "additionalProperties": false
                     }
+                },
+                {
+                    "name": "get-ospf-graph",
+                    "description": "Get OSPF topology graph data for network visualization and analysis: the area's SPF graph with router names and per-link costs, built from the LSDB. 'version' selects OSPFv2 (2, the default) or OSPFv3 (3).",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "version": {
+                                "type": "integer",
+                                "enum": [2, 3],
+                                "description": "OSPF version: 2 (OSPFv2, default) or 3 (OSPFv3)."
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "name": "get-ospf-spf",
+                    "description": "Get OSPF SPF (shortest path first) results as JSON: per-vertex cost and first hops from this router. 'version' selects OSPFv2 (2, the default) or OSPFv3 (3). Unlike IS-IS, OSPF's SPF result carries no hop-by-hop path lists; join vertex ids against get-ospf-graph for names and links.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "version": {
+                                "type": "integer",
+                                "enum": [2, 3],
+                                "description": "OSPF version: 2 (OSPFv2, default) or 3 (OSPFv3)."
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "name": "get-ospf-flex-algo",
+                    "description": "Get OSPF Flexible Algorithm (RFC 9350) state as JSON: each configured algorithm's definition and constraints, its per-algorithm SPF status, and per-algorithm routes. 'version' selects OSPFv2 (2, the default) or OSPFv3 (3).",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "version": {
+                                "type": "integer",
+                                "enum": [2, 3],
+                                "description": "OSPF version: 2 (OSPFv2, default) or 3 (OSPFv3)."
+                            }
+                        },
+                        "additionalProperties": false
+                    }
                 }
             ],
             "ttlMs": CACHE_TTL_MS,
@@ -345,6 +394,9 @@ impl ZmcpServer {
             "get-isis-graph" => self.isis_tools.get_isis_graph(arguments).await,
             "get-isis-spf" => self.isis_tools.get_isis_spf(arguments).await,
             "get-isis-flex-algo" => self.isis_tools.get_isis_flex_algo(arguments).await,
+            "get-ospf-graph" => self.ospf_tools.get_ospf_graph(arguments).await,
+            "get-ospf-spf" => self.ospf_tools.get_ospf_spf(arguments).await,
+            "get-ospf-flex-algo" => self.ospf_tools.get_ospf_flex_algo(arguments).await,
             _ => {
                 warn!("Unknown tool requested: {}", tool_name);
                 return tool_result(format!("Unknown tool: {}", tool_name), true);
@@ -435,6 +487,9 @@ mod tests {
             "get-isis-graph",
             "get-isis-spf",
             "get-isis-flex-algo",
+            "get-ospf-graph",
+            "get-ospf-spf",
+            "get-ospf-flex-algo",
         ] {
             assert!(
                 names.contains(&expected),
@@ -504,7 +559,7 @@ mod tests {
             .await
             .expect("response");
         let result = &resp["result"];
-        assert!(result["tools"].as_array().is_some_and(|t| t.len() == 5));
+        assert!(result["tools"].as_array().is_some_and(|t| t.len() == 8));
         assert_eq!(result["resultType"], json!("complete"));
         assert_eq!(result["cacheScope"], json!("private"));
         assert!(result["ttlMs"].is_u64());

--- a/vtyctl/src/mcp/tools/isis.rs
+++ b/vtyctl/src/mcp/tools/isis.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::collections::HashMap;
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::mcp::client::ZebraClient;
 
@@ -39,36 +39,9 @@ impl IsisTools {
     /// output parses. `empty` is returned for a daemon with no data
     /// (protocol not configured yet), so callers always get valid JSON.
     async fn show_json(&self, subcommand: &str, empty: &str) -> Result<String> {
-        match self.client.show_isis_command(subcommand, true).await {
-            Ok(output) => {
-                debug!(
-                    "Received data for 'show isis {}': {} bytes",
-                    subcommand,
-                    output.len()
-                );
-                if output.trim().is_empty() {
-                    warn!("'show isis {}' returned empty output", subcommand);
-                    return Ok(empty.to_string());
-                }
-                match serde_json::from_str::<Value>(&output) {
-                    Ok(parsed) => Ok(serde_json::to_string_pretty(&parsed)?),
-                    Err(e) => {
-                        error!("Failed to parse 'show isis {}' JSON: {}", subcommand, e);
-                        // If parsing fails but we have data, it might be
-                        // text format — return it rather than losing it.
-                        warn!(
-                            "'show isis {}' data is not JSON, returning as-is",
-                            subcommand
-                        );
-                        Ok(output)
-                    }
-                }
-            }
-            Err(e) => {
-                error!("Failed to run 'show isis {}': {}", subcommand, e);
-                Err(anyhow::anyhow!("Error retrieving IS-IS data: {}", e))
-            }
-        }
+        self.client
+            .show_json(&format!("show isis {}", subcommand), empty)
+            .await
     }
 
     /// Get ISIS topology graph data. Without `algorithm` this is the

--- a/vtyctl/src/mcp/tools/mod.rs
+++ b/vtyctl/src/mcp/tools/mod.rs
@@ -1,3 +1,4 @@
 pub mod commands;
 pub mod isis;
+pub mod ospf;
 pub mod show;

--- a/vtyctl/src/mcp/tools/ospf.rs
+++ b/vtyctl/src/mcp/tools/ospf.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
+
+use crate::mcp::client::ZebraClient;
+
+/// OSPF-specific tools for network topology analysis — the OSPFv2/v3
+/// siblings of the IS-IS tool family. One tool set serves both
+/// versions: the `version` argument (2, the default, or 3) selects
+/// between the `show ospf …` and `show ospfv3 …` command families.
+#[derive(Clone)]
+pub struct OspfTools {
+    client: ZebraClient,
+}
+
+/// Parse the optional `version` argument shared by the OSPF tools and
+/// return the show-command base for it: absent or 2 means OSPFv2
+/// (`show ospf …`), 3 means OSPFv3 (`show ospfv3 …`).
+fn version_base(args: &HashMap<String, Value>) -> Result<&'static str> {
+    match args.get("version") {
+        None => Ok("ospf"),
+        Some(value) => match value.as_u64() {
+            Some(2) => Ok("ospf"),
+            Some(3) => Ok("ospfv3"),
+            _ => Err(anyhow::anyhow!(
+                "'version' must be 2 (OSPFv2) or 3 (OSPFv3)"
+            )),
+        },
+    }
+}
+
+impl OspfTools {
+    pub fn new(client: ZebraClient) -> Self {
+        Self { client }
+    }
+
+    /// Get the OSPF topology graph: the area's SPF graph with router
+    /// names and per-link costs, as built from the LSDB.
+    pub async fn get_ospf_graph(&self, args: HashMap<String, Value>) -> Result<String> {
+        debug!("Getting OSPF graph with args: {:?}", args);
+        let base = version_base(&args)?;
+        // OSPFv2 renders a single graph object, OSPFv3 a vertex array —
+        // match each version's empty shape.
+        let empty = if base == "ospf" { "{}" } else { "[]" };
+        self.client
+            .show_json(&format!("show {} graph", base), empty)
+            .await
+    }
+
+    /// Get the OSPF SPF tree: per-vertex cost and first hops from this
+    /// router. Unlike IS-IS, OSPF's primary SPF does not retain full
+    /// hop-by-hop vertex chains, so the result carries no `paths` list.
+    pub async fn get_ospf_spf(&self, args: HashMap<String, Value>) -> Result<String> {
+        debug!("Getting OSPF SPF with args: {:?}", args);
+        let base = version_base(&args)?;
+        self.client
+            .show_json(&format!("show {} spf", base), "[]")
+            .await
+    }
+
+    /// Get the OSPF Flexible Algorithm state: each configured
+    /// algorithm's definition and constraints, its per-algorithm SPF
+    /// status, and the per-algorithm routes.
+    pub async fn get_ospf_flex_algo(&self, args: HashMap<String, Value>) -> Result<String> {
+        debug!("Getting OSPF flex-algo state with args: {:?}", args);
+        let base = version_base(&args)?;
+        self.client
+            .show_json(&format!("show {} flex-algo", base), "[]")
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn args(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn version_base_defaults_to_v2() {
+        assert_eq!(version_base(&args(&[])).unwrap(), "ospf");
+    }
+
+    #[test]
+    fn version_base_selects_command_family() {
+        assert_eq!(
+            version_base(&args(&[("version", json!(2))])).unwrap(),
+            "ospf"
+        );
+        assert_eq!(
+            version_base(&args(&[("version", json!(3))])).unwrap(),
+            "ospfv3"
+        );
+    }
+
+    #[test]
+    fn version_base_rejects_other_values() {
+        for bad in [json!(1), json!(4), json!(0), json!("3"), json!(-3)] {
+            assert!(
+                version_base(&args(&[("version", bad.clone())])).is_err(),
+                "expected error for {bad}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_reject_invalid_version() {
+        let tools = OspfTools::new(ZebraClient::new("127.0.0.1".to_string(), 2650));
+        for call in ["graph", "spf", "flex-algo"] {
+            let a = args(&[("version", json!(9))]);
+            let err = match call {
+                "graph" => tools.get_ospf_graph(a).await.unwrap_err(),
+                "spf" => tools.get_ospf_spf(a).await.unwrap_err(),
+                _ => tools.get_ospf_flex_algo(a).await.unwrap_err(),
+            };
+            assert!(err.to_string().contains("must be 2"), "{call}: {err}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New MCP tools `get-ospf-graph`, `get-ospf-spf`, `get-ospf-flex-algo`, each taking `version` (2, the default, or 3) to select between the `show ospf` and `show ospfv3` command families. Thin validated wrappers over the daemon's existing JSON show handlers, like their IS-IS siblings.
- Documented divergence: OSPF's primary SPF retains no hop-by-hop vertex chains (`full_path` runs only for virtual-link transit areas), so `get-ospf-spf` returns per-vertex cost and first hops; consumers join vertex ids against `get-ospf-graph`.
- The per-command JSON validation moves from `IsisTools` into `ZebraClient::show_json`, shared by both tool families.
- Book: the Native MCP Server chapter gains the eight-tool catalog (arguments, returns, read-only contract); new AI Native chapter documents the 3D Traffic Path Visualizer (`ai/topology`) with architecture, run instructions, and the algorithm-0-vs-128 / fr-sg-partition walkthroughs; SUMMARY nests it under the MCP chapter.

## Test plan

- `cargo test -p vtyctl` (31 pass, incl. new version-arg tests); clippy + fmt clean; `mdbook build` renders the new chapter.
- Live on `ospfv2-srmpls`: graph/spf return real topology data, flex-algo `[]`, `version: 9` rejected, v3-on-v2 answers "OSPFv3 is not configured or running".
- Live on `ospfv3-srmpls` with `version: 3`: all three tools; live `tools/list` advertises all 8 tools.

Generated with [Claude Code](https://claude.com/claude-code)