### PR TITLE
docs: AI & Ontology demo runbook + book chapter

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -164,6 +164,7 @@
 
 - [Native MCP Server](ch-13-00-mcp-server.md)
   - [3D Traffic Path Visualizer](ch-13-01-topology-viewer.md)
+  - [AI-Designed Flex-Algorithm](ch-13-02-flexalgo-ai-demo.md)
 
 ## Logging and Monitoring
 

--- a/book/src/ch-13-00-mcp-server.md
+++ b/book/src/ch-13-00-mcp-server.md
@@ -103,6 +103,11 @@ committing configuration through `apply-config` (root sessions hold the
 admin role automatically). Started unprivileged, it goes through
 `sudo -n` for each forwarded call.
 
+Fleet mode plus the configuration tools is what powers the
+[AI-Designed Flex-Algorithm](ch-13-02-flexalgo-ai-demo.md) demonstration:
+one Claude Desktop connector, eleven routers, and a single sentence of
+intent turned into committed configuration.
+
 ## Current protocol, older clients welcome
 
 The server speaks the stateless [MCP 2026-07-28

--- a/book/src/ch-13-02-flexalgo-ai-demo.md
+++ b/book/src/ch-13-02-flexalgo-ai-demo.md
@@ -1,0 +1,111 @@
+# AI-Designed Flex-Algorithm
+
+Everything in the two previous sections comes together in one
+demonstration: an AI assistant designs, deploys, and verifies an IS-IS
+Flexible Algorithm (RFC 9350) on a running eleven-router network — from a
+single sentence of operator intent.
+
+The division of labor is the interesting part:
+
+* the **operator** states intent: *"constrained traffic must never cross
+  a trans-Pacific link"*;
+* the **ontology** supplies meaning: which router is in which region —
+  knowledge the routing protocols do not carry;
+* the **IGP** supplies topology: the live link-state graph;
+* the **assistant** turns the three into committed device configuration,
+  through the same MCP tools an operator's scripts would use.
+
+No part of the answer is scripted. The assistant has to derive which
+links cross the Pacific by joining the ontology's regions against the
+IS-IS graph, read each router's running configuration to find interface
+names and an unused SID index block, author the four configuration parts
+(affinity-map, link coloring, the algorithm definition, per-loopback
+algorithm SIDs), commit them router by router, and prove the result.
+
+## The lab
+
+[`playset/isis-flexalgo-ai`](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-flexalgo-ai)
+is an eleven-node global backbone (US, EU, and AP regions) running plain
+IS-IS with SR-MPLS — deliberately stripped of every trace of
+Flex-Algorithm configuration. Its sibling
+[`playset/isis-flexalgo`](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-flexalgo)
+is the same network with the Flex-Algorithm hand-written: the answer key
+the AI's work can be compared against.
+
+`ontology.json` describes each router — short name, full name, region —
+and doubles as the fleet roster:
+
+``` json
+{ "name": "tk", "full-name": "Tokyo", "region": "AP" }
+```
+
+## The wiring
+
+One connector entry gives the assistant the whole lab. The playset's
+`mcp.sh` starts `vtyctl mcp --fleet ontology.json` (self-elevating via
+`sudo -n`), and Claude Desktop points at it:
+
+``` json
+{
+  "mcpServers": {
+    "zebra-fleet": {
+      "command": "/path/to/zebra-rs/playset/isis-flexalgo-ai/mcp.sh"
+    }
+  }
+}
+```
+
+Every tool takes a `router` argument; `apply-config` commits each
+router's changes as one atomic transaction, and a rejected line costs
+nothing — the daemon reports it, and the assistant corrects itself.
+
+## The arc
+
+With the lab up (`./up.sh`) and the connector configured, the operator
+pastes a goal-level prompt — the full recommended text lives in the
+[playset README](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-flexalgo-ai#the-prompt)
+— and watches the tool-call stream:
+
+1. `get-ontology` → three regions.
+2. `get-isis-graph` → seventeen links, of which exactly three join a US
+   router to an AP router: `se–sg`, `sj–tk`, `sj–sy`.
+3. `get-config` per router → interface names, and algorithm-0 SID
+   indexes 100..1100, so the new per-algorithm SIDs need a disjoint
+   block.
+4. `apply-config` × 11 → affinity-map, both ends of the three links
+   colored `trans-pacific`, `flex-algo 128` with
+   `exclude-any: trans-pacific` (advertised by at least two routers),
+   and a second loopback prefix-SID per router.
+5. `get-isis-flex-algo`, `get-isis-spf algorithm=128` → all eleven
+   routers participate, and Tokyo reaches Seattle via Singapore,
+   Frankfurt, and Chicago — never touching the Pacific.
+
+The network converges within seconds of the last commit. On the
+[3D topology viewer](ch-13-01-topology-viewer.md), the Algorithm
+selector — which offered only `0 — SPF` against the baseline — now
+lists `128 — exclude-any: trans-pacific`, and selecting it swings the
+Tokyo-to-Seattle path the long way around the globe.
+
+## Why this works
+
+Three properties of the MCP surface carry the demo:
+
+* **Round-trip syntax.** `get-config` format `formal` returns the
+  configuration as `set ...` lines — exactly what `apply-config`
+  consumes. The assistant learns the configuration grammar from the
+  device itself and writes changes in the same dialect.
+* **Atomic, self-describing failure.** The Apply transaction either
+  commits everything or nothing, and the error names the offending
+  line. Trial and error is safe, so the assistant can be wrong once
+  and right the second time without ever leaving the network in a
+  half-configured state.
+* **Semantics live beside the network.** The ontology is data the IGP
+  cannot know. Serving it through the same MCP server the routers live
+  behind is what lets a single prompt say "trans-Pacific" and mean
+  three specific links.
+
+The encore writes itself: ask the assistant to remove everything it
+added — configuration delete through the same tools — or to add a
+second algorithm with the opposite constraint. And `./down.sh && ./up.sh`
+always rebuilds the pristine baseline, because the committed changes
+live only in the running daemons, not in the yaml files they boot from.

--- a/playset/isis-flexalgo-ai/README.md
+++ b/playset/isis-flexalgo-ai/README.md
@@ -143,6 +143,8 @@ visually: started against this playset, its Algorithm selector offers only
 
 ## Stage 2: let the AI build the FlexAlgo
 
+### The wiring
+
 The assistant works through the zebra-rs MCP server. `./mcp.sh` starts it
 in **fleet mode** (`vtyctl mcp --fleet ontology.json`): one stdio server
 fronting all eleven routers, where every tool takes a `router` argument
@@ -172,8 +174,71 @@ enter the namespaces and to commit configuration, so grant passwordless
 sudo for the vtyctl binary — the header of `mcp.sh` has the exact
 sudoers line.
 
-The end state to expect is the hand-written playset next door. When the AI
-has done its job:
+### The prompt
+
+The point of the demo is that the operator supplies *intent*, not
+configuration — but a live demo also wants a predictable arc, so the
+recommended prompt states the goal, names the mechanism, and leaves every
+interesting decision (which links, which interfaces, which SID indexes,
+what to put on each of the eleven routers) to the assistant:
+
+> You are operating a network lab through the zebra-fleet MCP server: an
+> eleven-router IS-IS + SR-MPLS backbone. `get-ontology` tells you each
+> router's name, full name and region.
+>
+> New compliance requirement: a class of constrained traffic must never
+> cross a trans-Pacific link — between the US and AP regions this
+> traffic has to travel the other way around, via Europe.
+>
+> Implement this with an IS-IS Flexible Algorithm (algorithm 128, IGP
+> metric, SR-MPLS data plane):
+>
+> 1. Work out from the ontology and the live IS-IS topology which links
+>    cross the Pacific. Do not ask me — derive it.
+> 2. Extract the running configuration of the routers and generate the
+>    changes: a shared affinity-map, coloring on both ends of each
+>    trans-Pacific link, the algorithm definition with its constraint
+>    (advertised by at least two routers), and a second loopback
+>    prefix-SID per router for algorithm 128 that does not collide with
+>    the existing SID indexes.
+> 3. Apply and commit the changes on every router with `apply-config`.
+> 4. Verify your own work: all eleven routers must participate in
+>    algorithm 128, and Tokyo must reach Seattle without touching a
+>    trans-Pacific link. Show me Tokyo's algorithm-128 paths before you
+>    declare success.
+
+For a braver run, compress it to pure intent and watch the assistant
+work out the rest itself:
+
+> Constrained traffic may not cross trans-Pacific links. Design and
+> deploy an IS-IS Flex-Algorithm on every router of this lab that
+> enforces it, then prove it worked.
+
+### What to watch
+
+The tool-call stream in Claude Desktop *is* the demo. The expected arc:
+
+1. `get-ontology` — the assistant learns `se..at` are US, `ln`/`fr` are
+   EU, `sg`/`sy`/`tk` are AP.
+2. `get-isis-graph` on some router — seventeen links; exactly three
+   connect a US name to an AP name: `se–sg`, `sj–tk`, `sj–sy`.
+3. `get-config` per router — current interface names and the algorithm-0
+   SID indexes 100..1100 (so a disjoint block, e.g. +2000, is needed).
+4. `apply-config` — eleven calls, one atomic commit per router:
+   affinity-map, `affinity trans-pacific` on both ends of the three
+   links, the `flex-algo 128` definition with `exclude-any`, and a
+   `flex-algo-prefix-sid` per loopback. A wrong line costs nothing:
+   the whole batch is discarded and the error names the offending
+   line, so the assistant corrects itself and retries.
+5. `get-isis-flex-algo` / `get-isis-spf algorithm=128` — self-check:
+   participation `[0, 128]` on all eleven, and Tokyo's constrained
+   paths run through Singapore and Frankfurt.
+
+IS-IS floods and converges within a few seconds of the last commit.
+
+### Check the result yourself
+
+The end state to expect is the hand-written playset next door:
 
 ``` shell
 tk>show isis flex-algo
@@ -188,9 +253,30 @@ tk>show isis flex-algo 128 route
 must show **every** US destination leaving Tokyo via `tk-sg` (Singapore)
 — the long way round through Asia and Europe — while `show ip route`
 keeps using the direct Pacific crossing. The
-[isis-flexalgo README](../isis-flexalgo/README.md) walks through all of
-the verification detail, down to pushing the algorithm-128 label and
-proving the path with TTLs.
+[3D topology viewer](../../ai/topology/README.md) shows the same moment
+visually: refresh it and the Algorithm selector now offers
+`128 — exclude-any: trans-pacific`; select it and the Tokyo-to-Seattle
+path swings the long way around the globe. For the deepest proof — real
+packets steered by the algorithm-128 label, verified hop by hop with
+TTLs — follow the
+[isis-flexalgo README](../isis-flexalgo/README.md), whose walkthrough
+applies verbatim once the AI has built the same configuration.
+
+### Encore, and resetting
+
+Two follow-ups that make good encores, both pure prompt work:
+
+* *"Now remove everything you added and prove the network is back to
+  algorithm 0 only."* — configuration delete through the same
+  `apply-config`, and the cleanest way to reset between runs.
+* *"Add algorithm 129 that must **stay on** trans-Pacific links
+  (include-any) with its own SID block."* — a second constraint class
+  over the same links.
+
+For a guaranteed clean slate, `./down.sh && ./up.sh` rebuilds the
+baseline from the yaml files in a few seconds — nothing the assistant
+commits survives a restart, because the daemons load their startup
+configuration from `<node>.yaml`.
 
 ``` shell
 $ ./down.sh


### PR DESCRIPTION
## Summary

Phase D — the final piece of the AI & Ontology demo (#2290 baseline
playset, #2291 MCP config tools + fleet mode). Docs only.

- **Playset runbook** (`playset/isis-flexalgo-ai/README.md` stage 2):
  the recommended goal-level demo prompt (states the intent and the
  mechanism; leaves trans-Pacific link derivation, interface names,
  SID planning, and per-router configuration to the assistant) plus a
  pure-intent variant; the expected five-step tool-call arc with the
  atomic-failure self-correction property spelled out; operator-side
  verification including the topology-viewer moment; encores
  (revert-by-prompt as the between-runs reset, an include-any
  algorithm 129) and `down.sh && up.sh` as the guaranteed clean slate.
- **Book**: new ch-13-02 "AI-Designed Flex-Algorithm" under AI Native —
  the operator/ontology/IGP/assistant division of labor, the wiring,
  the arc, and why the MCP surface carries it (round-trip set-line
  syntax, atomic self-describing failure, semantics served beside the
  network). Linked from SUMMARY and from ch-13-00's fleet section.

## Test plan

- `mdbook build` passes with the new chapter and SUMMARY entry.
- Runbook steps mirror the live end-to-end verification done in #2291
  (full FlexAlgo 128 rollout over apply-config on all 11 routers).

Generated with [Claude Code](https://claude.com/claude-code)