### PR TITLE
isis: hello padding-size knob + BDD proof of the hello-padding wire math

### DIFF
--- a/bdd/tests/configs/isis_hello_padding_mtu/a1.yaml
+++ b/bdd/tests/configs/isis_hello_padding_mtu/a1.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enabled: true
+    - if-name: i2
+      circuit-type: level-2-only
+      metric: 10
+      hello:
+        interval: 1
+        multiplier: 5
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_hello_padding_mtu/a2.yaml
+++ b/bdd/tests/configs/isis_hello_padding_mtu/a2.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: a2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enabled: true
+    - if-name: i1
+      circuit-type: level-2-only
+      metric: 10
+      hello:
+        interval: 1
+        multiplier: 5
+      ipv4:
+        enabled: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -341,6 +341,32 @@ async fn set_namespace_interface_state(
     );
 }
 
+/// Set the kernel MTU of an interface inside a namespace. zebra-rs has no
+/// interface `mtu` config leaf — it mirrors the kernel value via netlink
+/// (`Isis::link_mtu`) — so this is THE way a test controls the MTU that
+/// IS-IS hello padding and LSP sizing see.
+#[given(expr = "I set mtu {int} on interface {string} in namespace {string}")]
+#[when(expr = "I set mtu {int} on interface {string} in namespace {string}")]
+async fn set_namespace_interface_mtu(
+    world: &mut World,
+    mtu: u64,
+    interface: String,
+    namespace: String,
+) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(
+        &scoped,
+        "ip",
+        &["link", "set", "dev", &interface, "mtu", &mtu.to_string()],
+    )
+    .await
+    .expect("Failed to set interface MTU");
+    println!(
+        "✓ Interface {} in namespace {} mtu {}",
+        interface, scoped, mtu
+    );
+}
+
 // Keyword-agnostic on purpose: cucumber-rs binds a step to its
 // attribute keyword, and an `And` inherits the preceding `Given`/
 // `When`/`Then` — a `when`-only utility step silently SKIPS (along
