### PR TITLE
playset: isis-flexalgo-ai — no-FlexAlgo baseline for the AI & Ontology demo

### DIFF
--- a/playset/isis-flexalgo-ai/README.md
+++ b/playset/isis-flexalgo-ai/README.md
@@ -1,0 +1,713 @@
+# IS-IS Flexible Algorithm (RFC 9350)
+
+This playset demonstrates IS-IS Flexible Algorithm over SR-MPLS. An
+eleven-node global backbone runs the standard shortest-path algorithm
+(algorithm 0) *and* a second, constrained algorithm 128 at the same time,
+over the same links. Algorithm 128 is defined to avoid every trans-Pacific
+link, so traffic between Tokyo and the United States is forced the long way
+round — through Asia and Europe — while algorithm 0 keeps using the direct
+Pacific crossing.
+
+Each node runs zebra-rs in its own network namespace, and loads its own
+`<node>.yaml` at startup via the `--config-file` argument.
+
+## Topology
+
+Eleven nodes in three regions. The region of each node comes from
+`ontology.json`, which is the input the Flex-Algorithm design is derived
+from:
+
+```
+        AP                      US                        EU
+  ┌──────────────┐      ┌──────────────────┐      ┌─────────────────┐
+  │ tk  Tokyo    │      │ se  Seattle      │      │ ln  London      │
+  │ sy  Sydney   │      │ sj  San Jose     │      │ fr  Frankfurt   │
+  │ sg  Singapore│      │ ch  Chicago      │      └─────────────────┘
+  └──────────────┘      │ da  Dallas       │
+                        │ va  Virginia     │
+                        │ at  Atlanta      │
+                        └──────────────────┘
+```
+
+The six links that cross a region boundary are what the demo turns on:
+
+```
+  sj ── tk    US <-> AP    trans-pacific   excluded by algorithm 128
+  se ── sg    US <-> AP    trans-pacific   excluded by algorithm 128
+  sj ── sy    US <-> AP    trans-pacific   excluded by algorithm 128
+  ch ── ln    US <-> EU
+  va ── fr    US <-> EU
+  fr ── sg    EU <-> AP
+```
+
+Once all three trans-Pacific links are excluded, the only way for an AP node
+to reach a US node in algorithm 128 is `sg -> fr` into Europe and onward —
+which is exactly the "must go through Asia and Europe" property we are
+after. Every link has metric 10, and the full link list is in the appendix.
+
+## Bring up all nodes
+
+`./up.sh` sets up all namespaces and starts the zebra-rs routing daemon in
+each of them on that node's own `<node>.yaml` as `--config-file`.
+
+``` shell
+$ ./up.sh
+bring up
+runtime dir: /tmp/zebra-rs-playset/isis-flexalgo
+teardown: stop zebra-rs
+teardown: delete namespace se
+teardown: delete namespace sj
+...
+cleanup logs
+create namespace: sg
+create namespace: sy
+create namespace: tk
+create link: se-sg (se) <-> sg-se (sg)
+create link: se-sj (se) <-> sj-se (sj)
+create link: se-ch (se) <-> ch-se (ch)
+create link: sj-sy (sj) <-> sy-sj (sy)
+...
+start zebra-rs: ch
+start zebra-rs: da
+...
+start zebra-rs: tk
+sleep 3sec
+```
+
+You can then list the namespaces:
+
+``` shell
+$ ip netns
+tk
+sy
+sg
+fr
+ln
+at
+va
+da
+ch
+sj
+se
+```
+
+`./down.sh` tears the whole thing back down.
+
+## Algorithm 0: the unconstrained baseline
+
+Let's look at the ordinary routing table on node `tk` (Tokyo).
+
+``` shell
+$ sudo ip netns exec tk vty
+tk>show ip route
+Codes: K - kernel, D - DHCP route, C - connected, S - static
+       O - OSPF, IA - OSPF inter area, N1/N2 - OSPF NSSA external type 1/2
+       E1/E2 - OSPF external type 1/2
+       L1/L2 - IS-IS level-1/2, ia - IS-IS inter area, B - BGP
+       > - selected route, * - FIB route, S - Stale route, ? - backup route
+
+L2 *> 10.0.0.1/32 [115/30] via 192.168.6.1, tk-sj, label 16100, weight 1, 00:00:08
+                           via 192.168.15.1, tk-sg, label 16100, weight 1, 00:00:08
+L2 *> 10.0.0.2/32 [115/20] via 192.168.6.1, tk-sj, label (16200), 00:00:08
+L2 *> 10.0.0.3/32 [115/30] via 192.168.6.1, tk-sj, label 16300, 00:00:08
+L2 *> 10.0.0.4/32 [115/30] via 192.168.6.1, tk-sj, label 16400, 00:00:08
+L2 *> 10.0.0.5/32 [115/40] via 192.168.6.1, tk-sj, label 16500, weight 1, 00:00:08
+                           via 192.168.15.1, tk-sg, label 16500, weight 1, 00:00:08
+L2 *> 10.0.0.6/32 [115/40] via 192.168.6.1, tk-sj, label 16600, 00:00:08
+L2 *> 10.0.0.7/32 [115/40] via 192.168.6.1, tk-sj, label 16700, weight 1, 00:00:08
+                           via 192.168.15.1, tk-sg, label 16700, weight 1, 00:00:08
+L2 *> 10.0.0.8/32 [115/30] via 192.168.15.1, tk-sg, label 16800, 00:00:08
+L2 *> 10.0.0.9/32 [115/20] via 192.168.15.1, tk-sg, label (16900), 00:00:08
+L2 *> 10.0.0.10/32 [115/30] via 192.168.6.1, tk-sj, label 17000, weight 1, 00:00:08
+                            via 192.168.15.1, tk-sg, label 17000, weight 1, 00:00:08
+C  *> 10.0.0.11/32 is directly connected, lo, 00:00:09
+```
+
+This is plain SR-MPLS: `sj` (San Jose, `10.0.0.2`) is one hop away over the
+trans-Pacific link `tk-sj`, and most of the US is reached through it. The
+parenthesized labels such as `(16200)` mean implicit-null — the SID owner is
+directly adjacent, so penultimate-hop popping applies.
+
+Note that `show ip route` only ever shows algorithm 0. Flex-Algorithm routes
+live in their own per-algorithm RIB, shown further down.
+
+## Take a look at the YAML configuration
+
+Node `tk`'s configuration is in `tk.yaml`:
+
+``` yaml
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.11/32
+- if-name: tk-sj
+  ipv4:
+    address: 192.168.6.2/24
+- if-name: tk-sg
+  ipv4:
+    address: 192.168.15.2/24
+system:
+  hostname: tk
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0011.00
+    hostname: tk
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.11
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1100
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 3100
+    - if-name: tk-sj
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: tk-sg
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+```
+
+There are four moving parts, and they are worth separating:
+
+* **`affinity-map`** is the global name-to-bit table (RFC 7308 Extended
+  Admin Group). It binds the operator-friendly name `trans-pacific` to bit
+  position 0. This table is *not* advertised; every router needs the same
+  copy so that everyone agrees what bit 0 means. It lives at the top level
+  because it is shared with OSPF.
+
+* **The per-link `affinity`** list colours `tk-sj` — the Tokyo-to-US link —
+  with `trans-pacific`. `tk-sg` carries no affinity. This is the only place
+  the topology is described; the algorithm definition below never names a
+  link.
+
+* **`flex-algo 128`** is the Flex-Algorithm Definition (FAD). It says: use
+  the IGP metric, forward over SR-MPLS, and `exclude-any: trans-pacific` —
+  prune every link carrying that colour before running SPF.
+
+* **`flex-algo-prefix-sid`** gives the loopback a *second* Prefix-SID, index
+  3100, valid only in algorithm 128, alongside the algorithm-0 index 1100.
+  Two algorithms means two independent paths to the same loopback, so they
+  need two different labels to steer with.
+
+In this playset only `ch` and `sg` additionally set
+`advertise-definition: true`. At least one router per area must originate
+the FAD; two are configured for redundancy, one in the US and one in AP.
+Every other node carries the identical definition and simply participates.
+
+A note on the SID numbering: algorithm-0 indexes are 100..1100 and
+algorithm-128 indexes are 2100..3100. They must not overlap, because both
+resolve against the *same* SRGB (base 16000) — reusing an index across
+algorithms would collide in the label space and cross-wire the two
+topologies.
+
+## How the constraint reaches the wire
+
+Everything above is carried in `tk`'s own LSP. This one dump shows all
+three mechanisms at once:
+
+``` shell
+tk>show isis database detail
+tk.00-00                  *      178  0x00000001  0xb581      1190  0/0/0
+  Area address: 49.0000
+  Protocol Supported: IPv4
+  LSP Buffer Size: 1492
+  Hostname: tk
+  Router Capability: 10.0.0.11, D:0 S:0
+   Segment Routing: I:1 V:1, Global Block: Label(16000), Range: 8000
+   Segment Routing Algorithm: SPF(0) FlexAlgo(128)
+   Segment Routing Local Block: Label(15000), Range: 100
+  TE Router ID: 10.0.0.11
+  Extended IS Reachability:
+   Neighbor ID: 0000.0000.0002.00, Metric: 10
+    Application Specific Link Attributes:
+     L:0 SABM: 0x10 UDABM: 0x
+     Applications: Flex-Algo
+      Ext Admin Group: [0] 0x00000001
+    Adjacency SID: Label(15000), Flag: F:0 B:0 V:1 L:1 S:0 P:0, Weight: 0
+  Extended IS Reachability:
+   Neighbor ID: 0000.0000.0009.00, Metric: 10
+    Adjacency SID: Label(15001), Flag: F:0 B:0 V:1 L:1 S:0 P:0, Weight: 0
+  Extended IP Reachability: 10.0.0.11/32 (Metric: 10)
+   SID: Index(1100), Algorithm: SPF(0), Flags: R:0 N:1 P:0 E:0 V:0 L:0
+   SID: Index(3100), Algorithm: FlexAlgo(128), Flags: R:0 N:1 P:0 E:0 V:0 L:0
+  Extended IP Reachability: 192.168.6.0/24 (Metric: 10)
+  Extended IP Reachability: 192.168.15.0/24 (Metric: 10)
+```
+
+* `Segment Routing Algorithm: SPF(0) FlexAlgo(128)` is the *participation*
+  advertisement — `tk` computes and forwards both algorithms.
+* Neighbour `0000.0000.0002` is `sj`, i.e. the link `tk-sj`. It carries an
+  **Application Specific Link Attributes** sub-TLV (ASLA, RFC 9479) with
+  `Applications: Flex-Algo` and `Ext Admin Group: [0] 0x00000001` — bit 0
+  set, the `trans-pacific` colour. Neighbour `0000.0000.0009` (`sg`) has no
+  ASLA at all, because that link is uncoloured. This is the constraint
+  crossing the wire; remote routers prune the link using this bit, not using
+  any local configuration.
+* The loopback advertises **two** Prefix-SIDs, one per algorithm.
+
+The two Adjacency SID labels (`15000`, `15001`) are handed out of the SRLB in
+the order the adjacencies come up, so which link gets which label varies from
+one `./up.sh` to the next. Only the *algorithm* they belong to is fixed —
+Adj-SIDs are shared by every algorithm.
+
+## Examine the Flex-Algorithm state
+
+``` shell
+tk>show isis flex-algo
+Area 49.0000:
+
+Local Flex-Algorithms:
+  Algo  Metric                 Priority Adv FRR       Constraints
+  128   igp                    -        no  off       exclude-any=trans-pacific
+
+Level-2:
+  Peer FADs:
+    ch (0000.0000.0003): algo 128 priority 128 metric-type 0 calc-type 0
+    sg (0000.0000.0009): algo 128 priority 128 metric-type 0 calc-type 0
+  Peer SR-Algorithm Participation:
+    se (0000.0000.0001): [0, 128]
+    sj (0000.0000.0002): [0, 128]
+    ch (0000.0000.0003): [0, 128]
+    da (0000.0000.0004): [0, 128]
+    va (0000.0000.0005): [0, 128]
+    at (0000.0000.0006): [0, 128]
+    ln (0000.0000.0007): [0, 128]
+    fr (0000.0000.0008): [0, 128]
+    sg (0000.0000.0009): [0, 128]
+    sy (0000.0000.0010): [0, 128]
+```
+
+`Adv no` on the local entry means `tk` is not a FAD originator; it uses the
+definition learned from `ch` and `sg`, both of which appear under
+`Peer FADs`. Every one of the ten peers reports `[0, 128]`, so the whole
+domain participates. `FRR off` is the TI-LFA state, explained at the end of
+this document.
+
+Right after `./up.sh` a node may briefly show `[0]` for a peer whose updated
+LSP is still flooding. It settles within a few seconds.
+
+Add an algorithm id to narrow the same view to one algorithm — the
+participation list drops the peers that do not run it, and the FAD table
+keeps only that row:
+
+``` shell
+tk>show isis flex-algo 128
+Area 49.0000:
+
+Local Flex-Algorithm 128:
+  Algo  Metric                 Priority Adv FRR       Constraints
+  128   igp                    -        no  off       exclude-any=trans-pacific
+
+L2 peers participating in algorithm 128:
+  se (0000.0000.0001)
+  sj (0000.0000.0002)
+  ch (0000.0000.0003)
+  da (0000.0000.0004)
+  va (0000.0000.0005)
+  at (0000.0000.0006)
+  ln (0000.0000.0007)
+  fr (0000.0000.0008)
+  sg (0000.0000.0009)
+  sy (0000.0000.0010)
+```
+
+That algorithm id is the entry point to every per-algorithm view:
+`show isis flex-algo <128-255> {route | topology | spf | graph | repair-list}`.
+The un-suffixed `show isis route|topology|spf|graph` stay algorithm-0 views.
+
+## Algorithm 128: the constrained paths
+
+``` shell
+tk>show isis flex-algo 128 route
+Area 49.0000:
+
+Level-2 Algorithm 128:
+  Prefix               Metric   Nexthop          Interface    Label
+  10.0.0.1/32          60       192.168.15.1     tk-sg        18100
+  10.0.0.2/32          60       192.168.15.1     tk-sg        18200
+  10.0.0.3/32          50       192.168.15.1     tk-sg        18300
+  10.0.0.4/32          60       192.168.15.1     tk-sg        18400
+  10.0.0.5/32          40       192.168.15.1     tk-sg        18500
+  10.0.0.6/32          50       192.168.15.1     tk-sg        18600
+  10.0.0.7/32          40       192.168.15.1     tk-sg        18700
+  10.0.0.8/32          30       192.168.15.1     tk-sg        18800
+  10.0.0.9/32          20       192.168.15.1     tk-sg        18900
+  10.0.0.10/32         30       192.168.15.1     tk-sg        19000
+```
+
+This is the whole point of the demo. **Every** destination leaves Tokyo over
+`tk-sg` towards Singapore. The `tk-sj` link — one hop from San Jose in
+algorithm 0 — is not used for anything, because the FAD pruned it before SPF
+ran. Reaching San Jose (`10.0.0.2`) now costs 60 instead of 20.
+
+The reverse direction behaves the same way. On `se` (Seattle), which has a
+trans-Pacific link `se-sg` of its own:
+
+``` shell
+se>show isis flex-algo 128 route
+Area 49.0000:
+
+Level-2 Algorithm 128:
+  Prefix               Metric   Nexthop          Interface    Label
+  10.0.0.2/32          20       192.168.1.2      se-sj        18200
+  10.0.0.3/32          20       192.168.2.2      se-ch        18300
+  10.0.0.4/32          30       192.168.1.2      se-sj        18400
+  10.0.0.4/32          30       192.168.2.2      se-ch        18400
+  10.0.0.5/32          30       192.168.2.2      se-ch        18500
+  10.0.0.6/32          40       192.168.1.2      se-sj        18600
+  10.0.0.6/32          40       192.168.2.2      se-ch        18600
+  10.0.0.7/32          30       192.168.2.2      se-ch        18700
+  10.0.0.8/32          40       192.168.2.2      se-ch        18800
+  10.0.0.9/32          50       192.168.2.2      se-ch        18900
+  10.0.0.10/32         60       192.168.2.2      se-ch        19000
+  10.0.0.11/32         60       192.168.2.2      se-ch        19100
+```
+
+Seattle reaches Tokyo (`10.0.0.11`) eastwards via `se-ch` at a cost of 60,
+even though Singapore is a single directly-connected hop away on `se-sg`.
+Prefixes with two rows (`10.0.0.4`, `10.0.0.6`) are ECMP within
+algorithm 128.
+
+The older spelling `show isis flex-algo route algorithm 128` still parses and
+prints the same table, but it is a deprecated alias kept for existing
+scripts; `show isis flex-algo 128 route` is the supported form. Dropping the
+algorithm id — `show isis flex-algo route` — dumps every algorithm's RIB at
+once.
+
+## Look at the pruned topology itself
+
+The route table is the *result*. Three more per-algorithm views show the
+input and the intermediate steps, and each one has an algorithm-0 twin to
+compare against.
+
+`graph` is the raw link-state graph after the FAD has pruned it. On `se`,
+compare the two — the trans-Pacific neighbour is simply not there in
+algorithm 128:
+
+``` shell
+se>show isis graph
+
+L2 IS-IS Graph:
+
+Nodes:
+  se [0000.0000.0001] (id: 0)
+    Links:
+      -> sg (cost: 10)
+      -> sj (cost: 10)
+      -> ch (cost: 10)
+      <- sj (cost: 10)
+      <- ch (cost: 10)
+      <- sg (cost: 10)
+...
+
+se>show isis flex-algo 128 graph
+
+L2 algo 128 IS-IS Graph:
+
+Nodes:
+  se [0000.0000.0001] (id: 0)
+    Links:
+      -> sj (cost: 10)
+      -> ch (cost: 10)
+      <- sj (cost: 10)
+      <- ch (cost: 10)
+...
+```
+
+`sg` is gone from `se`'s adjacency list in algorithm 128 — and further down
+the same dump, `sj` has lost `sy` and `tk` for the same reason.
+
+`spf` is the tree computed over that graph, with the full path list per
+destination. Tokyo is the clearest case:
+
+``` shell
+se>show isis spf
+...
+  Destination tk, cost 20
+    [0] nexthop sj (se-sj)
+    [1] nexthop sg (se-sg)
+    paths:
+      [0] sj -> tk
+      [1] sg -> tk
+
+se>show isis flex-algo 128 spf
+...
+  Destination tk, cost 50
+    [0] nexthop ch (se-ch)
+    paths:
+      [0] ch -> ln -> fr -> sg -> tk
+      [1] ch -> va -> fr -> sg -> tk
+```
+
+`topology` is the same tree in the FRR-style table, prefixes included. The
+tail of `se`'s algorithm-128 table shows the AP nodes arriving late, parented
+by `sg` — that is the Europe-to-Asia entry point:
+
+``` shell
+se>show isis flex-algo 128 topology
+Area 49.0000:
+IS-IS paths to level-2 routers that speak IP (algorithm 128)
+ Vertex                 Type          Metric  Next-Hop  Interface  Parent
+ -------------------------------------------------------------------------
+ se
+ ...
+ sg                     TE-IS         40      ch        se-ch      fr
+ sy                     TE-IS         50      ch        se-ch      sg
+ tk                     TE-IS         50      ch        se-ch      sg
+ 10.0.0.10/32           IP TE         60      ch        se-ch      sy
+ 10.0.0.11/32           IP TE         60      ch        se-ch      tk
+```
+
+## `show mpls ilm` — two label ranges, one table
+
+``` shell
+se>show mpls ilm
+   P Dist Local  Outgoing    Prefix             Outgoing     Next Hop
+          Label  Label       or ID              Interface
+-- - ---- ------ ----------- ------------------ ------------ ---------------
+*> i 115  15000  Pop         SR Adj (idx 0  )   se-sj        192.168.1.2
+*> i 115  15001  Pop         SR Adj (idx 1  )   se-ch        192.168.2.2
+*> i 115  15002  Pop         SR Adj (idx 2  )   se-sg        192.168.0.2
+*> i 115  16100  Pop         SR Pfx (idx 100)   lo           10.0.0.1
+*> i 115  16200  Pop         SR Pfx (idx 200)   se-sj        192.168.1.2
+*> i 115  16300  Pop         SR Pfx (idx 300)   se-ch        192.168.2.2
+...
+*> i 115  16900  Pop         SR Pfx (idx 900)   se-sg        192.168.0.2
+*> i 115  17000  17000       SR Pfx (idx 1000)  se-sg        192.168.0.2
+*> i 115  17000  17000       SR Pfx (idx 1000)  se-sj        192.168.1.2
+*> i 115  17100  17100       SR Pfx (idx 1100)  se-sg        192.168.0.2
+*> i 115  17100  17100       SR Pfx (idx 1100)  se-sj        192.168.1.2
+*> i 115  18200  Pop         SR Pfx (idx 2200)  se-sj        192.168.1.2
+*> i 115  18300  Pop         SR Pfx (idx 2300)  se-ch        192.168.2.2
+*> i 115  18400  18400       SR Pfx (idx 2400)  se-sj        192.168.1.2
+*> i 115  18400  18400       SR Pfx (idx 2400)  se-ch        192.168.2.2
+*> i 115  18500  18500       SR Pfx (idx 2500)  se-ch        192.168.2.2
+...
+*> i 115  18900  18900       SR Pfx (idx 2900)  se-ch        192.168.2.2
+*> i 115  19000  19000       SR Pfx (idx 3000)  se-ch        192.168.2.2
+*> i 115  19100  19100       SR Pfx (idx 3100)  se-ch        192.168.2.2
+```
+
+The `161xx`-`171xx` entries are algorithm 0 and the `182xx`-`191xx` entries
+are algorithm 128, in one ILM. The contrast is easiest to see on Tokyo's two
+node SIDs:
+
+| label | algo | outgoing interface | direction |
+|:------|:-----|:-------------------|:----------|
+| 17100 | 0    | `se-sg` / `se-sj`  | across the Pacific |
+| 19100 | 128  | `se-ch`            | eastward via Europe |
+
+Same destination, same router, two labels, two completely different paths.
+That is what a Flex-Algorithm buys you: the choice of path is made by which
+label you push.
+
+## Send real traffic over algorithm 128
+
+`ping` on its own follows algorithm 0, because that is what the IP routing
+table holds. To exercise the constrained path we push Tokyo's
+algorithm-128 node SID (19100) explicitly. Use a private routing table so
+zebra-rs's own table is left alone:
+
+``` shell
+$ sudo ip netns exec se ip route replace 10.0.0.11/32 \
+      encap mpls 19100 via 192.168.2.2 dev se-ch table 100
+$ sudo ip netns exec se ip rule add from 10.0.0.1 to 10.0.0.11 lookup 100 pref 100
+$ sudo ip netns exec se ping -c 3 -I 10.0.0.1 10.0.0.11
+--- 10.0.0.11 ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 1284ms
+```
+
+Now watch the same packet at three points along the way. Seattle pushes the
+label and sends it *east*:
+
+``` shell
+se>tcpdump -lni se-ch "mpls and icmp[0]==8"
+14:52:19.588147 MPLS (label 19100, tc 0, [S], ttl 64) IP 10.0.0.1 > 10.0.0.11: ICMP echo request, id 29646, seq 1, length 64
+```
+
+Frankfurt hands it to Singapore, still carrying 19100:
+
+``` shell
+fr>tcpdump -lni fr-sg "mpls and icmp[0]==8"
+14:52:19.588169 MPLS (label 19100, tc 0, [S], ttl 61) IP 10.0.0.1 > 10.0.0.11: ICMP echo request, id 29646, seq 1, length 64
+```
+
+And it arrives at Tokyo from Singapore as plain IP, because `sg` is the
+penultimate hop and popped the label:
+
+``` shell
+tk>tcpdump -lni tk-sg "icmp[0]==8"
+14:52:19.588176 IP 10.0.0.1 > 10.0.0.11: ICMP echo request, id 29646, seq 1, length 64
+```
+
+The TTL is the proof of the route taken. It leaves `se` at 64 and reaches
+the `fr-sg` link at 61, so exactly three routers decremented it in between:
+
+```
+  se ──> ch ──> ln ──> fr ──> sg ──> tk
+  64     63     62     61
+```
+
+**Seattle → Chicago → London → Frankfurt → Singapore → Tokyo.** US to Europe
+to Asia, never touching a trans-Pacific link — while algorithm 0 is
+simultaneously carrying ordinary traffic straight across the Pacific on
+`se-sg`.
+
+Remember to remove the test rule afterwards:
+
+``` shell
+$ sudo ip netns exec se ip rule del from 10.0.0.1 to 10.0.0.11 lookup 100 pref 100
+$ sudo ip netns exec se ip route flush table 100
+```
+
+## Things to try
+
+* Colour a different set of links and watch the algorithm-128 RIB change
+  without touching a single metric.
+* Give algorithm 128 `include-any` instead of `exclude-any` to express the
+  constraint the other way round.
+* Add a second algorithm (129) with its own FAD, colours and Prefix-SID
+  index block, and run three topologies over the same links.
+* Down the `fr-sg` link (`sudo ip netns exec fr ip link set fr-sg down`).
+  Algorithm 128 partitions — AP has no other way out — while algorithm 0
+  keeps working over the Pacific.
+
+## A note on TI-LFA
+
+TI-LFA is enabled once, at the instance level, with `fast-reroute ti-lfa`.
+Every algorithm the router participates in inherits it — there is no
+per-algorithm *enable* — and each algorithm's repair is computed inside its
+own constrained topology. This matches IOS-XR, Juniper and FRR. To exclude
+one algorithm, opt it out:
+
+``` yaml
+    flex-algo:
+    - algo: 128
+      fast-reroute:
+        disable: null
+```
+
+The effective state per algorithm is visible in `show isis flex-algo`:
+
+``` shell
+tk>show isis flex-algo
+Local Flex-Algorithms:
+  Algo  Metric                 Priority Adv FRR       Constraints
+  128   igp                    -        no  off       exclude-any=trans-pacific
+```
+
+| FRR | meaning |
+|:---|:---|
+| `on` | inherited from the instance and computed |
+| `off` | instance-level TI-LFA is not enabled |
+| `disabled` | this algorithm opted out with `fast-reroute disable` |
+
+This lab reads `off` because no node enables `fast-reroute ti-lfa` by
+default. Enable it and the repairs show up per algorithm — and they are *not* the
+algorithm-0 repairs. Add `fast-reroute: {ti-lfa: {}}` under `router isis`
+in `se.yaml`, then compare:
+
+``` shell
+se>show isis repair-list
+Level AFI   Prefix                 Primary via            Repair via             Segments
+L2    ipv4  10.0.0.5/32            192.168.2.2            192.168.0.2            [16800, 15000, 16500]
+L2    ipv4  10.0.0.7/32            192.168.2.2            192.168.0.2            [16800, 15001, 16700]
+L2    ipv4  10.0.0.8/32            192.168.0.2            192.168.2.2            [16700, 15001, 16800]
+L2    ipv4  192.168.11.0/24        192.168.2.2            192.168.0.2            [16800, 15000]
+
+se>show isis flex-algo 128 repair-list
+Level AFI   Prefix                 Primary via            Repair via             Segments
+L2    ipv4  10.0.0.5/32            192.168.2.2            192.168.1.2            [18600, 15001, 18500]
+L2    ipv4  10.0.0.7/32            192.168.2.2            192.168.1.2            [18600, 18700]
+```
+
+The two lists are computed independently, so they need not cover the same
+prefixes — each holds only what its own topology could produce a repair for.
+
+Take `10.0.0.5/32`, which both protect. The algorithm-0 repair leaves over
+`192.168.0.2` — that is `se-sg`, **the trans-Pacific link algorithm 128
+exists to avoid** — carrying algorithm-0 labels (`16xxx`). The
+algorithm-128 repair leaves over `192.168.1.2` (`se-sj`) with
+algorithm-128 labels (`18xxx`).
+
+That difference is the whole point: a repair must be computed in the
+algorithm's own topology *and* expressed with its own SIDs, or the backup
+path silently violates the constraint the algorithm was created to
+enforce. Adjacency segments (`15xxx`) are shared — an Adj-SID means "pop
+and forward over this link" regardless of algorithm, and the link is
+already known to be in the algorithm's topology. Which Adj-SID lands in a
+given segment list, and which of two equal-cost repairs wins, both depend on
+adjacency-formation order, so these exact values move between runs; the
+`16xxx` / `18xxx` split does not.
+
+When a node on the repair path advertises no Prefix-SID for this
+algorithm, the whole repair is dropped rather than approximated with an
+algorithm-0 label, so the destination is simply unprotected under that
+algorithm.
+
+## Appendix: Loopbacks and Prefix-SIDs
+
+| name | region | full name | loopback     | algo-0 SID / label | algo-128 SID / label |
+|:-----|:-------|:----------|:-------------|:-------------------|:---------------------|
+| se   | US     | Seattle   | 10.0.0.1/32  | 100 / 16100        | 2100 / 18100         |
+| sj   | US     | San Jose  | 10.0.0.2/32  | 200 / 16200        | 2200 / 18200         |
+| ch   | US     | Chicago   | 10.0.0.3/32  | 300 / 16300        | 2300 / 18300         |
+| da   | US     | Dallas    | 10.0.0.4/32  | 400 / 16400        | 2400 / 18400         |
+| va   | US     | Virginia  | 10.0.0.5/32  | 500 / 16500        | 2500 / 18500         |
+| at   | US     | Atlanta   | 10.0.0.6/32  | 600 / 16600        | 2600 / 18600         |
+| ln   | EU     | London    | 10.0.0.7/32  | 700 / 16700        | 2700 / 18700         |
+| fr   | EU     | Frankfurt | 10.0.0.8/32  | 800 / 16800        | 2800 / 18800         |
+| sg   | AP     | Singapore | 10.0.0.9/32  | 900 / 16900        | 2900 / 18900         |
+| sy   | AP     | Sydney    | 10.0.0.10/32 | 1000 / 17000       | 3000 / 19000         |
+| tk   | AP     | Tokyo     | 10.0.0.11/32 | 1100 / 17100       | 3100 / 19100         |
+
+SRGB base is 16000, SRLB base 15000. `ch` and `sg` advertise the FAD.
+
+## Appendix: Networks
+
+All links have metric 10. Addresses are `.1` on the first-listed node and
+`.2` on the second.
+
+| link  | network         | regions  | affinity      |
+|:------|:----------------|:---------|:--------------|
+| se-sg | 192.168.0.0/24  | US <-> AP | trans-pacific |
+| se-sj | 192.168.1.0/24  | US        |               |
+| se-ch | 192.168.2.0/24  | US        |               |
+| sj-sy | 192.168.3.0/24  | US <-> AP | trans-pacific |
+| sj-da | 192.168.4.0/24  | US        |               |
+| sj-ch | 192.168.5.0/24  | US        |               |
+| sj-tk | 192.168.6.0/24  | US <-> AP | trans-pacific |
+| ch-da | 192.168.7.0/24  | US        |               |
+| ch-va | 192.168.8.0/24  | US        |               |
+| ch-ln | 192.168.9.0/24  | US <-> EU |               |
+| da-at | 192.168.10.0/24 | US        |               |
+| va-at | 192.168.11.0/24 | US        |               |
+| va-fr | 192.168.12.0/24 | US <-> EU |               |
+| ln-fr | 192.168.13.0/24 | EU        |               |
+| fr-sg | 192.168.14.0/24 | EU <-> AP |               |
+| sg-tk | 192.168.15.0/24 | AP        |               |
+| sg-sy | 192.168.16.0/24 | AP        |               |

