### PR TITLE
vty: --vty-socket on the shell and clients, filesystem UDS transport

### DIFF
--- a/book/src/ch-00-05-command-line-options.md
+++ b/book/src/ch-00-05-command-line-options.md
@@ -16,7 +16,7 @@ this chapter explains what each option does and how they interact.
 | `--log-format` | | `terminal \| json \| elasticsearch` | `terminal` | Log record serialization |
 | `--no-nhid` | | — | off | Embed nexthops in routes instead of using nexthop IDs (kernels < 5.3) |
 | `--pid-file` | | `PATH` | `/var/run/zebra-rs.pid` (daemon mode) | Write the process ID to this file |
-| `--vty-socket` | | `unix:NAME \| tcp:HOST:PORT` | `unix:zebra-rs/vty` | Management (VTY gRPC) listen address |
+| `--vty-socket` | | `unix:NAME \| unix:/PATH \| tcp:HOST:PORT` | `unix:zebra-rs/vty` | Management (VTY gRPC) listen address |
 
 ## `-c`, `--config-file FILENAME`
 
@@ -123,10 +123,15 @@ managers and for the test harness to locate and stop the daemon. In
 ## `--vty-socket ADDRESS`
 
 Sets the address the management interface (the VTY gRPC server that
-`vtyctl` connects to) listens on. Two forms are accepted:
+`vtyctl` connects to) listens on. Three forms are accepted:
 
 - `unix:NAME` — a Linux abstract unix-domain socket (the default,
   `unix:zebra-rs/vty`).
+- `unix:/PATH` — a filesystem unix-domain socket; a name starting with
+  `/` selects this form. A stale socket file left by a dead daemon is
+  removed and rebound; a live one refuses startup, matching the
+  abstract socket's `EADDRINUSE`. `unix:@NAME` forces the abstract
+  interpretation even when NAME starts with `/`.
 - `tcp:HOST:PORT` — a TCP endpoint.
 
 Running several daemons on one host — for example in test namespaces —

--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -139,9 +139,10 @@ that is combined with `--port` (the historical form).
 
 | Option | Default | Notes |
 |---|---|---|
-| `--host <URI>` (alias `--vty-socket`) | `unix:zebra-rs/vty` | Server endpoint URI |
+| `--vty-socket <URI>` | `unix:zebra-rs/vty` | Global; usable before or after the subcommand |
+| `--host <URI>` (per subcommand) | — | Back-compat override; wins over `--vty-socket` |
 
-`--host` / `--vty-socket` accepts:
+Both accept:
 
 - `unix:NAME` — abstract Unix socket
 - `unix:/PATH` — filesystem Unix socket
@@ -158,7 +159,9 @@ vtyctl show 'show ip route'
 # Inside a netns
 ip netns exec vrf-red vtyctl show 'show ip route'
 
-# Filesystem socket, daemon syntax
+# Filesystem socket, daemon syntax — flag valid on either side
+# of the subcommand
+vtyctl --vty-socket unix:/tmp/zebra-rs show 'show ip route'
 vtyctl show --vty-socket unix:/tmp/zebra-rs 'show ip route'
 
 # Remote TCP

--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -19,6 +19,7 @@ programmatic or remote access.
 | Transport | URI form | When to use |
 |---|---|---|
 | Abstract Unix socket (default) | `unix:NAME` | Local management; per-netns isolation |
+| Filesystem Unix socket | `unix:/PATH` | Local management; visible socket file, container bind-mounts |
 | TCP | `tcp:HOST:PORT` | Remote/programmatic access (opt-in) |
 
 ### Abstract Unix sockets
@@ -43,11 +44,33 @@ Two zebra-rs instances in the same netns trying to bind the same
 abstract name produces `EADDRINUSE` — this is a configuration error
 and the second daemon fails to start.
 
+### Filesystem Unix sockets
+
+A `unix:` name starting with `/` binds a socket file at that path
+instead (e.g. `unix:/tmp/zebra-rs`). Unlike abstract sockets the file
+outlives the daemon, so startup distinguishes leftovers from live
+listeners: a stale socket file is silently removed and rebound, a path
+with a live daemon behind it refuses startup (the `EADDRINUSE`
+equivalent), and a path occupied by a non-socket file is never touched.
+
+The socket file is created world-connectable (mode `0666`): the
+authorization model is per-RPC via `SO_PEERCRED` roles, exactly as on
+the abstract socket, which has no filesystem permission check at all.
+Place the socket in a restricted directory when connect-level
+gating is wanted. `unix:@NAME` forces the abstract interpretation even
+when the name starts with `/`.
+
 ### TCP
 
 TCP has no transport-level authentication: anyone who can reach the
 port can issue commands. Use it only on a trusted management network
 or behind a firewall.
+
+The role model depends on `SO_PEERCRED`, which only Unix sockets
+provide, so TCP peers get no session at all: `show` and completion
+work, but `enable`, `configure`, and `apply` are refused with
+`no session` — even for root. Configuration changes require one of
+the Unix socket transports.
 
 ## Server: `zebra-rs --vty-socket`
 
@@ -56,6 +79,8 @@ or behind a firewall.
     VTY gRPC listen address.
     Forms:
       unix:NAME           Linux abstract Unix socket (default)
+      unix:/PATH          filesystem Unix socket
+      unix:@NAME          explicitly abstract, even when NAME starts with /
       tcp:HOST:PORT       TCP listener
     Default: unix:zebra-rs/vty
 ```
@@ -70,6 +95,9 @@ zebra-rs
 ip netns exec vrf-red  zebra-rs &
 ip netns exec vrf-blue zebra-rs &
 
+# Filesystem socket
+zebra-rs --vty-socket unix:/tmp/zebra-rs
+
 # Legacy TCP behavior
 zebra-rs --vty-socket tcp:0.0.0.0:2666
 ```
