### PR TITLE
fib: enlarge netlink monitor rcvbuf and resync on overrun

### DIFF
--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -200,6 +200,14 @@ pub enum FibMessage {
     /// The forwarding plane confirmed (or rejected) a route install.
     /// Raised by the FPM tee; see [`RouteOffload`].
     RouteOffload(RouteOffload),
+    /// The kernel netlink monitor socket overran (`ENOBUFS`): its
+    /// receive queue was full, so the kernel dropped an unknown number
+    /// of notifications before we could read them. Multicast netlink
+    /// has no flow control — this is the only signal that our mirrors
+    /// of kernel state may have silently diverged. Handled by
+    /// `Rib::netlink_overrun_resync`, which re-dumps the replay-safe
+    /// kernel tables.
+    Overrun,
 }
 
 /// One kernel bridge MDB entry, reduced to the fields EVPN cares about.

--- a/zebra-rs/src/fib/netlink/dump.rs
+++ b/zebra-rs/src/fib/netlink/dump.rs
@@ -32,6 +32,32 @@ pub async fn fib_dump(rib: &mut Rib) -> Result<()> {
     Ok(())
 }
 
+/// Re-dump the kernel tables that are safe to replay mid-run after a
+/// netlink receive-queue overrun (`FibMessage::Overrun`): links,
+/// addresses, neighbors, and the bridge MDB. All of these flow through
+/// upsert-shaped `process_fib_msg` paths that already absorb duplicate
+/// delivery in normal operation, so replaying current kernel state is
+/// idempotent and recovers any additions/updates the overrun dropped.
+/// (A dropped *deletion* stays lost until the object is touched again —
+/// mark-and-sweep reconciliation is a separate project.)
+///
+/// Routes are deliberately NOT re-dumped. The monitor socket never
+/// sees self-originated events (the kernel excludes the sender from
+/// multicast), so `route_from_msg` doesn't map our own `rtm_protocol`
+/// values back to their owners — everything non-DHCP dumps as
+/// `RibType::Kernel`. Replaying a route dump mid-run would re-ingest
+/// every route this daemon installed as a phantom kernel route
+/// shadowing the real protocol entry.
+pub async fn fib_resync(rib: &mut Rib) -> Result<()> {
+    link_dump(rib, rib.fib_handle.handle.clone()).await?;
+    address_dump(rib, rib.fib_handle.handle.clone()).await?;
+    neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Inet).await?;
+    neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Inet6).await?;
+    neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Bridge).await?;
+    mdb_dump(rib, rib.fib_handle.handle.clone()).await;
+    Ok(())
+}
+
 /// Dump the kernel bridge MDB (`RTM_GETMDB`) so EVPN learns memberships
 /// that existed before start-up. rtnetlink has no MDB helper, so issue
 /// the dump request by hand and feed each `RTM_NEWMDB` reply through the

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::os::fd::AsRawFd;
 
 use futures::stream::StreamExt;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
@@ -494,6 +495,71 @@ enum FdbOp {
     Delete,
 }
 