@@ -1995,6 +2021,185 @@ async fn isis_database_not_has_lsp_from(
     println!(
         "✓ IS-IS {} database in {} has no LSP from '{}'",
         level, scoped, ident
+    );
+}
+
+/// Extract the on-wire lengths (Ethernet header included, FCS not — i.e.
+/// what tcpdump records) of the IS-IS Hello frames in a classic-format
+/// pcap byte stream. IIH frames are picked out of the capture by hand:
+/// 14-byte Ethernet header, 3-byte LLC `FE FE 03`, ISO discriminator
+/// 0x83, then PDU type (low 5 bits of byte 21) in {15, 16, 17} for
+/// L1-LAN / L2-LAN / P2P IIH. Doing the discrimination here keeps the
+/// BPF filter side down to the coarse `isis` primitive, so LSP / CSNP /
+/// PSNP frames in the same capture are simply skipped, not miscounted.
+fn pcap_iih_frame_lens(bytes: &[u8]) -> Vec<usize> {
+    if bytes.len() < 24 {
+        return Vec::new();
+    }
+    // Classic pcap magic, microsecond or nanosecond, either endianness.
+    let le = match &bytes[0..4] {
+        [0xd4, 0xc3, 0xb2, 0xa1] | [0x4d, 0x3c, 0xb2, 0xa1] => true,
+        [0xa1, 0xb2, 0xc3, 0xd4] | [0xa1, 0xb2, 0x3c, 0x4d] => false,
+        magic => panic!("not a classic pcap capture (magic {:02x?})", magic),
+    };
+    let read_u32 = |b: &[u8]| -> usize {
+        let arr: [u8; 4] = b.try_into().unwrap();
+        (if le {
+            u32::from_le_bytes(arr)
+        } else {
+            u32::from_be_bytes(arr)
+        }) as usize
+    };
+    let mut lens = Vec::new();
+    let mut off = 24;
+    while off + 16 <= bytes.len() {
+        let incl = read_u32(&bytes[off + 8..off + 12]);
+        let orig = read_u32(&bytes[off + 12..off + 16]);
+        let frame_start = off + 16;
+        if frame_start + incl > bytes.len() {
+            break; // truncated final record from a killed tcpdump
+        }
+        let frame = &bytes[frame_start..frame_start + incl];
+        off = frame_start + incl;
+        if frame.len() < 22 || frame[14..17] != [0xFE, 0xFE, 0x03] || frame[17] != 0x83 {
+            continue;
+        }
+        if matches!(frame[21] & 0x1f, 15 | 16 | 17) {
+            lens.push(orig);
+        }
+    }
+    lens
+}
+
+/// Capture IS-IS frames *sent* on `interface` in `scoped` (`-Q out`, so
+/// inbound frames from the peer never pollute the sample) and return the
+/// wire lengths of the IIH frames among them. tcpdump runs under
+/// `timeout`, so it ends either by reaching the frame count (exit 0) or
+/// at the deadline (exit 124, which `exec_in_netns` reports as Err) —
+/// both leave a parseable `-U`-flushed pcap, so the Err is deliberately
+/// ignored and the assertion is made on whatever was captured. `-Z root`
+/// stops Ubuntu's tcpdump from dropping privileges before it opens the
+/// dump file.
+///
+/// The BPF filter matches the LLC + ISO discriminator bytes by offset
+/// rather than using libpcap's `isis` primitive: an IIH padded to a
+/// >1500-byte MTU carries the payload length in the 802.3 length field
+/// (zebra-rs and FRR both send it via sockaddr_ll that way), and a value
+/// above 1536 makes libpcap classify the frame as an unknown EtherType —
+/// so `isis` silently misses exactly the full-MTU frames this capture
+/// exists to measure.
+async fn capture_iih_frame_lens(scoped: &str, interface: &str) -> Vec<usize> {
+    let pcap = format!("/tmp/{}_{}_iih.pcap", scoped, interface);
+    let _ = netns::exec_in_netns(scoped, "rm", &["-f", &pcap]).await;
+    let _ = netns::exec_in_netns(
+        scoped,
+        "timeout",
+        &[
+            "15",
+            "tcpdump",
+            "-c",
+            "8",
+            "-i",
+            interface,
+            "-Q",
+            "out",
+            "-Z",
+            "root",
+            "-U",
+            "-w",
+            &pcap,
+            "ether[14:2] = 0xfefe and ether[16] = 3 and ether[17] = 0x83",
+        ],
+    )
+    .await;
+    // The dump file is root-owned; make it readable for the harness user.
+    let _ = netns::exec_in_netns(scoped, "chmod", &["644", &pcap]).await;
+    let bytes = fs::read(&pcap)
+        .unwrap_or_else(|e| panic!("no capture file {} ({}): did tcpdump start?", pcap, e));
+    pcap_iih_frame_lens(&bytes)
+}
+
+/// Assert the padded size of transmitted IS-IS Hellos: every captured IIH
+/// frame must be `expected` bytes on the wire, minus at most 2 bytes of
+/// tolerance. `expected` is interface MTU + 14: the padder fills the PDU
+/// to MTU − 3, the send path prepends the 3-byte LLC header (payload =
+/// exactly MTU), and the capture counts the 14-byte Ethernet header. The
+/// tolerance exists because a remainder of 1–2 bytes cannot form a
+/// padding TLV (2-byte header), so those land unused; the padder never
+/// overshoots.
+#[then(
+    expr = "IS-IS hellos sent on interface {string} in namespace {string} should be {int} bytes on the wire"
+)]
+async fn isis_hellos_should_be_size(
+    world: &mut World,
+    interface: String,
+    namespace: String,
+    expected: u64,
+) {
+    let scoped = world.ns(&namespace);
+    let lens = capture_iih_frame_lens(&scoped, &interface).await;
+    let expected = expected as usize;
+    assert!(
+        lens.len() >= 2,
+        "captured only {} IIH frame(s) on {} in {}; need at least 2 for a stable size assertion",
+        lens.len(),
+        interface,
+        scoped
+    );
+    assert!(
+        lens.iter()
+            .all(|&l| l <= expected && l >= expected.saturating_sub(2)),
+        "IIH frames on {} in {} measured {:?} bytes on the wire, expected {} (−2 tolerated)",
+        interface,
+        scoped,
+        lens,
+        expected
+    );
+    println!(
+        "✓ {} IIH frames on {} in {} all {} bytes on the wire (expected {})",
+        lens.len(),
+        interface,
+        scoped,
+        lens[0],
+        expected
+    );
+}
+
+/// Negative sibling for the padding-disabled case: every captured IIH must
+/// be strictly smaller than `bound` bytes on the wire.
+#[then(
+    expr = "IS-IS hellos sent on interface {string} in namespace {string} should be smaller than {int} bytes on the wire"
+)]
+async fn isis_hellos_should_be_smaller(
+    world: &mut World,
+    interface: String,
+    namespace: String,
+    bound: u64,
+) {
+    let scoped = world.ns(&namespace);
+    let lens = capture_iih_frame_lens(&scoped, &interface).await;
+    let bound = bound as usize;
+    assert!(
+        lens.len() >= 2,
+        "captured only {} IIH frame(s) on {} in {}; need at least 2 for a stable size assertion",
+        lens.len(),
+        interface,
+        scoped
+    );
+    assert!(
+        lens.iter().all(|&l| l < bound),
+        "IIH frames on {} in {} measured {:?} bytes on the wire, expected all under {}",
+        interface,
+        scoped,
+        lens,
+        bound
+    );
+    println!(
+        "✓ {} IIH frames on {} in {} all under {} bytes on the wire",
+        lens.len(),
+        interface,
+        scoped,
+        bound
     );
 }
 

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -2064,7 +2064,7 @@ fn pcap_iih_frame_lens(bytes: &[u8]) -> Vec<usize> {
         if frame.len() < 22 || frame[14..17] != [0xFE, 0xFE, 0x03] || frame[17] != 0x83 {
             continue;
         }
-        if matches!(frame[21] & 0x1f, 15 | 16 | 17) {
+        if matches!(frame[21] & 0x1f, 15..=17) {
             lens.push(orig);
         }
     }
@@ -2082,12 +2082,12 @@ fn pcap_iih_frame_lens(bytes: &[u8]) -> Vec<usize> {
 /// dump file.
 ///
 /// The BPF filter matches the LLC + ISO discriminator bytes by offset
-/// rather than using libpcap's `isis` primitive: an IIH padded to a
-/// >1500-byte MTU carries the payload length in the 802.3 length field
-/// (zebra-rs and FRR both send it via sockaddr_ll that way), and a value
-/// above 1536 makes libpcap classify the frame as an unknown EtherType —
-/// so `isis` silently misses exactly the full-MTU frames this capture
-/// exists to measure.
+/// rather than using libpcap's `isis` primitive: an IIH padded to an
+/// MTU above 1500 bytes carries the payload length in the 802.3 length
+/// field (zebra-rs and FRR both send it via sockaddr_ll that way), and
+/// a value above 1536 makes libpcap classify the frame as an unknown
+/// EtherType — so `isis` silently misses exactly the full-MTU frames
+/// this capture exists to measure.
 async fn capture_iih_frame_lens(scoped: &str, interface: &str) -> Vec<usize> {
     let pcap = format!("/tmp/{}_{}_iih.pcap", scoped, interface);
     let _ = netns::exec_in_netns(scoped, "rm", &["-f", &pcap]).await;

--- a/bdd/tests/features/isis_hello_padding_mtu.feature
+++ b/bdd/tests/features/isis_hello_padding_mtu.feature
@@ -1,0 +1,81 @@
+@isis_hello_padding_mtu
+@isis
+Feature: IS-IS Hello padding fills the interface MTU exactly, and hello-padding disable is the mismatch escape hatch
+  As a network operator
+  I want IS-IS Hellos padded to exactly the interface MTU (and no further),
+  so an adjacency only forms when the link really carries full-MTU PDUs in
+  both directions — and I want `hello padding disable` to bring a
+  mismatched-MTU adjacency up when I decide that check is not what I need.
+
+  Wire arithmetic this feature pins down (the recurring interop question):
+  the padder fills the IIH PDU to MTU - 3, the send path prepends the
+  3-byte LLC header (FE FE 03), so the Ethernet payload is EXACTLY the
+  interface MTU, and a capture shows MTU + 14 (Ethernet header; +4 more
+  with FCS on a physical wire). MTU 1600 here means 1614-byte frames in
+  tcpdump — precisely as MTU 4096 means 4110-byte frames. That is correct
+  under Linux/IETF MTU semantics (MTU = max L2 payload); a peer whose
+  configured "MTU" counts the Ethernet header and FCS inside the number
+  (media-MTU semantics, 18 bytes of overhead) will both send smaller
+  padded Hellos and DROP ours as giants, exactly like a receiver whose
+  kernel MTU is simply lower — which is how the mismatch scenario below
+  models it.
+
+  Test Topology:
+  ```
+   a1 ───────────── a2
+   i2  10.0.12.0/30  i1
+   lo 10.0.0.1/32   lo 10.0.0.2/32
+  ```
+
+  Both routers are level-2-only on a broadcast (LAN) circuit with 1 s
+  Hellos and hold-time 5 s, so MTU-change fallout lands within seconds.
+
+  Scenario: Matched MTUs — Hellos are padded to exactly MTU + 14 on the wire and the adjacency forms
+    Given a clean test environment
+    When I create namespace "a1"
+    And I create namespace "a2"
+    And I connect namespace "a1" interface "i2" to namespace "a2" interface "i1"
+    And I set mtu 1600 on interface "i2" in namespace "a1"
+    And I set mtu 1600 on interface "i1" in namespace "a2"
+    And I start zebra-rs in namespace "a1"
+    And I start zebra-rs in namespace "a2"
+    And I apply config "a1.yaml" to namespace "a1"
+    And I apply config "a2.yaml" to namespace "a2"
+    Then isis neighbor in namespace "a1" at level 2 on interface "i2" should be up
+    And isis neighbor in namespace "a2" at level 2 on interface "i1" should be up
+    # The padded IIH occupies the full 1600-byte payload; tcpdump adds the
+    # 14-byte Ethernet header. Anything larger would be an overshoot bug
+    # (frames the peer must drop); anything below 1612 would be under-padding.
+    And IS-IS hellos sent on interface "i2" in namespace "a1" should be 1614 bytes on the wire
+    And IS-IS hellos sent on interface "i1" in namespace "a2" should be 1614 bytes on the wire
+    And ping from "a2" to "10.0.0.1" should succeed
+
+  Scenario: Receiver with a smaller MTU silently drops the padded Hellos — adjacency refuses to form while ordinary traffic still flows
+    Given the test topology exists
+    # a2 now models the mismatched peer: its kernel drops ingress frames
+    # over ~1518 bytes, while a1 keeps probing at its own MTU. This is the
+    # vendor-interop trap in miniature — link fine, pings fine, IS-IS down.
+    When I set mtu 1500 on interface "i1" in namespace "a2"
+    And I wait 10 seconds
+    Then IS-IS hellos sent on interface "i2" in namespace "a1" should be 1614 bytes on the wire
+    And isis neighbor in namespace "a2" at level 2 on interface "i1" should not be up
+    And isis neighbor in namespace "a1" at level 2 on interface "i2" should not be up
+    # Small frames still traverse the link: only the full-MTU Hellos die.
+    And ping from "a2" to "10.0.12.1" should succeed
+    And ping from "a2" to "10.0.0.1" should fail
+
+  Scenario: hello padding disable on the big-MTU side brings the adjacency back up
+    Given the test topology exists
+    When I apply command "set router isis interface i2 hello padding disable" in namespace "a1"
+    Then isis neighbor in namespace "a2" at level 2 on interface "i1" should be up
+    And isis neighbor in namespace "a1" at level 2 on interface "i2" should be up
+    And IS-IS hellos sent on interface "i2" in namespace "a1" should be smaller than 200 bytes on the wire
+    And ping from "a2" to "10.0.0.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "a1"
+    And I stop zebra-rs in namespace "a2"
+    And I delete namespace "a1"
+    And I delete namespace "a2"
+    Then the test environment should be clean

--- a/bdd/tests/features/isis_hello_padding_mtu.feature
+++ b/bdd/tests/features/isis_hello_padding_mtu.feature
@@ -1,11 +1,13 @@
 @isis_hello_padding_mtu
 @isis
-Feature: IS-IS Hello padding fills the interface MTU exactly, and hello-padding disable is the mismatch escape hatch
+Feature: IS-IS Hello padding fills the interface MTU exactly, with padding-size and padding disable as the mismatch escape hatches
   As a network operator
   I want IS-IS Hellos padded to exactly the interface MTU (and no further),
   so an adjacency only forms when the link really carries full-MTU PDUs in
-  both directions — and I want `hello padding disable` to bring a
-  mismatched-MTU adjacency up when I decide that check is not what I need.
+  both directions — and when the peer's MTU accounting disagrees with mine,
+  I want `hello padding-size <bytes>` to pad to the exact frame length the
+  peer accepts (the number read straight out of a capture), or
+  `hello padding disable` to skip the probe entirely.
 
   Wire arithmetic this feature pins down (the recurring interop question):
   the padder fills the IIH PDU to MTU - 3, the send path prepends the
@@ -63,6 +65,23 @@ Feature: IS-IS Hello padding fills the interface MTU exactly, and hello-padding 
     # Small frames still traverse the link: only the full-MTU Hellos die.
     And ping from "a2" to "10.0.12.1" should succeed
     And ping from "a2" to "10.0.0.1" should fail
+
+  Scenario: hello padding-size pads to an explicit wire length the smaller-MTU peer accepts
+    Given the test topology exists
+    # The surgical fix when the peer's MTU number cannot be changed: tell
+    # a1 to pad its Hellos to a 1514-byte frame — the size read from the
+    # peer-side capture — instead of its own 1600 MTU. The MTU probe
+    # still runs, just at the length both sides agree on. This is the
+    # miniature of `padding-size 4092` against a media-MTU-4096 vendor.
+    When I apply command "set router isis interface i2 hello padding-size 1514" in namespace "a1"
+    Then isis neighbor in namespace "a2" at level 2 on interface "i1" should be up
+    And isis neighbor in namespace "a1" at level 2 on interface "i2" should be up
+    And IS-IS hellos sent on interface "i2" in namespace "a1" should be 1514 bytes on the wire
+    And ping from "a2" to "10.0.0.1" should eventually succeed
+    # Deleting the override restores the default full-MTU probe (1600+14),
+    # which this link (still 1500 on the a2 side) again cannot carry.
+    When I apply command "delete router isis interface i2 hello padding-size" in namespace "a1"
+    Then IS-IS hellos sent on interface "i2" in namespace "a1" should be 1614 bytes on the wire
 
   Scenario: hello padding disable on the big-MTU side brings the adjacency back up
     Given the test topology exists

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -77,6 +77,7 @@
   - [Passive Interfaces](ch-07-07-isis-passive.md)
   - [Egress Protection (Mirror SID)](ch-07-08-isis-egress-protection.md)
   - [Conditional Tracing](ch-07-09-isis-tracing.md)
+  - [Hello Padding and MTU](ch-07-10-isis-hello-padding.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Minimum Working Example](ch-08-04-ospf-minimum-working-example.md)
   - [Area Configuration](ch-08-05-ospf-area-configuration.md)

--- a/book/src/ch-07-01-isis-timers.md
+++ b/book/src/ch-07-01-isis-timers.md
@@ -86,10 +86,18 @@ packets later is far worse).
 | YANG leaf | Default | Values |
 |---|---|---|
 | `/router/isis/interface/<n>/hello/padding` | `always` | `always`, `disable` |
+| `/router/isis/interface/<n>/hello/padding-size` | unset (interface MTU) | 64..16384 bytes |
 
 `disable` skips padding entirely. Operationally useful only when
 intentionally hiding an MTU mismatch (very rare) or to save a small
 amount of bandwidth on extremely high-fanout broadcast LANs.
+
+`padding-size` pads toward an explicit on-wire frame length instead of
+the interface MTU — the surgical fix for peers whose configured "MTU"
+counts L2 overhead inside the number and who therefore drop full-MTU
+padded Hellos as giants. See
+[Hello Padding and MTU](ch-07-10-isis-hello-padding.md) for the wire
+arithmetic and the interop story.
 
 ## Database synchronization — CSNP and PSNP intervals
 
@@ -314,6 +322,7 @@ qualifiers can be added later if a deployment needs them.
 | hello interval | 3 s | per-interface |
 | hello multiplier | 10 | per-interface |
 | hello padding | always | per-interface |
+| hello padding-size | unset (interface MTU) | per-interface |
 | csnp-interval | 10 s | per-interface |
 | psnp-interval | 2 s | per-interface |
 | lsp-refresh-interval | 900 s | instance |
@@ -384,6 +393,7 @@ prefer BFD over aggressive hellos.
 | `interface/<n>/hello/interval` | `isis hello-interval` (interface) |
 | `interface/<n>/hello/multiplier` | `isis hello-multiplier` (interface) |
 | `interface/<n>/hello/padding` | `isis hello-padding` (interface) |
+| `interface/<n>/hello/padding-size` | (no IOS-XR equivalent — explicit pad-to frame length) |
 | `interface/<n>/csnp-interval` | `isis csnp-interval` (interface) |
 | `interface/<n>/psnp-interval` | `isis retransmit-interval`-adjacent (no exact IOS-XR equivalent — PSNP ack pacing) |
 

--- a/book/src/ch-07-10-isis-hello-padding.md
+++ b/book/src/ch-07-10-isis-hello-padding.md
@@ -1,0 +1,117 @@
+# IS-IS Hello Padding and MTU
+
+IS-IS Hello PDUs are padded to the full interface MTU so that an
+adjacency only forms when the link really carries maximum-size PDUs in
+both directions (the ISO 10589 MTU probe). A link that silently eats
+large frames is far worse discovered later — as black-holed LSPs or
+data traffic — than as an adjacency that refuses to come up.
+
+This chapter pins down exactly what lands on the wire, the vendor
+interop trap that follows from it, and the two escape hatches:
+`hello padding-size` and `hello padding disable`.
+
+## What a padded Hello looks like on the wire
+
+The padder fills the IIH PDU to `MTU − 3`, the send path prepends the
+3-byte LLC header (`FE FE 03`), and the kernel adds the 14-byte
+Ethernet header. With a 4096-byte interface MTU:
+
+```
+Ethernet Header                  14
+Ethernet Payload (4093 + 3) =  4096
+  IIH PDU        = 4093
+  LLC header     =    3
+                        14 + 4096 = 4110
+```
+
+A packet capture therefore shows **MTU + 14** byte Hello frames — 4110
+for MTU 4096, 1514 for MTU 1500. This is correct under Linux/IETF MTU
+semantics (MTU = maximum L2 payload, Ethernet header excluded) and is
+byte-identical to FRR and Cisco IOS behaviour. The interface MTU is
+read from the kernel via netlink; there is no separate zebra-rs MTU
+configuration.
+
+## The interop trap: peers that count MTU differently
+
+Some platforms configure MTU in *media MTU* terms — the number includes
+the 14-byte Ethernet header, and on some platforms the 4-byte FCS as
+well. Such a peer configured with "MTU 4096" pads its own Hellos 18
+bytes smaller (4092-byte frames in a capture) **and drops our
+4110-byte frames on ingress as giants**.
+
+The symptom pattern is distinctive:
+
+- pings and ordinary traffic cross the link fine (small frames);
+- both sides send Hellos, but each side's padded Hello never arrives
+  at the other, or arrives in only one direction;
+- the adjacency sits in Down/Init forever with nothing logged — the
+  drop happens in the receiving interface, below IS-IS.
+
+The clean fix is to make both sides agree on the payload size: raise
+the media-MTU peer's number by 18 (4096 → 4114), or lower the
+zebra-rs-side kernel MTU by 18 (4096 → 4078). When neither number can
+be changed, use `padding-size`.
+
+## Padding to an explicit frame length — `hello padding-size`
+
+```
+set router isis interface eth0 hello padding-size 4092
+```
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/isis/interface/<n>/hello/padding-size` | unset (interface MTU) | 64..16384 | bytes |
+
+`padding-size` pads Hellos toward an explicit target instead of the
+interface MTU. The value is the **on-wire Ethernet frame length as
+read from a packet capture** — 14-byte header + LLC + PDU, FCS
+excluded — because that is the one number both ends of an MTU-semantics
+dispute can see and agree on: `padding-size 4092` against a
+media-MTU-4096 peer emits exactly the 4092-byte frames the peer itself
+sends, and the MTU probe still runs, just at the length both sides
+accept.
+
+Semantics worth knowing:
+
+- The 14-byte Ethernet header is subtracted internally; the result is
+  clamped to the interface MTU (the kernel rejects payloads above it),
+  so an over-large value degrades to plain full-MTU padding.
+- The padder never truncates a Hello. A value smaller than the
+  unpadded Hello simply means no padding is added.
+- Ignored while `hello padding disable` is set.
+- Runtime `set`/`delete` re-originates Hellos immediately — no
+  restart, no adjacency flap needed for the new size to take effect.
+
+`show isis interface detail` confirms what is on the wire:
+
+```
+    Hello interval: 3, Holddown count: 10, Padding: yes (size 4092)
+```
+
+The blunter alternative, `hello padding disable`, skips the probe
+entirely (see [Timer Configuration](ch-07-01-isis-timers.md)); the
+adjacency then forms across the mismatch, which is acceptable while
+`lsp-mtu` (default 1497) stays below both sides' real capacity.
+
+## Debugging with tcpdump
+
+One capture pitfall: libpcap's `isis` filter primitive **misses**
+padded Hellos on links with MTU above ~1500. The 802.3 length field
+carries the payload length (zebra-rs and FRR both send it that way),
+and values above 1536 make libpcap classify the frame as an unknown
+EtherType, so `tcpdump isis` shows the small PDUs but not the padded
+IIHs — exactly the frames under investigation. Match the LLC and ISO
+discriminator bytes by offset instead:
+
+```
+tcpdump -i eth0 'ether[14:2] = 0xfefe and ether[16] = 3 and ether[17] = 0x83'
+```
+
+## BDD coverage
+
+The `isis_hello_padding_mtu` feature proves the whole story end to
+end: matched MTUs pad to exactly MTU + 14 and the adjacency forms; a
+receiver with a smaller MTU silently drops the padded Hellos while
+pings still pass; `padding-size` shrinks the frames to a length the
+peer accepts and the adjacency recovers; deleting it restores full-MTU
+probing; and `padding disable` skips the probe entirely.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -298,6 +298,10 @@ impl Isis {
             link::config_hello_padding,
         );
         self.callback_add(
+            "/router/isis/interface/hello/padding-size",
+            link::config_hello_padding_size,
+        );
+        self.callback_add(
             "/router/isis/interface/ipv4/enabled",
             link::config_ipv4_enable,
         );

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -215,7 +215,7 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     let resolved = auth::resolve_send(&link.config.hello_auth, link.key_chains, chrono::Utc::now());
     auth::append_auth_tlv(&mut hello.tlvs, resolved.as_ref());
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
-        hello.padding(link.state.mtu as usize);
+        hello.padding(link.config.hello_pad_target(link.state.mtu as usize));
     }
     hello
 }
@@ -302,7 +302,7 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     let resolved = auth::resolve_send(&link.config.hello_auth, link.key_chains, chrono::Utc::now());
     auth::append_auth_tlv(&mut hello.tlvs, resolved.as_ref());
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
-        hello.padding(link.state.mtu as usize);
+        hello.padding(link.config.hello_pad_target(link.state.mtu as usize));
     }
     hello
 }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -341,6 +341,15 @@ pub struct LinkConfig {
     pub hello_interval: Option<u16>,
     pub hello_multiplier: Option<u16>,
     pub hello_padding: Option<HelloPaddingPolicy>,
+    /// `.../hello/padding-size`: pad Hellos toward this on-wire Ethernet
+    /// frame length instead of the interface MTU. Expressed as the frame
+    /// size an operator reads out of a capture (14-byte Ethernet header +
+    /// LLC + PDU, FCS excluded), because that is the number both ends of
+    /// an MTU-semantics dispute can see and agree on. Interop escape
+    /// hatch for peers whose configured "MTU" counts L2 overhead inside
+    /// the number and who therefore drop our full-MTU padded Hellos as
+    /// giants.
+    pub hello_padding_size: Option<u16>,
     pub holddown_count: Option<u32>,
 
     pub psnp_interval: Option<u32>,
@@ -627,6 +636,21 @@ impl LinkConfig {
 
     pub fn hello_padding(&self) -> HelloPaddingPolicy {
         self.hello_padding.unwrap_or(HelloPaddingPolicy::Always)
+    }
+
+    /// The payload budget `padding()` fills toward (LLC + PDU bytes).
+    /// Defaults to the interface MTU — payload becomes exactly MTU, the
+    /// ISO 10589 full-MTU probe. A configured `padding-size` states the
+    /// same target as the on-wire frame length, so the 14-byte Ethernet
+    /// header is subtracted here; the result is clamped to the MTU
+    /// because the kernel rejects sends whose payload exceeds the
+    /// device MTU. The padder never truncates a Hello, so a size below
+    /// the unpadded PDU just means no padding is added.
+    pub fn hello_pad_target(&self, mtu: usize) -> usize {
+        match self.hello_padding_size {
+            Some(size) => mtu.min((size as usize).saturating_sub(14)),
+            None => mtu,
+        }
     }
     pub fn holddown_count(&self) -> u32 {
         self.holddown_count.unwrap_or(Self::DEFAULT_HOLDDOWN_COUNT)
@@ -1949,6 +1973,21 @@ pub fn config_hello_padding(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Op
     Some(())
 }
 
+pub fn config_hello_padding_size(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let size = args.u16()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+
+    if op.is_set() {
+        link.config.hello_padding_size = Some(size);
+    } else {
+        link.config.hello_padding_size = None;
+    }
+
+    hello_reoriginate(link, &isis.tx);
+    Some(())
+}
+
 pub fn config_hello_interval(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let interval = args.u16()?;
@@ -2235,6 +2274,18 @@ fn render_auth_block_from(info: &AuthInfo) -> String {
     buf
 }
 
+/// The `Padding:` column of `show isis interface detail`: yes/no as in
+/// FRR, plus the configured `padding-size` override when one is set —
+/// that value changes what lands on the wire, so the operator checking
+/// an interop dispute must be able to see it here.
+fn padding_column(config: &LinkConfig) -> String {
+    match (config.hello_padding(), config.hello_padding_size) {
+        (HelloPaddingPolicy::Disable, _) => "no".to_string(),
+        (_, Some(size)) => format!("yes (size {})", size),
+        _ => "yes".to_string(),
+    }
+}
+
 pub fn show_detail_entry(buf: &mut String, link: &IsisLink, level: Level) -> std::fmt::Result {
     writeln!(
         buf,
@@ -2242,11 +2293,7 @@ pub fn show_detail_entry(buf: &mut String, link: &IsisLink, level: Level) -> std
         link.config.metric(),
         link.state.nbrs_up.get(&level)
     )?;
-    let padding = if link.config.hello_padding() == HelloPaddingPolicy::Always {
-        "yes"
-    } else {
-        "no"
-    };
+    let padding = padding_column(&link.config);
     writeln!(
         buf,
         "    Hello interval: {}, Holddown count: {}, Padding: {}",
@@ -2278,11 +2325,7 @@ pub fn show_detail_entry(buf: &mut String, link: &IsisLink, level: Level) -> std
 }
 
 fn build_level_info(link: &IsisLink, level: Level) -> LevelInfo {
-    let padding = if link.config.hello_padding() == HelloPaddingPolicy::Always {
-        "yes".to_string()
-    } else {
-        "no".to_string()
-    };
+    let padding = padding_column(&link.config);
 
     LevelInfo {
         metric: link.config.metric(),
@@ -2707,6 +2750,56 @@ pub fn show_dis_history(
     }
 
     Ok(buf)
+}
+
+#[cfg(test)]
+mod hello_pad_target_tests {
+    use super::*;
+
+    /// Unset ⇒ the ISO 10589 full-MTU probe: payload budget == MTU,
+    /// so the wire frame is MTU + 14. The interop question this
+    /// arithmetic answers: MTU 4096 ⇒ 4110-byte frames in a capture.
+    #[test]
+    fn default_is_interface_mtu() {
+        let config = LinkConfig::default();
+        assert_eq!(config.hello_pad_target(4096), 4096);
+    }
+
+    /// `padding-size` speaks in capture frame bytes; the payload
+    /// budget drops the 14-byte Ethernet header. Size 4092 against a
+    /// 4096-MTU interface ⇒ budget 4078 ⇒ 4075-byte IIH PDU ⇒ a
+    /// 4092-byte frame the media-MTU peer accepts.
+    #[test]
+    fn size_subtracts_ethernet_header() {
+        let config = LinkConfig {
+            hello_padding_size: Some(4092),
+            ..Default::default()
+        };
+        assert_eq!(config.hello_pad_target(4096), 4078);
+    }
+
+    /// A size above MTU + 14 must clamp to the MTU — the kernel
+    /// rejects AF_PACKET sends whose payload exceeds the device MTU,
+    /// so honoring the raw value would kill every Hello.
+    #[test]
+    fn size_clamps_to_interface_mtu() {
+        let config = LinkConfig {
+            hello_padding_size: Some(9000),
+            ..Default::default()
+        };
+        assert_eq!(config.hello_pad_target(1500), 1500);
+    }
+
+    /// Degenerate size (below the Ethernet header) saturates to 0;
+    /// the padder then adds nothing rather than underflowing.
+    #[test]
+    fn tiny_size_saturates() {
+        let config = LinkConfig {
+            hello_padding_size: Some(10),
+            ..Default::default()
+        };
+        assert_eq!(config.hello_pad_target(1500), 0);
+    }
 }
 
 #[cfg(test)]

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3533,6 +3533,23 @@ module config {
                 enum disable;
               }
             }
+            leaf padding-size {
+              ext:help "Pad Hellos to this Ethernet frame length instead of the interface MTU";
+              type uint16 {
+                range "64..16384";
+              }
+              units "bytes";
+              description
+                "On-wire Ethernet frame length Hello padding fills toward,
+                 as read from a packet capture: 14-byte Ethernet header +
+                 3-byte LLC header + IIH PDU, FCS excluded. Overrides the
+                 default full-interface-MTU target, for peers whose
+                 configured MTU counts L2 overhead inside the number and
+                 who therefore drop full-MTU padded Hellos as giants.
+                 Clamped to the interface MTU; a value below the unpadded
+                 Hello size simply disables padding growth (the Hello is
+                 never truncated). Ignored when padding is disable.";
+            }
             leaf interval {
               ext:help "Hello PDU transmit interval (seconds)";
               type uint16 {
@@ -4100,6 +4117,23 @@ module config {
                   enum always;
                   enum disable;
                 }
+              }
+              leaf padding-size {
+                ext:help "Pad Hellos to this Ethernet frame length instead of the interface MTU";
+                type uint16 {
+                  range "64..16384";
+                }
+                units "bytes";
+                description
+                  "On-wire Ethernet frame length Hello padding fills toward,
+                   as read from a packet capture: 14-byte Ethernet header +
+                   3-byte LLC header + IIH PDU, FCS excluded. Overrides the
+                   default full-interface-MTU target, for peers whose
+                   configured MTU counts L2 overhead inside the number and
+                   who therefore drop full-MTU padded Hellos as giants.
+                   Clamped to the interface MTU; a value below the unpadded
+                   Hello size simply disables padding growth (the Hello is
+                   never truncated). Ignored when padding is disable.";
               }
               leaf interval {
                 ext:help "Hello PDU transmit interval (seconds)";


### PR DESCRIPTION
## Background

An interop report asked why zebra-rs sends 4110-byte IS-IS Hello frames on a 4096-MTU interface while the peer (another vendor) sends 4092-byte ones and drops ours, keeping the adjacency down. The 4110 is correct behavior: Hellos are padded to the full interface MTU (ISO 10589 MTU probe) —

```
Ethernet Header                  14
Ethernet Payload (4093 + 3) =  4096
  IIH PDU        = 4093
  LLC header     =    3
                        14 + 4096 = 4110
```

— identical to FRR and Cisco IOS (MTU 1500 ⇒ 1514-byte Hellos). The peer's 4092 means its configured "MTU" counts 18 bytes of L2 overhead (14-byte header + 4-byte FCS) inside the number, so it both pads smaller and drops our full-payload frames as giants.

## What this PR does

**1. BDD feature `isis_hello_padding_mtu`** pins the wire arithmetic and the failure mode:
- matched MTUs (1600/1600): every captured IIH is exactly MTU + 14 = 1614 bytes and the adjacency forms;
- receiver lowered to 1500: the padded Hellos are silently dropped and the adjacency refuses to form **while pings still pass** — the reported symptom in miniature;
- `hello padding disable` recovers the adjacency with sub-200-byte Hellos.

New harness steps: `I set mtu N on interface ...` and a tcpdump-based assertion of transmitted IIH wire sizes. The capture matches the LLC/ISO bytes by offset instead of libpcap's `isis` primitive — a padded IIH on a >1500-MTU link carries the payload length in the 802.3 length field, and values above 1536 make libpcap classify the frame as an unknown EtherType, so `isis` silently misses exactly the frames under test.

**2. New knob `hello padding-size`** (`/router/isis/interface/hello/padding-size`, uint16 64..16384, global + per-VRF trees) pads Hellos toward an explicit target instead of the interface MTU, for the case where neither side's MTU number can be changed. The value is the **on-wire Ethernet frame length as read from a capture** (14-byte header + LLC + PDU, FCS excluded) — the one number both ends of an MTU-semantics dispute can see and agree on: `padding-size 4092` against a media-MTU-4096 vendor emits exactly the 4092-byte frames the vendor itself sends. Internally the 14-byte header is subtracted and the result clamped to the interface MTU; the padder never truncates, so an undersized value just means no padding growth. Ignored while `padding disable` is set; runtime set/delete re-originates Hellos immediately. `show isis interface detail` renders the override as `Padding: yes (size N)`.

## Validation

- BDD: 5 scenarios green, including the new one — `padding-size 1514` on the mismatched link (a1=1600, a2=1500) shrinks Hellos to exactly 1514-byte frames, the adjacency comes up and routes flow; deleting the leaf restores 1614-byte full-MTU probing.
- 4 new unit tests pin `hello_pad_target` (default = MTU, header subtraction, MTU clamp, saturation); full zebra-rs suite: 2031 passed.
- Workspace `cargo fmt` and `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)