--- a/playset/isis-flexalgo-ai/README.md
+++ b/playset/isis-flexalgo-ai/README.md
@@ -1,21 +1,41 @@
-# IS-IS Flexible Algorithm (RFC 9350)
+# IS-IS FlexAlgo — AI & Ontology demo
 
-This playset demonstrates IS-IS Flexible Algorithm over SR-MPLS. An
-eleven-node global backbone runs the standard shortest-path algorithm
-(algorithm 0) *and* a second, constrained algorithm 128 at the same time,
-over the same links. Algorithm 128 is defined to avoid every trans-Pacific
-link, so traffic between Tokyo and the United States is forced the long way
-round — through Asia and Europe — while algorithm 0 keeps using the direct
-Pacific crossing.
+This playset is the *starting point* of a demonstration in which an AI
+assistant designs and deploys an IS-IS Flexible Algorithm (RFC 9350) on a
+running network, using nothing but the network's own management plane (MCP
+over gRPC) and the semantic description of the network in `ontology.json`.
 
-Each node runs zebra-rs in its own network namespace, and loads its own
-`<node>.yaml` at startup via the `--config-file` argument.
+It is the same eleven-node global backbone as
+[`playset/isis-flexalgo`](../isis-flexalgo/README.md) — same namespaces,
+links, addresses and algorithm-0 Prefix-SIDs — but with **every trace of
+Flex-Algorithm configuration removed**. Plain IS-IS with SR-MPLS comes up;
+what the constrained topology should look like exists only as intent. The
+hand-written playset next door is the answer key.
 