+/// Receive-buffer size (bytes) requested for the FIB monitor socket.
+///
+/// The socket subscribes to seven multicast groups below, and multicast
+/// netlink has no flow control: once the receive queue is full the
+/// kernel drops the notification and the next recv fails with ENOBUFS.
+/// The kernel default (`net.core.rmem_default`, 208 KiB ≈ a few hundred
+/// queued messages at skb-truesize accounting) is far too small for a
+/// busy segment — the cold-start ARP burst of a few thousand BGP peers
+/// overruns it in well under a second. 16 MiB rides out such bursts and
+/// costs memory only while messages are actually queued.
+const MONITOR_RCVBUF_BYTES: libc::c_int = 16 * 1024 * 1024;
+
+/// `setsockopt(SOL_SOCKET, opt)` with [`MONITOR_RCVBUF_BYTES`], where
+/// `opt` is `SO_RCVBUF` or `SO_RCVBUFFORCE` (netlink-sys only wraps the
+/// former).
+fn set_rcvbuf(fd: std::os::fd::RawFd, opt: libc::c_int) -> std::io::Result<()> {
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            opt,
+            &MONITOR_RCVBUF_BYTES as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+/// Enlarge the monitor socket's kernel receive buffer. `SO_RCVBUFFORCE`
+/// first — it ignores the `net.core.rmem_max` cap but wants
+/// CAP_NET_ADMIN, which the daemon holds anyway for route installs.
+/// Falls back to plain `SO_RCVBUF` (silently clamped to `rmem_max`)
+/// when that is denied. Quiet on success, warns when the buffer ends up
+/// smaller than requested — the daemon keeps running either way, just
+/// with a higher overrun risk under event bursts.
+fn monitor_rcvbuf_enlarge(sock: &netlink_sys::Socket) {
+    let fd = sock.as_raw_fd();
+    if set_rcvbuf(fd, libc::SO_RCVBUFFORCE).is_ok() {
+        return;
+    }
+    if let Err(e) = set_rcvbuf(fd, libc::SO_RCVBUF) {
+        tracing::warn!(
+            "fib: could not enlarge monitor socket receive buffer to {MONITOR_RCVBUF_BYTES} \
+             bytes ({e}); netlink overruns are likely under event bursts"
+        );
+        return;
+    }
+    // getsockopt reports double the effective setting (socket(7));
+    // under the doubled request it means rmem_max clamped us.
+    if let Ok(effective) = sock.get_rx_buf_sz()
+        && (effective as i64) < 2 * MONITOR_RCVBUF_BYTES as i64
+    {
+        tracing::warn!(
+            "fib: monitor socket receive buffer clamped to {} bytes by net.core.rmem_max \
+             (wanted {}); raise rmem_max or grant CAP_NET_ADMIN to reduce netlink overrun risk",
+            effective,
+            2 * MONITOR_RCVBUF_BYTES as i64,
+        );
+    }
+}
+
 impl FibHandle {
     pub fn new(rib_tx: UnboundedSender<FibMessage>, no_nhid: bool) -> anyhow::Result<Self> {
         // Baseline sysctls are applied (and any per-knob failures warned
@@ -501,6 +567,11 @@ impl FibHandle {
         // constructs this handle and before any FIB interaction — so there
         // is no need to enable them here too.
         let (mut connection, handle, mut messages) = new_connection()?;
+
+        // Before subscribing to any multicast group, enlarge the
+        // receive buffer past the kernel default — see
+        // `monitor_rcvbuf_enlarge` for why the default overruns.
+        monitor_rcvbuf_enlarge(connection.socket_mut().socket_mut());
 
         let mgroup_flags = RTMGRP_LINK
             | RTMGRP_IPV4_ROUTE
@@ -4579,6 +4650,14 @@ pub fn neighbor_from_msg(msg: NeighbourMessage) -> FibNeighbor {
 }
 
 fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<FibMessage>) {
+    // netlink-proto synthesizes an `Overrun` payload when recv fails
+    // with ENOBUFS — the kernel dropped an unknown number of
+    // notifications because the receive queue was full. Surface it so
+    // the RIB can re-dump kernel state instead of silently drifting.
+    if matches!(msg.payload, NetlinkPayload::Overrun(_)) {
+        let _ = tx.send(FibMessage::Overrun);
+        return;
+    }
     // Every arm forwards a parsed event to the RIB inbox. If RIB has
     // already shut down (or panicked) the receiver is dropped and the
     // send returns `SendError`; that is benign here — we don't want a

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -13,9 +13,9 @@ use super::{
 use crate::config::{Args, path_from_command};
 use crate::config::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel};
 use crate::context::Timer;
-use crate::fib::fib_dump;
 use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibChannel, FibHandle, FibMessage, FibNeighbor};
+use crate::fib::{fib_dump, fib_resync};
 use crate::rib::route::{
     AddrRecoveryState, ipv4_nexthop_sync, ipv6_nexthop_sync, nexthop_orphan_gc,
 };
@@ -1244,6 +1244,13 @@ pub struct Rib {
     /// `crate::rib::route::RECOVERY_*` if an external actor keeps
     /// fighting us.
     pub addr_recovery: BTreeMap<(u32, IpNet), AddrRecoveryState>,
+
+    /// When the last netlink receive-queue overrun triggered a
+    /// `fib_resync` re-dump; `None` until the first overrun. Rate-limits
+    /// `netlink_overrun_resync` — the re-dump itself keeps the monitor
+    /// socket's receive queue busy, so reacting to every overrun of a
+    /// sustained storm would stack re-dumps back-to-back.
+    pub overrun_resync_last: Option<std::time::Instant>,
 }
 
 /// Name of the dummy interface that hosts End-style seg6local routes
@@ -1348,6 +1355,7 @@ impl Rib {
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
             sr0_owned: false,
             addr_recovery: BTreeMap::new(),
+            overrun_resync_last: None,
         };
         rib.show_build();
         Ok(rib)
@@ -4364,6 +4372,14 @@ impl Rib {
                     self.api_snoop_leave(vni, vtep_local, entry.group, entry.source);
                 }
             }
+            FibMessage::Overrun => {
+                // Never dispatched here: the event loop intercepts
+                // Overrun before calling this function, because the
+                // resync re-dump feeds its results back through this
+                // very function and reacting in place would be async
+                // recursion. Kept for match exhaustiveness.
+                tracing::debug!("fib: overrun message outside event loop; ignored");
+            }
         }
     }
 