@@ -78,9 +106,18 @@ zebra-rs --vty-socket tcp:0.0.0.0:2666
 
 ### `vty` (interactive shell)
 
-`vty` invokes `vtyhelper` with no explicit endpoint, so it inherits
-the default `unix:zebra-rs/vty`. To talk to a TCP-mode daemon, export
-`CLI_SERVER_URL` before launching the shell:
+`vty` accepts the daemon's `--vty-socket` syntax directly; the value is
+consumed before bash's own option parsing and exported as
+`CLI_SERVER_URL` for every `vtyhelper` invocation the shell makes:
+
+```bash
+vty --vty-socket unix:my-zebra/vty          # non-default abstract name
+vty --vty-socket unix:/tmp/zebra-rs         # filesystem socket
+vty --vty-socket tcp:router.example.com:2666
+```
+
+Exporting `CLI_SERVER_URL` before launching the shell still works, and
+an explicit `--vty-socket` wins over an inherited `CLI_SERVER_URL`:
 
 ```bash
 CLI_SERVER_URL=tcp://router.example.com:2666 vty
@@ -94,20 +131,22 @@ CLI_SERVER_URL=tcp://router.example.com:2666 vty
 | `--port <PORT>` | `2666` | Used only with bare-host `--base` for back-compat |
 | `CLI_SERVER_URL` | (unset) | Environment override for `--base` |
 
-`--base` accepts `unix:NAME`, `tcp://host:port`, `http://host:port`,
-or a bare `http://host` prefix that is combined with `--port` (the
-historical form).
+`--base` accepts `unix:NAME`, `unix:/PATH`, `tcp:host:port`,
+`tcp://host:port`, `http://host:port`, or a bare `http://host` prefix
+that is combined with `--port` (the historical form).
 
 ### `vtyctl`
 
 | Option | Default | Notes |
 |---|---|---|
-| `--host <URI>` | `unix:zebra-rs/vty` | Server endpoint URI |
+| `--host <URI>` (alias `--vty-socket`) | `unix:zebra-rs/vty` | Server endpoint URI |
 
-`--host` accepts:
+`--host` / `--vty-socket` accepts:
 
 - `unix:NAME` — abstract Unix socket
-- `tcp://host:port`, `http://host:port` — TCP
+- `unix:/PATH` — filesystem Unix socket
+- `unix:@NAME` — explicitly abstract, even when NAME starts with `/`
+- `tcp:host:port`, `tcp://host:port`, `http://host:port` — TCP
 - bare hostname (e.g. `127.0.0.1`) — combined with `:2666` as TCP
 
 Examples:
@@ -118,6 +157,9 @@ vtyctl show 'show ip route'
 
 # Inside a netns
 ip netns exec vrf-red vtyctl show 'show ip route'
+
+# Filesystem socket, daemon syntax
+vtyctl show --vty-socket unix:/tmp/zebra-rs 'show ip route'
 
 # Remote TCP
 vtyctl show --host tcp://router.example.com:2666 'show bgp'

--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -90,6 +90,12 @@ The daemon owns a `SessionTable` keyed by `(peer_uid, parent_pid)`.
 Both components are derived from the kernel (`SO_PEERCRED` plus
 `/proc/{peer_pid}/status`), never from client-supplied data.
 
+Sessions therefore exist only for Unix-socket peers — abstract and
+filesystem sockets deliver `SO_PEERCRED` identically. A TCP peer has
+no kernel credentials, gets no session, and every role-gated RPC
+(`enable`, `configure`, `apply`) is refused with `no session`, root
+included; TCP is effectively limited to `show` and completion.
+
 ## Session key derivation
 
 For every incoming gRPC request the daemon resolves a session key:
@@ -310,9 +316,13 @@ Container deployments require either:
 - daemon and client in the same container, or
 - `--pid host` to share the host's PID namespace.
 
-A daemon in container A cannot serve a client in container B: the
-abstract Unix socket is also netns-scoped, so the connection cannot
-even be established.
+A daemon in container A cannot serve a client in container B over the
+default transport: the abstract Unix socket is netns-scoped, so the
+connection cannot even be established. A filesystem socket
+(`--vty-socket unix:/PATH`) bind-mounted into both containers *does*
+connect — but the PID-namespace requirement still applies, so without
+a shared PID namespace the daemon sees `peer_pid == 0` and rejects the
+request.
 
 When `SO_PEERCRED` returns `peer_pid == 0`, the peer is not visible
 in the daemon's PID namespace; the connection is rejected with

--- a/vty/additions/vtysh.c
+++ b/vty/additions/vtysh.c
@@ -20,6 +20,8 @@
 
 #include "config.h"
 #include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "vtysh.h"
 #include "shell.h"
@@ -31,6 +33,10 @@
 /* xxd -i vty.sh >vty.c */
 #include "vty.c"
 
+/* Endpoint URI captured from --vty-socket; exported as CLI_SERVER_URL
+   just before the vty startup string runs. */
+static char *cli_server_url = NULL;
+
 int
 cli_mode ()
 {
@@ -40,10 +46,129 @@ cli_mode ()
     return 0;
 }
 
