### PR TITLE
bgp: neighbor-group vpnv4/LU enable also warms up the label block

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7774,6 +7774,67 @@ mod neighbor_group_wiring_tests {
         );
     }
 
+    /// The group-level `afi-safi <family> enabled` statement does the
+    /// same eager label-block warm-up as the per-neighbor one — a
+    /// transit ASBR whose vpnv4 comes entirely from a group opinion
+    /// used to never request a block at all — and with the same
+    /// at-most-one guard: once a block is bound, further statements
+    /// (group or per-peer) must not draw more.
+    #[tokio::test]
+    async fn group_vpnv4_afi_safi_requests_at_most_one_label_block() {
+        let (mut bgp, mut rib_rx) = fresh_bgp_with_rib_rx();
+
+        // First group vpnv4 opinion, no block bound yet: request.
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "vpnv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            drain_label_block_requests(&mut rib_rx).len(),
+            1,
+            "first group vpnv4 statement must request a label block",
+        );
+
+        // Another group's opinion while the request is outstanding
+        // dedups on the pending flag.
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["H", "vpnv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(
+            drain_label_block_requests(&mut rib_rx).is_empty(),
+            "a group statement with a request outstanding must not re-request",
+        );
+
+        // After the grant lands, neither a group nor a per-peer vpnv4
+        // statement may draw another block.
+        bgp.process_rib_msg(crate::rib::api::RibRx::LabelBlock {
+            start: 16,
+            size: 1024,
+        });
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["I", "vpnv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_afi_safi(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "vpnv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(
+            drain_label_block_requests(&mut rib_rx).is_empty(),
+            "statements after the grant must not draw another block",
+        );
+    }
+
     /// Deleting one group afi-safi entry (or the whole group) drops
     /// its opinions and the member falls back to the built-in default
     /// plus its own statements.

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -341,6 +341,7 @@ pub fn config_neighbor_group_afi_safi_enabled(
     let name = args.string()?;
     let family: AfiSafi = args.afi_safi()?;
     let group = bgp.neighbor_groups.entry(name.clone()).or_default();
+    let mut label_block_needed = false;
     match op {
         ConfigOp::Set => {
             let enabled = args.boolean()?;
@@ -348,6 +349,7 @@ pub fn config_neighbor_group_afi_safi_enabled(
             for fam in mp_family_expand(family) {
                 group.afi_safi.entry(fam).or_default().enabled = enabled;
             }
+            label_block_needed = enabled && matches!(family.safi, Safi::MplsLabel | Safi::MplsVpn);
         }
         ConfigOp::Delete => {
             // `enabled` is the entry's mandatory core: dropping it
@@ -359,6 +361,14 @@ pub fn config_neighbor_group_afi_safi_enabled(
             }
         }
         _ => return Some(()),
+    }
+    // Enabling a Labeled-Unicast or VPN family on the group needs the
+    // same dynamic label-block warm-up as the per-neighbor statement
+    // (`config_afi_safi`): a transit ASBR whose vpnv4 comes entirely
+    // from a group opinion would otherwise never request a block. Same
+    // guard — ask only while no block is bound yet.
+    if label_block_needed && bgp.vrf_label_alloc.is_none() {
+        bgp.request_label_block();
     }
     sweep_group_afi_safi(bgp, &name);
     Some(())


### PR DESCRIPTION
## Summary

Follow-up to #2294. The per-neighbor afi-safi handler eagerly requests the dynamic MPLS label block on a vpnv4/labeled-unicast `enabled` statement, but the group-level handler (`config_neighbor_group_afi_safi_enabled`) never did — a transit ASBR whose VPN family comes entirely from a neighbor-group opinion would never request a block and originate label-less until some other consumer asked for one.

Mirror the warm-up on the group path, under the same at-most-one guard introduced in #2294 (`vrf_label_alloc.is_none()`), so no configuration shape — group, per-peer, or mixed — can draw more than one warm-up block.

## Test plan

- New regression test `group_vpnv4_afi_safi_requests_at_most_one_label_block`: exactly one request on the first group vpnv4 opinion; no re-request while it is outstanding; after the grant lands, neither a further group statement nor a per-peer vpnv4 statement draws another block. Verified red-first: with the fix stashed it fails on "first group vpnv4 statement must request a label block".
- `cargo test -p zebra-rs --bin zebra-rs`: 2034 passed, 0 failed.
- `cargo fmt` and workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)