@@ -5103,6 +5119,38 @@ impl Rib {
             .await;
     }
 
+    /// React to a kernel netlink receive-queue overrun
+    /// ([`FibMessage::Overrun`]): the kernel dropped an unknown number
+    /// of monitor notifications, so the local link / address / neighbor
+    /// mirrors may have silently diverged. Re-dump the replay-safe
+    /// kernel tables through `fib_resync` — see its doc for what is
+    /// replayed and why routes are excluded.
+    ///
+    /// Rate-limited: the kernel raises one ENOBUFS per congestion
+    /// episode, and a sustained storm produces episodes back-to-back —
+    /// while the re-dump itself keeps the receive queue busy. An
+    /// overrun inside the cool-down is only logged; the state it
+    /// signals is covered by the previous re-dump or by the next
+    /// overrun after the window.
+    async fn netlink_overrun_resync(&mut self) {
+        const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(10);
+        if let Some(last) = self.overrun_resync_last
+            && last.elapsed() < COOLDOWN
+        {
+            tracing::warn!(
+                "netlink receive-queue overrun within resync cool-down; re-dump skipped"
+            );
+            return;
+        }
+        self.overrun_resync_last = Some(std::time::Instant::now());
+        tracing::warn!(
+            "netlink receive-queue overrun: kernel dropped notifications; re-dumping kernel state"
+        );
+        if let Err(err) = fib_resync(self).await {
+            tracing::warn!("netlink overrun resync failed: {err}");
+        }
+    }
+
     pub async fn event_loop(&mut self) {
         // Before FIB interaction, apply the baseline sysctls. A knob that
         // can't be set (its backing module isn't loaded, or this kernel
@@ -5156,7 +5204,15 @@ impl Rib {
                     self.process_msg(env.msg, table_id).await;
                 }
                 Some(msg) = self.fib.rx.recv() => {
-                    self.process_fib_msg(msg).await;
+                    // Overrun is intercepted here rather than inside
+                    // `process_fib_msg`: the resync re-dump feeds its
+                    // results back through `process_fib_msg`, so
+                    // handling it there would be async recursion.
+                    if matches!(msg, FibMessage::Overrun) {
+                        self.netlink_overrun_resync().await;
+                    } else {
+                        self.process_fib_msg(msg).await;
+                    }
                 }
                 Some(msg) = self.cm.rx.recv() => {
                     self.process_cm_msg(msg).await;


### PR DESCRIPTION
## Summary

Running `zebra-rs` against a ~2000-peer BGP segment logs `netlink socket buffer full` warnings from netlink-proto. Root cause: the FIB monitor socket subscribes to seven rtnetlink multicast groups but ran with the kernel-default receive buffer (`net.core.rmem_default`, 208 KiB). Multicast netlink has no flow control, so a neighbor-event burst (cold-start ARP resolution for thousands of peers, synchronized delay-probe waves) overruns the queue; the kernel drops notifications, recv fails with `ENOBUFS`, and the synthesized `NLMSG_OVERRUN` was silently discarded — the RIB desyncs from kernel state with no recovery.

Two changes:

- **`FibHandle::new` enlarges the monitor socket receive buffer to 16 MiB** before joining any multicast group: `SO_RCVBUFFORCE` first (ignores `rmem_max`; the daemon holds `CAP_NET_ADMIN` anyway for route installs), plain `SO_RCVBUF` as the unprivileged fallback, warning when `rmem_max` clamps the result. Quiet on success.
- **Overrun now surfaces as `FibMessage::Overrun`** and the RIB event loop reacts with `fib_resync`: a re-dump of the replay-safe kernel tables (links, addresses, neighbors, bridge MDB) through the same upsert-shaped `process_fib_msg` paths the startup dump uses, rate-limited to one re-dump per 10 s so a sustained storm can't stack re-dumps.

Routes are deliberately excluded from the resync: the monitor socket never sees self-originated events, so `route_from_msg` labels every non-DHCP dumped route as `RibType::Kernel` — a mid-run route replay would re-ingest every route the daemon itself installed as a phantom kernel route shadowing the real protocol entry. Missed deletions also stay lost until the object is touched again; a mark-and-sweep reconcile is a possible follow-up and the doc comments say so explicitly.

## Test plan

- `cargo test --workspace --exclude bdd`: 2940 passed, 0 failed.
- `cargo clippy --workspace --exclude bdd --all-targets`: clean.
- Live verification in an isolated netns: `strace` shows `setsockopt(SOL_SOCKET, SO_RCVBUFFORCE, [16777216]) = 0` on the monitor socket at startup.

Generated with [Claude Code](https://claude.com/claude-code)