### PR TITLE
topology: add selectable globe designs

### DIFF
--- a/ai/topology/README.md
+++ b/ai/topology/README.md
@@ -70,6 +70,22 @@ earth textures load from unpkg.com, integrity-pinned).
 * Click a path arc (or its legend chip) for the hop-by-hop table with link
   and cumulative metrics.
 
+### Globe designs
+
+The Globe dropdown switches the earth's look between four designs:
+
+| design          | texture             | character                                |
+|-----------------|---------------------|------------------------------------------|
+| **Blue Marble** | `earth-blue-marble` | photographic satellite earth (default)   |
+| **Day**         | `earth-day`         | flat political-relief daylight map       |
+| **Night lights**| `earth-night`       | city lights on a dark earth              |
+| **Dark**        | `earth-dark`        | muted grey earth — the arcs pop the most |
+
+All textures come from the same three-globe example set on unpkg.com the
+default already loads from. The choice is mirrored into the `globe` URL
+parameter (like source, destination and algorithm), so it survives a
+reload and travels with a shared link.
+
 ### Flags
 
 | flag         | default                                | meaning                        |

--- a/ai/topology/README.md
+++ b/ai/topology/README.md
@@ -76,8 +76,8 @@ The Globe dropdown switches the earth's look between four designs:
 
 | design          | texture             | character                                |
 |-----------------|---------------------|------------------------------------------|
-| **Blue Marble** | `earth-blue-marble` | photographic satellite earth (default)   |
-| **Day**         | `earth-day`         | flat political-relief daylight map       |
+| **Day**         | `earth-day`         | flat relief daylight map (default)       |
+| **Blue Marble** | `earth-blue-marble` | photographic satellite earth             |
 | **Night lights**| `earth-night`       | city lights on a dark earth              |
 | **Dark**        | `earth-dark`        | muted grey earth — the arcs pop the most |
 

