### PR TITLE
mcp: config apply/read tools, ontology, and fleet mode

### DIFF
--- a/book/src/ch-13-00-mcp-server.md
+++ b/book/src/ch-13-00-mcp-server.md
@@ -21,6 +21,10 @@ Point Claude — or any MCP-aware agent — at zebra-rs and describe what you wa
 - **Draft policy.** "Write a route-map that prefers the SRv6 path and tags it
   with community 65000:100." The agent drafts the configuration for you to
   review and apply.
+- **Commit changes.** "Define a Flex-Algorithm that avoids the trans-Pacific
+  links." The agent reads the running configuration with `get-config`,
+  writes the change as `set` lines, and commits it atomically with
+  `apply-config`.
 
 The agent sees exactly what an operator sees at the CLI — one source of truth,
 no diverging copy of the network.
@@ -43,10 +47,9 @@ to any MCP client and your assistant can reach the router straight away:
 
 ## The tools
 
-The server is read-only by contract: every tool answers from the daemon's
-live state, and none of them mutate it. Two tools cover the whole `show`
-surface, and a small typed family serves the data that topology-aware
-agents ask for most:
+Two tools cover the whole `show` surface, a small typed family serves the
+data that topology-aware agents ask for most, and a configuration pair
+closes the loop from reading state to changing it:
 
 | tool | arguments | returns |
 |:-----|:----------|:--------|
@@ -58,6 +61,16 @@ agents ask for most:
 | `get-ospf-graph` | `version` | the OSPF area graph with router names and link costs. `version` selects OSPFv2 (2, the default) or OSPFv3 (3). |
 | `get-ospf-spf` | `version` | the OSPF SPF tree: per-vertex cost and first hops. OSPF's SPF does not retain hop-by-hop vertex chains, so join vertex ids against `get-ospf-graph` for names and links. |
 | `get-ospf-flex-algo` | `version` | OSPF Flexible Algorithm state: each configured algorithm's definition and constraints, its per-algorithm SPF status, and per-algorithm routes. |
+| `get-config` | `format` | the running configuration. `formal` (the default) is one `set ...` line per node — the same syntax `apply-config` consumes; `cli`, `json` and `yaml` select the other serializations. |
+| `apply-config` | `commands` | applies a list of `set ...` / `delete ...` lines as one atomic transaction: the daemon validates everything first, and on any error nothing is applied and the offending line comes back in the error. Lines that are not set/delete are refused. |
+| `get-ontology` | — | operator-provided semantic metadata about the routers (full names, regions, coordinates, ...) from the JSON file named by `vtyctl mcp --ontology <path>`. The tool is registered only when the flag is given. |
+
+Everything except `apply-config` answers from the daemon's live state
+without mutating it. `apply-config` is the single write surface, and it
+inherits the VTY session model: sessions from root hold the admin role
+automatically, so a server started inside the router's namespace via
+`sudo` can commit, while an unprivileged one is refused with
+"admin role required".
 
 The typed `get-*` tools return validated JSON, so an agent — or an ordinary
 program using MCP as its API — can consume them without scraping CLI text.

--- a/book/src/ch-13-00-mcp-server.md
+++ b/book/src/ch-13-00-mcp-server.md
@@ -77,6 +77,32 @@ program using MCP as its API — can consume them without scraping CLI text.
 The [3D Traffic Path Visualizer](ch-13-01-topology-viewer.md) is exactly
 that: a web application whose only data plane is these tools.
 
+## One server, a fleet of routers
+
+A lab or a deployment rarely has just one router. When each zebra-rs runs
+in its own network namespace (the playset convention), its VTY endpoint is
+an abstract Unix socket that only exists inside that namespace — so one
+MCP server per router would be the natural but painful shape: eleven
+connector entries for an eleven-node lab.
+
+Fleet mode collapses that to one entry:
+
+``` shell
+$ sudo vtyctl mcp --fleet ontology.json
+```
+
+The JSON file names the routers (each `name` is also its network
+namespace). Every tool then takes a required `router` argument — the
+schema enumerates the valid names — and the server forwards the call to a
+one-shot `vtyctl mcp` spawned inside that router's namespace. The fleet
+file doubles as the ontology, so `get-ontology` (served by the fleet
+server itself, no `router` argument) works out of the box.
+
+The server must run as root: entering namespaces requires it, and so does
+committing configuration through `apply-config` (root sessions hold the
+admin role automatically). Started unprivileged, it goes through
+`sudo -n` for each forwarded call.
+
 ## Current protocol, older clients welcome
 
 The server speaks the stateless [MCP 2026-07-28

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -61,7 +61,7 @@ playset:
 	@bad=`find out/playset -type f ! \( \
 		-name '*.yaml' -o -name '*.json' -o -name '*.md' -o -name '*.drawio' \
 		-o -name '*.png' -o -name '*.svg' \
-		-o -name 'up.sh' -o -name 'down.sh' -o -name 'topology.sh' \
+		-o -name 'up.sh' -o -name 'down.sh' -o -name 'mcp.sh' -o -name 'topology.sh' \
 		-o -name 'common.sh' -o -name 'netns.sh' -o -name 'playset.sh' -o -name 'zebra-rs.sh' \)`; \
 	if [ -n "$$bad" ]; then \
 		echo "playset: file(s) not covered by cargo-deb assets (add a glob in zebra-rs/Cargo.toml):"; \

--- a/packaging/verify-playset-layout.sh
+++ b/packaging/verify-playset-layout.sh
@@ -36,14 +36,14 @@ if [ ! -d "$staged" ]; then
 fi
 
 # Expected: every staged regular file, at the mirrored path under $prefix.
-# up.sh/down.sh are the operator entry points and ship executable; every other
-# asset (the sourced lib/ helpers and the data files) ships 0644. This mirrors
-# the mode column of the asset table in ../zebra-rs/Cargo.toml.
+# up.sh/down.sh/mcp.sh are the operator entry points and ship executable;
+# every other asset (the sourced lib/ helpers and the data files) ships 0644.
+# This mirrors the mode column of the asset table in ../zebra-rs/Cargo.toml.
 expected="$(
 	cd "$staged"
 	find . -type f | sed 's|^\./||' | while IFS= read -r f; do
 		case "${f##*/}" in
-		up.sh | down.sh) mode=755 ;;
+		up.sh | down.sh | mcp.sh) mode=755 ;;
 		*) mode=644 ;;
 		esac
 		printf '%s %s/%s\n' "$mode" "$prefix" "$f"

--- a/playset/isis-flexalgo-ai/README.md
+++ b/playset/isis-flexalgo-ai/README.md
@@ -143,14 +143,34 @@ visually: started against this playset, its Algorithm selector offers only
 
 ## Stage 2: let the AI build the FlexAlgo
 