+/* Rewrite a --vty-socket value into the endpoint URI vtyhelper's
+   connector accepts, or return NULL if the form is not recognized.
+   The daemon's --vty-socket syntax is the contract: `unix:NAME'
+   passes through verbatim — vtyhelper resolves the name the same way
+   the daemon does (`/PATH' filesystem, `@NAME' explicitly abstract,
+   bare NAME abstract) — and `tcp:HOST:PORT' is rewritten to the
+   client's tcp://HOST:PORT.  Full client URIs (tcp://, http://,
+   https://) pass through unchanged. */
+static char *
+cli_vty_socket_uri (const char *value)
+{
+  char *uri;
+
+  if (strncmp (value, "unix:", 5) == 0)
+    {
+      if (value[5] == '\0')
+	return NULL;
+      uri = malloc (strlen (value) + 1);
+      if (uri)
+	strcpy (uri, value);
+      return uri;
+    }
+  if (strncmp (value, "tcp://", 6) == 0
+      || strncmp (value, "http://", 7) == 0
+      || strncmp (value, "https://", 8) == 0)
+    {
+      uri = malloc (strlen (value) + 1);
+      if (uri)
+	strcpy (uri, value);
+      return uri;
+    }
+  if (strncmp (value, "tcp:", 4) == 0)
+    {
+      const char *hostport = value + 4;
+
+      if (*hostport == '\0')
+	return NULL;
+      uri = malloc (strlen (hostport) + sizeof ("tcp://"));
+      if (uri)
+	sprintf (uri, "tcp://%s", hostport);
+      return uri;
+    }
+  return NULL;
+}
+
+/* Consume `--vty-socket URI' / `--vty-socket=URI' from the leading
+   option block of ARGV before bash's own long-option parsing, which
+   would reject it as an invalid option.  The value is remembered and
+   exported as CLI_SERVER_URL when the vty startup string runs; a
+   plain setenv() here would be lost, because bash builds its variable
+   table from the environ array it captured before setenv() could
+   reallocate it.  Returns the new ARGC. */
+int
+cli_option_parse (int argc, char **argv)
+{
+  int i, consumed;
+  const char *value;
+  char *uri;
+
+  for (i = 1; i < argc; i++)
+    {
+      char *arg = argv[i];
+
+      /* The option block ends where bash's would: at `--' or the
+	 first word that is not an option. */
+      if (arg[0] != '-' && arg[0] != '+')
+	break;
+      if (strcmp (arg, "--") == 0)
+	break;
+
+      if (strcmp (arg, "--vty-socket") == 0)
+	{
+	  if (i + 1 >= argc)
+	    {
+	      fprintf (stderr, "%s: --vty-socket: option requires an argument\n",
+		       argv[0]);
+	      exit (2);
+	    }
+	  value = argv[i + 1];
+	  consumed = 2;
+	}
+      else if (strncmp (arg, "--vty-socket=", 13) == 0)
+	{
+	  value = arg + 13;
+	  consumed = 1;
+	}
+      else
+	continue;
+
+      uri = cli_vty_socket_uri (value);
+      if (uri == NULL)
+	{
+	  fprintf (stderr,
+		   "%s: --vty-socket: expected unix:NAME or tcp:HOST:PORT, got `%s'\n",
+		   argv[0], value);
+	  exit (2);
+	}
+      free (cli_server_url);
+      cli_server_url = uri;
+
+      /* Shift the consumed words (and the terminating NULL) out. */
+      memmove (argv + i, argv + i + consumed,
+	       (argc - i - consumed + 1) * sizeof (char *));
+      argc -= consumed;
+      i--;
+    }
+  return argc;
+}
+
 void
 cli_execute_startup_string()
 {
-  char *str = malloc(vty_sh_len + 1);
+  char *str;
+
+  /* --vty-socket wins over an inherited CLI_SERVER_URL. */
+  if (cli_server_url)
+    {
+      SHELL_VAR *var = bind_variable ("CLI_SERVER_URL", cli_server_url, 0);
+      if (var)
+	set_auto_export (var);
+    }
+
+  str = malloc(vty_sh_len + 1);
   memcpy(str, vty_sh, vty_sh_len);
   str[vty_sh_len] = '\0';
 

--- a/vty/additions/vtysh.h
+++ b/vty/additions/vtysh.h
@@ -24,6 +24,7 @@
 #include "stdc.h"
 
 extern int cli_mode __P((void));
+extern int cli_option_parse __P((int, char **));
 extern void cli_execute_startup_string __P((void));
 
 #endif /* _VTYSH_H_ */

--- a/vty/patches/0001-vty-hooks.patch
+++ b/vty/patches/0001-vty-hooks.patch
@@ -266,7 +266,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  # builtin c sources
 diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.3/shell.c vty/shell.c
 --- bash-5.3/shell.c	2025-03-26 13:40:19.000000000 -0700
-+++ vty/shell.c	2026-05-09 14:26:42.289000443 -0700
++++ vty/shell.c	2026-08-18 19:46:08.437000421 -0700
 @@ -57,6 +57,7 @@
  #include "mailcheck.h"
  #include "builtins.h"
@@ -275,7 +275,17 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  
  #if defined (JOB_CONTROL)
  #include "jobs.h"
-@@ -1233,7 +1234,10 @@
+@@ -471,6 +472,9 @@
+ 
+   /* Parse argument flags from the input line. */
+ 
++  /* Consume vty-specific options before bash sees them. */
++  argc = cli_option_parse (argc, argv);
++
+   /* Find full word arguments first. */
+   arg_index = parse_long_options (argv, arg_index, argc);
+   
+@@ -1233,7 +1237,10 @@
  
        /* bash */
        if (act_like_sh == 0 && no_rc == 0)

--- a/vty/tests/vty-socket/run.py
+++ b/vty/tests/vty-socket/run.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Exercise the patched vty binary's --vty-socket option.
+
+Unlike the exit-hook suite, which runs vty.sh under stock bash, these
+cases need the patched binary itself: the option is consumed in
+shell.c/vtysh.c before bash's own long-option parsing would reject it,
+and surfaces as an exported CLI_SERVER_URL by the time vty.sh invokes
+vtyhelper. The stub helper on PATH records the CLI_SERVER_URL it
+inherits, which is the entire contract under test.
+
+Run after `make -C vty`; exits with a SKIP message when build/vty is
+absent so it never gates an unbuilt tree.
+
+Usage: vty/tests/vty-socket/run.py [-v]
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+VTY = HERE.parents[1] / "build" / "vty"
+
+VERBOSE = "-v" in sys.argv[1:]
+
+_SHIM = None
+
+
+def shim_dir():
+    global _SHIM
+    if _SHIM is None:
+        _SHIM = Path(tempfile.mkdtemp(prefix="vty-sock-shim-"))
+        stub = HERE / "stub-vtyhelper"
+        os.chmod(stub, 0o755)
+        (_SHIM / "vtyhelper").symlink_to(stub)
+    return _SHIM
+
+
+def run(args, env_extra=None, interactive=True):
+    """Run the patched vty and return (urls_seen, stdout+stderr, rc)."""
+    log = tempfile.NamedTemporaryFile(prefix="vty-sock-", suffix=".log", delete=False)
+    log.close()
+
+    env = dict(os.environ)
+    env.pop("CLI_SERVER_URL", None)
+    env["PATH"] = f"{shim_dir()}:{env['PATH']}"
+    env["STUB_LOG"] = log.name
+    env["CLI_EXIT_PROMPT_TIMEOUT"] = "2"
+    env["CLI_PAGER"] = "cat"
+    env.update(env_extra or {})
+
+    argv = [str(VTY)] + args + (["-i"] if interactive else [])
+    proc = subprocess.run(
+        argv,
+        input=b"exit\n" if interactive else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        timeout=20,
+    )
+
+    urls = [
+        line.strip()
+        for line in Path(log.name).read_text().splitlines()
+        if line.strip()
+    ]
+    os.unlink(log.name)
+    text = proc.stdout.decode("utf-8", "replace")
+    if VERBOSE:
+        print(f"--- argv {argv}\n--- output ---\n{text}\n--- urls {urls}")
+    return urls, text, proc.returncode
+
+
+FAILURES = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"ok   {name}")
+    else:
+        print(f"FAIL {name}{(': ' + detail) if detail else ''}")
+        FAILURES.append(name)
+
+
+def one_url(urls):
+    """The URL every helper call in the session saw, or None if mixed."""
+    return urls[0] if urls and len(set(urls)) == 1 else None
+
+
+def case_abstract():
+    urls, _, _ = run(["--vty-socket", "unix:custom/sock"])
+    check("abstract name reaches helper", one_url(urls) == "unix:custom/sock", str(urls))
+
+
+def case_path():
+    urls, _, _ = run(["--vty-socket", "unix:/tmp/zebra-rs-test"])
+    check("filesystem path passes verbatim", one_url(urls) == "unix:/tmp/zebra-rs-test", str(urls))
+
+
+def case_equals_form():
+    urls, _, _ = run(["--vty-socket=unix:eq/sock"])
+    check("--vty-socket=VALUE form", one_url(urls) == "unix:eq/sock", str(urls))
+
+
+def case_explicit_abstract():
+    # `@` resolution belongs to the helper's connector; the shell must
+    # not strip it.
+    urls, _, _ = run(["--vty-socket", "unix:@/tmp/forced-abstract"])
+    check("@ passes verbatim", one_url(urls) == "unix:@/tmp/forced-abstract", str(urls))
+
+
+def case_tcp_daemon_form():
+    urls, _, _ = run(["--vty-socket", "tcp:192.0.2.1:2666"])
+    check("tcp:HOST:PORT normalized", one_url(urls) == "tcp://192.0.2.1:2666", str(urls))
+
+
+def case_flag_beats_env():
+    urls, _, _ = run(
+        ["--vty-socket", "unix:flagwins"],
+        {"CLI_SERVER_URL": "unix:fromenv"},
+    )
+    check("flag beats inherited env", one_url(urls) == "unix:flagwins", str(urls))
+
+
+def case_env_passthrough():
+    urls, _, _ = run([], {"CLI_SERVER_URL": "unix:fromenv"})
+    check("env alone still honored", one_url(urls) == "unix:fromenv", str(urls))
+
+
+def case_default_unset():
+    urls, _, _ = run([])
+    check("no flag leaves env unset", one_url(urls) == "<unset>", str(urls))
+
+
+def case_missing_value():
+    _, text, rc = run(["--vty-socket"], interactive=False)
+    check("missing value exits 2", rc == 2, f"rc={rc}")
+    check("missing value reports", "requires an argument" in text, text[-200:])
+
+
+def case_bad_value():
+    _, text, rc = run(["--vty-socket", "bogus", "-c", "echo hi"], interactive=False)
+    check("bad value exits 2", rc == 2, f"rc={rc}")
+    check("bad value reports forms", "unix:NAME" in text, text[-200:])
+
+
+def case_noninteractive_consumed():
+    _, text, rc = run(
+        ["--vty-socket", "unix:foo", "-c", "echo consumed"], interactive=False
+    )
+    check("option consumed before -c", rc == 0 and "consumed" in text, text[-200:])
+
+
+def main():
+    if not VTY.exists():
+        print(f"SKIP: {VTY} not built (run `make -C vty` first)")
+        return 0
+    for fn in (
+        case_abstract,
+        case_path,
+        case_equals_form,
+        case_explicit_abstract,
+        case_tcp_daemon_form,
+        case_flag_beats_env,
+        case_env_passthrough,
+        case_default_unset,
+        case_missing_value,
+        case_bad_value,
+        case_noninteractive_consumed,
+    ):
+        fn()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} failing: {', '.join(FAILURES)}")
+        return 1
+    print("all vty-socket checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vty/tests/vty-socket/stub-vtyhelper
+++ b/vty/tests/vty-socket/stub-vtyhelper
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Stub `vtyhelper` for the vty --vty-socket tests.
+#
+# Every invocation appends the CLI_SERVER_URL it inherited to STUB_LOG —
+# that env var is the whole contract between the patched binary's option
+# handling and the helper, so recording it is the entire test surface.
+set -u
+
+[[ -n ${STUB_LOG:-} ]] && printf '%s\n' "${CLI_SERVER_URL:-<unset>}" >>"${STUB_LOG}"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -u|--uncommitted) exit 1 ;;              # clean: no exit prompt
+    -l|--logout) exit 0 ;;
+    -H|--hostname) echo "sockstub"; exit 0 ;;
+    -f|--first) echo "configure"; exit 0 ;;
+    *) shift ;;
+  esac
+done
+exit 0