-## Topology
+## The demo in two stages
+
+1. **Configuration without FlexAlgo.** `./up.sh` brings up the baseline
+   below. There is no affinity map, no link coloring, no Flex-Algorithm
+   Definition and no per-algorithm SIDs anywhere in the domain.
+
+2. **AI-generated FlexAlgo.** From Claude Desktop, connected to the lab
+   through MCP, a goal-level prompt — *"traffic in a constrained class must
+   never cross a trans-Pacific link"* — is all the operator supplies. The
+   assistant extracts the running configuration, reads the ontology to learn
+   which router sits in which region, identifies the trans-Pacific links
+   from the IS-IS topology, then generates, applies and commits the full
+   Flex-Algorithm configuration on every router — and verifies its own work
+   through the same MCP tools.
+
+The point of the exercise: the operator states *intent*, the ontology
+supplies *meaning* (regions), the IGP supplies *topology*, and the AI turns
+the three into committed device configuration.
+
+## Topology and ontology
 
 Eleven nodes in three regions. The region of each node comes from
-`ontology.json`, which is the input the Flex-Algorithm design is derived
-from:
+`ontology.json` — this file is the only place the demo says anything about
+geography, and it is the input the AI derives the design from:
 
 ```
         AP                      US                        EU
@@ -29,685 +49,131 @@ from:
                         └──────────────────┘
 ```
 
