### PR TITLE
isis: keep the padding-size help line under 80 columns

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3534,7 +3534,7 @@ module config {
               }
             }
             leaf padding-size {
-              ext:help "Pad Hellos to this Ethernet frame length instead of the interface MTU";
+              ext:help "Pad Hellos to this on-wire frame length instead of MTU";
               type uint16 {
                 range "64..16384";
               }
@@ -4119,7 +4119,7 @@ module config {
                 }
               }
               leaf padding-size {
-                ext:help "Pad Hellos to this Ethernet frame length instead of the interface MTU";
+                ext:help "Pad Hellos to this on-wire frame length instead of MTU";
                 type uint16 {
                   range "64..16384";
                 }


### PR DESCRIPTION
Follow-up to #2287: the CLI completion line for `hello padding-size` rendered at ~92 columns —

```
> <64..16384>          Pad Hellos to this Ethernet frame length instead of the interface MTU
```

The `ext:help` string is trimmed from 70 to 54 characters ("Pad Hellos to this on-wire frame length instead of MTU"), keeping the rendered line at ~77 columns in both the global and per-VRF trees. The long-form wire-math semantics stay in the leaf's `description`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)