--- a/vtyctl/src/endpoint.rs
+++ b/vtyctl/src/endpoint.rs
@@ -5,9 +5,9 @@ use tonic::transport::{Channel, Endpoint};
 ///
 /// Accepts:
 /// - bare hostname/IP (`127.0.0.1`) — becomes `http://127.0.0.1:2666`
-/// - `unix:NAME`, `tcp://…`, `http://…`, `https://…` — used as-is
+/// - `unix:NAME`, `tcp:…`, `tcp://…`, `http://…`, `https://…` — used as-is
 pub fn host_uri(host: &str) -> String {
-    if host.starts_with("unix:") || host.contains("://") {
+    if host.starts_with("unix:") || host.starts_with("tcp:") || host.contains("://") {
         host.to_string()
     } else {
         format!("http://{host}:2666")
@@ -20,12 +20,18 @@ pub fn host_uri(host: &str) -> String {
 /// - `http://host:port` / `https://host:port` — TCP via tonic Endpoint
 /// - `tcp://host:port` — alias for `http://host:port`
 /// - `unix:NAME` — Linux abstract Unix socket (e.g. `unix:zebra-rs/vty`)
+/// - `unix:/PATH` — filesystem Unix socket (e.g. `unix:/tmp/zebra-rs`)
+/// - `unix:@NAME` — explicitly abstract, even when NAME starts with `/`
 pub async fn connect(uri: &str) -> Result<Channel> {
     #[cfg(target_os = "linux")]
     if let Some(name) = uri.strip_prefix("unix:") {
-        return connect_abstract(name).await;
+        return connect_unix(name).await;
     }
+    // `tcp://HOST:PORT` and the daemon-style `tcp:HOST:PORT` both mean
+    // plain-TCP gRPC, which tonic spells `http://`.
     let normalized = if let Some(rest) = uri.strip_prefix("tcp://") {
+        format!("http://{rest}")
+    } else if let Some(rest) = uri.strip_prefix("tcp:") {
         format!("http://{rest}")
     } else {
         uri.to_string()
@@ -38,27 +44,36 @@ pub async fn connect(uri: &str) -> Result<Channel> {
 }
 
 #[cfg(target_os = "linux")]
-async fn connect_abstract(name: &str) -> Result<Channel> {
+async fn connect_unix(name: &str) -> Result<Channel> {
     use hyper_util::rt::TokioIo;
     use std::os::linux::net::SocketAddrExt;
     use std::os::unix::net::{SocketAddr as StdSockAddr, UnixStream as StdUnixStream};
     use tokio::net::UnixStream;
     use tower::service_fn;
 
-    let name = name.trim_start_matches('@').to_string();
+    // `@NAME` is explicitly abstract, `/PATH` is a filesystem socket, and
+    // a bare NAME stays an abstract name (the historical default).
+    let (is_path, name) = match name.strip_prefix('@') {
+        Some(rest) => (false, rest.to_string()),
+        None => (name.starts_with('/'), name.to_string()),
+    };
     if name.is_empty() {
         return Err(anyhow!("unix name must be non-empty"));
     }
     let name_for_err = name.clone();
     // The endpoint URI is a placeholder; the connector ignores it and dials
-    // the abstract Unix socket each time tonic calls it.
+    // the Unix socket each time tonic calls it.
     Endpoint::try_from("http://[::]:50051")?
         .connect_with_connector(service_fn(move |_: tonic::transport::Uri| {
             let name = name.clone();
             async move {
-                let addr = StdSockAddr::from_abstract_name(name.as_bytes())
-                    .map_err(std::io::Error::other)?;
-                let std = StdUnixStream::connect_addr(&addr)?;
+                let std = if is_path {
+                    StdUnixStream::connect(&name)?
+                } else {
+                    let addr = StdSockAddr::from_abstract_name(name.as_bytes())
+                        .map_err(std::io::Error::other)?;
+                    StdUnixStream::connect_addr(&addr)?
+                };
                 std.set_nonblocking(true)?;
                 let stream = UnixStream::from_std(std)?;
                 Ok::<_, std::io::Error>(TokioIo::new(stream))

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -14,16 +14,34 @@ pub mod watch;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    #[arg(
+        long,
+        global = true,
+        help = "Server endpoint URI (unix:NAME, unix:/PATH, tcp:HOST:PORT); \
+                usable before or after the subcommand [default: unix:zebra-rs/vty]"
+    )]
+    vty_socket: Option<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
+}
+
+const DEFAULT_ENDPOINT: &str = "unix:zebra-rs/vty";
+
+/// Effective endpoint: the per-subcommand `--host` wins over the global
+/// `--vty-socket`; both fall back to the default abstract socket.
+fn endpoint<'a>(host: &'a Option<String>, vty_socket: &'a Option<String>) -> &'a str {
+    host.as_deref()
+        .or(vty_socket.as_deref())
+        .unwrap_or(DEFAULT_ENDPOINT)
 }
 
 #[derive(Subcommand)]
 enum Commands {
     #[command(disable_help_flag = true)]
     Apply {
-        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
-        host: String,
+        #[arg(short, long, help = "Server endpoint URI (overrides --vty-socket)")]
+        host: Option<String>,
 
         #[arg(short, long, help = "Config filename", default_value = "")]
         filename: String,
@@ -33,16 +51,16 @@ enum Commands {
     },
     #[command(disable_help_flag = true)]
     Clear {
-        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
-        host: String,
+        #[arg(short, long, help = "Server endpoint URI (overrides --vty-socket)")]
+        host: Option<String>,
 
         #[arg(help = "Clear command to execute")]
         command: String,
     },
     #[command(disable_help_flag = true)]
     Show {
-        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
-        host: String,
+        #[arg(short, long, help = "Server endpoint URI (overrides --vty-socket)")]
+        host: Option<String>,
 
         #[arg(short, long, help = "Output in JSON format")]
         json: bool,
@@ -52,8 +70,8 @@ enum Commands {
     },
     #[command(disable_help_flag = true)]
     Watch {
-        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
-        host: String,
+        #[arg(short, long, help = "Server endpoint URI (overrides --vty-socket)")]
+        host: Option<String>,
 
         #[arg(
             short,
@@ -67,8 +85,12 @@ enum Commands {
     },
     /// Start MCP (Model Context Protocol) server for AI assistant integration
     Mcp {
-        #[arg(short = 'H', long, default_value = "unix:zebra-rs/vty")]
-        host: String,
+        #[arg(
+            short = 'H',
+            long,
+            help = "Server endpoint URI (overrides --vty-socket)"
+        )]
+        host: Option<String>,
 
         #[arg(
             short,
@@ -119,20 +141,20 @@ async fn main() -> Result<()> {
             filename,
             command,
         }) => {
-            apply::apply(host, filename, command.as_ref()).await?;
+            apply::apply(endpoint(host, &cli.vty_socket), filename, command.as_ref()).await?;
         }
         Some(Commands::Clear { host, command }) => {
-            clear::clear(host, command).await?;
+            clear::clear(endpoint(host, &cli.vty_socket), command).await?;
         }
         Some(Commands::Show {
             host,
             json,
             command,
         }) => {
-            show::show(host, command, *json).await?;
+            show::show(endpoint(host, &cli.vty_socket), command, *json).await?;
         }
         Some(Commands::Watch { host, json, path }) => {
-            watch::watch(host, *json, path.clone()).await?;
+            watch::watch(endpoint(host, &cli.vty_socket), *json, path.clone()).await?;
         }
         Some(Commands::Mcp {
             host,
@@ -141,7 +163,14 @@ async fn main() -> Result<()> {
             ontology,
             fleet,
         }) => {
-            mcp::run(host, *port, *debug, ontology.as_deref(), fleet.as_deref()).await?;
+            mcp::run(
+                endpoint(host, &cli.vty_socket),
+                *port,
+                *debug,
+                ontology.as_deref(),
+                fleet.as_deref(),
+            )
+            .await?;
         }
         None => {
             print_help();

--- a/vtyhelper/src/endpoint.rs
+++ b/vtyhelper/src/endpoint.rs
@@ -7,12 +7,18 @@ use tonic::transport::{Channel, Endpoint};
 /// - `http://host:port` / `https://host:port` — TCP via tonic Endpoint
 /// - `tcp://host:port` — alias for `http://host:port`
 /// - `unix:NAME` — Linux abstract Unix socket (e.g. `unix:zebra-rs/vty`)
+/// - `unix:/PATH` — filesystem Unix socket (e.g. `unix:/tmp/zebra-rs`)
+/// - `unix:@NAME` — explicitly abstract, even when NAME starts with `/`
 pub async fn connect(uri: &str) -> Result<Channel> {
     #[cfg(target_os = "linux")]
     if let Some(name) = uri.strip_prefix("unix:") {
-        return connect_abstract(name).await;
+        return connect_unix(name).await;
     }
+    // `tcp://HOST:PORT` and the daemon-style `tcp:HOST:PORT` both mean
+    // plain-TCP gRPC, which tonic spells `http://`.
     let normalized = if let Some(rest) = uri.strip_prefix("tcp://") {
+        format!("http://{rest}")
+    } else if let Some(rest) = uri.strip_prefix("tcp:") {
         format!("http://{rest}")
     } else {
         uri.to_string()
@@ -25,27 +31,36 @@ pub async fn connect(uri: &str) -> Result<Channel> {
 }
 
 #[cfg(target_os = "linux")]
-async fn connect_abstract(name: &str) -> Result<Channel> {
+async fn connect_unix(name: &str) -> Result<Channel> {
     use hyper_util::rt::TokioIo;
     use std::os::linux::net::SocketAddrExt;
     use std::os::unix::net::{SocketAddr as StdSockAddr, UnixStream as StdUnixStream};
     use tokio::net::UnixStream;
     use tower::service_fn;
 
-    let name = name.trim_start_matches('@').to_string();
+    // `@NAME` is explicitly abstract, `/PATH` is a filesystem socket, and
+    // a bare NAME stays an abstract name (the historical default).
+    let (is_path, name) = match name.strip_prefix('@') {
+        Some(rest) => (false, rest.to_string()),
+        None => (name.starts_with('/'), name.to_string()),
+    };
     if name.is_empty() {
         return Err(anyhow!("unix name must be non-empty"));
     }
     let name_for_err = name.clone();
     // The endpoint URI is a placeholder; the connector ignores it and dials
-    // the abstract Unix socket each time tonic calls it.
+    // the Unix socket each time tonic calls it.
     Endpoint::try_from("http://[::]:50051")?
         .connect_with_connector(service_fn(move |_: tonic::transport::Uri| {
             let name = name.clone();
             async move {
-                let addr = StdSockAddr::from_abstract_name(name.as_bytes())
-                    .map_err(std::io::Error::other)?;
-                let std = StdUnixStream::connect_addr(&addr)?;
+                let std = if is_path {
+                    StdUnixStream::connect(&name)?
+                } else {
+                    let addr = StdSockAddr::from_abstract_name(name.as_bytes())
+                        .map_err(std::io::Error::other)?;
+                    StdUnixStream::connect_addr(&addr)?
+                };
                 std.set_nonblocking(true)?;
                 let stream = UnixStream::from_std(std)?;
                 Ok::<_, std::io::Error>(TokioIo::new(stream))

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -85,7 +85,7 @@ struct Cli {
     #[arg(
         short,
         long,
-        help = "Server endpoint URI (unix:NAME, tcp://host:port, http://host:port). \
+        help = "Server endpoint URI (unix:NAME, unix:/PATH, tcp://host:port, http://host:port). \
                 Bare host like 'http://127.0.0.1' is combined with --port for backward compat.",
         default_value = "unix:zebra-rs/vty"
     )]
@@ -103,13 +103,13 @@ fn privilege_get() -> u32 {
 
 /// Build the endpoint URI from the parsed CLI.
 ///
-/// `--base` may already be a full URI (`unix:…`, `tcp://host:port`,
-/// `http://host:port`) — in which case `--port` is ignored. Otherwise the
-/// legacy `{base}:{port}` concatenation is used, matching the historical
-/// `http://127.0.0.1` + `2666` defaults.
+/// `--base` may already be a full URI (`unix:…`, `tcp:host:port`,
+/// `tcp://host:port`, `http://host:port`) — in which case `--port` is
+/// ignored. Otherwise the legacy `{base}:{port}` concatenation is used,
+/// matching the historical `http://127.0.0.1` + `2666` defaults.
 fn endpoint_uri(base: &str, port: u32) -> String {
     if base.starts_with("unix:")
-        || base.starts_with("tcp://")
+        || base.starts_with("tcp:")
         || base.starts_with("http://") && base.matches(':').count() >= 2
         || base.starts_with("https://") && base.matches(':').count() >= 2
     {

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
@@ -585,11 +586,13 @@ impl Apply for ApplyService {
 ///
 /// `AbstractUds` uses a Linux abstract Unix socket whose name is scoped by the
 /// process network namespace, which is the isolation primitive we rely on for
-/// per-netns zebra-rs deployments.
+/// per-netns zebra-rs deployments. `Uds` binds a filesystem socket at the
+/// given absolute path instead.
 #[derive(Debug, Clone)]
 pub enum VtyAddr {
     Tcp(SocketAddr),
     AbstractUds(String),
+    Uds(PathBuf),
 }
 
 impl VtyAddr {
@@ -601,11 +604,22 @@ impl VtyAddr {
             return Ok(Self::Tcp(addr));
         }
         if let Some(rest) = s.strip_prefix("unix:") {
-            let name = rest.trim_start_matches('@').to_string();
-            if name.is_empty() {
+            // `unix:@NAME` is explicitly abstract, `unix:/PATH` binds a
+            // filesystem socket, and bare `unix:NAME` stays an abstract
+            // name (the historical default).
+            if let Some(name) = rest.strip_prefix('@') {
+                if name.is_empty() {
+                    anyhow::bail!("unix name must be non-empty");
+                }
+                return Ok(Self::AbstractUds(name.to_string()));
+            }
+            if rest.starts_with('/') {
+                return Ok(Self::Uds(PathBuf::from(rest)));
+            }
+            if rest.is_empty() {
                 anyhow::bail!("unix name must be non-empty");
             }
-            return Ok(Self::AbstractUds(name));
+            return Ok(Self::AbstractUds(rest.to_string()));
         }
         anyhow::bail!("--vty-socket must start with 'tcp:' or 'unix:'");
     }
@@ -862,6 +876,11 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
             tracing::debug!("VTY gRPC listening on abstract UDS @{name}");
             tokio::spawn(async move { builder.serve_with_incoming(incoming).await });
         }
+        VtyAddr::Uds(path) => {
+            let incoming = bind_path_uds(&path)?;
+            tracing::debug!("VTY gRPC listening on UDS {}", path.display());
+            tokio::spawn(async move { builder.serve_with_incoming(incoming).await });
+        }
     }
     Ok(())
 }
@@ -898,9 +917,86 @@ fn bind_abstract_uds(name: &str) -> anyhow::Result<tokio_stream::wrappers::UnixL
     Ok(UnixListenerStream::new(listener))
 }
 
+fn bind_path_uds(
+    path: &std::path::Path,
+) -> anyhow::Result<tokio_stream::wrappers::UnixListenerStream> {
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+    use std::os::unix::net::{UnixListener as StdUnixListener, UnixStream as StdUnixStream};
+    use tokio::net::UnixListener;
+    use tokio_stream::wrappers::UnixListenerStream;
+
+    let disp = path.display();
+
+    // A filesystem socket outlives its daemon, so distinguish a stale
+    // leftover (unlink and rebind) from a live one — abstract sockets get
+    // this for free as EADDRINUSE, and quietly stealing the path from a
+    // running daemon must stay just as impossible here.
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_socket() => {
+            if StdUnixStream::connect(path).is_ok() {
+                anyhow::bail!(
+                    "VTY socket {disp} is already in use.\n\
+                     Another zebra-rs daemon is likely listening on it.",
+                );
+            }
+            std::fs::remove_file(path)
+                .map_err(|e| anyhow::anyhow!("remove stale VTY socket {disp}: {e}"))?;
+        }
+        Ok(_) => anyhow::bail!("VTY socket path {disp} exists and is not a socket"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(anyhow::anyhow!("stat VTY socket path {disp}: {e}")),
+    }
+
+    let std_listener = StdUnixListener::bind(path)
+        .map_err(|e| anyhow::anyhow!("failed to bind VTY socket {disp}: {e}"))?;
+
+    // Authorization is per-RPC via SO_PEERCRED roles, matching the abstract
+    // socket, which has no filesystem permission check at all — so open the
+    // socket file to all local users; restrict via the parent directory
+    // where a tighter policy is wanted.
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o666))
+        .map_err(|e| anyhow::anyhow!("set permissions on VTY socket {disp}: {e}"))?;
+
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| anyhow::anyhow!("set_nonblocking on VTY socket {disp}: {e}"))?;
+    let listener = UnixListener::from_std(std_listener)
+        .map_err(|e| anyhow::anyhow!("register VTY socket {disp} with tokio: {e}"))?;
+    Ok(UnixListenerStream::new(listener))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn vty_addr_parse_recognizes_all_forms() {
+        assert!(matches!(
+            VtyAddr::parse("tcp:127.0.0.1:2666"),
+            Ok(VtyAddr::Tcp(_))
+        ));
+        match VtyAddr::parse("unix:zebra-rs/vty").unwrap() {
+            VtyAddr::AbstractUds(name) => assert_eq!(name, "zebra-rs/vty"),
+            other => panic!("expected abstract, got {other:?}"),
+        }
+        match VtyAddr::parse("unix:@zebra-rs/vty").unwrap() {
+            VtyAddr::AbstractUds(name) => assert_eq!(name, "zebra-rs/vty"),
+            other => panic!("expected abstract, got {other:?}"),
+        }
+        match VtyAddr::parse("unix:/tmp/zebra-rs").unwrap() {
+            VtyAddr::Uds(path) => assert_eq!(path, PathBuf::from("/tmp/zebra-rs")),
+            other => panic!("expected filesystem UDS, got {other:?}"),
+        }
+        // An explicit `@` wins even when the name looks like a path.
+        match VtyAddr::parse("unix:@/tmp/zebra-rs").unwrap() {
+            VtyAddr::AbstractUds(name) => assert_eq!(name, "/tmp/zebra-rs"),
+            other => panic!("expected abstract, got {other:?}"),
+        }
+        assert!(VtyAddr::parse("unix:").is_err());
+        assert!(VtyAddr::parse("unix:@").is_err());
+        assert!(VtyAddr::parse("bogus").is_err());
+        assert!(VtyAddr::parse("tcp:nonsense").is_err());
+    }
 
     #[tokio::test]
     async fn forward_show_stream_passes_items_through() {

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -104,7 +104,7 @@ struct Arg {
 
     #[arg(
         long,
-        help = "VTY gRPC listen address. Forms: unix:NAME (Linux abstract socket) or tcp:HOST:PORT",
+        help = "VTY gRPC listen address. Forms: unix:NAME (Linux abstract socket), unix:/PATH (filesystem socket) or tcp:HOST:PORT",
         default_value = "unix:zebra-rs/vty"
     )]
     vty_socket: String,


### PR DESCRIPTION
## Summary

- `vty --vty-socket <URI>` — the shell now accepts the daemon's socket syntax directly. A new argv scan (`cli_option_parse` in `vtysh.c`, hooked into `shell.c` ahead of bash's own long-option parsing) consumes the flag and exports it as `CLI_SERVER_URL` through bash's variable table just before `vty.sh` runs; a plain `setenv` would be lost because bash builds its variables from the environ array captured before `setenv` could reallocate it. The flag wins over an inherited `CLI_SERVER_URL`; both `--vty-socket VALUE` and `=VALUE` forms work; errors exit 2.
- `vtyctl --vty-socket` — global arg valid before or after the subcommand (`vtyctl --vty-socket unix:/tmp/zebra-rs show 'show ip route'`), with per-subcommand `--host` kept as a back-compat override that wins when both are given.
- `unix:/PATH` now means a **filesystem** Unix socket in the daemon, `vtyhelper`, and `vtyctl`: a stale socket file is unlinked and rebound, a live one refuses startup (the abstract socket's `EADDRINUSE` equivalent), a non-socket file is never touched, and the socket is created 0666 since authorization stays per-RPC via `SO_PEERCRED` roles. `unix:@NAME` forces the abstract interpretation; both clients also accept the daemon-style `tcp:HOST:PORT` spelling.
- Book: transports, client flags, and the transport-to-session mapping (TCP peers get no session, so `enable`/`configure`/`apply` are refused — root included).

## Test plan

- New `vty/tests/vty-socket/run.py`: 13 checks driving the patched binary against a stub vtyhelper — consumption, normalization, `@`/path pass-through, precedence, error exits. All pass.
- `VtyAddr::parse` unit test covering every form; `cargo test -p zebra-rs` / `-p vtyctl` / `-p vtyhelper` green; workspace clippy clean; `vty/tests/exit-hook` regression-clean.
- Live-verified against real daemons: filesystem UDS (stale rebind, live-daemon refusal, non-socket refusal, non-root View denial + root implicit-Admin apply), abstract regression incl. `unix:@`, TCP incl. the fail-closed no-session posture, and every vtyctl flag placement.

Generated with [Claude Code](https://claude.com/claude-code)