-The six links that cross a region boundary are what the demo turns on:
+Six links cross a region boundary; three of them cross the Pacific:
 
 ```
-  sj ── tk    US <-> AP    trans-pacific   excluded by algorithm 128
-  se ── sg    US <-> AP    trans-pacific   excluded by algorithm 128
-  sj ── sy    US <-> AP    trans-pacific   excluded by algorithm 128
+  sj ── tk    US <-> AP    trans-Pacific
+  se ── sg    US <-> AP    trans-Pacific
+  sj ── sy    US <-> AP    trans-Pacific
   ch ── ln    US <-> EU
   va ── fr    US <-> EU
   fr ── sg    EU <-> AP
 ```
 
-Once all three trans-Pacific links are excluded, the only way for an AP node
-to reach a US node in algorithm 128 is `sg -> fr` into Europe and onward —
-which is exactly the "must go through Asia and Europe" property we are
-after. Every link has metric 10, and the full link list is in the appendix.
+Nothing in the router configuration marks these links. Deciding that the
+constraint "no trans-Pacific" maps to exactly those three links — because
+their endpoints are in `US` and `AP` respectively — is the AI's job.
 
-## Bring up all nodes
+Every link has metric 10, and the loopback / addressing plan is identical
+to the appendices of the
+[isis-flexalgo README](../isis-flexalgo/README.md#appendix-loopbacks-and-prefix-sids).
 
-`./up.sh` sets up all namespaces and starts the zebra-rs routing daemon in
-each of them on that node's own `<node>.yaml` as `--config-file`.
+## What is configured — and what is not
+
+Each `<node>.yaml` carries only the algorithm-0 baseline:
+
+* interfaces and addresses, `system hostname`
+* `router isis`: NET, level-2-only, `segment-routing mpls`, `te-router-id`
+* per-interface IS-IS: point-to-point, metric 10
+* one algorithm-0 `prefix-sid` per loopback (indexes 100..1100, SRGB 16000)
+
+Compared with `playset/isis-flexalgo`, the following are **absent** — this
+is precisely the set the AI has to author:
+
+* the global `affinity-map` (name-to-bit table, RFC 7308)
+* the per-interface `affinity` coloring on the trans-Pacific links
+* the `flex-algo` definition (FAD) with `exclude-any`, including
+  `advertise-definition` on at least one router
+* the per-loopback `flex-algo-prefix-sid` (a second, non-overlapping SID
+  index block — the hand-written playset uses algo-0 index + 2000)
+
+## Stage 1: bring up the baseline
 
 ``` shell
 $ ./up.sh
-bring up
-runtime dir: /tmp/zebra-rs-playset/isis-flexalgo
-teardown: stop zebra-rs
-teardown: delete namespace se
-teardown: delete namespace sj
-...
-cleanup logs
-create namespace: sg
-create namespace: sy
-create namespace: tk
-create link: se-sg (se) <-> sg-se (sg)
-create link: se-sj (se) <-> sj-se (sj)
-create link: se-ch (se) <-> ch-se (ch)
-create link: sj-sy (sj) <-> sy-sj (sy)
-...
-start zebra-rs: ch
-start zebra-rs: da
-...
-start zebra-rs: tk
-sleep 3sec
 ```
 
-You can then list the namespaces:
+This creates one network namespace per node and starts zebra-rs in each on
+its own `<node>.yaml`. Runtime state lives in
+`/tmp/zebra-rs-playset/isis-flexalgo-ai/`.
 
-``` shell
-$ ip netns
-tk
-sy
-sg
-fr
-ln
-at
-va
-da
-ch
-sj
-se
-```
+> The namespaces share their names (`se` … `tk`) with `playset/isis-flexalgo`,
+> so only one of the two playsets can be up at a time.
 
-`./down.sh` tears the whole thing back down.
-
-## Algorithm 0: the unconstrained baseline
-
-Let's look at the ordinary routing table on node `tk` (Tokyo).
+Verify that routing works and that no Flex-Algorithm exists anywhere:
 
 ``` shell
 $ sudo ip netns exec tk vty
 tk>show ip route
-Codes: K - kernel, D - DHCP route, C - connected, S - static
-       O - OSPF, IA - OSPF inter area, N1/N2 - OSPF NSSA external type 1/2
-       E1/E2 - OSPF external type 1/2
-       L1/L2 - IS-IS level-1/2, ia - IS-IS inter area, B - BGP
-       > - selected route, * - FIB route, S - Stale route, ? - backup route
-
-L2 *> 10.0.0.1/32 [115/30] via 192.168.6.1, tk-sj, label 16100, weight 1, 00:00:08
-                           via 192.168.15.1, tk-sg, label 16100, weight 1, 00:00:08
-L2 *> 10.0.0.2/32 [115/20] via 192.168.6.1, tk-sj, label (16200), 00:00:08
-L2 *> 10.0.0.3/32 [115/30] via 192.168.6.1, tk-sj, label 16300, 00:00:08
-L2 *> 10.0.0.4/32 [115/30] via 192.168.6.1, tk-sj, label 16400, 00:00:08
-L2 *> 10.0.0.5/32 [115/40] via 192.168.6.1, tk-sj, label 16500, weight 1, 00:00:08
-                           via 192.168.15.1, tk-sg, label 16500, weight 1, 00:00:08
-L2 *> 10.0.0.6/32 [115/40] via 192.168.6.1, tk-sj, label 16600, 00:00:08
-L2 *> 10.0.0.7/32 [115/40] via 192.168.6.1, tk-sj, label 16700, weight 1, 00:00:08
-                           via 192.168.15.1, tk-sg, label 16700, weight 1, 00:00:08
-L2 *> 10.0.0.8/32 [115/30] via 192.168.15.1, tk-sg, label 16800, 00:00:08
-L2 *> 10.0.0.9/32 [115/20] via 192.168.15.1, tk-sg, label (16900), 00:00:08
-L2 *> 10.0.0.10/32 [115/30] via 192.168.6.1, tk-sj, label 17000, weight 1, 00:00:08
-                            via 192.168.15.1, tk-sg, label 17000, weight 1, 00:00:08
-C  *> 10.0.0.11/32 is directly connected, lo, 00:00:09
+L2 *> 10.0.0.1/32 [115/30] via 192.168.6.1, tk-sj, label 16100, weight 1, ...
+                           via 192.168.15.1, tk-sg, label 16100, weight 1, ...
+L2 *> 10.0.0.2/32 [115/20] via 192.168.6.1, tk-sj, label (16200), ...
+...
 ```
 
-This is plain SR-MPLS: `sj` (San Jose, `10.0.0.2`) is one hop away over the
-trans-Pacific link `tk-sj`, and most of the US is reached through it. The
-parenthesized labels such as `(16200)` mean implicit-null — the SID owner is
-directly adjacent, so penultimate-hop popping applies.
-
-Note that `show ip route` only ever shows algorithm 0. Flex-Algorithm routes
-live in their own per-algorithm RIB, shown further down.
-
-## Take a look at the YAML configuration
-
-Node `tk`'s configuration is in `tk.yaml`:
-
-``` yaml
-interface:
-- if-name: lo
-  ipv4:
-    address: 10.0.0.11/32
-- if-name: tk-sj
-  ipv4:
-    address: 192.168.6.2/24
-- if-name: tk-sg
-  ipv4:
-    address: 192.168.15.2/24
-system:
-  hostname: tk
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
-router:
-  isis:
-    net: 49.0000.0000.0000.0011.00
-    hostname: tk
-    is-type: level-2-only
-    segment-routing:
-      mpls: {}
-    te-router-id: 10.0.0.11
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
-    interface:
-    - if-name: lo
-      ipv4:
-        enabled: true
-        prefix-sid:
-          index: 1100
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 3100
-    - if-name: tk-sj
-      network-type: point-to-point
-      affinity:
-      - trans-pacific
-      ipv4:
-        enabled: true
-      metric: 10
-    - if-name: tk-sg
-      network-type: point-to-point
-      ipv4:
-        enabled: true
-      metric: 10
-```
-
-There are four moving parts, and they are worth separating:
-
-* **`affinity-map`** is the global name-to-bit table (RFC 7308 Extended
-  Admin Group). It binds the operator-friendly name `trans-pacific` to bit
-  position 0. This table is *not* advertised; every router needs the same
-  copy so that everyone agrees what bit 0 means. It lives at the top level
-  because it is shared with OSPF.
-
-* **The per-link `affinity`** list colours `tk-sj` — the Tokyo-to-US link —
-  with `trans-pacific`. `tk-sg` carries no affinity. This is the only place
-  the topology is described; the algorithm definition below never names a
-  link.
-
-* **`flex-algo 128`** is the Flex-Algorithm Definition (FAD). It says: use
-  the IGP metric, forward over SR-MPLS, and `exclude-any: trans-pacific` —
-  prune every link carrying that colour before running SPF.
-
-* **`flex-algo-prefix-sid`** gives the loopback a *second* Prefix-SID, index
-  3100, valid only in algorithm 128, alongside the algorithm-0 index 1100.
-  Two algorithms means two independent paths to the same loopback, so they
-  need two different labels to steer with.
-
-In this playset only `ch` and `sg` additionally set
-`advertise-definition: true`. At least one router per area must originate
-the FAD; two are configured for redundancy, one in the US and one in AP.
-Every other node carries the identical definition and simply participates.
-
-A note on the SID numbering: algorithm-0 indexes are 100..1100 and
-algorithm-128 indexes are 2100..3100. They must not overlap, because both
-resolve against the *same* SRGB (base 16000) — reusing an index across
-algorithms would collide in the label space and cross-wire the two
-topologies.
-
-## How the constraint reaches the wire
-
-Everything above is carried in `tk`'s own LSP. This one dump shows all
-three mechanisms at once:
-
-``` shell
-tk>show isis database detail
-tk.00-00                  *      178  0x00000001  0xb581      1190  0/0/0
-  Area address: 49.0000
-  Protocol Supported: IPv4
-  LSP Buffer Size: 1492
-  Hostname: tk
-  Router Capability: 10.0.0.11, D:0 S:0
-   Segment Routing: I:1 V:1, Global Block: Label(16000), Range: 8000
-   Segment Routing Algorithm: SPF(0) FlexAlgo(128)
-   Segment Routing Local Block: Label(15000), Range: 100
-  TE Router ID: 10.0.0.11
-  Extended IS Reachability:
-   Neighbor ID: 0000.0000.0002.00, Metric: 10
-    Application Specific Link Attributes:
-     L:0 SABM: 0x10 UDABM: 0x
-     Applications: Flex-Algo
-      Ext Admin Group: [0] 0x00000001
-    Adjacency SID: Label(15000), Flag: F:0 B:0 V:1 L:1 S:0 P:0, Weight: 0
-  Extended IS Reachability:
-   Neighbor ID: 0000.0000.0009.00, Metric: 10
-    Adjacency SID: Label(15001), Flag: F:0 B:0 V:1 L:1 S:0 P:0, Weight: 0
-  Extended IP Reachability: 10.0.0.11/32 (Metric: 10)
-   SID: Index(1100), Algorithm: SPF(0), Flags: R:0 N:1 P:0 E:0 V:0 L:0
-   SID: Index(3100), Algorithm: FlexAlgo(128), Flags: R:0 N:1 P:0 E:0 V:0 L:0
-  Extended IP Reachability: 192.168.6.0/24 (Metric: 10)
-  Extended IP Reachability: 192.168.15.0/24 (Metric: 10)
-```
-
-* `Segment Routing Algorithm: SPF(0) FlexAlgo(128)` is the *participation*
-  advertisement — `tk` computes and forwards both algorithms.
-* Neighbour `0000.0000.0002` is `sj`, i.e. the link `tk-sj`. It carries an
-  **Application Specific Link Attributes** sub-TLV (ASLA, RFC 9479) with
-  `Applications: Flex-Algo` and `Ext Admin Group: [0] 0x00000001` — bit 0
-  set, the `trans-pacific` colour. Neighbour `0000.0000.0009` (`sg`) has no
-  ASLA at all, because that link is uncoloured. This is the constraint
-  crossing the wire; remote routers prune the link using this bit, not using
-  any local configuration.
-* The loopback advertises **two** Prefix-SIDs, one per algorithm.
-
-The two Adjacency SID labels (`15000`, `15001`) are handed out of the SRLB in
-the order the adjacencies come up, so which link gets which label varies from
-one `./up.sh` to the next. Only the *algorithm* they belong to is fixed —
-Adj-SIDs are shared by every algorithm.
-
-## Examine the Flex-Algorithm state
+Ordinary SR-MPLS, and Tokyo reaches the US straight across the Pacific
+(San Jose is one hop on `tk-sj`). The Flex-Algorithm view is empty:
 
 ``` shell
 tk>show isis flex-algo
 Area 49.0000:
 
-Local Flex-Algorithms:
-  Algo  Metric                 Priority Adv FRR       Constraints
-  128   igp                    -        no  off       exclude-any=trans-pacific
+Local Flex-Algorithms: (none configured)
 
 Level-2:
-  Peer FADs:
-    ch (0000.0000.0003): algo 128 priority 128 metric-type 0 calc-type 0
-    sg (0000.0000.0009): algo 128 priority 128 metric-type 0 calc-type 0
   Peer SR-Algorithm Participation:
-    se (0000.0000.0001): [0, 128]
-    sj (0000.0000.0002): [0, 128]
-    ch (0000.0000.0003): [0, 128]
-    da (0000.0000.0004): [0, 128]
-    va (0000.0000.0005): [0, 128]
-    at (0000.0000.0006): [0, 128]
-    ln (0000.0000.0007): [0, 128]
-    fr (0000.0000.0008): [0, 128]
-    sg (0000.0000.0009): [0, 128]
-    sy (0000.0000.0010): [0, 128]
+    se (0000.0000.0001): [0]
+    sj (0000.0000.0002): [0]
+    ...
+    sy (0000.0000.0010): [0]
 ```
 
-`Adv no` on the local entry means `tk` is not a FAD originator; it uses the
-definition learned from `ch` and `sg`, both of which appear under
-`Peer FADs`. Every one of the ten peers reports `[0, 128]`, so the whole
-domain participates. `FRR off` is the TI-LFA state, explained at the end of
-this document.
-
-Right after `./up.sh` a node may briefly show `[0]` for a peer whose updated
-LSP is still flooding. It settles within a few seconds.
-
-Add an algorithm id to narrow the same view to one algorithm — the
-participation list drops the peers that do not run it, and the FAD table
-keeps only that row:
+and the wire agrees — all eleven routers advertise participation in
+algorithm 0 only:
 
 ``` shell
-tk>show isis flex-algo 128
-Area 49.0000:
-
-Local Flex-Algorithm 128:
-  Algo  Metric                 Priority Adv FRR       Constraints
-  128   igp                    -        no  off       exclude-any=trans-pacific
-
-L2 peers participating in algorithm 128:
-  se (0000.0000.0001)
-  sj (0000.0000.0002)
-  ch (0000.0000.0003)
-  da (0000.0000.0004)
-  va (0000.0000.0005)
-  at (0000.0000.0006)
-  ln (0000.0000.0007)
-  fr (0000.0000.0008)
-  sg (0000.0000.0009)
-  sy (0000.0000.0010)
+tk>show isis database detail | grep "Segment Routing Algorithm"
+   Segment Routing Algorithm: SPF(0)
+   ...
 ```
 
-That algorithm id is the entry point to every per-algorithm view:
-`show isis flex-algo <128-255> {route | topology | spf | graph | repair-list}`.
-The un-suffixed `show isis route|topology|spf|graph` stay algorithm-0 views.
+The [3D topology viewer](../../ai/topology/README.md) makes the same point
+visually: started against this playset, its Algorithm selector offers only
+`0 — SPF`.
 
-## Algorithm 128: the constrained paths
+## Stage 2: let the AI build the FlexAlgo
 
-``` shell
-tk>show isis flex-algo 128 route
-Area 49.0000:
+The assistant works through the zebra-rs MCP server (`vtyctl mcp`), which
+exposes the lab to Claude Desktop: reading the ontology, extracting each
+router's running configuration (`show running-config formal` — the same
+`set`-line syntax the configuration is applied with), inspecting the IS-IS
+graph, applying and committing configuration, and verifying the result.
+The MCP wiring for configuration apply and the Claude Desktop setup are
+being added to `vtyctl`; this section will grow the exact connector
+configuration and the demo prompt as they land.
 
-Level-2 Algorithm 128:
-  Prefix               Metric   Nexthop          Interface    Label
-  10.0.0.1/32          60       192.168.15.1     tk-sg        18100
-  10.0.0.2/32          60       192.168.15.1     tk-sg        18200
-  10.0.0.3/32          50       192.168.15.1     tk-sg        18300
-  10.0.0.4/32          60       192.168.15.1     tk-sg        18400
-  10.0.0.5/32          40       192.168.15.1     tk-sg        18500
-  10.0.0.6/32          50       192.168.15.1     tk-sg        18600
-  10.0.0.7/32          40       192.168.15.1     tk-sg        18700
-  10.0.0.8/32          30       192.168.15.1     tk-sg        18800
-  10.0.0.9/32          20       192.168.15.1     tk-sg        18900
-  10.0.0.10/32         30       192.168.15.1     tk-sg        19000
-```
-
-This is the whole point of the demo. **Every** destination leaves Tokyo over
-`tk-sg` towards Singapore. The `tk-sj` link — one hop from San Jose in
-algorithm 0 — is not used for anything, because the FAD pruned it before SPF
-ran. Reaching San Jose (`10.0.0.2`) now costs 60 instead of 20.
-
-The reverse direction behaves the same way. On `se` (Seattle), which has a
-trans-Pacific link `se-sg` of its own:
-
-``` shell
-se>show isis flex-algo 128 route
-Area 49.0000:
-
-Level-2 Algorithm 128:
-  Prefix               Metric   Nexthop          Interface    Label
-  10.0.0.2/32          20       192.168.1.2      se-sj        18200
-  10.0.0.3/32          20       192.168.2.2      se-ch        18300
-  10.0.0.4/32          30       192.168.1.2      se-sj        18400
-  10.0.0.4/32          30       192.168.2.2      se-ch        18400
-  10.0.0.5/32          30       192.168.2.2      se-ch        18500
-  10.0.0.6/32          40       192.168.1.2      se-sj        18600
-  10.0.0.6/32          40       192.168.2.2      se-ch        18600
-  10.0.0.7/32          30       192.168.2.2      se-ch        18700
-  10.0.0.8/32          40       192.168.2.2      se-ch        18800
-  10.0.0.9/32          50       192.168.2.2      se-ch        18900
-  10.0.0.10/32         60       192.168.2.2      se-ch        19000
-  10.0.0.11/32         60       192.168.2.2      se-ch        19100
-```
-
-Seattle reaches Tokyo (`10.0.0.11`) eastwards via `se-ch` at a cost of 60,
-even though Singapore is a single directly-connected hop away on `se-sg`.
-Prefixes with two rows (`10.0.0.4`, `10.0.0.6`) are ECMP within
-algorithm 128.
-
-The older spelling `show isis flex-algo route algorithm 128` still parses and
-prints the same table, but it is a deprecated alias kept for existing
-scripts; `show isis flex-algo 128 route` is the supported form. Dropping the
-algorithm id — `show isis flex-algo route` — dumps every algorithm's RIB at
-once.
-
-## Look at the pruned topology itself
-
-The route table is the *result*. Three more per-algorithm views show the
-input and the intermediate steps, and each one has an algorithm-0 twin to
-compare against.
-
-`graph` is the raw link-state graph after the FAD has pruned it. On `se`,
-compare the two — the trans-Pacific neighbour is simply not there in
-algorithm 128:
-
-``` shell
-se>show isis graph
-
-L2 IS-IS Graph:
-
-Nodes:
-  se [0000.0000.0001] (id: 0)
-    Links:
-      -> sg (cost: 10)
-      -> sj (cost: 10)
-      -> ch (cost: 10)
-      <- sj (cost: 10)
-      <- ch (cost: 10)
-      <- sg (cost: 10)
-...
-
-se>show isis flex-algo 128 graph
-
-L2 algo 128 IS-IS Graph:
-
-Nodes:
-  se [0000.0000.0001] (id: 0)
-    Links:
-      -> sj (cost: 10)
-      -> ch (cost: 10)
-      <- sj (cost: 10)
-      <- ch (cost: 10)
-...
-```
-
-`sg` is gone from `se`'s adjacency list in algorithm 128 — and further down
-the same dump, `sj` has lost `sy` and `tk` for the same reason.
-
-`spf` is the tree computed over that graph, with the full path list per
-destination. Tokyo is the clearest case:
-
-``` shell
-se>show isis spf
-...
-  Destination tk, cost 20
-    [0] nexthop sj (se-sj)
-    [1] nexthop sg (se-sg)
-    paths:
-      [0] sj -> tk
-      [1] sg -> tk
-
-se>show isis flex-algo 128 spf
-...
-  Destination tk, cost 50
-    [0] nexthop ch (se-ch)
-    paths:
-      [0] ch -> ln -> fr -> sg -> tk
-      [1] ch -> va -> fr -> sg -> tk
-```
-
-`topology` is the same tree in the FRR-style table, prefixes included. The
-tail of `se`'s algorithm-128 table shows the AP nodes arriving late, parented
-by `sg` — that is the Europe-to-Asia entry point:
-
-``` shell
-se>show isis flex-algo 128 topology
-Area 49.0000:
-IS-IS paths to level-2 routers that speak IP (algorithm 128)
- Vertex                 Type          Metric  Next-Hop  Interface  Parent
- -------------------------------------------------------------------------
- se
- ...
- sg                     TE-IS         40      ch        se-ch      fr
- sy                     TE-IS         50      ch        se-ch      sg
- tk                     TE-IS         50      ch        se-ch      sg
- 10.0.0.10/32           IP TE         60      ch        se-ch      sy
- 10.0.0.11/32           IP TE         60      ch        se-ch      tk
-```
-
-## `show mpls ilm` — two label ranges, one table
-
-``` shell
-se>show mpls ilm
-   P Dist Local  Outgoing    Prefix             Outgoing     Next Hop
-          Label  Label       or ID              Interface
--- - ---- ------ ----------- ------------------ ------------ ---------------
-*> i 115  15000  Pop         SR Adj (idx 0  )   se-sj        192.168.1.2
-*> i 115  15001  Pop         SR Adj (idx 1  )   se-ch        192.168.2.2
-*> i 115  15002  Pop         SR Adj (idx 2  )   se-sg        192.168.0.2
-*> i 115  16100  Pop         SR Pfx (idx 100)   lo           10.0.0.1
-*> i 115  16200  Pop         SR Pfx (idx 200)   se-sj        192.168.1.2
-*> i 115  16300  Pop         SR Pfx (idx 300)   se-ch        192.168.2.2
-...
-*> i 115  16900  Pop         SR Pfx (idx 900)   se-sg        192.168.0.2
-*> i 115  17000  17000       SR Pfx (idx 1000)  se-sg        192.168.0.2
-*> i 115  17000  17000       SR Pfx (idx 1000)  se-sj        192.168.1.2
-*> i 115  17100  17100       SR Pfx (idx 1100)  se-sg        192.168.0.2
-*> i 115  17100  17100       SR Pfx (idx 1100)  se-sj        192.168.1.2
-*> i 115  18200  Pop         SR Pfx (idx 2200)  se-sj        192.168.1.2
-*> i 115  18300  Pop         SR Pfx (idx 2300)  se-ch        192.168.2.2
-*> i 115  18400  18400       SR Pfx (idx 2400)  se-sj        192.168.1.2
-*> i 115  18400  18400       SR Pfx (idx 2400)  se-ch        192.168.2.2
-*> i 115  18500  18500       SR Pfx (idx 2500)  se-ch        192.168.2.2
-...
-*> i 115  18900  18900       SR Pfx (idx 2900)  se-ch        192.168.2.2
-*> i 115  19000  19000       SR Pfx (idx 3000)  se-ch        192.168.2.2
-*> i 115  19100  19100       SR Pfx (idx 3100)  se-ch        192.168.2.2
-```
-
-The `161xx`-`171xx` entries are algorithm 0 and the `182xx`-`191xx` entries
-are algorithm 128, in one ILM. The contrast is easiest to see on Tokyo's two
-node SIDs:
-
-| label | algo | outgoing interface | direction |
-|:------|:-----|:-------------------|:----------|
-| 17100 | 0    | `se-sg` / `se-sj`  | across the Pacific |
-| 19100 | 128  | `se-ch`            | eastward via Europe |
-
-Same destination, same router, two labels, two completely different paths.
-That is what a Flex-Algorithm buys you: the choice of path is made by which
-label you push.
-
-## Send real traffic over algorithm 128
-
-`ping` on its own follows algorithm 0, because that is what the IP routing
-table holds. To exercise the constrained path we push Tokyo's
-algorithm-128 node SID (19100) explicitly. Use a private routing table so
-zebra-rs's own table is left alone:
-
-``` shell
-$ sudo ip netns exec se ip route replace 10.0.0.11/32 \
-      encap mpls 19100 via 192.168.2.2 dev se-ch table 100
-$ sudo ip netns exec se ip rule add from 10.0.0.1 to 10.0.0.11 lookup 100 pref 100
-$ sudo ip netns exec se ping -c 3 -I 10.0.0.1 10.0.0.11
---- 10.0.0.11 ping statistics ---
-3 packets transmitted, 3 received, 0% packet loss, time 1284ms
-```
-
-Now watch the same packet at three points along the way. Seattle pushes the
-label and sends it *east*:
-
-``` shell
-se>tcpdump -lni se-ch "mpls and icmp[0]==8"
-14:52:19.588147 MPLS (label 19100, tc 0, [S], ttl 64) IP 10.0.0.1 > 10.0.0.11: ICMP echo request, id 29646, seq 1, length 64
-```
-
-Frankfurt hands it to Singapore, still carrying 19100:
-
-``` shell
-fr>tcpdump -lni fr-sg "mpls and icmp[0]==8"
-14:52:19.588169 MPLS (label 19100, tc 0, [S], ttl 61) IP 10.0.0.1 > 10.0.0.11: ICMP echo request, id 29646, seq 1, length 64
-```
-
-And it arrives at Tokyo from Singapore as plain IP, because `sg` is the
-penultimate hop and popped the label:
-
-``` shell
-tk>tcpdump -lni tk-sg "icmp[0]==8"
-14:52:19.588176 IP 10.0.0.1 > 10.0.0.11: ICMP echo request, id 29646, seq 1, length 64
-```
-
-The TTL is the proof of the route taken. It leaves `se` at 64 and reaches
-the `fr-sg` link at 61, so exactly three routers decremented it in between:
-
-```
-  se ──> ch ──> ln ──> fr ──> sg ──> tk
-  64     63     62     61
-```
-
-**Seattle → Chicago → London → Frankfurt → Singapore → Tokyo.** US to Europe
-to Asia, never touching a trans-Pacific link — while algorithm 0 is
-simultaneously carrying ordinary traffic straight across the Pacific on
-`se-sg`.
-
-Remember to remove the test rule afterwards:
-
-``` shell
-$ sudo ip netns exec se ip rule del from 10.0.0.1 to 10.0.0.11 lookup 100 pref 100
-$ sudo ip netns exec se ip route flush table 100
-```
-
-## Things to try
-
-* Colour a different set of links and watch the algorithm-128 RIB change
-  without touching a single metric.
-* Give algorithm 128 `include-any` instead of `exclude-any` to express the
-  constraint the other way round.
-* Add a second algorithm (129) with its own FAD, colours and Prefix-SID
-  index block, and run three topologies over the same links.
-* Down the `fr-sg` link (`sudo ip netns exec fr ip link set fr-sg down`).
-  Algorithm 128 partitions — AP has no other way out — while algorithm 0
-  keeps working over the Pacific.
-
-## A note on TI-LFA
-
-TI-LFA is enabled once, at the instance level, with `fast-reroute ti-lfa`.
-Every algorithm the router participates in inherits it — there is no
-per-algorithm *enable* — and each algorithm's repair is computed inside its
-own constrained topology. This matches IOS-XR, Juniper and FRR. To exclude
-one algorithm, opt it out:
-
-``` yaml
-    flex-algo:
-    - algo: 128
-      fast-reroute:
-        disable: null
-```
-
-The effective state per algorithm is visible in `show isis flex-algo`:
+The end state to expect is the hand-written playset next door. When the AI
+has done its job:
 
 ``` shell
 tk>show isis flex-algo
 Local Flex-Algorithms:
   Algo  Metric                 Priority Adv FRR       Constraints
   128   igp                    -        no  off       exclude-any=trans-pacific
+...
+
+tk>show isis flex-algo 128 route
 ```
 
-| FRR | meaning |
-|:---|:---|
-| `on` | inherited from the instance and computed |
-| `off` | instance-level TI-LFA is not enabled |
-| `disabled` | this algorithm opted out with `fast-reroute disable` |
-
-This lab reads `off` because no node enables `fast-reroute ti-lfa` by
-default. Enable it and the repairs show up per algorithm — and they are *not* the
-algorithm-0 repairs. Add `fast-reroute: {ti-lfa: {}}` under `router isis`
-in `se.yaml`, then compare:
+must show **every** US destination leaving Tokyo via `tk-sg` (Singapore)
+— the long way round through Asia and Europe — while `show ip route`
+keeps using the direct Pacific crossing. The
+[isis-flexalgo README](../isis-flexalgo/README.md) walks through all of
+the verification detail, down to pushing the algorithm-128 label and
+proving the path with TTLs.
 
 ``` shell
-se>show isis repair-list
-Level AFI   Prefix                 Primary via            Repair via             Segments
-L2    ipv4  10.0.0.5/32            192.168.2.2            192.168.0.2            [16800, 15000, 16500]
-L2    ipv4  10.0.0.7/32            192.168.2.2            192.168.0.2            [16800, 15001, 16700]
-L2    ipv4  10.0.0.8/32            192.168.0.2            192.168.2.2            [16700, 15001, 16800]
-L2    ipv4  192.168.11.0/24        192.168.2.2            192.168.0.2            [16800, 15000]
-
-se>show isis flex-algo 128 repair-list
-Level AFI   Prefix                 Primary via            Repair via             Segments
-L2    ipv4  10.0.0.5/32            192.168.2.2            192.168.1.2            [18600, 15001, 18500]
-L2    ipv4  10.0.0.7/32            192.168.2.2            192.168.1.2            [18600, 18700]
+$ ./down.sh
 ```
 
-The two lists are computed independently, so they need not cover the same
-prefixes — each holds only what its own topology could produce a repair for.
-
-Take `10.0.0.5/32`, which both protect. The algorithm-0 repair leaves over
-`192.168.0.2` — that is `se-sg`, **the trans-Pacific link algorithm 128
-exists to avoid** — carrying algorithm-0 labels (`16xxx`). The
-algorithm-128 repair leaves over `192.168.1.2` (`se-sj`) with
-algorithm-128 labels (`18xxx`).
-
-That difference is the whole point: a repair must be computed in the
-algorithm's own topology *and* expressed with its own SIDs, or the backup
-path silently violates the constraint the algorithm was created to
-enforce. Adjacency segments (`15xxx`) are shared — an Adj-SID means "pop
-and forward over this link" regardless of algorithm, and the link is
-already known to be in the algorithm's topology. Which Adj-SID lands in a
-given segment list, and which of two equal-cost repairs wins, both depend on
-adjacency-formation order, so these exact values move between runs; the
-`16xxx` / `18xxx` split does not.
-
-When a node on the repair path advertises no Prefix-SID for this
-algorithm, the whole repair is dropped rather than approximated with an
-algorithm-0 label, so the destination is simply unprotected under that
-algorithm.
-
-## Appendix: Loopbacks and Prefix-SIDs
-
-| name | region | full name | loopback     | algo-0 SID / label | algo-128 SID / label |
-|:-----|:-------|:----------|:-------------|:-------------------|:---------------------|
-| se   | US     | Seattle   | 10.0.0.1/32  | 100 / 16100        | 2100 / 18100         |
-| sj   | US     | San Jose  | 10.0.0.2/32  | 200 / 16200        | 2200 / 18200         |
-| ch   | US     | Chicago   | 10.0.0.3/32  | 300 / 16300        | 2300 / 18300         |
-| da   | US     | Dallas    | 10.0.0.4/32  | 400 / 16400        | 2400 / 18400         |
-| va   | US     | Virginia  | 10.0.0.5/32  | 500 / 16500        | 2500 / 18500         |
-| at   | US     | Atlanta   | 10.0.0.6/32  | 600 / 16600        | 2600 / 18600         |
-| ln   | EU     | London    | 10.0.0.7/32  | 700 / 16700        | 2700 / 18700         |
-| fr   | EU     | Frankfurt | 10.0.0.8/32  | 800 / 16800        | 2800 / 18800         |
-| sg   | AP     | Singapore | 10.0.0.9/32  | 900 / 16900        | 2900 / 18900         |
-| sy   | AP     | Sydney    | 10.0.0.10/32 | 1000 / 17000       | 3000 / 19000         |
-| tk   | AP     | Tokyo     | 10.0.0.11/32 | 1100 / 17100       | 3100 / 19100         |
-
-SRGB base is 16000, SRLB base 15000. `ch` and `sg` advertise the FAD.
-
-## Appendix: Networks
-
-All links have metric 10. Addresses are `.1` on the first-listed node and
-`.2` on the second.
-
-| link  | network         | regions  | affinity      |
-|:------|:----------------|:---------|:--------------|
-| se-sg | 192.168.0.0/24  | US <-> AP | trans-pacific |
-| se-sj | 192.168.1.0/24  | US        |               |
-| se-ch | 192.168.2.0/24  | US        |               |
-| sj-sy | 192.168.3.0/24  | US <-> AP | trans-pacific |
-| sj-da | 192.168.4.0/24  | US        |               |
-| sj-ch | 192.168.5.0/24  | US        |               |
-| sj-tk | 192.168.6.0/24  | US <-> AP | trans-pacific |
-| ch-da | 192.168.7.0/24  | US        |               |
-| ch-va | 192.168.8.0/24  | US        |               |
-| ch-ln | 192.168.9.0/24  | US <-> EU |               |
-| da-at | 192.168.10.0/24 | US        |               |
-| va-at | 192.168.11.0/24 | US        |               |
-| va-fr | 192.168.12.0/24 | US <-> EU |               |
-| ln-fr | 192.168.13.0/24 | EU        |               |
-| fr-sg | 192.168.14.0/24 | EU <-> AP |               |
-| sg-tk | 192.168.15.0/24 | AP        |               |
-| sg-sy | 192.168.16.0/24 | AP        |               |
+tears the lab back down.

--- a/playset/isis-flexalgo-ai/at.yaml
+++ b/playset/isis-flexalgo-ai/at.yaml
@@ -1,0 +1,51 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+- if-name: at-da
+  ipv4:
+    address: 192.168.10.2/24
+- if-name: at-va
+  ipv4:
+    address: 192.168.11.2/24
+system:
+  hostname: at
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: at
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.6
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 600
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2600
+    - if-name: at-da
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: at-va
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/at.yaml
+++ b/playset/isis-flexalgo-ai/at.yaml
@@ -10,10 +10,6 @@ interface:
     address: 192.168.11.2/24
 system:
   hostname: at
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0006.00
@@ -22,23 +18,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.6
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 600
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2600
     - if-name: at-da
       network-type: point-to-point
       ipv4:

--- a/playset/isis-flexalgo-ai/ch.yaml
+++ b/playset/isis-flexalgo-ai/ch.yaml
@@ -1,0 +1,76 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: ch-se
+  ipv4:
+    address: 192.168.2.2/24
+- if-name: ch-sj
+  ipv4:
+    address: 192.168.5.2/24
+- if-name: ch-da
+  ipv4:
+    address: 192.168.7.1/24
+- if-name: ch-va
+  ipv4:
+    address: 192.168.8.1/24
+- if-name: ch-ln
+  ipv4:
+    address: 192.168.9.1/24
+system:
+  hostname: ch
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: ch
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.3
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 300
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2300
+    - if-name: ch-se
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: ch-sj
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: ch-da
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: ch-va
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: ch-ln
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/ch.yaml
+++ b/playset/isis-flexalgo-ai/ch.yaml
@@ -19,10 +19,6 @@ interface:
     address: 192.168.9.1/24
 system:
   hostname: ch
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0003.00
@@ -31,24 +27,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.3
-    flex-algo:
-    - algo: 128
-      advertise-definition: true
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 300
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2300
     - if-name: ch-se
       network-type: point-to-point
       ipv4:

--- a/playset/isis-flexalgo-ai/da.yaml
+++ b/playset/isis-flexalgo-ai/da.yaml
@@ -1,0 +1,59 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: da-sj
+  ipv4:
+    address: 192.168.4.2/24
+- if-name: da-ch
+  ipv4:
+    address: 192.168.7.2/24
+- if-name: da-at
+  ipv4:
+    address: 192.168.10.1/24
+system:
+  hostname: da
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: da
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.4
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 400
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2400
+    - if-name: da-sj
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: da-ch
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: da-at
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/da.yaml
+++ b/playset/isis-flexalgo-ai/da.yaml
@@ -13,10 +13,6 @@ interface:
     address: 192.168.10.1/24
 system:
   hostname: da
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0004.00
@@ -25,23 +21,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.4
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 400
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2400
     - if-name: da-sj
       network-type: point-to-point
       ipv4:

--- a/playset/isis-flexalgo-ai/down.sh
+++ b/playset/isis-flexalgo-ai/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS FlexAlgo namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/isis-flexalgo-ai/fr.yaml
+++ b/playset/isis-flexalgo-ai/fr.yaml
@@ -1,0 +1,59 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+- if-name: fr-va
+  ipv4:
+    address: 192.168.12.2/24
+- if-name: fr-ln
+  ipv4:
+    address: 192.168.13.2/24
+- if-name: fr-sg
+  ipv4:
+    address: 192.168.14.1/24
+system:
+  hostname: fr
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: fr
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.8
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 800
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2800
+    - if-name: fr-va
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: fr-ln
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: fr-sg
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/fr.yaml
+++ b/playset/isis-flexalgo-ai/fr.yaml
@@ -13,10 +13,6 @@ interface:
     address: 192.168.14.1/24
 system:
   hostname: fr
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0008.00
@@ -25,23 +21,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.8
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 800
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2800
     - if-name: fr-va
       network-type: point-to-point
       ipv4:

--- a/playset/isis-flexalgo-ai/ln.yaml
+++ b/playset/isis-flexalgo-ai/ln.yaml
@@ -1,0 +1,51 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+- if-name: ln-ch
+  ipv4:
+    address: 192.168.9.2/24
+- if-name: ln-fr
+  ipv4:
+    address: 192.168.13.1/24
+system:
+  hostname: ln
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: ln
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.7
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 700
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2700
+    - if-name: ln-ch
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: ln-fr
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/ln.yaml
+++ b/playset/isis-flexalgo-ai/ln.yaml
@@ -10,10 +10,6 @@ interface:
     address: 192.168.13.1/24
 system:
   hostname: ln
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0007.00
@@ -22,23 +18,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.7
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 700
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2700
     - if-name: ln-ch
       network-type: point-to-point
       ipv4:

--- a/playset/isis-flexalgo-ai/ontology.json
+++ b/playset/isis-flexalgo-ai/ontology.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "se",
+    "full-name": "Seattle",
+    "region": "US"
+  },
+  {
+    "name": "sj",
+    "full-name": "San Jose",
+    "region": "US"
+  },
+  {
+    "name": "ch",
+    "full-name": "Chicago",
+    "region": "US"
+  },
+  {
+    "name": "da",
+    "full-name": "Dallas",
+    "region": "US"
+  },
+  {
+    "name": "va",
+    "full-name": "Virginia",
+    "region": "US"
+  },
+  {
+    "name": "at",
+    "full-name": "Atlanta",
+    "region": "US"
+  },
+  {
+    "name": "ln",
+    "full-name": "London",
+    "region": "EU"
+  },
+  {
+    "name": "fr",
+    "full-name": "Frankfurt",
+    "region": "EU"
+  },
+  {
+    "name": "sg",
+    "full-name": "Singapore",
+    "region": "AP"
+  },
+  {
+    "name": "sy",
+    "full-name": "Sydney",
+    "region": "AP"
+  },
+  {
+    "name": "tk",
+    "full-name": "Tokyo",
+    "region": "AP"
+  }
+]

