### PR TITLE
docs: ssh-stdio Claude Desktop connector for the fleet server

### DIFF
--- a/book/src/ch-13-02-flexalgo-ai-demo.md
+++ b/book/src/ch-13-02-flexalgo-ai-demo.md
@@ -55,6 +55,13 @@ One connector entry gives the assistant the whole lab. The playset's
 }
 ```
 
+When Claude Desktop runs on a different machine than the lab — a Mac in
+front of a Linux VM, say — the same connector rides over ssh, which
+carries the MCP stdio stream unchanged (`"command": "ssh"` with args
+`-T -o BatchMode=yes user@lab-host .../mcp.sh`); the
+[playset README](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-flexalgo-ai#the-wiring)
+has the full recipe.
+
 Every tool takes a `router` argument; `apply-config` commits each
 router's changes as one atomic transaction, and a rejected line costs
 nothing — the daemon reports it, and the assistant corrects itself.

--- a/playset/isis-flexalgo-ai/README.md
+++ b/playset/isis-flexalgo-ai/README.md
@@ -156,7 +156,8 @@ graph and SPF (`get-isis-graph`, `get-isis-spf`), and apply and commit
 configuration (`apply-config` — atomic per router: on any error nothing
 is applied and the offending line is returned).
 
-Connect Claude Desktop by adding to `claude_desktop_config.json`:
+When Claude Desktop runs **on the lab host itself**, connect it by
+adding to `claude_desktop_config.json`:
 
 ``` json
 {
@@ -168,11 +169,40 @@ Connect Claude Desktop by adding to `claude_desktop_config.json`:
 }
 ```
 
-(or `"command": "ssh", "args": ["-T", "user@lab-host", ".../mcp.sh"]`
-when Claude Desktop runs on another machine). The server needs root to
+When it runs **on another machine** — the typical case: Claude Desktop
+on a Mac, the lab in a Linux VM or server — bridge the connector over
+ssh, which carries the MCP stdio stream unchanged:
+
+``` json
+{
+  "mcpServers": {
+    "zebra-fleet": {
+      "command": "ssh",
+      "args": [
+        "-T",
+        "-o", "BatchMode=yes",
+        "user@lab-host",
+        "/path/to/zebra-rs/playset/isis-flexalgo-ai/mcp.sh"
+      ]
+    }
+  }
+}
+```
+
+On macOS the config file is
+`~/Library/Application Support/Claude/claude_desktop_config.json`;
+restart Claude Desktop after editing it, and the `zebra-fleet` server
+with its tools appears under the connectors. `-T` keeps the channel a
+plain pipe rather than a terminal, and `BatchMode=yes` makes ssh fail
+fast instead of hanging on a password prompt — so authentication must
+be by key (the usual `ssh-copy-id` setup).
+
+Two requirements on the lab host either way: the server needs root to
 enter the namespaces and to commit configuration, so grant passwordless
-sudo for the vtyctl binary — the header of `mcp.sh` has the exact
-sudoers line.
+sudo for the vtyctl binary (the header of `mcp.sh` has the exact
+sudoers line), and for the ssh variant its sshd must be reachable from
+the Desktop machine. The connector starts even while the lab is down —
+tool calls simply return errors until `./up.sh` has run.
 
 ### The prompt
 

--- a/playset/isis-flexalgo-ai/mcp.sh
+++ b/playset/isis-flexalgo-ai/mcp.sh
@@ -13,10 +13,13 @@
 #     }
 #   }
 #
-# If Claude Desktop runs on another machine, wrap it in ssh instead:
+# If Claude Desktop runs on another machine (e.g. a Mac), wrap it in
+# ssh instead — key-based auth required, BatchMode makes a missing key
+# fail fast instead of hanging on a password prompt:
 #
 #   "command": "ssh",
-#   "args": ["-T", "user@lab-host", "/path/to/.../mcp.sh"]
+#   "args": ["-T", "-o", "BatchMode=yes", "user@lab-host",
+#            "/path/to/.../mcp.sh"]
 #
 # The server runs as root (it must enter the routers' namespaces, and
 # committing configuration requires an admin session, which root holds


### PR DESCRIPTION
## Summary

Follow-up to #2292: the typical demo setup is Claude Desktop on a Mac
with the lab in a Linux VM or server, so document that variant properly
instead of a one-line aside.

- Playset README wiring section: both connector variants as full JSON
  blocks — local, and the ssh-stdio bridge (`-T` keeps the channel a
  plain pipe, `BatchMode=yes` fails fast on missing key auth) — plus
  the macOS config file path and the lab-host requirements (NOPASSWD
  sudo for vtyctl, reachable sshd). Notes that the connector starts
  even while the lab is down, tool calls simply erroring until up.sh.
- mcp.sh header and book ch-13-02 synced to the same form.

## Test plan

- Verified live over a real ssh hop: `ssh -T -o BatchMode=yes` into the
  lab host running mcp.sh (throwaway key, non-interactive session)
  answers tools/list with all 11 fleet tools — proving `sudo -n` works
  without a tty and the MCP stdio stream survives the bridge.
- `mdbook build` passes.

Generated with [Claude Code](https://claude.com/claude-code)