### PR TITLE
config: fix leaf-list save/load round-trip phantom commands

### DIFF
--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -281,7 +281,11 @@ impl Config {
                 if brace {
                     out.push_str(" {\n");
                 } else {
-                    out.push_str(";\n");
+                    // No trailing `;` after the closing brace: `};` made the
+                    // loader emit a phantom `set` for the bare parent path
+                    // (rejected at boot on every saved leaf-list). Close like
+                    // every other block.
+                    out.push('\n');
                 }
             } else if brace {
                 out.push_str(" {\n");
@@ -1095,6 +1099,25 @@ mod tests {
         assert!(output.contains("    10.0.0.1/32;"));
         assert!(output.contains("    10.0.0.2/32;"));
         assert!(output.contains("  }"));
+        // The leaf-list block must close with a bare `}` — the old `};`
+        // form made the loader emit a phantom `set prefix-test` that the
+        // schema rejected on every boot.
+        assert!(
+            !output.contains("};"),
+            "leaf-list close leaked a trailing semicolon:\n{}",
+            output
+        );
+
+        // True round-trip: the file we save must load back into exactly
+        // the commands that built it, phantom-free.
+        let cmds = crate::config::files::load_config_file(output);
+        assert_eq!(
+            cmds,
+            vec![
+                "set prefix-test member 10.0.0.1/32",
+                "set prefix-test member 10.0.0.2/32",
+            ]
+        );
     }
 
     /// Regression: `list()` (the flat "set command" form the commit

--- a/zebra-rs/src/config/files.rs
+++ b/zebra-rs/src/config/files.rs
@@ -35,6 +35,15 @@ pub fn load_config_file(input: String) -> Vec<String> {
                 stack.pop();
             }
             Token::SemiColon => {
+                // An empty statement — a `;` directly after `{`, `}`, or
+                // another `;` — names nothing and must not become a command.
+                // Configs saved before the writer fix closed every leaf-list
+                // block with `};`, and that stray `;` flattened into a bare
+                // parent-path `set` (e.g. `set interface eth0 ipv4`) that the
+                // schema rejected on every boot.
+                if cmds.is_empty() {
+                    continue;
+                }
                 stack.push(cmds.clone());
                 cmds.clear();
                 let cmd = flatten(&stack);
@@ -144,6 +153,38 @@ static {
                 .any(|c| c
                     == "set static ipv6 route 2001:db8:ff00:5::/64 segments fcbb:bbbb:3:fe00::"),
             "specific-prefix segments set line missing; got:\n{dump}"
+        );
+    }
+
+    #[test]
+    fn test_stray_semicolon_after_leaf_list_brace() {
+        // The exact shape the pre-fix writer saved for every leaf-list —
+        // `};` closing the address block. The stray `;` used to flatten
+        // into a phantom bare-path command (`set interface enp0s6 ipv4`)
+        // that the schema rejected on every boot. Old configs on disk
+        // still carry it, so the loader must treat it as an empty
+        // statement and emit only the real address command.
+        let config = r#"
+interface enp0s6 {
+  ipv4 {
+    address {
+      192.168.10.1/24;
+    };
+  }
+  ipv6 {
+    address {
+      2001:db8:ff00:10::1/64;
+    };
+  }
+}
+"#;
+        let cmds = load_config_file(config.to_string());
+        assert_eq!(
+            cmds,
+            vec![
+                "set interface enp0s6 ipv4 address 192.168.10.1/24",
+                "set interface enp0s6 ipv6 address 2001:db8:ff00:10::1/64",
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary

A user-reported boot error: `startup config ...: 6 command(s) rejected` listing bare container paths (`set interface enp0s6 ipv4`, …) for every interface address block in a saved config.

Root cause is a save/load round-trip bug spanning both halves of the CLI format:

- **Writer** (`configs.rs`): a leaf-list block was the only construct closed with `};` —
  ```
  address {
    192.168.10.1/24;
  };        ← stray semicolon
  ```
- **Loader** (`files.rs`): the brace parser flattened that stray `;` into a `set` command for whatever path was on the stack — a bare container path the schema rejects.

The real values were applied (each address command is emitted before its phantom), so the error was noise rather than lost config — but every boot of a self-saved config carrying any leaf-list errored.

## Fix

Both sides: the writer closes leaf-list blocks with a bare `}` like every other block, and the loader skips empty statements (`;` directly after `{`, `}`, or another `;`), so configs saved before the fix — like the reporter's — load cleanly without a re-save.

## Test plan

- New loader test replays the reported on-disk shape (`ipv4 { address { … }; }`) and pins the exact emitted command list — no phantoms.
- The writer round-trip test now asserts no `};` leaks and feeds its formatted output back through the loader.
- Full zebra-rs suite: 2032 passed. Workspace clippy and fmt clean.
- End-to-end: the `isis_srv6_base` BDD feature (its `z1.conf` still carries the old `};` form in the static-route segments block) passes against the fixed binary with zero rejected commands in the log.

Generated with [Claude Code](https://claude.com/claude-code)