-The assistant works through the zebra-rs MCP server (`vtyctl mcp`), which
-exposes the lab to Claude Desktop: reading the ontology, extracting each
-router's running configuration (`show running-config formal` — the same
-`set`-line syntax the configuration is applied with), inspecting the IS-IS
-graph, applying and committing configuration, and verifying the result.
-The MCP wiring for configuration apply and the Claude Desktop setup are
-being added to `vtyctl`; this section will grow the exact connector
-configuration and the demo prompt as they land.
+The assistant works through the zebra-rs MCP server. `./mcp.sh` starts it
+in **fleet mode** (`vtyctl mcp --fleet ontology.json`): one stdio server
+fronting all eleven routers, where every tool takes a `router` argument
+and the call is forwarded into that router's network namespace. The
+assistant can read the ontology (`get-ontology`), extract any router's
+running configuration (`get-config`, whose default `formal` format is the
+same `set`-line syntax configuration is applied with), inspect the IS-IS
+graph and SPF (`get-isis-graph`, `get-isis-spf`), and apply and commit
+configuration (`apply-config` — atomic per router: on any error nothing
+is applied and the offending line is returned).
+
+Connect Claude Desktop by adding to `claude_desktop_config.json`:
+
+``` json
+{
+  "mcpServers": {
+    "zebra-fleet": {
+      "command": "/path/to/zebra-rs/playset/isis-flexalgo-ai/mcp.sh"
+    }
+  }
+}
+```
+
+(or `"command": "ssh", "args": ["-T", "user@lab-host", ".../mcp.sh"]`
+when Claude Desktop runs on another machine). The server needs root to
+enter the namespaces and to commit configuration, so grant passwordless
+sudo for the vtyctl binary — the header of `mcp.sh` has the exact
+sudoers line.
 
 The end state to expect is the hand-written playset next door. When the AI
 has done its job:

--- a/playset/isis-flexalgo-ai/mcp.sh
+++ b/playset/isis-flexalgo-ai/mcp.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# MCP fleet server for the isis-flexalgo-ai demo.
+#
+# One stdio MCP server that fronts all eleven routers: every tool takes a
+# `router` argument, and calls are forwarded into that router's network
+# namespace. Point Claude Desktop (or any MCP client) at this script:
+#
+#   {
+#     "mcpServers": {
+#       "zebra-fleet": {
+#         "command": "/path/to/zebra-rs/playset/isis-flexalgo-ai/mcp.sh"
+#       }
+#     }
+#   }
+#
+# If Claude Desktop runs on another machine, wrap it in ssh instead:
+#
+#   "command": "ssh",
+#   "args": ["-T", "user@lab-host", "/path/to/.../mcp.sh"]
+#
+# The server runs as root (it must enter the routers' namespaces, and
+# committing configuration requires an admin session, which root holds
+# automatically). Grant passwordless sudo for the vtyctl binary, e.g.
+# with visudo:
+#
+#   <user> ALL=(root) NOPASSWD: /path/to/zebra-rs/target/debug/vtyctl
+#
+set -eu
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "${DIR}/../.." && pwd)"
+
+VTYCTL="${VTYCTL_BIN:-}"
+if [ -z "${VTYCTL}" ]; then
+    for candidate in \
+        "${REPO}/target/debug/vtyctl" \
+        "${REPO}/target/release/vtyctl" \
+        /usr/bin/vtyctl; do
+        if [ -x "${candidate}" ]; then
+            VTYCTL="${candidate}"
+            break
+        fi
+    done
+fi
+if [ -z "${VTYCTL}" ]; then
+    echo "mcp.sh: no vtyctl binary found (set VTYCTL_BIN)" >&2
+    exit 1
+fi
+
+if [ "$(id -u)" -eq 0 ]; then
+    exec "${VTYCTL}" mcp --fleet "${DIR}/ontology.json"
+fi
+exec sudo -n "${VTYCTL}" mcp --fleet "${DIR}/ontology.json"

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -80,6 +80,13 @@ enum Commands {
 
         #[arg(short, long, help = "Enable debug logging")]
         debug: bool,
+
+        #[arg(
+            short,
+            long,
+            help = "Ontology JSON file to serve via the get-ontology tool"
+        )]
+        ontology: Option<String>,
     },
 }
 
@@ -119,8 +126,13 @@ async fn main() -> Result<()> {
         Some(Commands::Watch { host, json, path }) => {
             watch::watch(host, *json, path.clone()).await?;
         }
-        Some(Commands::Mcp { host, port, debug }) => {
-            mcp::run(host, *port, *debug).await?;
+        Some(Commands::Mcp {
+            host,
+            port,
+            debug,
+            ontology,
+        }) => {
+            mcp::run(host, *port, *debug, ontology.as_deref()).await?;
         }
         None => {
             print_help();

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -87,6 +87,14 @@ enum Commands {
             help = "Ontology JSON file to serve via the get-ontology tool"
         )]
         ontology: Option<String>,
+
+        #[arg(
+            short,
+            long,
+            help = "Serve a whole fleet: ontology JSON file naming the routers \
+                    (name = netns); adds a 'router' argument to every tool"
+        )]
+        fleet: Option<String>,
     },
 }
 
@@ -131,8 +139,9 @@ async fn main() -> Result<()> {
             port,
             debug,
             ontology,
+            fleet,
         }) => {
-            mcp::run(host, *port, *debug, ontology.as_deref()).await?;
+            mcp::run(host, *port, *debug, ontology.as_deref(), fleet.as_deref()).await?;
         }
         None => {
             print_help();

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -3,9 +3,10 @@ use tokio_stream::StreamExt;
 use tonic::Request;
 use tracing::{debug, error};
 
+use crate::vty::apply_client::ApplyClient;
 use crate::vty::exec_client::ExecClient;
 use crate::vty::show_client::ShowClient;
-use crate::vty::{ExecCode, ExecRequest, ExecType, ShowRequest};
+use crate::vty::{ApplyCode, ApplyRequest, ExecCode, ExecRequest, ExecType, ShowRequest};
 
 /// A single completion candidate for the token following a command line,
 /// parsed from the daemon's completion engine output.
@@ -152,6 +153,47 @@ impl ZebraClient {
         }
     }
 
+    /// Apply configuration lines and commit them atomically.
+    ///
+    /// The daemon's Apply service is transactional: a line that fails to
+    /// parse, or a failed schema validation at commit, discards the whole
+    /// candidate and nothing is applied. It is also admin-gated — sessions
+    /// from uid 0 hold the Admin role automatically; anything else is
+    /// refused with "admin role required".
+    pub async fn apply_config(&self, lines: &[String]) -> Result<String> {
+        let endpoint = self.endpoint();
+        debug!("Applying {} config line(s) via {}", lines.len(), endpoint);
+
+        let channel = crate::endpoint::connect(&endpoint).await?;
+        let mut client = ApplyClient::new(channel);
+
+        let requests: Vec<ApplyRequest> = lines
+            .iter()
+            .map(|line| ApplyRequest {
+                line: format!("{line}\n"),
+            })
+            .collect();
+        let count = requests.len();
+
+        let reply = client
+            .apply(Request::new(tokio_stream::iter(requests)))
+            .await?
+            .into_inner();
+
+        if reply.apply_code == ApplyCode::Applied as i32 {
+            Ok(format!("applied: {count} line(s) committed"))
+        } else {
+            // `description` is the daemon's own detail: the offending line
+            // for per-line failures, the validation message for commit
+            // failures. Pass it through so the caller can self-correct.
+            Err(anyhow::anyhow!(
+                "apply failed ({}): {}",
+                apply_code_name(reply.apply_code),
+                reply.description
+            ))
+        }
+    }
+
     /// Return the completion candidates for the token *after* `line`, using
     /// the daemon's completion engine (the same one that backs CLI `?`/TAB).
     /// Completion is not admin-gated, so a View session can enumerate the
@@ -189,6 +231,17 @@ impl ZebraClient {
                 Err(e)
             }
         }
+    }
+}
+
+/// Human-readable name for a daemon `ApplyCode`.
+fn apply_code_name(code: i32) -> &'static str {
+    match ApplyCode::try_from(code) {
+        Ok(ApplyCode::Applied) => "applied",
+        Ok(ApplyCode::FormatError) => "format error",
+        Ok(ApplyCode::ParseError) => "parse error",
+        Ok(ApplyCode::MissingMandatory) => "missing mandatory node",
+        Err(_) => "unknown error",
     }
 }
 

