### PR TITLE
playset: link Flex-Algo manual from isis-flexalgo-ai AI prompt

### DIFF
--- a/playset/isis-flexalgo-ai/README.md
+++ b/playset/isis-flexalgo-ai/README.md
@@ -221,7 +221,9 @@ what to put on each of the eleven routers) to the assistant:
 > traffic has to travel the other way around, via Europe.
 >
 > Implement this with an IS-IS Flexible Algorithm (algorithm 128, IGP
-> metric, SR-MPLS data plane):
+> metric, SR-MPLS data plane). The zebra-rs Flex-Algorithm configuration
+> manual is at <https://zebra.rs/docs.html#ch-07-11-isis-flexalgo> —
+> follow its syntax and consistency rules:
 >
 > 1. Work out from the ontology and the live IS-IS topology which links
 >    cross the Pacific. Do not ask me — derive it.


### PR DESCRIPTION
## Summary
- Add the published Flex-Algo configuration manual URL (https://zebra.rs/docs.html#ch-07-11-isis-flexalgo, merged in #2302) to the recommended AI prompt in `playset/isis-flexalgo-ai/README.md`, so the assistant driving the demo over MCP is pointed at the exact `set`-line syntax and consistency rules.

## Test plan
- Docs-only change (playset README). Verified the anchor is live: the deployed `book/docs-data.js` bundle contains `ch-07-11-isis-flexalgo`.

Generated with [Claude Code](https://claude.com/claude-code)