--- a/playset/isis-flexalgo-ai/se.yaml
+++ b/playset/isis-flexalgo-ai/se.yaml
@@ -1,0 +1,61 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: se-sg
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: se-sj
+  ipv4:
+    address: 192.168.1.1/24
+- if-name: se-ch
+  ipv4:
+    address: 192.168.2.1/24
+system:
+  hostname: se
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: se
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.1
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 100
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2100
+    - if-name: se-sg
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: se-sj
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: se-ch
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/se.yaml
+++ b/playset/isis-flexalgo-ai/se.yaml
@@ -13,10 +13,6 @@ interface:
     address: 192.168.2.1/24
 system:
   hostname: se
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0001.00
@@ -25,27 +21,14 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.1
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 100
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2100
     - if-name: se-sg
       network-type: point-to-point
-      affinity:
-      - trans-pacific
       ipv4:
         enabled: true
       metric: 10

--- a/playset/isis-flexalgo-ai/sg.yaml
+++ b/playset/isis-flexalgo-ai/sg.yaml
@@ -1,0 +1,70 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.9/32
+- if-name: sg-se
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: sg-fr
+  ipv4:
+    address: 192.168.14.2/24
+- if-name: sg-tk
+  ipv4:
+    address: 192.168.15.1/24
+- if-name: sg-sy
+  ipv4:
+    address: 192.168.16.1/24
+system:
+  hostname: sg
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0009.00
+    hostname: sg
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.9
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 900
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2900
+    - if-name: sg-se
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sg-fr
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sg-tk
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sg-sy
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/sg.yaml
+++ b/playset/isis-flexalgo-ai/sg.yaml
@@ -16,10 +16,6 @@ interface:
     address: 192.168.16.1/24
 system:
   hostname: sg
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0009.00
@@ -28,28 +24,14 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.9
-    flex-algo:
-    - algo: 128
-      advertise-definition: true
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 900
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2900
     - if-name: sg-se
       network-type: point-to-point