--- a/vtyctl/src/mcp/fleet.rs
+++ b/vtyctl/src/mcp/fleet.rs
@@ -1,0 +1,294 @@
+//! Fleet mode: one MCP server fronting many per-netns zebra-rs daemons.
+//!
+//! Each router of a playset runs zebra-rs in its own network namespace,
+//! listening on the abstract Unix socket `@zebra-rs/vty` — and abstract
+//! sockets are network-namespaced, so a daemon is only reachable from
+//! inside its namespace. The fleet server therefore adds a `router`
+//! argument to every tool and forwards each call to a one-shot
+//! `ip netns exec <router> vtyctl mcp` child (this same binary), speaking
+//! the MCP 2026-07-28 stateless revision over the child's stdio: one
+//! `tools/call` line out, one response line back, no handshake.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+const PROTOCOL_VERSION: &str = "2026-07-28";
+const META_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
+const META_CLIENT_CAPABILITIES: &str = "io.modelcontextprotocol/clientCapabilities";
+
+/// Per-forwarded-call deadline. Generous — `show` on a large table plus
+/// the netns process spawn stays well inside it.
+const CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The router roster and how to reach each member.
+#[derive(Clone, Debug)]
+pub struct Fleet {
+    /// Router names in ontology order; by playset convention each name is
+    /// also the router's network namespace.
+    routers: Vec<String>,
+    /// Daemon VTY endpoint as seen from inside each namespace.
+    host: String,
+}
+
+impl Fleet {
+    /// Build the roster from the ontology file: every entry's `name` is a
+    /// router. Fails on an unreadable file or a malformed roster so fleet
+    /// mode dies at server start, not at first call.
+    pub fn new(ontology_path: &Path, host: &str) -> Result<Self> {
+        let text = std::fs::read_to_string(ontology_path)
+            .with_context(|| format!("cannot read fleet file {}", ontology_path.display()))?;
+        let routers = roster_from_ontology(&text)
+            .with_context(|| format!("fleet file {}", ontology_path.display()))?;
+        Ok(Self::from_roster(routers, host))
+    }
+
+    pub fn from_roster(routers: Vec<String>, host: &str) -> Self {
+        Self {
+            routers,
+            host: host.to_string(),
+        }
+    }
+
+    pub fn routers(&self) -> &[String] {
+        &self.routers
+    }
+
+    /// Forward one tool call to `router` and return the tool's text output.
+    pub async fn call(&self, router: &str, tool: &str, arguments: Value) -> Result<String> {
+        if !self.routers.iter().any(|r| r == router) {
+            bail!(
+                "unknown router '{}'; known routers: {}",
+                router,
+                self.routers.join(", ")
+            );
+        }
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool,
+                "arguments": arguments,
+                "_meta": {
+                    META_PROTOCOL_VERSION: PROTOCOL_VERSION,
+                    META_CLIENT_CAPABILITIES: {},
+                },
+            },
+        });
+
+        let response = tokio::time::timeout(CALL_TIMEOUT, self.roundtrip(router, &request))
+            .await
+            .map_err(|_| anyhow!("call '{tool}' on router '{router}' timed out"))??;
+
+        extract_tool_text(&response, router)
+    }
+
+    /// Build the command that runs this binary's own `mcp` server inside
+    /// the router's namespace. When the fleet server itself is not root,
+    /// go through `sudo -n` — non-interactive, so a misconfigured sudo
+    /// fails fast instead of hanging the call on a password prompt.
+    fn command(&self, netns: &str) -> Result<Command> {
+        let exe = std::env::current_exe().context("cannot resolve own executable path")?;
+
+        let mut argv: Vec<std::ffi::OsString> = Vec::new();
+        if !is_root() {
+            argv.extend(["sudo".into(), "-n".into()]);
+        }
+        argv.extend(["ip".into(), "netns".into(), "exec".into(), netns.into()]);
+        argv.push(exe.into());
+        argv.extend(["mcp".into(), "-H".into(), self.host.as_str().into()]);
+
+        let mut cmd = Command::new(&argv[0]);
+        cmd.args(&argv[1..]);
+        Ok(cmd)
+    }
+
+    /// One stateless request/response exchange with a freshly spawned
+    /// per-router server.
+    async fn roundtrip(&self, netns: &str, request: &Value) -> Result<Value> {
+        let mut child = self
+            .command(netns)?
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| format!("failed to spawn vtyctl mcp for router '{netns}'"))?;
+
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut stderr = child.stderr.take().expect("piped stderr");
+
+        let mut line = serde_json::to_string(request)?;
+        line.push('\n');
+        stdin.write_all(line.as_bytes()).await?;
+        // Closing stdin lets the child exit after answering, so it reaps
+        // itself once the response is read.
+        drop(stdin);
+
+        let mut lines = BufReader::new(stdout).lines();
+        let response = loop {
+            match lines.next_line().await? {
+                // Skip anything that is not a JSON object (stray log noise).
+                Some(l) => match serde_json::from_str::<Value>(&l) {
+                    Ok(v) if v.is_object() => break Some(v),
+                    _ => continue,
+                },
+                None => break None,
+            }
+        };
+
+        match response {
+            Some(v) => {
+                let _ = child.wait().await;
+                Ok(v)
+            }
+            None => {
+                // Child exited without answering — surface its stderr,
+                // which is where sudo and connection errors land.
+                let mut err = String::new();
+                let _ = stderr.read_to_string(&mut err).await;
+                let status = child.wait().await?;
+                bail!(
+                    "vtyctl mcp for router '{netns}' exited ({status}) without a response: {}",
+                    err.trim()
+                );
+            }
+        }
+    }
+}
+
+/// Parse the ontology JSON into the router roster.
+fn roster_from_ontology(text: &str) -> Result<Vec<String>> {
+    let parsed: Value = serde_json::from_str(text).context("not valid JSON")?;
+    let entries = parsed
+        .as_array()
+        .ok_or_else(|| anyhow!("must be a JSON array of router objects"))?;
+
+    let mut routers = Vec::with_capacity(entries.len());
+    for (i, entry) in entries.iter().enumerate() {
+        let name = entry.get("name").and_then(Value::as_str).unwrap_or("");
+        if name.is_empty() {
+            bail!("entry {i} has no 'name'");
+        }
+        if routers.iter().any(|r| r == name) {
+            bail!("duplicate router name '{name}'");
+        }
+        routers.push(name.to_string());
+    }
+    if routers.is_empty() {
+        bail!("names no routers");
+    }
+    Ok(routers)
+}
+
+/// Extract the text content from a forwarded `tools/call` response,
+/// propagating both protocol errors and tool-level `isError` results.
+fn extract_tool_text(response: &Value, router: &str) -> Result<String> {
+    if let Some(error) = response.get("error") {
+        bail!("MCP error from router '{router}': {error}");
+    }
+    let result = response
+        .get("result")
+        .ok_or_else(|| anyhow!("response from router '{router}' has no result"))?;
+    let text = result
+        .pointer("/content/0/text")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("result from router '{router}' has no text content"))?;
+    if result.get("isError").and_then(Value::as_bool) == Some(true) {
+        // The child already spelled the error out (usually with an
+        // "Error: " prefix the caller's own wrapper would duplicate).
+        bail!("{}", text.strip_prefix("Error: ").unwrap_or(text));
+    }
+    Ok(text.to_string())
+}
+
+fn is_root() -> bool {
+    // SAFETY: geteuid is always safe to call.
+    unsafe { libc_geteuid() == 0 }
+}
+
+unsafe fn libc_geteuid() -> u32 {
+    // Avoid a libc dependency for one syscall wrapper: geteuid is
+    // exported by glibc/musl under this exact name and signature.
+    unsafe extern "C" {
+        fn geteuid() -> u32;
+    }
+    unsafe { geteuid() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roster_parses_names_in_order() {
+        let text = r#"[{"name":"tk","region":"AP"},{"name":"se","region":"US"}]"#;
+        assert_eq!(roster_from_ontology(text).unwrap(), vec!["tk", "se"]);
+    }
+
+    #[test]
+    fn roster_rejects_bad_shapes() {
+        for (text, needle) in [
+            ("{}", "JSON array"),
+            ("[]", "no routers"),
+            (r#"[{"region":"AP"}]"#, "no 'name'"),
+            (r#"[{"name":""}]"#, "no 'name'"),
+            (r#"[{"name":"tk"},{"name":"tk"}]"#, "duplicate"),
+            ("not json", "not valid JSON"),
+        ] {
+            let err = roster_from_ontology(text).unwrap_err().to_string();
+            assert!(err.contains(needle), "{text}: {err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn call_rejects_unknown_router_before_spawning() {
+        let fleet = Fleet::from_roster(vec!["tk".into(), "se".into()], "unix:zebra-rs/vty");
+        let err = fleet
+            .call("nowhere", "show", json!({}))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown router 'nowhere'"), "{err}");
+        assert!(err.contains("tk, se"), "{err}");
+    }
+
+    #[test]
+    fn extract_text_propagates_error_shapes() {
+        let err = extract_tool_text(&json!({"error": {"code": -32601}}), "tk")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("MCP error from router 'tk'"), "{err}");
+
+        let err = extract_tool_text(
+            &json!({"result": {"content": [{"type":"text","text":"Error: apply failed"}], "isError": true}}),
+            "tk",
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(err, "apply failed");
+
+        let err = extract_tool_text(&json!({"result": {"content": []}}), "tk")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no text content"), "{err}");
+    }
+
+    #[test]
+    fn extract_text_returns_success_payload() {
+        let text = extract_tool_text(
+            &json!({"result": {"content": [{"type":"text","text":"applied: 2 line(s) committed"}], "isError": false}}),
+            "tk",
+        )
+        .unwrap();
+        assert_eq!(text, "applied: 2 line(s) committed");
+    }
+}

--- a/vtyctl/src/mcp/mod.rs
+++ b/vtyctl/src/mcp/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod fleet;
 pub mod server;
 pub mod tools;
 
@@ -7,11 +8,18 @@ use std::path::Path;
 use tracing::{debug, error};
 use tracing_subscriber::{self, Registry};
 
+use fleet::Fleet;
 use server::ZmcpServer;
 use tools::ontology::OntologyTool;
 
 /// Run the MCP server
-pub async fn run(host: &str, port: u32, debug_mode: bool, ontology: Option<&str>) -> Result<()> {
+pub async fn run(
+    host: &str,
+    port: u32,
+    debug_mode: bool,
+    ontology: Option<&str>,
+    fleet: Option<&str>,
+) -> Result<()> {
     // Initialize tracing - disable all terminal output for MCP compatibility
     // Only enable logging if explicitly requested via RUST_LOG environment variable
     if std::env::var("RUST_LOG").is_ok() || debug_mode {
@@ -37,22 +45,30 @@ pub async fn run(host: &str, port: u32, debug_mode: bool, ontology: Option<&str>
     // `http(s)://` / `tcp://` URIs are used as-is). Pre-prepending `http://`
     // here would corrupt `unix:` sockets — including the default
     // `unix:zebra-rs/vty` — into the unparseable `http://unix:...`.
-    // Fail fast on an unreadable or non-JSON ontology file, before the
-    // client sees a server that would break on first get-ontology call.
+    // Fleet mode: the ontology file doubles as the router roster, so
+    // `--fleet` alone also serves get-ontology (an explicit `--ontology`
+    // still wins). Both fail fast on a bad file, before the client sees
+    // a server that would break on its first call.
+    let fleet_srv = fleet
+        .map(|path| Fleet::new(Path::new(path), host))
+        .transpose()?;
     let ontology_tool = ontology
+        .or(fleet)
         .map(|path| OntologyTool::new(Path::new(path)))
         .transpose()?;
 
-    let server = ZmcpServer::new(host.to_string(), port, ontology_tool);
+    let server = ZmcpServer::new(host.to_string(), port, ontology_tool, fleet_srv);
 
-    // Test connection to zebra-rs
-    if let Err(e) = server.zebra_client().test_connection().await {
-        error!("Failed to connect to zebra-rs: {}", e);
-        error!("Make sure zebra-rs is running on the specified address");
-        return Err(e);
+    // Test connection to zebra-rs. In fleet mode there is no local daemon
+    // to dial — each call spawns a per-router child — so skip the probe.
+    if server.fleet().is_none() {
+        if let Err(e) = server.zebra_client().test_connection().await {
+            error!("Failed to connect to zebra-rs: {}", e);
+            error!("Make sure zebra-rs is running on the specified address");
+            return Err(e);
+        }
+        debug!("Successfully connected to zebra-rs");
     }
-
-    debug!("Successfully connected to zebra-rs");
 
     server.run().await?;
 

--- a/vtyctl/src/mcp/mod.rs
+++ b/vtyctl/src/mcp/mod.rs
@@ -3,13 +3,15 @@ pub mod server;
 pub mod tools;
 
 use anyhow::Result;
+use std::path::Path;
 use tracing::{debug, error};
 use tracing_subscriber::{self, Registry};
 
 use server::ZmcpServer;
+use tools::ontology::OntologyTool;
 
 /// Run the MCP server
-pub async fn run(host: &str, port: u32, debug_mode: bool) -> Result<()> {
+pub async fn run(host: &str, port: u32, debug_mode: bool, ontology: Option<&str>) -> Result<()> {
     // Initialize tracing - disable all terminal output for MCP compatibility
     // Only enable logging if explicitly requested via RUST_LOG environment variable
     if std::env::var("RUST_LOG").is_ok() || debug_mode {
@@ -35,7 +37,13 @@ pub async fn run(host: &str, port: u32, debug_mode: bool) -> Result<()> {
     // `http(s)://` / `tcp://` URIs are used as-is). Pre-prepending `http://`
     // here would corrupt `unix:` sockets — including the default
     // `unix:zebra-rs/vty` — into the unparseable `http://unix:...`.
-    let server = ZmcpServer::new(host.to_string(), port);
+    // Fail fast on an unreadable or non-JSON ontology file, before the
+    // client sees a server that would break on first get-ontology call.
+    let ontology_tool = ontology
+        .map(|path| OntologyTool::new(Path::new(path)))
+        .transpose()?;
+
+    let server = ZmcpServer::new(host.to_string(), port, ontology_tool);
 
     // Test connection to zebra-rs
     if let Err(e) = server.zebra_client().test_connection().await {

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -6,7 +6,9 @@ use tracing::{debug, error, warn};
 
 use super::client::ZebraClient;
 use super::tools::commands::CommandsTool;
+use super::tools::config::ConfigTools;
 use super::tools::isis::IsisTools;
+use super::tools::ontology::OntologyTool;
 use super::tools::ospf::OspfTools;
 use super::tools::show::ShowTool;
 
@@ -86,15 +88,20 @@ pub struct ZmcpServer {
     ospf_tools: OspfTools,
     show_tool: ShowTool,
     commands_tool: CommandsTool,
+    config_tools: ConfigTools,
+    /// Present only when the server was started with `--ontology <path>`;
+    /// the `get-ontology` tool is registered iff this is set.
+    ontology_tool: Option<OntologyTool>,
 }
 
 impl ZmcpServer {
-    pub fn new(base_url: String, port: u32) -> Self {
+    pub fn new(base_url: String, port: u32, ontology_tool: Option<OntologyTool>) -> Self {
         let zebra_client = ZebraClient::new(base_url, port);
         let isis_tools = IsisTools::new(zebra_client.clone());
         let ospf_tools = OspfTools::new(zebra_client.clone());
         let show_tool = ShowTool::new(zebra_client.clone());
         let commands_tool = CommandsTool::new(zebra_client.clone());
+        let config_tools = ConfigTools::new(zebra_client.clone());
 
         Self {
             zebra_client,
@@ -102,6 +109,8 @@ impl ZmcpServer {
             ospf_tools,
             show_tool,
             commands_tool,
+            config_tools,
+            ontology_tool,
         }
     }
 
@@ -239,7 +248,7 @@ impl ZmcpServer {
                     "listChanged": false
                 }
             },
-            "instructions": "Read-only view of a zebra-rs routing daemon. Call list-show-commands to discover the available show commands, then execute them with the show tool.",
+            "instructions": "Interface to a zebra-rs routing daemon. Call list-show-commands to discover the read-only show commands and run them with the show tool. Read the configuration with get-config (format 'formal' is set-line syntax) and change it with apply-config, which validates and commits set/delete lines as one atomic transaction.",
             "ttlMs": CACHE_TTL_MS,
             "cacheScope": "private"
         })
@@ -247,7 +256,52 @@ impl ZmcpServer {
 
     fn tools_list(&self) -> Value {
         debug!("Listing available tools");
-        json!({
+        let mut extra_tools = vec![
+            json!({
+                "name": "get-config",
+                "description": "Get the daemon's running configuration. Format 'formal' (the default) returns one 'set ...' line per node — the same syntax apply-config consumes; 'cli' returns indented configuration blocks; 'json' and 'yaml' return the configuration tree in those serializations.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "string",
+                            "enum": ["formal", "cli", "json", "yaml"],
+                            "description": "Serialization of the configuration (default 'formal')."
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }),
+            json!({
+                "name": "apply-config",
+                "description": "Apply configuration changes and commit them atomically. Each element of 'commands' must be a single 'set ...' or 'delete ...' line in the syntax shown by get-config format 'formal'. The daemon validates and commits all lines as one transaction: on any error nothing is applied and the error detail (including the offending line) is returned, so a failed call is safe to correct and retry.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "commands": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                            "description": "Configuration lines, each beginning with 'set ' or 'delete '."
+                        }
+                    },
+                    "required": ["commands"],
+                    "additionalProperties": false
+                }
+            }),
+        ];
+        if self.ontology_tool.is_some() {
+            extra_tools.push(json!({
+                "name": "get-ontology",
+                "description": "Get the operator-provided network ontology as JSON: semantic metadata about the routers (short name, full name, region, ...) that the routing protocols do not carry. Use it to map intent expressed in business terms — regions, sites, jurisdictions — onto the topology.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                }
+            }));
+        }
+        let mut result = json!({
             "tools": [
                 {
                     "name": "list-show-commands",
@@ -371,7 +425,12 @@ impl ZmcpServer {
             ],
             "ttlMs": CACHE_TTL_MS,
             "cacheScope": "private"
-        })
+        });
+        result["tools"]
+            .as_array_mut()
+            .expect("tools is an array")
+            .extend(extra_tools);
+        result
     }
 
     pub async fn handle_tool_call(&self, params: Value) -> Value {
@@ -397,6 +456,14 @@ impl ZmcpServer {
             "get-ospf-graph" => self.ospf_tools.get_ospf_graph(arguments).await,
             "get-ospf-spf" => self.ospf_tools.get_ospf_spf(arguments).await,
             "get-ospf-flex-algo" => self.ospf_tools.get_ospf_flex_algo(arguments).await,
+            "get-config" => self.config_tools.get_config(arguments).await,
+            "apply-config" => self.config_tools.apply_config(arguments).await,
+            "get-ontology" => match &self.ontology_tool {
+                Some(tool) => tool.read(),
+                None => Err(anyhow::anyhow!(
+                    "no ontology configured; start the server with 'vtyctl mcp --ontology <path>'"
+                )),
+            },
             _ => {
                 warn!("Unknown tool requested: {}", tool_name);
                 return tool_result(format!("Unknown tool: {}", tool_name), true);
@@ -468,7 +535,21 @@ mod tests {
     use super::*;
 
     fn server() -> ZmcpServer {
-        ZmcpServer::new("127.0.0.1".to_string(), 2650)
+        ZmcpServer::new("127.0.0.1".to_string(), 2650, None)
+    }
+
+    /// A server with the ontology tool wired to a real temp file.
+    fn server_with_ontology() -> (ZmcpServer, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "vtyctl-server-ontology-{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, r#"[{"name":"tk","region":"AP"}]"#).unwrap();
+        let tool = OntologyTool::new(&path).unwrap();
+        (
+            ZmcpServer::new("127.0.0.1".to_string(), 2650, Some(tool)),
+            path,
+        )
     }
 
     #[tokio::test]
@@ -490,12 +571,63 @@ mod tests {
             "get-ospf-graph",
             "get-ospf-spf",
             "get-ospf-flex-algo",
+            "get-config",
+            "apply-config",
         ] {
             assert!(
                 names.contains(&expected),
                 "missing {expected}; tools: {names:?}"
             );
         }
+        // get-ontology is registered only when --ontology names a file.
+        assert!(!names.contains(&"get-ontology"), "tools: {names:?}");
+    }
+
+    #[tokio::test]
+    async fn ontology_tool_is_listed_and_served_when_configured() {
+        let (server, path) = server_with_ontology();
+        let req = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        let resp = server.handle_request(req).await.expect("response");
+        let names: Vec<&str> = resp["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .filter_map(|t| t["name"].as_str())
+            .collect();
+        assert!(names.contains(&"get-ontology"), "tools: {names:?}");
+
+        let result = server
+            .handle_tool_call(json!({"name": "get-ontology", "arguments": {}}))
+            .await;
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(result["isError"], json!(false));
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("\"region\": \"AP\""), "{text}");
+    }
+
+    #[tokio::test]
+    async fn ontology_tool_errors_when_unconfigured() {
+        let result = server()
+            .handle_tool_call(json!({"name": "get-ontology", "arguments": {}}))
+            .await;
+        assert_eq!(result["isError"], json!(true));
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("--ontology"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn apply_config_rejects_bad_lines_before_dialing() {
+        // Client-side validation runs before any gRPC dial, so these fail
+        // fast even with no daemon listening.
+        let result = server()
+            .handle_tool_call(json!({
+                "name": "apply-config",
+                "arguments": {"commands": ["configure terminal"]}
+            }))
+            .await;
+        assert_eq!(result["isError"], json!(true));
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("'set ...' or 'delete ...'"), "{text}");
     }
 
     async fn negotiate(requested: Option<&str>) -> Value {
@@ -559,7 +691,7 @@ mod tests {
             .await
             .expect("response");
         let result = &resp["result"];
-        assert!(result["tools"].as_array().is_some_and(|t| t.len() == 8));
+        assert!(result["tools"].as_array().is_some_and(|t| t.len() == 10));
         assert_eq!(result["resultType"], json!("complete"));
         assert_eq!(result["cacheScope"], json!("private"));
         assert!(result["ttlMs"].is_u64());

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -493,30 +493,30 @@ impl ZmcpServer {
         // Fleet mode: forward everything except get-ontology to the named
         // router's own one-shot server. The child validates the tool name
         // and arguments, so unknown tools still answer with a tool error.
-        if let Some(fleet) = &self.fleet {
-            if tool_name != "get-ontology" {
-                let mut arguments = arguments;
-                let router = match arguments.remove("router") {
-                    Some(Value::String(r)) => r,
-                    _ => {
-                        return tool_result(
-                            String::from(
-                                "Missing required 'router' argument: this server fronts a \
-                                 fleet, name the target router",
-                            ),
-                            true,
-                        );
-                    }
-                };
-                let forwarded = Value::Object(arguments.into_iter().collect());
-                return match fleet.call(&router, tool_name, forwarded).await {
-                    Ok(text) => tool_result(text, false),
-                    Err(e) => {
-                        error!("Fleet call failed: {}", e);
-                        tool_result(format!("Error: {}", e), true)
-                    }
-                };
-            }
+        if let Some(fleet) = &self.fleet
+            && tool_name != "get-ontology"
+        {
+            let mut arguments = arguments;
+            let router = match arguments.remove("router") {
+                Some(Value::String(r)) => r,
+                _ => {
+                    return tool_result(
+                        String::from(
+                            "Missing required 'router' argument: this server fronts a \
+                             fleet, name the target router",
+                        ),
+                        true,
+                    );
+                }
+            };
+            let forwarded = Value::Object(arguments.into_iter().collect());
+            return match fleet.call(&router, tool_name, forwarded).await {
+                Ok(text) => tool_result(text, false),
+                Err(e) => {
+                    error!("Fleet call failed: {}", e);
+                    tool_result(format!("Error: {}", e), true)
+                }
+            };
         }
 
         let result = match tool_name {

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -5,6 +5,7 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{debug, error, warn};
 
 use super::client::ZebraClient;
+use super::fleet::Fleet;
 use super::tools::commands::CommandsTool;
 use super::tools::config::ConfigTools;
 use super::tools::isis::IsisTools;
@@ -89,13 +90,23 @@ pub struct ZmcpServer {
     show_tool: ShowTool,
     commands_tool: CommandsTool,
     config_tools: ConfigTools,
-    /// Present only when the server was started with `--ontology <path>`;
-    /// the `get-ontology` tool is registered iff this is set.
+    /// Present only when the server was started with `--ontology <path>`
+    /// (or `--fleet`, whose file doubles as the ontology); the
+    /// `get-ontology` tool is registered iff this is set.
     ontology_tool: Option<OntologyTool>,
+    /// Fleet mode (`--fleet <path>`): every tool except `get-ontology`
+    /// gains a required `router` argument and is forwarded to a one-shot
+    /// per-router server inside that router's network namespace.
+    fleet: Option<Fleet>,
 }
 
 impl ZmcpServer {
-    pub fn new(base_url: String, port: u32, ontology_tool: Option<OntologyTool>) -> Self {
+    pub fn new(
+        base_url: String,
+        port: u32,
+        ontology_tool: Option<OntologyTool>,
+        fleet: Option<Fleet>,
+    ) -> Self {
         let zebra_client = ZebraClient::new(base_url, port);
         let isis_tools = IsisTools::new(zebra_client.clone());
         let ospf_tools = OspfTools::new(zebra_client.clone());
@@ -111,11 +122,16 @@ impl ZmcpServer {
             commands_tool,
             config_tools,
             ontology_tool,
+            fleet,
         }
     }
 
     pub fn zebra_client(&self) -> &ZebraClient {
         &self.zebra_client
+    }
+
+    pub fn fleet(&self) -> Option<&Fleet> {
+        self.fleet.as_ref()
     }
 
     pub async fn handle_request(&self, request: Value) -> Option<Value> {
@@ -241,6 +257,11 @@ impl ZmcpServer {
     }
 
     fn discover_result(&self) -> Value {
+        let instructions = if self.fleet.is_some() {
+            "Interface to a fleet of zebra-rs routing daemons; every tool except get-ontology takes a 'router' argument naming which one to talk to. Call list-show-commands to discover the read-only show commands and run them with the show tool. Read a router's configuration with get-config (format 'formal' is set-line syntax) and change it with apply-config, which validates and commits set/delete lines as one atomic transaction. get-ontology returns the operator's semantic metadata about the routers."
+        } else {
+            "Interface to a zebra-rs routing daemon. Call list-show-commands to discover the read-only show commands and run them with the show tool. Read the configuration with get-config (format 'formal' is set-line syntax) and change it with apply-config, which validates and commits set/delete lines as one atomic transaction."
+        };
         json!({
             "supportedVersions": supported_versions(),
             "capabilities": {
@@ -248,7 +269,7 @@ impl ZmcpServer {
                     "listChanged": false
                 }
             },
-            "instructions": "Interface to a zebra-rs routing daemon. Call list-show-commands to discover the read-only show commands and run them with the show tool. Read the configuration with get-config (format 'formal' is set-line syntax) and change it with apply-config, which validates and commits set/delete lines as one atomic transaction.",
+            "instructions": instructions,
             "ttlMs": CACHE_TTL_MS,
             "cacheScope": "private"
         })
@@ -430,6 +451,28 @@ impl ZmcpServer {
             .as_array_mut()
             .expect("tools is an array")
             .extend(extra_tools);
+
+        // Fleet mode: every tool that talks to a daemon needs to say which
+        // one, so inject a required `router` argument into each schema.
+        // get-ontology is served by the fleet server itself and stays as
+        // it is.
+        if let Some(fleet) = &self.fleet {
+            for tool in result["tools"].as_array_mut().expect("tools is an array") {
+                if tool["name"] == json!("get-ontology") {
+                    continue;
+                }
+                let schema = &mut tool["inputSchema"];
+                schema["properties"]["router"] = json!({
+                    "type": "string",
+                    "enum": fleet.routers(),
+                    "description": "Target router (also its network namespace name)."
+                });
+                match schema.get_mut("required") {
+                    Some(Value::Array(required)) => required.push(json!("router")),
+                    _ => schema["required"] = json!(["router"]),
+                }
+            }
+        }
         result
     }
 
@@ -446,6 +489,35 @@ impl ZmcpServer {
             .unwrap_or_default();
 
         debug!("Calling tool: {}", tool_name);
+
+        // Fleet mode: forward everything except get-ontology to the named
+        // router's own one-shot server. The child validates the tool name
+        // and arguments, so unknown tools still answer with a tool error.
+        if let Some(fleet) = &self.fleet {
+            if tool_name != "get-ontology" {
+                let mut arguments = arguments;
+                let router = match arguments.remove("router") {
+                    Some(Value::String(r)) => r,
+                    _ => {
+                        return tool_result(
+                            String::from(
+                                "Missing required 'router' argument: this server fronts a \
+                                 fleet, name the target router",
+                            ),
+                            true,
+                        );
+                    }
+                };
+                let forwarded = Value::Object(arguments.into_iter().collect());
+                return match fleet.call(&router, tool_name, forwarded).await {
+                    Ok(text) => tool_result(text, false),
+                    Err(e) => {
+                        error!("Fleet call failed: {}", e);
+                        tool_result(format!("Error: {}", e), true)
+                    }
+                };
+            }
+        }
 
         let result = match tool_name {
             "list-show-commands" => self.commands_tool.list_show_commands().await,
@@ -535,7 +607,14 @@ mod tests {
     use super::*;
 
     fn server() -> ZmcpServer {
-        ZmcpServer::new("127.0.0.1".to_string(), 2650, None)
+        ZmcpServer::new("127.0.0.1".to_string(), 2650, None, None)
+    }
+
+    /// A fleet server with a fixed roster (no daemon, no netns needed —
+    /// the tests below only exercise listing and argument validation).
+    fn fleet_server() -> ZmcpServer {
+        let fleet = Fleet::from_roster(vec!["tk".into(), "se".into()], "unix:zebra-rs/vty");
+        ZmcpServer::new("127.0.0.1".to_string(), 2650, None, Some(fleet))
     }
 
     /// A server with the ontology tool wired to a real temp file.
@@ -547,7 +626,7 @@ mod tests {
         std::fs::write(&path, r#"[{"name":"tk","region":"AP"}]"#).unwrap();
         let tool = OntologyTool::new(&path).unwrap();
         (
-            ZmcpServer::new("127.0.0.1".to_string(), 2650, Some(tool)),
+            ZmcpServer::new("127.0.0.1".to_string(), 2650, Some(tool), None),
             path,
         )
     }
@@ -613,6 +692,61 @@ mod tests {
         assert_eq!(result["isError"], json!(true));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("--ontology"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn fleet_tools_require_a_router_argument() {
+        let req = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        let resp = fleet_server().handle_request(req).await.expect("response");
+        for tool in resp["result"]["tools"].as_array().expect("tools array") {
+            let name = tool["name"].as_str().unwrap();
+            let schema = &tool["inputSchema"];
+            if name == "get-ontology" {
+                assert!(
+                    schema["properties"].get("router").is_none(),
+                    "get-ontology must stay router-less"
+                );
+                continue;
+            }
+            assert_eq!(
+                schema["properties"]["router"]["enum"],
+                json!(["tk", "se"]),
+                "{name} router enum"
+            );
+            assert!(
+                schema["required"]
+                    .as_array()
+                    .is_some_and(|r| r.contains(&json!("router"))),
+                "{name} must require router; schema: {schema}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn fleet_call_without_router_is_an_error() {
+        let result = fleet_server()
+            .handle_tool_call(json!({
+                "name": "show",
+                "arguments": {"command": "show version"}
+            }))
+            .await;
+        assert_eq!(result["isError"], json!(true));
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("'router'"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn fleet_call_rejects_unknown_router() {
+        let result = fleet_server()
+            .handle_tool_call(json!({
+                "name": "show",
+                "arguments": {"command": "show version", "router": "mars"}
+            }))
+            .await;
+        assert_eq!(result["isError"], json!(true));
+        let text = result["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("unknown router 'mars'"), "{text}");
+        assert!(text.contains("tk, se"), "{text}");
     }
 
     #[tokio::test]

--- a/vtyctl/src/mcp/tools/config.rs
+++ b/vtyctl/src/mcp/tools/config.rs
@@ -1,0 +1,210 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::debug;
+
+use crate::mcp::client::ZebraClient;
+
+/// Serializations `get-config` can return. `formal` leads because it is the
+/// round-trip format: the same `set ...` line syntax `apply-config` consumes.
+const FORMATS: &[&str] = &["formal", "cli", "json", "yaml"];
+
+/// Configuration tools: read the running configuration and apply changes.
+///
+/// `apply-config` is the MCP server's only write surface. It forwards
+/// explicit `set` / `delete` lines to the daemon's Apply service, which
+/// validates and commits them as one transaction — on any error the whole
+/// candidate is discarded and nothing is applied. The service also accepts
+/// whole YAML/JSON documents, but those REPLACE the entire running
+/// configuration, so this tool refuses anything that is not a set/delete
+/// line rather than let a stray document line trigger a full replace.
+#[derive(Clone)]
+pub struct ConfigTools {
+    client: ZebraClient,
+}
+
+impl ConfigTools {
+    pub fn new(client: ZebraClient) -> Self {
+        Self { client }
+    }
+
+    /// `get-config`: the running configuration in the requested
+    /// serialization (default `formal`).
+    pub async fn get_config(&self, args: HashMap<String, Value>) -> Result<String> {
+        let format = match args.get("format") {
+            None => "formal",
+            Some(v) => v
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("'format' must be a string"))?,
+        };
+        if !FORMATS.contains(&format) {
+            return Err(anyhow::anyhow!(
+                "'format' must be one of formal, cli, json, yaml; got '{}'",
+                format
+            ));
+        }
+
+        // The bare command is the CLI-block rendering; the other formats
+        // are selected by a trailing keyword.
+        let command = if format == "cli" {
+            String::from("show running-config")
+        } else {
+            format!("show running-config {}", format)
+        };
+
+        debug!("Fetching running config: {}", command);
+        let output = self.client.show_command(&command, false).await?;
+        if output.trim().is_empty() {
+            Ok(String::from("(empty configuration)"))
+        } else {
+            Ok(output)
+        }
+    }
+
+    /// `apply-config`: validate the line shape client-side, then hand the
+    /// lines to the daemon's transactional Apply service.
+    pub async fn apply_config(&self, args: HashMap<String, Value>) -> Result<String> {
+        let lines = parse_config_lines(args.get("commands"))?;
+        debug!("Applying {} config line(s)", lines.len());
+        self.client.apply_config(&lines).await
+    }
+}
+
+/// Validate the `commands` argument: a non-empty array of strings, each a
+/// single `set ...` or `delete ...` line. Anything else is rejected here,
+/// before it reaches the daemon's format sniffer (see the type-level
+/// comment for why that matters).
+fn parse_config_lines(value: Option<&Value>) -> Result<Vec<String>> {
+    let items = value.and_then(|v| v.as_array()).ok_or_else(|| {
+        anyhow::anyhow!("Missing required 'commands' argument (an array of strings)")
+    })?;
+    if items.is_empty() {
+        return Err(anyhow::anyhow!("'commands' must not be empty"));
+    }
+
+    let mut lines = Vec::with_capacity(items.len());
+    for (i, item) in items.iter().enumerate() {
+        let line = item.as_str().map(str::trim).unwrap_or("");
+        if line.is_empty() {
+            return Err(anyhow::anyhow!(
+                "commands[{}] must be a non-empty string",
+                i
+            ));
+        }
+        if line.contains('\n') {
+            return Err(anyhow::anyhow!(
+                "commands[{}] contains a newline; pass one command per array element",
+                i
+            ));
+        }
+        let mut tokens = line.split_whitespace();
+        let verb = tokens.next().unwrap_or("");
+        if !(verb == "set" || verb == "delete") || tokens.next().is_none() {
+            return Err(anyhow::anyhow!(
+                "commands[{}] must be a 'set ...' or 'delete ...' line; got '{}'",
+                i,
+                line
+            ));
+        }
+        lines.push(line.to_string());
+    }
+    Ok(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tool() -> ConfigTools {
+        ConfigTools::new(ZebraClient::new("127.0.0.1".to_string(), 2650))
+    }
+
+    fn args(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn get_config_rejects_unknown_format() {
+        let err = tool()
+            .get_config(args(&[("format", json!("xml"))]))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be one of"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn get_config_rejects_non_string_format() {
+        let err = tool()
+            .get_config(args(&[("format", json!(42))]))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be a string"), "{err}");
+    }
+
+    #[test]
+    fn accepts_set_and_delete_lines() {
+        let lines = parse_config_lines(Some(&json!([
+            "set routing isis net 49.0000.0000.0001.00",
+            "  delete interface lo shutdown  ",
+        ])))
+        .unwrap();
+        assert_eq!(
+            lines,
+            vec![
+                "set routing isis net 49.0000.0000.0001.00".to_string(),
+                "delete interface lo shutdown".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_commands() {
+        for value in [None, Some(json!("set x y")), Some(json!({}))] {
+            let err = parse_config_lines(value.as_ref()).unwrap_err().to_string();
+            assert!(err.contains("array of strings"), "{value:?}: {err}");
+        }
+        let err = parse_config_lines(Some(&json!([])))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn rejects_lines_that_are_not_set_or_delete() {
+        for bad in [
+            "configure terminal",
+            "interface: {}",
+            "settle down",
+            "set",
+            "delete",
+            "show running-config",
+        ] {
+            let err = parse_config_lines(Some(&json!([bad])))
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("'set ...' or 'delete ...'"), "{bad}: {err}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_string_and_blank_elements() {
+        for bad in [json!([42]), json!([""]), json!(["   "]), json!([null])] {
+            let err = parse_config_lines(Some(&bad)).unwrap_err().to_string();
+            assert!(err.contains("non-empty string"), "{bad}: {err}");
+        }
+    }
+
+    #[test]
+    fn rejects_embedded_newlines() {
+        let err = parse_config_lines(Some(&json!(["set system hostname x\nkey: value"])))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("one command per array element"), "{err}");
+    }
+}

--- a/vtyctl/src/mcp/tools/mod.rs
+++ b/vtyctl/src/mcp/tools/mod.rs
@@ -1,4 +1,6 @@
 pub mod commands;
+pub mod config;
 pub mod isis;
+pub mod ontology;
 pub mod ospf;
 pub mod show;

--- a/vtyctl/src/mcp/tools/ontology.rs
+++ b/vtyctl/src/mcp/tools/ontology.rs
@@ -1,0 +1,74 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Serves the operator-provided network ontology file to MCP clients:
+/// semantic metadata about the routers (short name, full name, region,
+/// coordinates, ...) that the routing protocols do not carry. Only
+/// registered when `vtyctl mcp --ontology <path>` names a file.
+#[derive(Clone, Debug)]
+pub struct OntologyTool {
+    path: PathBuf,
+}
+
+impl OntologyTool {
+    /// Validate the file up front (readable, valid JSON) so a bad path
+    /// fails at server start rather than at the first tool call.
+    pub fn new(path: &Path) -> Result<Self> {
+        let tool = Self {
+            path: path.to_path_buf(),
+        };
+        tool.read()?;
+        Ok(tool)
+    }
+
+    /// Read the ontology fresh on every call, so edits to the file are
+    /// visible without restarting the server.
+    pub fn read(&self) -> Result<String> {
+        let text = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("cannot read ontology file {}", self.path.display()))?;
+        let parsed: serde_json::Value = serde_json::from_str(&text)
+            .with_context(|| format!("ontology file {} is not valid JSON", self.path.display()))?;
+        Ok(serde_json::to_string_pretty(&parsed)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_file(name: &str, content: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "vtyctl-ontology-{}-{}.json",
+            name,
+            std::process::id()
+        ));
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn round_trips_valid_json() {
+        let path = temp_file("valid", r#"[{"name":"tk","region":"AP"}]"#);
+        let tool = OntologyTool::new(&path).unwrap();
+        let text = tool.read().unwrap();
+        std::fs::remove_file(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed[0]["region"], serde_json::json!("AP"));
+    }
+
+    #[test]
+    fn rejects_missing_file_at_construction() {
+        let err = OntologyTool::new(Path::new("/nonexistent/ontology.json"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("cannot read ontology file"), "{err}");
+    }
+
+    #[test]
+    fn rejects_invalid_json_at_construction() {
+        let path = temp_file("invalid", "name: tk\nregion: AP\n");
+        let err = OntologyTool::new(&path).unwrap_err().to_string();
+        std::fs::remove_file(&path).unwrap();
+        assert!(err.contains("not valid JSON"), "{err}");
+    }
+}

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -92,6 +92,7 @@ assets = [
   # again — that check is what caught it.
   ["../packaging/out/playset/**/[u]p.sh",        "usr/share/zebra-rs/playset/",     "755"],
   ["../packaging/out/playset/**/[d]own.sh",      "usr/share/zebra-rs/playset/",     "755"],
+  ["../packaging/out/playset/**/[m]cp.sh",       "usr/share/zebra-rs/playset/",     "755"],
   ["../packaging/out/playset/**/[t]opology.sh",  "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/[c]ommon.sh",    "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/[n]etns.sh",     "usr/share/zebra-rs/playset/",     "644"],


### PR DESCRIPTION
## Summary

Phases B and C of the AI & Ontology demo (baseline playset landed in
#2290): give MCP clients a write path and make a whole multi-router lab
reachable from a single Claude Desktop connector entry.

**Config + ontology tools (`5c9f3c82`)**
- `apply-config` — the server's single write surface. Forwards explicit
  `set ...` / `delete ...` lines to the daemon's Apply service, which
  validates and commits them as one atomic transaction; on any error
  nothing is applied and the offending line is returned so the caller
  can self-correct. Non-set/delete lines are refused client-side (a
  stray document line would otherwise trigger the format sniffer's
  whole-config replace). Admin gating rides the VTY session model
  (uid-0 sessions hold the role automatically).
- `get-config` — running configuration as `formal` (default; the same
  set-line syntax apply-config consumes), `cli`, `json`, or `yaml`.
- `get-ontology` — operator's semantic router metadata from the file
  named by the new `vtyctl mcp --ontology <path>` flag; registered only
  when given, fail-fast on a bad file.

**Fleet mode (`86b8f715`)**
- `vtyctl mcp --fleet <ontology.json>` — one stdio server fronting the
  whole roster (entry `name` = netns, the playset convention). Every
  tool except `get-ontology` gains a required `router` argument whose
  schema enumerates the roster; calls are forwarded to a one-shot
  `ip netns exec <router> vtyctl mcp` child, the spawn-per-call pattern
  proven in ai/topology. The fleet file doubles as the ontology.
- `playset/isis-flexalgo-ai/mcp.sh` — Claude Desktop entry point, with
  the connector JSON, ssh-stdio variant, and sudoers line in its header;
  the playset README documents the wiring.
- Book ch-13: three new catalog rows, the read-only contract rewritten
  around the single write surface, and a fleet-mode section.

## Test plan

- 52 vtyctl unit tests (line validation, roster parsing, forwarded
  response extraction, fleet schema injection, router validation).
- `cargo test --workspace --exclude bdd`, workspace clippy and fmt clean.
- Live on playset/isis-flexalgo-ai: the full FlexAlgo 128 configuration
  applied to all 11 routers through `apply-config` alone reproduces the
  hand-written playset's algorithm-128 route table exactly; a batch with
  one bad line applies nothing.
- Live through `mcp.sh` as one long-lived process driven like Claude
  Desktop: 12/12 checks — tools/list with the 11-router enum,
  show/get-config/apply-config across three routers, commit-then-revert,
  daemon parse error surfaced through the fleet, unknown/missing router
  rejected without spawning.

Generated with [Claude Code](https://claude.com/claude-code)