--- a/ai/topology/static/app.js
+++ b/ai/topology/static/app.js
@@ -16,6 +16,40 @@ const REGION_COLORS = {
 const BASE_ARC_COLOR = 'rgba(170, 180, 200, 0.35)';
 const INACTIVE_COLOR = '#95a5a6';
 
+// Globe designs: a few looks for the earth itself, selectable from the
+// Globe dropdown (and the `globe` URL parameter). Every texture comes
+// from the same integrity-known three-globe example set on unpkg.com
+// the viewer already loads its earth from; the bump map and star-field
+// background are shared, only the surface and atmosphere change.
+const TEXTURE_BASE = '//unpkg.com/three-globe/example/img/';
+const GLOBE_DESIGNS = {
+    'blue-marble': {
+        label: 'Blue Marble',
+        globe: TEXTURE_BASE + 'earth-blue-marble.jpg',
+        atmosphereColor: '#3b82f6',
+        atmosphereAltitude: 0.18,
+    },
+    'day': {
+        label: 'Day',
+        globe: TEXTURE_BASE + 'earth-day.jpg',
+        atmosphereColor: '#93c5fd',
+        atmosphereAltitude: 0.18,
+    },
+    'night': {
+        label: 'Night lights',
+        globe: TEXTURE_BASE + 'earth-night.jpg',
+        atmosphereColor: '#f59e0b',
+        atmosphereAltitude: 0.15,
+    },
+    'dark': {
+        label: 'Dark',
+        globe: TEXTURE_BASE + 'earth-dark.jpg',
+        atmosphereColor: '#64748b',
+        atmosphereAltitude: 0.12,
+    },
+};
+const DEFAULT_DESIGN = 'blue-marble';
+
 let map;
 
 // Rendered state
@@ -38,9 +72,10 @@ let algorithmsSeq = 0;
 // the user set up stays put while the arcs re-route under it.
 let lastFocusKey = null;
 
-// Selections are mirrored into the URL query, so Source, Destination and
-// Algorithm all survive a page reload (and a view can be shared as a
-// link). Consumed once at startup, written back on every load.
+// Selections are mirrored into the URL query, so Source, Destination,
+// Algorithm and Globe all survive a page reload (and a view can be
+// shared as a link). Consumed once at startup, written back on every
+// load and on a globe-design change.
 const initialParams = new URLSearchParams(window.location.search);
 
 function selectValue(sel, value) {
@@ -56,17 +91,34 @@ function syncUrl() {
     params.set('source', document.getElementById('source').value);
     params.set('destination', document.getElementById('destination').value);
     params.set('algorithm', document.getElementById('algorithm').value || '0');
+    const globe = document.getElementById('globe').value;
+    if (globe !== DEFAULT_DESIGN) params.set('globe', globe);
     history.replaceState(null, '', '?' + params.toString());
+}
+
+function applyGlobeDesign(name) {
+    const design = GLOBE_DESIGNS[name] || GLOBE_DESIGNS[DEFAULT_DESIGN];
+    map.globeImageUrl(design.globe)
+        .atmosphereColor(design.atmosphereColor)
+        .atmosphereAltitude(design.atmosphereAltitude);
+}
+
+function initGlobeSelect() {
+    const sel = document.getElementById('globe');
+    Object.entries(GLOBE_DESIGNS).forEach(([value, design]) => {
+        const opt = document.createElement('option');
+        opt.value = value;
+        opt.textContent = design.label;
+        sel.appendChild(opt);
+    });
+    selectValue(sel, initialParams.get('globe')) || selectValue(sel, DEFAULT_DESIGN);
 }
 
 function initMap() {
     const container = document.getElementById('map');
     map = Globe()(container)
-        .globeImageUrl('//unpkg.com/three-globe/example/img/earth-blue-marble.jpg')
-        .bumpImageUrl('//unpkg.com/three-globe/example/img/earth-topology.png')
-        .backgroundImageUrl('//unpkg.com/three-globe/example/img/night-sky.png')
-        .atmosphereColor('#3b82f6')
-        .atmosphereAltitude(0.18)
+        .bumpImageUrl(TEXTURE_BASE + 'earth-topology.png')
+        .backgroundImageUrl(TEXTURE_BASE + 'night-sky.png')
         .arcColor('color')
         .arcStroke(d => d.base ? 0.22 : 0.5)
         .arcAltitudeAutoScale(d => d.base ? 0.25 : 0.4)
@@ -82,6 +134,8 @@ function initMap() {
         .pointRadius(0.4)
         .pointLabel('label')
         .pointOfView({ lat: 30, lng: -30, altitude: 2.5 });
+
+    applyGlobeDesign(document.getElementById('globe').value);
 
     // Auto-rotate gently until the user interacts
     const controls = map.controls();
@@ -496,8 +550,15 @@ function populatePathDetail(idx) {
 // --- Event listeners ---
 
 document.addEventListener('DOMContentLoaded', () => {
+    initGlobeSelect();
     initMap();
     loadRouters();
+
+    // A globe-design flip only restyles the earth — no router re-query.
+    document.getElementById('globe').addEventListener('change', (e) => {
+        applyGlobeDesign(e.target.value);
+        syncUrl();
+    });
 
     document.getElementById('source').addEventListener('change', async (e) => {
         if (e.target.value) {

--- a/ai/topology/static/app.js
+++ b/ai/topology/static/app.js
@@ -23,16 +23,16 @@ const INACTIVE_COLOR = '#95a5a6';
 // background are shared, only the surface and atmosphere change.
 const TEXTURE_BASE = '//unpkg.com/three-globe/example/img/';
 const GLOBE_DESIGNS = {
-    'blue-marble': {
-        label: 'Blue Marble',
-        globe: TEXTURE_BASE + 'earth-blue-marble.jpg',
-        atmosphereColor: '#3b82f6',
-        atmosphereAltitude: 0.18,
-    },
     'day': {
         label: 'Day',
         globe: TEXTURE_BASE + 'earth-day.jpg',
         atmosphereColor: '#93c5fd',
+        atmosphereAltitude: 0.18,
+    },
+    'blue-marble': {
+        label: 'Blue Marble',
+        globe: TEXTURE_BASE + 'earth-blue-marble.jpg',
+        atmosphereColor: '#3b82f6',
         atmosphereAltitude: 0.18,
     },
     'night': {
@@ -48,7 +48,7 @@ const GLOBE_DESIGNS = {
         atmosphereAltitude: 0.12,
     },
 };
-const DEFAULT_DESIGN = 'blue-marble';
+const DEFAULT_DESIGN = 'day';
 
 let map;
 

--- a/ai/topology/static/index.html
+++ b/ai/topology/static/index.html
@@ -29,6 +29,10 @@
             </select>
         </label>
         <label>
+            Globe
+            <select id="globe" title="Earth texture and atmosphere"></select>
+        </label>
+        <label>
             &nbsp;
             <button id="refresh" class="refresh-btn" title="Re-query the routers">Refresh</button>
         </label>


### PR DESCRIPTION
## Summary

The 3D topology viewer hardcoded one earth look (blue-marble texture, fixed blue atmosphere). This adds a **Globe** dropdown with four designs — **Day** (new default), **Blue Marble**, **Night lights**, and **Dark** — each pairing a three-globe example texture with a matching atmosphere color and altitude. The bump map and star-field background stay shared.

- A design flip only restyles the earth; it never re-queries the routers over MCP.
- The choice is mirrored into a `globe` URL parameter (omitted at the default) so it survives reloads and travels with shared links, matching the existing source/destination/algorithm behavior.
- All textures come from the same integrity-known `unpkg.com/three-globe/example/img/` set already in use — no new external host.
- README gains a "Globe designs" section documenting the four looks and the URL parameter.

## Test plan

- `node --check` on the modified `app.js`.
- Rebuilt `zebra-topology` (statics are `include_str!`-embedded) and smoke-tested the running server: `/` serves the new Globe select, `/static/app.js` serves the design code, and the binary embeds `DEFAULT_DESIGN = 'day'`.
- Verified all four texture URLs respond on unpkg.
- `cargo fmt --check`, workspace clippy, and `cargo test --workspace --exclude bdd` all clean (41/41 suites ok).

Generated with [Claude Code](https://claude.com/claude-code)