-      affinity:
-      - trans-pacific
       ipv4:
         enabled: true
       metric: 10

--- a/playset/isis-flexalgo-ai/sj.yaml
+++ b/playset/isis-flexalgo-ai/sj.yaml
@@ -1,0 +1,79 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: sj-se
+  ipv4:
+    address: 192.168.1.2/24
+- if-name: sj-sy
+  ipv4:
+    address: 192.168.3.1/24
+- if-name: sj-da
+  ipv4:
+    address: 192.168.4.1/24
+- if-name: sj-ch
+  ipv4:
+    address: 192.168.5.1/24
+- if-name: sj-tk
+  ipv4:
+    address: 192.168.6.1/24
+system:
+  hostname: sj
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: sj
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.2
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 200
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2200
+    - if-name: sj-se
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sj-sy
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sj-da
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sj-ch
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sj-tk
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/sj.yaml
+++ b/playset/isis-flexalgo-ai/sj.yaml
@@ -19,10 +19,6 @@ interface:
     address: 192.168.6.1/24
 system:
   hostname: sj
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0002.00
@@ -31,23 +27,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.2
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 200
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2200
     - if-name: sj-se
       network-type: point-to-point
       ipv4:
@@ -55,8 +40,6 @@ router:
       metric: 10
     - if-name: sj-sy
       network-type: point-to-point
-      affinity:
-      - trans-pacific
       ipv4:
         enabled: true
       metric: 10
@@ -72,8 +55,6 @@ router:
       metric: 10
     - if-name: sj-tk
       network-type: point-to-point
-      affinity:
-      - trans-pacific
       ipv4:
         enabled: true
       metric: 10

--- a/playset/isis-flexalgo-ai/sy.yaml
+++ b/playset/isis-flexalgo-ai/sy.yaml
@@ -1,0 +1,53 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.10/32
+- if-name: sy-sj
+  ipv4:
+    address: 192.168.3.2/24
+- if-name: sy-sg
+  ipv4:
+    address: 192.168.16.2/24
+system:
+  hostname: sy
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0010.00
+    hostname: sy
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.10
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1000
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 3000
+    - if-name: sy-sj
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: sy-sg
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/sy.yaml
+++ b/playset/isis-flexalgo-ai/sy.yaml
@@ -10,10 +10,6 @@ interface:
     address: 192.168.16.2/24
 system:
   hostname: sy
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0010.00
@@ -22,27 +18,14 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.10
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 1000
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 3000
     - if-name: sy-sj
       network-type: point-to-point
-      affinity:
-      - trans-pacific
       ipv4:
         enabled: true
       metric: 10

--- a/playset/isis-flexalgo-ai/tk.yaml
+++ b/playset/isis-flexalgo-ai/tk.yaml
@@ -1,0 +1,53 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.11/32
+- if-name: tk-sj
+  ipv4:
+    address: 192.168.6.2/24
+- if-name: tk-sg
+  ipv4:
+    address: 192.168.15.2/24
+system:
+  hostname: tk
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0011.00
+    hostname: tk
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.11
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 1100
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 3100
+    - if-name: tk-sj
+      network-type: point-to-point
+      affinity:
+      - trans-pacific
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: tk-sg
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/tk.yaml
+++ b/playset/isis-flexalgo-ai/tk.yaml
@@ -10,10 +10,6 @@ interface:
     address: 192.168.15.2/24
 system:
   hostname: tk
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0011.00
@@ -22,27 +18,14 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.11
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 1100
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 3100
     - if-name: tk-sj
       network-type: point-to-point
-      affinity:
-      - trans-pacific
       ipv4:
         enabled: true
       metric: 10

--- a/playset/isis-flexalgo-ai/topology.sh
+++ b/playset/isis-flexalgo-ai/topology.sh
@@ -1,0 +1,30 @@
+# IS-IS FlexAlgo demo
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(se sj ch da va at ln fr sg sy tk)
+
+PLAYSET_LINKS=(
+    se:se-sg:sg:sg-se
+    se:se-sj:sj:sj-se
+    se:se-ch:ch:ch-se
+    sj:sj-sy:sy:sy-sj
+    sj:sj-da:da:da-sj
+    sj:sj-ch:ch:ch-sj
+    sj:sj-tk:tk:tk-sj
+    ch:ch-da:da:da-ch
+    ch:ch-va:va:va-ch
+    ch:ch-ln:ln:ln-ch
+    da:da-at:at:at-da
+    va:va-at:at:at-va
+    va:va-fr:fr:fr-va
+    ln:ln-fr:fr:fr-ln
+    fr:fr-sg:sg:sg-fr
+    sg:sg-tk:tk:tk-sg
+    sg:sg-sy:sy:sy-sg
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(se sj ch da va at ln fr sg sy tk)
+
+# Routers with vtyctl YAML config (end hosts e1/e2 have no config).
+PLAYSET_ROUTERS=(se sj ch da va at ln fr sg sy tk)

--- a/playset/isis-flexalgo-ai/up.sh
+++ b/playset/isis-flexalgo-ai/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the IS-IS FlexAlgo namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up

--- a/playset/isis-flexalgo-ai/va.yaml
+++ b/playset/isis-flexalgo-ai/va.yaml
@@ -1,0 +1,59 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: va-ch
+  ipv4:
+    address: 192.168.8.2/24
+- if-name: va-at
+  ipv4:
+    address: 192.168.11.1/24
+- if-name: va-fr
+  ipv4:
+    address: 192.168.12.1/24
+system:
+  hostname: va
+affinity-map:
+  affinity:
+  - name: trans-pacific
+    bit-position: 0
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: va
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.5
+    flex-algo:
+    - algo: 128
+      metric-type: igp
+      dataplane:
+        sr-mpls: true
+      affinity:
+        exclude-any:
+        - trans-pacific
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 500
+        flex-algo-prefix-sid:
+        - algo: 128
+          index: 2500
+    - if-name: va-ch
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: va-at
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10
+    - if-name: va-fr
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      metric: 10

--- a/playset/isis-flexalgo-ai/va.yaml
+++ b/playset/isis-flexalgo-ai/va.yaml
@@ -13,10 +13,6 @@ interface:
     address: 192.168.12.1/24
 system:
   hostname: va
-affinity-map:
-  affinity:
-  - name: trans-pacific
-    bit-position: 0
 router:
   isis:
     net: 49.0000.0000.0000.0005.00
@@ -25,23 +21,12 @@ router:
     segment-routing:
       mpls: {}
     te-router-id: 10.0.0.5
-    flex-algo:
-    - algo: 128
-      metric-type: igp
-      dataplane:
-        sr-mpls: true
-      affinity:
-        exclude-any:
-        - trans-pacific
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
           index: 500
-        flex-algo-prefix-sid:
-        - algo: 128
-          index: 2500
     - if-name: va-ch
       network-type: point-to-point
       ipv4:


### PR DESCRIPTION
## Summary

Seeds the AI & Ontology demo: an AI assistant, connected from Claude
Desktop over MCP, will design and commit the IS-IS Flexible Algorithm
configuration itself, deriving the design from `ontology.json` regions
and the live IGP topology. This PR is Phase A — the starting-point
playset.

- Copy `playset/isis-flexalgo` verbatim as `playset/isis-flexalgo-ai`
  (first commit, for reviewable history).
- Strip the eleven yamls to a plain IS-IS + SR-MPLS baseline: remove the
  global `affinity-map`, the `trans-pacific` coloring on the six ends of
  the three US↔AP links, the `flex-algo 128` FAD (incl.
  `advertise-definition` on ch/sg), and every `flex-algo-prefix-sid`.
  Algorithm-0 prefix-SIDs, SR-MPLS and te-router-id stay — this is
  exactly the set the AI has to author.
- Rewrite the README around the demo: two-stage storyline,
  ontology-as-input framing, baseline verification with real command
  output, expected end state. `playset/isis-flexalgo` remains the
  hand-written answer key.

The MCP write surface (`apply-config`, `get-ontology`, fleet mode for
Claude Desktop) follows in separate PRs.

## Test plan

- Brought the playset up live on a fresh debug build: all 11 daemons
  parse the stripped configs; IS-IS converges with the full algorithm-0
  SR-MPLS table on tk.
- `show isis flex-algo` reports `(none configured)` with every peer
  participating in `[0]` only; all 11 LSPs advertise
  `Segment Routing Algorithm: SPF(0)` — baseline is FlexAlgo-free on
  the wire.
- `show running-config formal` round-trips through the existing MCP
  `show` tool (set-line syntax, matching the Apply service input).
- `./down.sh` tears down clean — no leaked daemons or namespaces.

Generated with [Claude Code](https://claude.com/claude-code)