### PR TITLE
isis: implement TI-LFA micro-loop avoidance

### DIFF
--- a/bdd/docs/isis_tilfa_bfd.md
+++ b/bdd/docs/isis_tilfa_bfd.md
@@ -16,11 +16,17 @@ PDUs, not IP) keep flowing, so the teardown is provably BFD's doing
 — the exact failure class the kernel's autonomous link-down path
 cannot cover.
 
-The switchover itself is observable only in the daemon log (the
-"rewired N protection group(s) onto repairs" line is emitted ONLY
-when at least one group actually moved): its kernel state is
-superseded within milliseconds by the post-convergence SPF routes,
-which is by design — the switchover is a bridge, not a steady state.
+The switchover itself is observable in the daemon log (the "rewired N
+protection group(s) onto repairs" line is emitted ONLY when at least
+one group actually moved). The convergence scenario enables IS-IS
+micro-loop avoidance so SPF may complete while that activated repair is
+deliberately retained, then verifies fixed-delay release.
+
+The convergence scenario makes the ordering deterministic on the source:
+SPF uses a 1 ms throttle while self-LSP generation waits 1000 ms. It asserts
+that the first pre-commit SPF is rejected by the self-LSP generation gate,
+then that the post-commit SPF enters the normal hold. The timer leaves are
+deleted after recovery, restoring their built-in defaults.
 
 ## Test Topology
 

--- a/bdd/tests/features/isis_tilfa_bfd.feature
+++ b/bdd/tests/features/isis_tilfa_bfd.feature
@@ -16,11 +16,11 @@ Feature: IS-IS TI-LFA kernel-side fast-reroute on BFD failure
   — the exact failure class the kernel's autonomous link-down path
   cannot cover.
 
-  The switchover itself is observable only in the daemon log (the
-  "rewired N protection group(s) onto repairs" line is emitted ONLY
-  when at least one group actually moved): its kernel state is
-  superseded within milliseconds by the post-convergence SPF routes,
-  which is by design — the switchover is a bridge, not a steady state.
+  The switchover itself is observable in the daemon log (the "rewired
+  N protection group(s) onto repairs" line is emitted ONLY when at
+  least one group actually moved). The convergence scenario enables
+  IS-IS micro-loop avoidance so SPF may complete while that activated
+  repair is deliberately retained, then verifies fixed-delay release.
 
   Test Topology (same wiring and metrics as isis_tilfa):
   ```
@@ -83,16 +83,37 @@ Feature: IS-IS TI-LFA kernel-side fast-reroute on BFD failure
 
   Scenario: BFD-down with the link up triggers the kernel-side switchover
     Given the test topology exists
+    When I apply command "set router isis fast-reroute micro-loop-avoidance rib-update-delay 10000" in namespace "s"
+    Then show command "show isis micro-loop-avoidance" in namespace "s" should contain "operational"
+    # Force the pre-fix race deterministically: the first SPF snapshots
+    # the failed live adjacency before our delayed self-LSP has removed
+    # the corresponding edge from the LSDB. The generation gate must keep
+    # that transient result from consuming the failure candidate.
+    When I apply command "set router isis spf-interval initial-wait 1" in namespace "s"
+    And I apply command "set router isis spf-interval secondary-wait 1" in namespace "s"
+    And I apply command "set router isis spf-interval maximum-wait 1" in namespace "s"
+    And I apply command "set router isis lsp-gen-interval initial-wait 1000" in namespace "s"
+    And I apply command "set router isis lsp-gen-interval secondary-wait 1000" in namespace "s"
+    And I apply command "set router isis lsp-gen-interval maximum-wait 1000" in namespace "s"
+    And I wait 3 seconds
     Then ping from "s" to "10.0.0.8" should succeed
     # Kill BFD only: the link stays up (no autonomous kernel flush) and
     # IIHs keep flowing (no IS-IS hold-timer expiry) — s must learn of
     # the failure from BFD and bridge traffic onto the repairs itself.
     When I drop bfd control packets in namespace "s"
     Then bfd session in namespace "s" on interface "s-n1" should be down
+    And daemon log in namespace "s" should eventually contain "awaiting self-LSP generation"
+    # SPF has completed, but the old protected route object remains in
+    # place so its already-switched TI-LFA group cannot be reasserted back
+    # to the failed primary before downstream convergence catches up.
+    And show command "show isis micro-loop-avoidance" in namespace "s" should eventually contain "Level-2: holding"
+    And ping from "s" to "10.0.0.8" should succeed
     # The switchover fired: at least one protection group was rewired
     # onto its repair (this exact line is only logged when N > 0).
     And daemon log in namespace "s" should eventually contain "rewired"
     And daemon log in namespace "s" should eventually contain "protection group(s) onto repairs"
+    # The fixed deadline publishes the latest post-convergence snapshot.
+    And show command "show isis micro-loop-avoidance" in namespace "s" should eventually contain "Level-2: idle"
     # SPF reconvergence then re-routes around n1 entirely: d is reached
     # out the s-n2 plane, and forwarding is healthy end to end.
     And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2"
@@ -104,6 +125,16 @@ Feature: IS-IS TI-LFA kernel-side fast-reroute on BFD failure
     Then bfd session in namespace "s" on interface "s-n1" should be up
     And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n1"
     And ping from "s" to "10.0.0.8" should succeed
+    # Restore the built-in 50/200/5000 ms SPF and 50/5000/5000 ms
+    # LSP-generation profiles so this scenario leaves no timer overrides.
+    When I apply command "delete router isis spf-interval initial-wait" in namespace "s"
+    And I apply command "delete router isis spf-interval secondary-wait" in namespace "s"
+    And I apply command "delete router isis spf-interval maximum-wait" in namespace "s"
+    And I apply command "delete router isis lsp-gen-interval initial-wait" in namespace "s"
+    And I apply command "delete router isis lsp-gen-interval secondary-wait" in namespace "s"
+    And I apply command "delete router isis lsp-gen-interval maximum-wait" in namespace "s"
+    When I apply command "delete router isis fast-reroute micro-loop-avoidance" in namespace "s"
+    Then show command "show isis micro-loop-avoidance" in namespace "s" should contain "not configured"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/l3vpn_ospf_v4.feature
+++ b/bdd/tests/features/l3vpn_ospf_v4.feature
@@ -67,6 +67,20 @@ Feature: MPLS/VPN L3VPN (IPv4) with OSPFv2 PE-CE both segments
     Then ping from "c1" to "10.0.2.1" should eventually succeed
     And ping from "c2" to "10.0.1.1" should eventually succeed
 
+  # Moving a live interface out of a VRF is delivered to its per-VRF OSPF
+  # child as LinkDel; moving it back is a fresh LinkAdd.  The OSPF interface
+  # intent (especially enabled + point-to-point) must outlive that runtime
+  # OspfLink object and rebuild the adjacency without reapplying router ospf.
+  Scenario: OSPFv2 interface intent survives a VRF detach and reattach
+    Given the test topology exists
+    When I apply command "delete interface ce2 vrf vrf-cust" in namespace "pe2"
+    Then command "ip -d link show ce2" in namespace "pe2" should eventually not contain "master vrf-cust"
+    When I apply command "set interface ce2 vrf vrf-cust" in namespace "pe2"
+    Then command "ip -d link show ce2" in namespace "pe2" should eventually contain "master vrf-cust"
+    And show command "show ospf vrf vrf-cust neighbor" in namespace "pe2" should eventually contain "Full"
+    And show command "show running-config formal" in namespace "pe2" should contain "set router ospf vrf vrf-cust area 0.0.0.0 interface ce2 network-type point-to-point"
+    And ping from "c1" to "10.0.2.1" should eventually succeed
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "c1"

--- a/bdd/tests/features/l3vpn_ospf_v6.feature
+++ b/bdd/tests/features/l3vpn_ospf_v6.feature
@@ -60,6 +60,19 @@ Feature: SRv6 L3VPN (IPv6) with OSPFv3 PE-CE both segments
     Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
     And ping from "c2" to "2001:db8:c1::1" should eventually succeed
 
+  # Regression for the same shared OspfLink lifecycle as v2.  The running
+  # configuration is unchanged by the VRF move; only the transient kernel-link
+  # object is deleted and recreated inside the per-VRF OSPFv3 instance.
+  Scenario: OSPFv3 interface intent survives a VRF detach and reattach
+    Given the test topology exists
+    When I apply command "delete interface ce2 vrf vrf-cust" in namespace "pe2"
+    Then command "ip -d link show ce2" in namespace "pe2" should eventually not contain "master vrf-cust"
+    When I apply command "set interface ce2 vrf vrf-cust" in namespace "pe2"
+    Then command "ip -d link show ce2" in namespace "pe2" should eventually contain "master vrf-cust"
+    And show command "show ospfv3 vrf vrf-cust neighbor" in namespace "pe2" should eventually contain "Full"
+    And show command "show running-config formal" in namespace "pe2" should contain "set router ospfv3 vrf vrf-cust area 0.0.0.0 interface ce2 network-type point-to-point"
+    And ping from "c1" to "2001:db8:c2::1" should eventually succeed
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "c1"

--- a/book/src/ch-12-00-nexthop-protect.md
+++ b/book/src/ch-12-00-nexthop-protect.md
@@ -101,6 +101,41 @@ Notes:
   shadow — an operator knob for exercising the repair path without
   rewiring the topology.
 
+### IS-IS micro-loop avoidance
+
+TI-LFA protects the local repair path, but different routers can still
+publish their post-convergence routes at different times. IS-IS can keep
+the already-activated repair in use for a fixed interval while the rest of
+the network converges:
+
+```
+router isis {
+  segment-routing mpls;
+  fast-reroute {
+    ti-lfa;
+    micro-loop-avoidance {
+      rib-update-delay 5000;  // milliseconds, 1..60000
+    }
+  }
+}
+```
+
+The delay starts only after a local link/BFD/adjacency failure and a
+successful protection activation. A per-level self-LSP generation gate also
+requires SPF to have observed the post-failure local topology; this prevents a
+faster SPF timer from consuming the candidate against the old self LSP.
+Eligible algorithm-0 native IPv4/IPv6 routes retain their old, switched
+TI-LFA protection group. Before that topology commit, an affected protected
+route omitted by the transient SPF is retained too; authoritative
+post-commit withdrawals, new prefixes, unprotected routes, Flex-Algorithm
+routes, and MPLS ILM updates remain immediate. The deadline is fixed and is
+not extended by additional SPF results. Activation failure, overlapping
+failures, recovery, a topology-gate watchdog, or a relevant configuration
+change fails open to normal convergence.
+
+This knob is currently IS-IS-only. OSPFv2 and OSPFv3 continue to use their
+existing TI-LFA convergence behavior.
+
 ## Scaling the TI-LFA computation (compute modes)
 
 The repair pre-computation is per-destination work: every protected

--- a/book/src/ch-14-04-show-isis.md
+++ b/book/src/ch-14-04-show-isis.md
@@ -158,6 +158,17 @@ Level-1 IPv4:
 
 JSON: `{ area, levels: [ { level, ipv4, ipv6 } ] }`.
 
+### `show isis micro-loop-avoidance`
+
+The IS-IS local-convergence-delay phase (`idle`, `candidate`, or `holding`)
+for each level, including the failed interface/cause, protection activation
+status, committed and last-SPF self-LSP generations, topology-gate readiness
+and watchdog time, remaining hold time, held IPv4/IPv6 prefix counts, and
+lifetime release/abort/failure counters.
+
+JSON: `{ enabled, operational, inactive_reason, rib_update_delay_ms,
+levels: [ … ] }`.
+
 ### `show isis fast-reroute prefix <A.B.C.D/M> detail`
 
 The TI-LFA protection detail for one IPv4 prefix — per-nexthop backup

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1015,8 +1015,11 @@ impl ParseBe<IsisTlvIpv4IfAddr> for IsisTlvIpv4IfAddr {
             )));
         }
         let addrs = input
-            .chunks_exact(4)
-            .map(|c| Ipv4Addr::from([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .copied()
+            .map(Ipv4Addr::from)
             .collect();
         Ok((&input[input.len()..], Self { addrs }))
     }
@@ -1241,12 +1244,11 @@ fn parse_ipv6_addr_array(input: &[u8]) -> IResult<&[u8], Vec<Ipv6Addr>> {
         )));
     }
     let addrs = input
-        .chunks_exact(16)
-        .map(|c| {
-            let mut octets = [0u8; 16];
-            octets.copy_from_slice(c);
-            Ipv6Addr::from(octets)
-        })
+        .as_chunks::<16>()
+        .0
+        .iter()
+        .copied()
+        .map(Ipv6Addr::from)
         .collect();
     Ok((&input[input.len()..], addrs))
 }

--- a/crates/packet-utils/src/fad.rs
+++ b/crates/packet-utils/src/fad.rs
@@ -39,11 +39,9 @@ impl FadSrlg {
     /// Parse 4-byte SRLG values; a trailing remainder shorter than 4 bytes is
     /// dropped (matches the OSPFv2 `many0` and OSPFv3 `while >= 4` originals).
     pub fn parse_value(value: &[u8]) -> Self {
+        let (srlgs, _) = value.as_chunks::<4>();
         Self {
-            srlgs: value
-                .chunks_exact(4)
-                .map(|c| u32::from_be_bytes([c[0], c[1], c[2], c[3]]))
-                .collect(),
+            srlgs: srlgs.iter().copied().map(u32::from_be_bytes).collect(),
         }
     }
 

--- a/crates/stamp-packet/src/return_path.rs
+++ b/crates/stamp-packet/src/return_path.rs
@@ -184,8 +184,11 @@ impl ReturnPathSubTlvValue {
                     return Err(ParseError::BadLabelStackLength { len: val.len() });
                 }
                 let stack = val
-                    .chunks_exact(4)
-                    .map(|c| MplsLabelEntry::from_raw(u32::from_be_bytes(c.try_into().unwrap())))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .copied()
+                    .map(|c| MplsLabelEntry::from_raw(u32::from_be_bytes(c)))
                     .collect();
                 Self::SrMplsLabelStack(stack)
             }
@@ -194,8 +197,11 @@ impl ReturnPathSubTlvValue {
                     return Err(ParseError::BadSegmentListLength { len: val.len() });
                 }
                 let sids = val
-                    .chunks_exact(16)
-                    .map(|c| Ipv6Addr::from(<[u8; 16]>::try_from(c).unwrap()))
+                    .as_chunks::<16>()
+                    .0
+                    .iter()
+                    .copied()
+                    .map(Ipv6Addr::from)
                     .collect();
                 Self::Srv6SegmentList(sids)
             }

--- a/docs/design/isis-micro-loop-avoidance.md
+++ b/docs/design/isis-micro-loop-avoidance.md
@@ -1,0 +1,791 @@
+# IS-IS TI-LFA Micro-loop Avoidance — Design
+
+Status: IMPLEMENTED — native algorithm-0 slice (2026-08-20)
+
+Implementation scope: the landed slice provides the per-level
+candidate/hold controller, RIB activation acknowledgement, stale-SPF
+revision gate, a per-level self router-LSP generation commit gate, native
+IPv4/IPv6 route partitioning, fixed timer, configuration/show surfaces, and
+BFD topology coverage. The generation gate preserves an affected protected
+route even when a pre-commit SPF omits it entirely, while post-commit
+withdrawals remain immediate. The graph-delta classifier, explicit
+`Suppressed` phase, Flex-Algorithm/ILM delay, and the additional
+physical-link/SRv6 BDD cases described below remain follow-up
+hardening/coverage rather than claims about this initial slice.
+
+This document designs the first zebra-rs micro-loop avoidance feature:
+an IS-IS-local, TI-LFA-backed RIB update delay. OSPF is deliberately
+out of scope for the first implementation, but the state machine and
+publish boundary are shaped so OSPF can reuse them later.
+
+The standards basis is [RFC 8333](https://www.rfc-editor.org/rfc/rfc8333.html)
+(local convergence delay) together with
+[RFC 9855](https://www.rfc-editor.org/rfc/rfc9855.html) (TI-LFA).
+RFC 9855 is explicit that TI-LFA alone does not prevent distributed
+convergence micro-loops: releasing a repair before downstream routers
+have converged can create one, and local convergence delay is one way
+to prevent that early release.
+
+## 1. Decision
+
+When this router detects a single local IS-IS adjacency/link loss:
+
+1. Activate the already-installed TI-LFA repair immediately. The
+   existing `Nexthop::Protect` fast path does this with an atomic
+   nexthop-group replacement for BFD loss; this design generalizes the
+   same operation to adjacency expiry. Kernel link-down performs the
+   equivalent promotion autonomously.
+2. Originate/flood the topology change and compute SPF/TI-LFA normally.
+3. Publish unrelated, new, and withdrawn routes immediately.
+4. For each changed route that was protected against the failed local
+   resource, keep its old, active TI-LFA repair in the RIB/FIB for a
+   configured delay.
+5. At expiry, publish the latest post-convergence route and its newly
+   computed repair for the next failure.
+
+The timer delays **route publication**, not LSP flooding or SPF. That is
+the important architectural boundary: other routers must learn the
+failure promptly, and zebra-rs must still compute and retain the latest
+desired state while forwarding remains on the old repair.
+
+The initial mode is always **protected-prefix only**. An unprotected
+old route is never retained after its primary fails. This is safer than
+an instance-wide blind delay and directly matches the request to build
+micro-loop avoidance on TI-LFA.
+
+## 2. What this does and does not guarantee
+
+### 2.1 Covered in the first implementation
+
+- IS-IS Level 1 and Level 2, with independent per-level state.
+- IPv4/SR-MPLS and IPv6/SRv6 `Nexthop::Protect` routes.
+- The IPv6 MT-2 RIB, which already flows through `rib_v6`.
+- Local physical-link down, BFD down while the link remains up, and
+  IS-IS adjacency expiry, provided the repair was demonstrably
+  activated.
+- A single local failure epoch. A second or ambiguous topology event
+  aborts the delay and converges normally.
+
+This prevents loops involving the local point of repair (PLR), which is
+the scope of RFC 8333. It is incrementally deployable and requires no
+new IS-IS TLV or neighbor capability.
+
+### 2.2 Explicit non-goals
+
+- Remote micro-loops that do not involve this PLR.
+- Link-up, metric-change, overload-bit, prefix-only, or other remote
+  topology events.
+- Ordered FIB (RFC 6976) and network-wide convergence ranks.
+- Temporary post-convergence SR policies computed on every router.
+  That is the broader “SR micro-loop avoidance” mechanism; it requires
+  old/new topology path encoding and is not the same as retaining a
+  precomputed TI-LFA repair.
+- Multiple simultaneous failures or SRLG failure correlation.
+- OSPFv2/OSPFv3 implementation in this series.
+- Flex-Algorithm RIBs and MPLS ILM publication delay. They remain
+  immediate in the first implementation and are the next dataplane
+  extension after native algorithm-0 IPv4/IPv6.
+
+Incoming SR-MPLS Prefix-SID traffic also needs the corresponding ILM to
+carry `Nexthop::Protect` before it can claim the same protection. Today
+`mpls_route()` retains backup information in `SpfIlm`, but
+`make_ilm_entry()` renders only a `Uni`/`Multi` primary. Native IP and
+recursively resolved traffic are covered first; protected ILMs are a
+separate implementation slice (Slice E in Section 14).
+
+## 3. Current behavior and the gap
+
+The current pipeline is:
+
+```text
+local failure
+  -> TI-LFA protection group switches to its repair
+  -> self LSP is regenerated and flooded
+  -> Message::SpfCalc(level)
+  -> build_spf_input()
+  -> spawn_blocking(compute_spf)          # SPF + new TI-LFA repairs
+  -> Message::SpfDone(output)
+  -> apply_spf_result()
+  -> apply_routing_updates()
+  -> diff_apply()                         # post-convergence RibAdd
+```
+
+`apply_spf_result()` currently replaces the old route within
+milliseconds. Re-adding a protected route also causes
+`resolve_nexthop_protect()` to return its protection group to
+`ProtectActive::Primary`. The repair is therefore an intentionally
+short bridge, as documented in
+`docs/design/nexthop-protect-kernel-failover.md`.
+
+That early release is the micro-loop window. The new first hop may
+still forward according to the old topology and send the packet back
+to this router. The desired sequence is instead:
+
+```text
+failure     SPF done             delay expires
+   |           |                       |
+   v           v                       v
+primary -> old TI-LFA repair -----> new SPF primary
+           (other routers converge)
+```
+
+The repair to retain is the one attached to the **old published
+route**. A repair computed by the post-failure SPF protects against a
+future failure in the new topology; it must not replace the repair for
+the failure currently in progress.
+
+## 4. Configuration
+
+Add a presence container beside `ti-lfa` under the existing IS-IS
+`fast-reroute` container:
+
+```yang
+container micro-loop-avoidance {
+  presence "Enable TI-LFA-backed local micro-loop avoidance";
+  leaf rib-update-delay {
+    type uint32 { range "1..60000"; }
+    units milliseconds;
+    default "5000";
+  }
+}
+```
+
+Example configuration:
+
+```text
+router isis {
+  segment-routing mpls;
+  fast-reroute {
+    ti-lfa;
+    micro-loop-avoidance {
+      rib-update-delay 5000;
+    }
+  }
+}
+```
+
+Equivalent set syntax:
+
+```text
+set router isis fast-reroute ti-lfa
+set router isis fast-reroute micro-loop-avoidance rib-update-delay 5000
+```
+
+Decisions:
+
+- Disabled by default.
+- A bare `micro-loop-avoidance` uses 5000 ms.
+- The timer range is 1..60000 ms. Operators should set it above the
+  measured worst-case network convergence time.
+- Do not add a YANG `must` tying the container to `ti-lfa`. Config
+  transaction ordering and temporarily staged configuration should
+  remain flexible. Runtime state reports `inactive: ti-lfa disabled`
+  until both are enabled and an SR dataplane can build repairs.
+- Changing or deleting this configuration during an active hold is a
+  fail-open operation: cancel the timer and publish the latest pending
+  snapshot immediately. A future event uses the new value.
+- `fast-reroute backup-as-primary` is a repair-test knob and is not
+  combined with micro-loop avoidance. When it is set, MLA reports
+  inactive rather than trying to reinterpret the inverted roles.
+
+Add these fields to `isis::config::IsisConfig`:
+
+```rust
+pub micro_loop_avoidance: bool,
+pub micro_loop_rib_update_delay_ms: u32, // default 5000
+```
+
+Configuration callbacks live in `isis/config.rs`. Enabling the knob
+does not originate an LSP and does not need an SPF: it changes only the
+next eligible convergence event. Disable/config-change must send a
+controller flush message if a hold is active.
+
+## 5. Failure identity and eligibility
+
+Blindly delaying every `SpfDone` is unsafe. The controller first needs
+proof of a local failure and then decides per route whether the old
+repair covers it.
+
+### 5.1 Local failure hint
+
+Before tearing down an adjacency, capture:
+
+```rust
+struct LocalFailure {
+    id: u64,
+    level: Level,
+    cause: FailureCause,       // LinkDown | BfdDown | AdjacencyExpired
+    ifindex: u32,
+    peer: IsisSysId,
+    peer_vertex: Option<usize>,
+    pseudonode: Option<IsisNeighborId>,
+    nexthops: BTreeSet<IpAddr>,
+    detected_at: Instant,
+}
+```
+
+The capture must happen while the neighbor entry still holds its IPv4
+and IPv6 link-local addresses. Refactor the duplicate address capture
+in `process_bfd_down()` into the common adjacency-teardown path so BFD
+and hold-timer expiry have identical protection behavior.
+
+`link_state_down()` creates one hint per affected level before it drops
+the neighbor maps. A physical link-down needs no `ProtectSwitch`: the
+RIB/kernel link-down path already invalidates the primary and promotes
+the installed shadow repair.
+
+For BFD and adjacency expiry with an operational link, call
+`RibClient::protect_switch()` before SPF. Extend the request with a
+failure cookie and return a targeted result to IS-IS:
+
+```rust
+Message::ProtectSwitch { addr, cookie }
+RibRx::ProtectSwitchResult {
+    cookie,
+    addr,
+    rewired_protect_groups,
+    evicted_ecmp_groups,
+}
+```
+
+The existing RIB function already returns `(switched, evicted)`, so
+this is an API plumbing change, not a new dataplane operation. A
+link-up failure is eligible only after at least one protection group
+was rewired. If the result has `rewired_protect_groups == 0` (including
+`--no-nhid`), converge immediately; holding a dead primary without
+proof of repair would turn protection into a black hole. ECMP eviction
+alone does not qualify a route for the delay.
+
+### 5.2 Topology validation
+
+The implemented native slice first uses an explicit local commit gate. Each
+complete self router-LSP set increments a per-level generation exactly once,
+after every fragment and trailing-fragment purge is in the LSDB. A failure
+candidate records the next required generation, and `SpfInput` stamps the
+generation of the graph it actually built. Therefore an SPF started against
+the pre-failure self LSP remains ineligible even if it completes after the
+new LSP is installed. While waiting, only old protected routes matching the
+failed resource are restored into the published snapshot, including a route
+omitted from desired RIB; unrelated changes continue immediately. A bounded
+internal watchdog derived from the existing LSP-generation and SPF maximum
+waits fails open if the commit or activation never completes. No new operator
+timer is required.
+
+The graph-delta classifier below remains the stricter follow-up design:
+
+A local event hint is necessary but not sufficient. Add a monotonically
+increasing per-level `topology_revision`, stamp it into `SpfInput` and
+`SpfOutput`, and compute the graph delta before `build_spf_input()`
+replaces `top.graph[level]`.
+
+A candidate remains eligible only when the topology delta describes
+the hinted resource:
+
+- one local outgoing adjacency on the captured ifindex disappeared;
+- the matching reverse edge may disappear in the same or a later SPF;
+- for a broadcast circuit, the equivalent local-router/pseudonode
+  edges are accepted;
+- no edge was added, no other edge disappeared, and no unrelated
+  metric changed.
+
+An LSP refresh with identical topology is ignored. Any delta the
+classifier cannot prove belongs to the same failure is “foreign” and
+aborts the candidate/hold. This intentionally prefers ordinary
+convergence over a questionable delay.
+
+If an SPF was snapshotted before the failure but finishes afterwards,
+its revision is stale. Do not publish that output. The existing
+`spf_pending` latch must drive the already-scheduled fresh run. This
+also removes a pre-existing, short stale-SPF publication window.
+
+### 5.3 Per-route eligibility
+
+Only a `different` old/new prefix is deferred, and only when all of
+the following hold:
+
+1. The old published route has exactly one primary nexthop.
+2. That nexthop matches the failure's ifindex, peer system ID, or
+   captured gateway address.
+3. The old nexthop has a non-empty TI-LFA backup.
+4. The RIB confirmed activation for a link-up failure, or the failure
+   is a physical link-down with autonomous kernel promotion.
+5. A usable new route exists and no longer uses the failed resource.
+6. `backup-as-primary` is off.
+
+Use a primary-only comparison helper: a change only to the repair for
+the *next* failure must not be mistaken for a primary transition.
+
+The other table-diff classes are deliberately immediate:
+
+| Diff class | Action | Reason |
+|---|---|---|
+| `only_curr` (withdrawal) | immediate delete | never retain a possibly dead destination |
+| `only_next` (new prefix) | immediate add | there is no old forwarding state to loop through |
+| `different`, unprotected | immediate add/delete | no safe repair exists to retain |
+| `different`, unrelated primary | immediate add | not traffic using the failed local resource |
+| `different`, eligible protected primary | defer | old repair is active and loop-free |
+| `identical` | no-op | preserve current state |
+
+## 6. State machine
+
+Maintain one controller per IS-IS level:
+
+```rust
+enum MlaPhase {
+    Idle,
+    Candidate(Candidate),
+    Holding(Hold),
+    Suppressed { until_revision: u64 },
+}
+
+struct Hold {
+    token: u64,
+    failure: LocalFailure,
+    started_at: Instant,
+    deadline: Instant,
+    timer: Timer,
+    latest: IsisRouteSnapshot,
+    deferred: DeferredCounts,
+}
+```
+
+`Suppressed` means a second/ambiguous event occurred. It prevents a
+multi-failure burst from being misclassified as a new single failure;
+one current-revision SPF is published normally before the controller
+returns to `Idle`.
+
+```text
+Idle
+  | proven local failure
+  v
+Candidate
+  | current SPF + matching delta + active repair + eligible route(s)
+  v
+Holding ---------------- timer expiry ----------------> Idle
+  |                          publish latest
+  |
+  +-- same failure update --> replace latest, keep original deadline
+  |
+  +-- foreign/second event --> publish latest --> Suppressed
+  |
+  +-- disable/config change -> publish latest ----------> Idle
+
+Candidate -- no repair / no eligible route / bad delta --> normal publish --> Idle
+Candidate -- foreign/second event ----------------------> Suppressed
+```
+
+Timer messages carry their token:
+
+```rust
+Message::MicroloopExpire { level, token }
+Message::MicroloopAbort { level, token, reason }
+```
+
+Dropping `Timer` cancels its task; checking the token makes an already
+queued stale expiry harmless.
+
+The deadline starts when the first qualifying post-failure SPF reaches
+the publish boundary, not when BFD detects the failure. This gives
+remote routers the full configured convergence interval after the
+topology has been flooded/computed. A matching follow-up SPF replaces
+`latest` but never extends the deadline, so LSP churn cannot retain the
+repair indefinitely.
+
+## 7. Separate desired state from published state
+
+The current `top.rib`, `top.rib_v6`, `top.rib_flex_algo`,
+`top.rib6_flex_algo`, and `top.ilm` maps serve both as show state and as
+the next `table_diff()` baseline. During a hold, “latest SPF result” and
+“published forwarding state” are different, so that implicit coupling
+must become explicit.
+
+Introduce a materialized snapshot:
+
+```rust
+struct IsisRouteSnapshot {
+    v4: PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
+    flex_v4: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>,
+    flex_v6: BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>,
+    flex_srv6_export: BTreeMap<u8, BTreeMap<IpNet, Ipv6Addr>>,
+    ilm: BTreeMap<u32, SpfIlm>,
+}
+```
+
+Refactor `apply_spf_result()` into three conceptual stages:
+
+```text
+1. accept_spf_result
+   update graph/SPF/TI-LFA caches and telemetry
+
+2. materialize_route_snapshot
+   build v4/v6/flex/ILM desired tables without publishing them
+
+3. publish_route_snapshot
+   table_diff against the published snapshot and send RIB messages
+```
+
+The controller sits between stages 2 and 3. Its partition operation
+constructs a partially published snapshot:
+
+- eligible prefixes retain their old published value;
+- every immediate class takes its new desired value;
+- `Hold.latest` owns the full latest desired snapshot.
+
+At expiry, diff the partially published snapshot against
+`Hold.latest`. Updates already sent immediately compare identical; only
+the held transitions remain.
+
+The existing `top.rib*` maps should continue to mean **published**
+state so existing show output and diff logic remain truthful. The
+latest SPF and TI-LFA graph caches continue to update immediately.
+`show isis micro-loop-avoidance` explains the intentional difference.
+
+Do not sleep in `SpfDone`, block the IS-IS actor, or defer the whole
+`SpfOutput`: LSDB processing, subsequent SPF coalescing, BFD recovery,
+show commands, and abort events must remain live throughout the delay.
+
+## 8. Side effects around route publication
+
+`apply_spf_result()` currently mixes route publication with other
+side effects. Split them by semantics:
+
+- Update graph, SPF result, TI-LFA result, and compute telemetry
+  immediately.
+- Recompute and register Mirror-SID egress protections immediately;
+  those registrations reflect LSDB state, not this route hold.
+- Reconcile the local self Prefix-SID ILM immediately; it is derived
+  from local configuration, not the remote SPF.
+- Publish/defer algorithm-0, MT-2, and Flex-Algorithm route snapshots
+  through the MLA controller.
+- In the first slice, publish transit ILM changes immediately and count
+  them as `unsupported_ilm`; Slice E in Section 14 closes that coverage
+  gap.
+- Run BGP-LS production from accepted LSDB/SPF state immediately. MLA
+  is a local forwarding decision and must not delay topology export.
+
+When BFD recovers during a hold, publish the pending post-failure routes
+**before** sending `ProtectRestore`. Otherwise the restore can briefly
+reactivate the old failed primary. Both operations use the same RIB
+client channel, so this ordering is enforceable.
+
+## 9. Handling another event during the delay
+
+RFC 8333 requires the delay to stop when a new convergence occurs. In
+this design:
+
+1. A topology-change hook classifies the change against the current
+   failure signature.
+2. A matching peer-side removal for the same failed adjacency may
+   update `Hold.latest`; the deadline is unchanged.
+3. Any other local failure, link recovery, edge/metric change, manual
+   SPF with changed topology, SR dataplane removal, or ambiguous delta
+   queues `MicroloopAbort`.
+4. Abort publishes the latest complete pending snapshot, cancels the
+   timer, and enters `Suppressed` until the next current SPF has been
+   published normally.
+
+If the foreign event arrives while still `Candidate`, there may be no
+pending snapshot to flush. Clear the candidate, mark the current
+revision suppressed, and allow its fresh SPF to publish normally.
+
+Prefix-only additions and withdrawals do not invalidate the failure
+epoch because they are never delayed. They publish immediately and are
+also folded into `Hold.latest`, preventing timer expiry from undoing
+them.
+
+## 10. Observability
+
+Add:
+
+```text
+show isis micro-loop-avoidance
+```
+
+Example:
+
+```text
+Micro-loop avoidance: enabled
+  Mode: TI-LFA protected-prefix local delay
+  RIB update delay: 5000 ms
+  L1: idle
+  L2: holding, 3178 ms remaining
+      cause: bfd-down, peer 0000.0000.0002, ifindex 8
+      failure-id: 42, topology-revision: 177
+      deferred: ipv4=814 ipv6=802
+      immediate: add=2 delete=1 change=4
+      repair activation: groups=9
+```
+
+When configured but unusable:
+
+```text
+Micro-loop avoidance: inactive (TI-LFA disabled)
+```
+
+Support JSON with stable fields for enabled/effective state, delay,
+phase, cause, peer, ifindex, remaining milliseconds, revision, counts,
+last completion reason, and cumulative counters.
+
+Cumulative per-level counters:
+
+- eligible local failures;
+- candidates rejected by reason (`no-repair`, `no-fast-activation`,
+  `ambiguous-delta`, `backup-as-primary`, `stale-spf`);
+- holds started and expired;
+- holds aborted by reason;
+- prefixes deferred by AFI/topology;
+- maximum and last actual hold duration;
+- unsupported protected ILMs observed.
+
+Log only state transitions at info level (`armed`, `expired`,
+`aborted`), with one summary line rather than one line per prefix.
+Per-prefix decisions belong behind IS-IS tracing.
+
+The dedicated command owns convergence-state counters; the existing
+`show isis fast-reroute summary` remains a TI-LFA protection inventory.
+
+## 11. Safety rules
+
+These invariants are load-bearing:
+
+1. **Never delay without an old repair.** New-SPF TI-LFA state is not
+   proof that the old route survived the current failure.
+2. **Never delay an authoritative withdrawal.** A withdrawal from an SPF
+   stamped with the required post-failure self-LSP generation is immediate.
+   A matching protected route omitted by an earlier generation is a
+   transitional snapshot and is retained until the commit gate resolves.
+3. **Never delay without repair activation evidence** when the link is
+   still operational.
+4. **Never re-add a held protected prefix before expiry.** RIB route
+   resolution would reset `ProtectActive::Switched` to `Primary`.
+5. **Never extend the original deadline** for matching follow-up SPFs.
+6. **Abort on uncertainty or a second event.** TI-LFA only promises
+   the modeled single failure.
+7. **A stale SPF cannot publish.** Its topology revision predates the
+   event it would overwrite, or its self-LSP generation predates the
+   candidate's required local-topology commit.
+8. **Timer cancellation is generation-safe.** A queued old expiry is a
+   no-op.
+9. **Configuration removal flushes, not drops, pending state.**
+10. **Protocol shutdown bypasses MLA.** Cleanup/withdrawal must never
+    wait for the update-delay timer.
+
+Additional guards:
+
+- Do not arm when `distribute.rib` is disabled.
+- Graceful-restart hold-back takes precedence; MLA is idle while the
+  restarter is holding the FIB.
+- A route whose new primary still references the failed interface is
+  ineligible and publishes normally (usually as a delete after empty
+  nexthop collapse).
+- L1 and L2 timers are independent, but a physical interface event may
+  create candidates for both levels with the same failure ID.
+- Per-VRF IS-IS instances own independent controllers and timers.
+
+## 12. Unit tests
+
+Put the pure partition and state-machine tests in
+`isis/microloop.rs`.
+
+Partition matrix:
+
+- changed single-primary route, matching failed nexthop, backup present
+  -> deferred;
+- matching route without backup -> immediate;
+- unrelated protected route -> immediate;
+- new route -> immediate;
+- withdrawal -> immediate;
+- ECMP route -> immediate;
+- new route still using failed resource -> immediate/fail open;
+- only the future backup changed -> immediate;
+- `backup-as-primary` -> immediate/inactive;
+- IPv4, IPv6, MT-2, and per-algorithm keys stay isolated.
+
+State-machine matrix (with a fake clock):
+
+- `Idle -> Candidate -> Holding -> Idle` on expiry;
+- no eligible prefixes returns directly to `Idle`;
+- zero rewired groups rejects a BFD/hold-timeout candidate;
+- matching reverse-edge update replaces `latest` without extending the
+  deadline;
+- second failure/foreign delta aborts and enters `Suppressed`;
+- config disable flushes;
+- BFD recovery flushes before restore;
+- stale SPF output is ignored;
+- stale timer token is ignored;
+- L1 and L2 holds do not overwrite one another;
+- a prefix added/withdrawn during a hold is not resurrected at expiry.
+
+RIB API tests:
+
+- `ProtectSwitchResult` is returned only to the requesting protocol;
+- cookie and table/VRF scope survive the round trip;
+- `rewired=0` on `--no-nhid`/no candidate;
+- ECMP eviction is reported separately and does not count as a TI-LFA
+  repair activation.
+
+## 13. BDD coverage
+
+Extend the existing `@tilfa_bfd` topology rather than creating another
+eight-node lab for the base case.
+
+1. Configure a visibly long delay (for example 4000 ms).
+2. Set the source SPF throttle to 1 ms and its self-LSP-generation throttle
+   to 1000 ms, forcing the pre-commit SPF ordering window.
+3. Drop BFD control packets while the data link and IS-IS IIHs remain
+   up.
+4. Assert the log reports `awaiting self-LSP generation` and the RIB reports
+   protection-group rewiring.
+5. Assert the post-commit SPF completes while
+   `show isis micro-loop-avoidance` remains
+   `holding`.
+6. During the hold, assert the active nexthop is the repair and still
+   carries its MPLS label stack (or SRv6 segment list), rather than the
+   plain post-convergence route.
+7. Run continuous traffic across the SPF-complete boundary and assert
+   no loss attributable to early repair release.
+8. After expiry, assert the plain post-convergence route is primary and
+   the controller is idle.
+9. Delete the temporary SPF/LSP timer leaves so their built-in defaults are
+   restored.
+
+Add focused scenarios for:
+
+- physical link-down autonomous promotion;
+- non-BFD adjacency expiry using `ProtectSwitch` before teardown;
+- SRv6 parity;
+- an unprotected prefix changing immediately during another prefix's
+  hold;
+- second link failure aborting the hold;
+- link recovery aborting the hold;
+- disabling MLA or TI-LFA during a hold;
+- remote-only link failure and link-up not arming local-delay MLA;
+- `--no-nhid` BFD failure rejecting the delay;
+- timer expiry after a matching follow-up SPF uses the newest desired
+  snapshot.
+
+The existing BDD comment saying the switched state is “superseded
+within milliseconds” must be updated: with MLA enabled, persistence
+through the configured RIB-update delay is now the behavior under test.
+
+## 14. Implementation slices
+
+### Slice A — publish-boundary refactor (behavior-neutral)
+
+- Add `IsisRouteSnapshot`.
+- Split materialization from publication in `isis/rib.rs`.
+- Keep existing maps as the published-state diff baseline.
+- Add equivalence tests proving every current diff emits the same RIB
+  messages with MLA disabled.
+
+### Slice B — failure identity and RIB acknowledgement
+
+- Add per-level topology revisions and stamp SPF input/output.
+- Capture `LocalFailure` before adjacency/link teardown.
+- Generalize fast repair activation to IS-IS adjacency expiry.
+- Add the cookie-bearing `ProtectSwitchResult` RIB API.
+- Reject stale SPF publication.
+
+### Slice C — controller, config, and show
+
+- Add `isis/microloop.rs` with the state machine and pure partitioner.
+- Add YANG/config callbacks and `Message::MicroloopExpire/Abort`.
+- Add text/JSON show output and transition counters.
+- Implement config-disable, recovery, shutdown, and foreign-event
+  abort ordering.
+
+### Slice D — native IPv4/IPv6 dataplane BDD
+
+- Extend SR-MPLS BFD coverage.
+- Add physical-link and abort tests.
+- Add SRv6 parity.
+- Document operator behavior in the book and TI-LFA playsets.
+
+### Slice E — SR-MPLS ILM protection
+
+- Render a Prefix-SID `SpfIlm` with an old TI-LFA backup as
+  `Nexthop::Protect`, using the repair stack as the MPLS new-destination
+  operation.
+- Verify `ProtectSwitch` rewires both IP routes and incoming-label ILMs.
+- Include protected ILM transitions in the delayed snapshot and remove
+  the `unsupported_ilm` qualification/counter.
+- Add transit-label packet captures, not only locally originated ping.
+
+Each slice should be independently reviewable; Slice A must land
+without changing forwarding behavior.
+
+## 15. Why not the alternatives
+
+### Delay SPF or the IS-IS actor
+
+Rejected. Flooding and SPF must continue promptly, and the actor must
+remain responsive to a second failure, recovery, show requests, and
+timer cancellation. RFC 8333 delays RIB/FIB update, not topology
+distribution.
+
+### Delay every route in the level
+
+Rejected for the TI-LFA-backed first implementation. It would retain
+unprotected routes and withdrawals, exactly where no safe forwarding
+state exists. A later explicit “all prefixes” mode would need a safe
+temporary SR path, not just a timer.
+
+### Install the new SPF route and keep its new TI-LFA backup active
+
+Rejected. That backup protects a possible next failure in the new
+topology; it is not necessarily a repair for the failure in progress.
+The safe state is the old route's already-activated repair.
+
+### Implement ordered FIB first
+
+Rejected for this series. Ordered FIB offers broader guarantees but
+requires old/new SPT ranking and coordinated network timing. Local
+delay reuses the protection and event machinery already present and
+requires no interoperability protocol.
+
+### Build temporary post-convergence SR policies now
+
+Deferred. This is the right future mechanism for remote events,
+link-up, metric changes, and all-prefix coverage. It needs a separate
+old/new topology path encoder, SID-depth handling, fallback behavior,
+and temporary policy lifecycle. Reusing the name “TI-LFA” for that
+work would obscure that it is computed after the event rather than
+pre-installed for local repair.
+
+## 16. OSPF later
+
+Do not add OSPF config or event hooks in this series. Keep the reusable
+seams narrow:
+
+- a protocol-neutral timer/token shell;
+- a generic table-diff partition helper parameterized by an eligibility
+  predicate;
+- the cookie-bearing RIB repair-activation result;
+- a snapshot publish contract: latest desired state versus currently
+  published state.
+
+IS-IS retains ownership of adjacency/pseudonode failure classification
+and route matching. A future OSPF port supplies area/interface/neighbor
+identity and LSA topology-delta validation without forcing IS-IS data
+types into shared code.
+
+## 17. Acceptance criteria
+
+The feature is complete when all of the following are true:
+
+- A BFD- or link-down-triggered, TI-LFA-protected IS-IS route remains
+  on its pre-failure repair after SPF completes and for the configured
+  delay.
+- The latest post-convergence route replaces it at expiry.
+- Withdrawals and unprotected changes are never delayed.
+- A second/ambiguous event or recovery cancels the hold and converges
+  normally.
+- No old timer or stale SPF can overwrite newer state.
+- SR-MPLS and SRv6 native routes behave identically.
+- Text and JSON show output explain whether the feature is inactive,
+  candidate, holding, expired, or aborted and why.
+- MLA-disabled behavior is message-for-message equivalent to the
+  current pipeline.
+- The documentation states the local-loop guarantee and does not claim
+  remote/link-up micro-loop prevention.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -4948,6 +4948,57 @@ mod yang_load_tests {
         );
     }
 
+    /// Pin the IS-IS-only micro-loop avoidance configuration and show
+    /// grammar. In particular, keep the millisecond delay range at
+    /// 1..60000 so zero cannot accidentally turn a fixed hold into an
+    /// immediate/repeating timer edge case.
+    #[test]
+    fn isis_microloop_avoidance_commands_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+        for cmd in [
+            "set router isis fast-reroute micro-loop-avoidance",
+            "set router isis fast-reroute micro-loop-avoidance rib-update-delay 5000",
+        ] {
+            let (code, _, _) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must parse");
+        }
+        for cmd in [
+            "set router isis fast-reroute micro-loop-avoidance rib-update-delay 0",
+            "set router isis fast-reroute micro-loop-avoidance rib-update-delay 60001",
+        ] {
+            let (code, _, _) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(
+                code,
+                ExecCode::Success,
+                "`{cmd}` must fail range validation"
+            );
+        }
+
+        let mut exec_yang = YangStore::new();
+        exec_yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        exec_yang
+            .read_with_resolve("exec")
+            .expect("exec mode loads");
+        exec_yang.identity_resolve();
+        let module = exec_yang.find_module("exec").expect("exec module present");
+        let entry = to_entry(&exec_yang, module);
+        let cmd = "show isis micro-loop-avoidance";
+        let (code, _, _) = parse(cmd, entry, None, State::new());
+        assert_eq!(code, ExecCode::Success, "`{cmd}` must parse");
+    }
+
     /// The top-level `bfd { tracing }` flag (conditional-tracing toggle) must
     /// be a settable path. It's a hand-added top-level container in
     /// `config.yang`; the BFD task reads it off the config broadcast.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -141,6 +141,14 @@ impl Isis {
         );
         self.callback_add("/router/isis/fast-reroute/ti-lfa", config_ti_lfa);
         self.callback_add(
+            "/router/isis/fast-reroute/micro-loop-avoidance",
+            config_microloop_avoidance,
+        );
+        self.callback_add(
+            "/router/isis/fast-reroute/micro-loop-avoidance/rib-update-delay",
+            config_microloop_rib_update_delay,
+        );
+        self.callback_add(
             "/router/isis/fast-reroute/ti-lfa/compute-mode/serial",
             config_ti_lfa_compute_mode_serial,
         );
@@ -517,6 +525,16 @@ pub struct IsisConfig {
     /// Adj-SID B-flag (RFC 8667 §2.2.1) emitted in TLV 22 sub-TLVs.
     pub ti_lfa_enabled: bool,
 
+    /// RFC 8333-style local convergence delay. When enabled, a local
+    /// failure that successfully activates a pre-installed TI-LFA repair
+    /// retains eligible native routes until `microloop_rib_update_delay_ms`.
+    pub microloop_avoidance_enabled: bool,
+
+    /// Fixed native RIB publication hold, in milliseconds. The deadline is
+    /// snapshotted when a hold starts and is never extended by later SPF
+    /// results. Default 5000 ms.
+    pub microloop_rib_update_delay_ms: u32,
+
     /// Set when /router/isis/fast-reroute/backup-as-primary is
     /// committed. Inverts the primary/backup metric-sort offset used
     /// by `make_rib_entry`: the TI-LFA repair installs at
@@ -799,6 +817,8 @@ impl Default for IsisConfig {
             sr_srv6_locator: Default::default(),
             sr_srv6_flex_algo_locators: Default::default(),
             ti_lfa_enabled: Default::default(),
+            microloop_avoidance_enabled: false,
+            microloop_rib_update_delay_ms: 5000,
             fast_reroute_backup_as_primary: Default::default(),
             ti_lfa_compute_mode: Default::default(),
             // Matches the YANG `default 8` on the sharding `shards` leaf.
@@ -1448,6 +1468,9 @@ fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     if isis.config.ti_lfa_enabled == prev {
         return Some(());
     }
+    if !isis.config.ti_lfa_enabled {
+        isis.microloop_abort_all();
+    }
     // Re-originate the self LSP so the Adj-SID B-flag (RFC 8667 §2.2.1)
     // reflects the new state at LSP-generation time. has_level() inside
     // process_lsp_originate filters out the wrong level for
@@ -1459,6 +1482,32 @@ fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     // drops them (on disable) for every prefix in this instance.
     let _ = isis.tx.send(Message::SpfCalc(Level::L1));
     let _ = isis.tx.send(Message::SpfCalc(Level::L2));
+    Some(())
+}
+
+fn config_microloop_avoidance(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    let enabled = op.is_set();
+    if isis.config.microloop_avoidance_enabled == enabled {
+        return Some(());
+    }
+    if !enabled {
+        // Publish any pending desired snapshot before disabling the gate;
+        // dropping the Timer alone would strand the old route cache.
+        isis.microloop_abort_all();
+    }
+    isis.config.microloop_avoidance_enabled = enabled;
+    Some(())
+}
+
+fn config_microloop_rib_update_delay(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let delay = if op.is_set() { args.u32()? } else { 5000 };
+    if isis.config.microloop_rib_update_delay_ms == delay {
+        return Some(());
+    }
+    // An active hold owns a fixed deadline. Treat changing its policy as
+    // an operator abort, publish now, and apply the new delay next event.
+    isis.microloop_abort_all();
+    isis.config.microloop_rib_update_delay_ms = delay;
     Some(())
 }
 
@@ -1562,6 +1611,9 @@ fn config_fast_reroute_backup_as_primary(isis: &mut Isis, _args: Args, op: Confi
     isis.config.fast_reroute_backup_as_primary = op.is_set();
     if isis.config.fast_reroute_backup_as_primary == prev {
         return Some(());
+    }
+    if isis.config.fast_reroute_backup_as_primary {
+        isis.microloop_abort_all();
     }
     // Re-run SPF so the RIB rebuilds with the inverted primary/backup
     // metric ordering. No LSP re-origination needed — the swap is a
@@ -2038,6 +2090,10 @@ fn config_te_router_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<
 
 fn config_distribute_rib(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let enable = args.boolean()?;
+
+    // A distribution-policy change invalidates the publication contract of
+    // an active hold. Release under the old policy before flipping it.
+    isis.microloop_abort_all();
 
     if op.is_set() {
         isis.config.distribute.rib = enable;

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -255,6 +255,9 @@ pub struct Isis {
     pub peer_algo_srv6: Levels<BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>>,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute<V4>>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRoute<V6>>>,
+    /// Runtime state for RFC 8333-style local convergence delay over
+    /// activated TI-LFA repairs. IS-IS-owned; OSPF remains untouched.
+    pub microloop: super::microloop::MicroloopState,
     /// Mirror SID node-protection stale-route retention: protected egress
     /// locators currently kept alive in the FIB (mapped to the Mirror SID
     /// they redirect to) after the protected egress's LSP aged out, so a
@@ -661,6 +664,7 @@ pub struct IsisTop<'a> {
     pub peer_algo_srv6: &'a mut Levels<BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>>,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute<V4>>>,
     pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRoute<V6>>>,
+    pub microloop: &'a mut super::microloop::MicroloopState,
     pub retained_locators: &'a mut Levels<BTreeMap<Ipv6Net, RetainEntry>>,
     pub egress_protect_registered: &'a mut BTreeMap<Ipv6Net, (std::net::Ipv6Addr, IsisSysId)>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
@@ -838,6 +842,7 @@ impl Isis {
                     Levels::<BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>>::default(),
                 rib: Levels::<PrefixMap<Ipv4Net, SpfRoute<V4>>>::default(),
                 rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRoute<V6>>>::default(),
+                microloop: super::microloop::MicroloopState::default(),
                 retained_locators: Levels::<BTreeMap<Ipv6Net, RetainEntry>>::default(),
                 egress_protect_registered: BTreeMap::new(),
                 ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
@@ -1452,6 +1457,10 @@ impl Isis {
             tracing::warn!("[GR Restart] begin ignored: already restarting");
             return;
         }
+        // Graceful restart owns the FIB hold-back policy. Flush any active
+        // micro-loop delay before entering GR so two independent retention
+        // controllers never overlap.
+        self.microloop_abort_all();
         let t1_timer = arm_t1_timer(&self.tx);
         self.restarting = Some(RestartingState {
             started_at: std::time::SystemTime::now(),
@@ -1952,6 +1961,24 @@ impl Isis {
                 if ev != NfsmEvent::HoldTimerExpire {
                     return;
                 }
+                // Snapshot failure identity before teardown removes the
+                // neighbor. The RIB acknowledgement is the activation
+                // commit point for micro-loop avoidance.
+                if let Some(link) = self.links.get(&ifindex)
+                    && let Some(nbr) = link.state.nbrs.get(&level).get(&sys_id)
+                {
+                    let mut nexthops = BTreeSet::new();
+                    nexthops.extend(nbr.addr4.keys().copied().map(std::net::IpAddr::V4));
+                    nexthops.extend(nbr.addr6l.iter().copied().map(std::net::IpAddr::V6));
+                    self.microloop_failure_begin(
+                        level,
+                        super::microloop::FailureCause::AdjacencyExpired,
+                        ifindex,
+                        BTreeSet::from([sys_id]),
+                        nexthops,
+                        false,
+                    );
+                }
                 let Some(mut link) = self.link_top(ifindex) else {
                     return;
                 };
@@ -2006,8 +2033,13 @@ impl Isis {
             }
             Message::SpfDone(output) => {
                 let level = output.level;
+                let stale = self
+                    .microloop
+                    .output_is_stale(level, output.microloop_revision);
                 let mut top = self.top();
-                apply_spf_result(&mut top, *output);
+                if !stale {
+                    apply_spf_result(&mut top, *output);
+                }
                 *top.spf_inflight.get_mut(&level) = false;
                 if std::mem::take(top.spf_pending.get_mut(&level)) {
                     let _ = self.tx.send(Message::SpfCalc(level));
@@ -2016,12 +2048,29 @@ impl Isis {
                 // Level-independent (config + global SR block, not SPF),
                 // so done once here after `top`'s borrow ends rather than
                 // in the per-level apply path; idempotent across L1/L2.
-                update_self_sid_ilm(self);
+                if !stale {
+                    update_self_sid_ilm(self);
+                }
                 // The LSDB is settled after SPF — push the BGP-LS producer's
                 // delta to BGP (RFC 9552). `top` is no longer used, so its
                 // mutable borrow of `self` has ended (NLL) and the disjoint
                 // field borrows inside `bgp_ls_produce` are free.
-                self.bgp_ls_produce();
+                if !stale {
+                    self.bgp_ls_produce();
+                }
+            }
+            Message::MicroloopActivation {
+                level,
+                failure_id,
+                activated,
+                rewired,
+                evicted,
+            } => self.microloop_activation_result(level, failure_id, activated, rewired, evicted),
+            Message::MicroloopExpire { level, token } => {
+                self.microloop_expire(level, token);
+            }
+            Message::MicroloopCandidateExpire { level, failure_id } => {
+                self.microloop_candidate_expire(level, failure_id);
             }
             Message::Recv(packet, ifindex, mac) => {
                 let Some(mut top) = self.link_top(ifindex) else {
@@ -2086,6 +2135,10 @@ impl Isis {
                 self.process_lsdb(ev, level, key);
             }
             Message::AdjacencyUp(level, ifindex) => {
+                // A neighbor returning before the fixed deadline invalidates
+                // the local-failure predicate even when no BFD session owns
+                // the recovery event.
+                self.microloop_abort_ifindex(ifindex);
                 self.schedule_lsp_originate(level, None);
 
                 let Some(mut link) = self.link_top(ifindex) else {
@@ -2480,8 +2533,8 @@ impl Isis {
         // total TLV footprint shrank). Send a Purge for each so the
         // network flushes them; the standard purge path emits a
         // RemainingLifetime=0 LSP at a bumped seq.
-        let self_sys = self.config.net.sys_id();
-        let orphans: Vec<IsisLspId> = self
+        let self_sys = top.config.net.sys_id();
+        let orphans: Vec<IsisLspId> = top
             .lsdb
             .get(&level)
             .iter()
@@ -2493,9 +2546,21 @@ impl Isis {
             })
             .map(|(id, _)| *id)
             .collect();
+        // Purge trailing fragments synchronously as part of this generation.
+        // Otherwise an SPF could snapshot the new fragment 0 together with
+        // an old higher fragment, yet carry the newly committed generation.
+        // `insert_self_originate` still floods and schedules SPF normally.
         for lsp_id in orphans {
-            let _ = self.tx.send(Message::LspPurge(level, lsp_id));
+            Self::process_lsp_purge_top(&mut top, level, lsp_id, self_sys);
         }
+
+        let generation = top.microloop.self_lsp_committed(level);
+        tracing::debug!(
+            level = %level,
+            self_lsp_generation = generation,
+            fragments = max_frag as usize + 1,
+            "isis: complete self router-LSP generation committed"
+        );
     }
 
     /// Throttle-aware front door for self-LSP origination. Multiple
@@ -2604,12 +2669,12 @@ impl Isis {
         );
     }
 
-    fn process_lsp_purge(&mut self, level: Level, lsp_id: IsisLspId) {
-        // Capture sys-id before `self.top()` takes the mutable borrow
-        // of `self.config`; needed for the RFC 6232 POI stamp below.
-        let own_sys_id = self.config.net.sys_id();
-        let mut top = self.top();
-
+    fn process_lsp_purge_top(
+        top: &mut IsisTop,
+        level: Level,
+        lsp_id: IsisLspId,
+        own_sys_id: IsisSysId,
+    ) {
         // Get current LSP if it exists. `saturating_add` so the
         // seq-number-wrap purge path (existing = u32::MAX - 1) emits
         // a final LSP at u32::MAX without panicking; the freeze
@@ -2618,7 +2683,7 @@ impl Isis {
             existing.lsp.seq_number.saturating_add(1)
         } else {
             isis_event_trace!(
-                self.tracing,
+                top.tracing,
                 LspPurge,
                 &level,
                 "Cannot purge LSP {} - not found in LSDB",
@@ -2644,9 +2709,17 @@ impl Isis {
         // was discarded, so the POI stamp landed in the LSDB but
         // never reached peers.
         let buf = lsp_emit(&mut purged_lsp, level, resolved.as_ref());
-        insert_self_originate(&mut top, level, purged_lsp, Some(buf.to_vec()));
+        insert_self_originate(top, level, purged_lsp, Some(buf.to_vec()));
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
+    }
+
+    fn process_lsp_purge(&mut self, level: Level, lsp_id: IsisLspId) {
+        // Capture sys-id before `self.top()` takes the mutable borrow
+        // of `self.config`; needed for the RFC 6232 POI stamp below.
+        let own_sys_id = self.config.net.sys_id();
+        let mut top = self.top();
+        Self::process_lsp_purge_top(&mut top, level, lsp_id, own_sys_id);
     }
 
     /// ISO 10589 §7.3.16.4 wait expired for one specific fragment:
@@ -3029,6 +3102,21 @@ impl Isis {
             return;
         };
         let ifindex = key.ifindex;
+        let mut failed_nhops = BTreeSet::from([key.remote]);
+        if let Some(link) = self.links.get(&ifindex)
+            && let Some(nbr) = link.state.nbrs.get(&level).get(&sys_id)
+        {
+            failed_nhops.extend(nbr.addr4.keys().copied().map(std::net::IpAddr::V4));
+            failed_nhops.extend(nbr.addr6l.iter().copied().map(std::net::IpAddr::V6));
+        }
+        self.microloop_failure_begin(
+            level,
+            super::microloop::FailureCause::BfdDown,
+            ifindex,
+            BTreeSet::from([sys_id]),
+            failed_nhops,
+            false,
+        );
         // Capture the toggle before borrowing the link — `link_top` takes
         // `&mut self`, so `self.tracing` is unreachable while `link` is held.
         let trace_bfd = self.tracing.should_trace_bfd();
@@ -3044,16 +3132,6 @@ impl Isis {
                 "isis: tearing down adjacency on bfd-down (RFC 5882 §5)",
             );
         }
-        // Capture the neighbour's nexthop addresses BEFORE the teardown
-        // removes the entry — these are the exact keys SPF used for this
-        // adjacency's routes (v4: interface addrs from TLV 132, v6: the
-        // link-locals from TLV 232), i.e. the addresses the RIB's
-        // protection groups key their primaries on.
-        let mut failed_nhops: Vec<std::net::IpAddr> = Vec::new();
-        if let Some(nbr) = link.state.nbrs.get(&level).get(&sys_id) {
-            failed_nhops.extend(nbr.addr4.keys().copied().map(std::net::IpAddr::V4));
-            failed_nhops.extend(nbr.addr6l.iter().copied().map(std::net::IpAddr::V6));
-        }
         // Tear the adjacency but keep the BFD session probing. This clears any
         // prior hold-down pin, so set the pin afterwards.
         nbr_hold_timer_expire(&mut link, level, sys_id, false);
@@ -3062,21 +3140,13 @@ impl Isis {
         // if the neighbour entry is absent from `nbrs` at that point (race:
         // BFD Up fires before the next IIH re-creates the entry).
         link.state.bfd_holddown_nbr.insert(*key, (level, sys_id));
-        // Fast-reroute switchover: rewire the
-        // pre-installed protection groups onto their TI-LFA repairs NOW,
-        // before the LSP regeneration / SPF / per-prefix reinstall pipeline
-        // even starts. One message per failed nexthop address; the RIB
-        // no-ops when nothing is protected. Channel ordering guarantees
-        // this lands before the post-convergence route updates.
-        for addr in failed_nhops {
-            let _ = self.ctx.rib.protect_switch(addr);
-        }
     }
 
     /// BFD session came Up: lift any hold-down pin for the neighbour so the
     /// next received IIH promotes its adjacency back to Up. A no-op when the
     /// neighbour was not held (e.g. the normal first-Up after adjacency form).
     fn process_bfd_up(&mut self, key: &crate::bfd::session::SessionKey) {
+        self.microloop_abort_ifindex(key.ifindex);
         // Undo the switchover's ECMP leg eviction FIRST, before any of the
         // early returns below. Each of those is a legitimate "no adjacency
         // bookkeeping to do" case — the neighbour re-formed from an IIH
@@ -3174,6 +3244,7 @@ impl Isis {
             peer_algo_srv6: &mut self.peer_algo_srv6,
             rib: &mut self.rib,
             rib_v6: &mut self.rib_v6,
+            microloop: &mut self.microloop,
             retained_locators: &mut self.retained_locators,
             egress_protect_registered: &mut self.egress_protect_registered,
             ilm: &mut self.ilm,
@@ -3902,6 +3973,27 @@ pub enum Message {
     /// one follow-up `SpfCalc` so coalesced LSDB changes still
     /// converge.
     SpfDone(Box<super::rib::SpfOutput>),
+    /// Completion of one RIB protection activation request. Multiple
+    /// address-scoped results aggregate into the candidate failure.
+    MicroloopActivation {
+        level: Level,
+        failure_id: u64,
+        activated: bool,
+        rewired: usize,
+        evicted: usize,
+    },
+    /// Fixed local-convergence delay expired. `token` makes callbacks
+    /// from cancelled/replaced holds harmless.
+    MicroloopExpire {
+        level: Level,
+        token: u64,
+    },
+    /// Safety watchdog for a failure candidate that never observes both a
+    /// completed protection activation and a post-failure self-LSP SPF.
+    MicroloopCandidateExpire {
+        level: Level,
+        failure_id: u64,
+    },
     AdjacencyUp(Level, u32),
     /// MaxAge wait expired after a seq-number-wrap purge (ISO 10589
     /// §7.3.16.4). Clears the per-fragment freeze entry for
@@ -3961,6 +4053,22 @@ impl Display for Message {
             }
             Message::SpfCalc(level) => write!(f, "[Message::SpfCalc({})]", level),
             Message::SpfDone(output) => write!(f, "[Message::SpfDone({})]", output.level),
+            Message::MicroloopActivation {
+                level,
+                failure_id,
+                activated,
+                ..
+            } => write!(
+                f,
+                "[Message::MicroloopActivation({level}, id={failure_id}, active={activated})]"
+            ),
+            Message::MicroloopExpire { level, token } => {
+                write!(f, "[Message::MicroloopExpire({level}, token={token})]")
+            }
+            Message::MicroloopCandidateExpire { level, failure_id } => write!(
+                f,
+                "[Message::MicroloopCandidateExpire({level}, id={failure_id})]"
+            ),
             Message::AdjacencyUp(level, ifindex) => {
                 write!(f, "[Message::AdjacencyUp({}:{})]", level, ifindex)
             }
@@ -4296,7 +4404,7 @@ mod purge_poi_tests {
 }
 
 #[cfg(test)]
-mod commit_gate_tests {
+mod commit_and_microloop_gate_tests {
     use tokio::sync::mpsc;
 
     use super::bfd_wiring_tests::{test_config_tx, test_ctx, test_rib_subscriber};
@@ -4317,6 +4425,54 @@ mod commit_gate_tests {
             test_rib_subscriber(),
             test_config_tx(),
         )
+    }
+
+    fn microloop_candidate(id: u64, ifindex: u32) -> super::super::microloop::Failure {
+        super::super::microloop::Failure {
+            id,
+            revision: id,
+            required_self_lsp_generation: id,
+            cause: super::super::microloop::FailureCause::BfdDown,
+            ifindex,
+            peers: BTreeSet::new(),
+            nexthops: BTreeSet::new(),
+            activation_pending: 0,
+            activated: true,
+            rewired: 1,
+            evicted: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_microloop_watchdog_cannot_clear_new_candidate() {
+        let mut isis = fresh_isis();
+        isis.microloop.levels.l2.candidate = Some(microloop_candidate(2, 7));
+
+        isis.microloop_candidate_expire(Level::L2, 1);
+        assert_eq!(
+            isis.microloop.levels.l2.candidate.as_ref().map(|c| c.id),
+            Some(2)
+        );
+        assert_eq!(isis.microloop.levels.l2.topology_timeouts, 0);
+
+        isis.microloop_candidate_expire(Level::L2, 2);
+        assert!(isis.microloop.levels.l2.candidate.is_none());
+        assert_eq!(isis.microloop.levels.l2.topology_timeouts, 1);
+        assert_eq!(isis.microloop.levels.l2.aborts, 1);
+        assert!(isis.spf_timer.l2.is_some());
+    }
+
+    #[tokio::test]
+    async fn recovery_cancels_only_the_matching_microloop_candidate() {
+        let mut isis = fresh_isis();
+        isis.microloop.levels.l1.candidate = Some(microloop_candidate(1, 7));
+        isis.microloop.levels.l2.candidate = Some(microloop_candidate(2, 8));
+
+        isis.microloop_abort_ifindex(7);
+        assert!(isis.microloop.levels.l1.candidate.is_none());
+        assert!(isis.microloop.levels.l2.candidate.is_some());
+        assert_eq!(isis.microloop.levels.l1.aborts, 1);
+        assert_eq!(isis.microloop.levels.l2.aborts, 0);
     }
 
     fn commit_start() -> ConfigRequest {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1063,6 +1063,9 @@ impl Isis {
     /// re-origination + SPF land naturally on each adjacency Up
     /// transition.
     pub fn link_state_up(&mut self, ifindex: u32) {
+        // Recovery before the fixed deadline invalidates the failed-resource
+        // predicate. Publish the latest desired snapshot immediately.
+        self.microloop_abort_ifindex(ifindex);
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
@@ -1094,6 +1097,42 @@ impl Isis {
     /// schedule SPF for both levels so the route table reflects the
     /// new topology.
     pub fn link_state_down(&mut self, ifindex: u32) {
+        self.link_state_down_inner(ifindex, true);
+    }
+
+    /// Protocol-only bounce used by configuration changes (network type,
+    /// passive mode). The kernel link is still forwarding, so this must not
+    /// claim kernel-autonomous TI-LFA activation or arm MLA.
+    fn link_state_down_admin(&mut self, ifindex: u32) {
+        self.link_state_down_inner(ifindex, false);
+    }
+
+    fn link_state_down_inner(&mut self, ifindex: u32, local_failure: bool) {
+        // For a real netlink failure the kernel has already made the
+        // interface unusable and activated the shadow repair. Capture all
+        // peers and nexthop keys before teardown. An administrative protocol
+        // bounce still performs teardown, but skips this candidate block.
+        for level in [Level::L1, Level::L2] {
+            let mut peers = BTreeSet::new();
+            let mut nexthops = BTreeSet::new();
+            if let Some(link) = self.links.get(&ifindex) {
+                for (sys_id, nbr) in link.state.nbrs.get(&level) {
+                    peers.insert(*sys_id);
+                    nexthops.extend(nbr.addr4.keys().copied().map(std::net::IpAddr::V4));
+                    nexthops.extend(nbr.addr6l.iter().copied().map(std::net::IpAddr::V6));
+                }
+            }
+            if local_failure && !peers.is_empty() {
+                self.microloop_failure_begin(
+                    level,
+                    super::microloop::FailureCause::LinkDown,
+                    ifindex,
+                    peers,
+                    nexthops,
+                    true,
+                );
+            }
+        }
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
@@ -1914,7 +1953,7 @@ pub fn config_network_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opt
     // schedules SPF for both levels. Adjacencies rebuild through
     // the normal hello / NFSM path under the new type.
     if type_changed {
-        isis.link_state_down(ifindex);
+        isis.link_state_down_admin(ifindex);
         isis.link_state_up(ifindex);
         return Some(());
     }
@@ -1951,7 +1990,7 @@ pub fn config_passive(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<(
     };
 
     if changed {
-        isis.link_state_down(ifindex);
+        isis.link_state_down_admin(ifindex);
         isis.link_state_up(ifindex);
     }
 

--- a/zebra-rs/src/isis/microloop.rs
+++ b/zebra-rs/src/isis/microloop.rs
@@ -1,0 +1,943 @@
+//! IS-IS micro-loop avoidance by delaying post-convergence publication.
+//!
+//! A local failure first activates the already-installed TI-LFA repair.
+//! SPF results are stamped with the complete self router-LSP generation they
+//! observed. Before the post-failure generation commits, affected protected
+//! routes retain their old route object (and therefore the RIB's switched
+//! protection group), even when the transient desired RIB omits them. Once
+//! committed, the native RIB publication boundary holds only eligible route
+//! changes; authoritative withdrawals and unrelated changes remain
+//! immediate. The latest desired snapshot is published when the fixed hold
+//! timer expires. See `docs/design/isis-micro-loop-avoidance.md`.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::net::IpAddr;
+use std::time::Instant;
+
+use ipnet::{Ipv4Net, Ipv6Net};
+use isis_packet::IsisSysId;
+use prefix_trie::PrefixMap;
+
+use super::inst::{Isis, IsisTop, Message};
+use super::level::{Level, Levels};
+use super::rib::{IsisRibFamily, SpfRoute, V4, V6};
+use crate::context::Timer;
+
+/// Extra time beyond the configured LSP-generation and SPF throttle
+/// ceilings before an uncommitted failure candidate fails open. The normal
+/// path is generation-driven; this watchdog only covers suppressed
+/// origination, a lost RIB acknowledgement, or a wedged SPF worker.
+const CANDIDATE_WATCHDOG_MARGIN_MS: u64 = 5_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureCause {
+    LinkDown,
+    BfdDown,
+    AdjacencyExpired,
+}
+
+impl fmt::Display for FailureCause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LinkDown => write!(f, "link-down"),
+            Self::BfdDown => write!(f, "bfd-down"),
+            Self::AdjacencyExpired => write!(f, "adjacency-expired"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Failure {
+    pub id: u64,
+    pub revision: u64,
+    /// The first complete self router-LSP generation that must be present in
+    /// the SPF snapshot before this candidate can be consumed.
+    pub required_self_lsp_generation: u64,
+    pub cause: FailureCause,
+    pub ifindex: u32,
+    pub peers: BTreeSet<IsisSysId>,
+    pub nexthops: BTreeSet<IpAddr>,
+    pub activation_pending: usize,
+    pub activated: bool,
+    pub rewired: usize,
+    pub evicted: usize,
+}
+
+pub struct Hold {
+    pub token: u64,
+    pub failure: Failure,
+    pub started: Instant,
+    pub held_v4: BTreeSet<Ipv4Net>,
+    pub held_v6: BTreeSet<Ipv6Net>,
+    pub pending_v4: PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    pub pending_v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
+    // The timer is parked in the state so Drop reliably cancels stale
+    // callbacks after an abort/recovery/config change.
+    pub timer: Timer,
+}
+
+impl fmt::Debug for Hold {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Hold")
+            .field("token", &self.token)
+            .field("failure", &self.failure)
+            .field("remaining", &self.timer.remaining())
+            .field("held_v4", &self.held_v4.len())
+            .field("held_v6", &self.held_v6.len())
+            .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct LevelState {
+    pub revision: u64,
+    /// Complete self router-LSP sets committed to the LSDB. This is distinct
+    /// from `revision`: the latter identifies a local failure epoch, while
+    /// this counter proves which local topology an SPF actually observed.
+    pub self_lsp_generation: u64,
+    pub last_spf_generation: u64,
+    pub candidate: Option<Failure>,
+    pub candidate_watchdog: Option<Timer>,
+    pub hold: Option<Hold>,
+    pub events: u64,
+    pub holds_started: u64,
+    pub prefixes_deferred: u64,
+    pub releases: u64,
+    pub aborts: u64,
+    pub activation_failures: u64,
+    pub topology_waits: u64,
+    pub topology_timeouts: u64,
+    pub no_eligible_routes: u64,
+    last_topology_wait_failure_id: Option<u64>,
+    pub suppressed_events: u64,
+    pub last_hold_duration_ms: Option<u64>,
+    pub max_hold_duration_ms: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct MicroloopState {
+    pub levels: Levels<LevelState>,
+    next_id: u64,
+    next_token: u64,
+}
+
+impl MicroloopState {
+    fn alloc_id(&mut self) -> u64 {
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        self.next_id
+    }
+
+    fn alloc_token(&mut self) -> u64 {
+        self.next_token = self.next_token.wrapping_add(1).max(1);
+        self.next_token
+    }
+
+    pub fn revision(&self, level: Level) -> u64 {
+        self.levels.get(&level).revision
+    }
+
+    pub fn self_lsp_generation(&self, level: Level) -> u64 {
+        self.levels.get(&level).self_lsp_generation
+    }
+
+    /// Record one complete self router-LSP origination. The caller invokes
+    /// this once per generated set, after every new fragment and synchronous
+    /// trailing-fragment purge has entered the LSDB.
+    pub fn self_lsp_committed(&mut self, level: Level) -> u64 {
+        let generation = &mut self.levels.get_mut(&level).self_lsp_generation;
+        *generation = generation.wrapping_add(1);
+        *generation
+    }
+
+    pub fn output_is_stale(&self, level: Level, revision: u64) -> bool {
+        let state = self.levels.get(&level);
+        revision < state.revision
+    }
+}
+
+impl Isis {
+    /// Record a locally detected failure. `kernel_activated` is true for
+    /// netlink link-down: the kernel has already moved the protection
+    /// indirection away from the failed interface. BFD/hold expiry instead
+    /// request an explicit RIB switchover and await its acknowledgement.
+    pub(crate) fn microloop_failure_begin(
+        &mut self,
+        level: Level,
+        cause: FailureCause,
+        ifindex: u32,
+        peers: BTreeSet<IsisSysId>,
+        nexthops: BTreeSet<IpAddr>,
+        kernel_activated: bool,
+    ) {
+        if !self.config.microloop_avoidance_enabled
+            || !self.config.ti_lfa_enabled
+            || self.config.fast_reroute_backup_as_primary
+            || !self.config.distribute.rib
+            || self.restarting.is_some()
+        {
+            // Preserve the pre-feature FRR behavior: the micro-loop knob
+            // controls retention, not whether a local BFD/adjacency failure
+            // activates installed protection at all.
+            if !kernel_activated && cause == FailureCause::BfdDown {
+                for addr in nexthops {
+                    let _ = self.ctx.rib.protect_switch(addr);
+                }
+            }
+            return;
+        }
+
+        // A second local failure invalidates the single-failure proof. Flush
+        // the existing desired snapshot and let this event converge normally.
+        // This is fail-open for availability and never extends the old hold.
+        let active = {
+            let state = self.microloop.levels.get(&level);
+            state.candidate.is_some() || state.hold.is_some()
+        };
+        if active {
+            // Do not publish the first failure's pending snapshot here: its
+            // post-convergence primary can itself be the newly failed
+            // resource. Cancel the hold and let the already-queued SPF for
+            // this failure publish one authoritative snapshot normally.
+            self.microloop_cancel(level);
+            let state = self.microloop.levels.get_mut(&level);
+            state.revision = state.revision.wrapping_add(1);
+            state.events += 1;
+            state.suppressed_events += 1;
+            if !kernel_activated {
+                for addr in nexthops {
+                    let _ = self.ctx.rib.protect_switch(addr);
+                }
+            }
+            return;
+        }
+
+        let id = self.microloop.alloc_id();
+        let required_self_lsp_generation =
+            self.microloop.self_lsp_generation(level).wrapping_add(1);
+        // YANG bounds each leaf but does not impose initial <= secondary <=
+        // maximum, so use the largest configured member of each profile.
+        let lsp_wait_bound = self
+            .config
+            .lsp_gen_initial_wait()
+            .max(self.config.lsp_gen_secondary_wait())
+            .max(self.config.lsp_gen_maximum_wait());
+        let spf_wait_bound = self
+            .config
+            .spf_initial_wait()
+            .max(self.config.spf_secondary_wait())
+            .max(self.config.spf_maximum_wait());
+        let watchdog_ms = u64::from(lsp_wait_bound)
+            .saturating_add(u64::from(spf_wait_bound))
+            .saturating_add(CANDIDATE_WATCHDOG_MARGIN_MS);
+        let state = self.microloop.levels.get_mut(&level);
+        state.revision = state.revision.wrapping_add(1);
+        state.events += 1;
+        let revision = state.revision;
+
+        let activation_pending = if kernel_activated { 0 } else { nexthops.len() };
+        state.candidate = Some(Failure {
+            id,
+            revision,
+            required_self_lsp_generation,
+            cause,
+            ifindex,
+            peers,
+            nexthops: nexthops.clone(),
+            activation_pending,
+            activated: kernel_activated,
+            rewired: 0,
+            evicted: 0,
+        });
+        tracing::info!(
+            level = %level,
+            failure_id = id,
+            revision,
+            cause = %cause,
+            ifindex,
+            activation_pending,
+            required_self_lsp_generation,
+            watchdog_ms,
+            "isis micro-loop avoidance: failure candidate recorded"
+        );
+
+        let tx = self.tx.clone();
+        state.candidate_watchdog = Some(Timer::once_ms(watchdog_ms, move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::MicroloopCandidateExpire {
+                    level,
+                    failure_id: id,
+                });
+            }
+        }));
+
+        // Every accepted candidate requires one post-teardown self router-LSP
+        // commit. P2P teardown already requests this, but doing it here also
+        // covers LAN adjacency expiry (where DIS processing may only rebuild
+        // the pseudonode LSP). Duplicate requests coalesce in the existing
+        // LSP-generation throttle.
+        let _ = self.tx.send(Message::LspOriginate(level, None));
+
+        if kernel_activated {
+            return;
+        }
+        if nexthops.is_empty() {
+            return;
+        }
+
+        for addr in nexthops {
+            let rx = self.ctx.rib.protect_switch_report(addr);
+            let tx = self.tx.clone();
+            tokio::spawn(async move {
+                let result = rx.await.ok();
+                let (activated, rewired, evicted) = result
+                    .map(|r| (r.activated(), r.rewired, r.evicted))
+                    .unwrap_or((false, 0, 0));
+                let _ = tx.send(Message::MicroloopActivation {
+                    level,
+                    failure_id: id,
+                    activated,
+                    rewired,
+                    evicted,
+                });
+            });
+        }
+    }
+
+    pub(crate) fn microloop_activation_result(
+        &mut self,
+        level: Level,
+        failure_id: u64,
+        activated: bool,
+        rewired: usize,
+        evicted: usize,
+    ) {
+        let state = self.microloop.levels.get_mut(&level);
+        let Some(candidate) = state.candidate.as_mut() else {
+            return;
+        };
+        if candidate.id != failure_id {
+            return;
+        }
+        let was_pending = candidate.activation_pending != 0;
+        candidate.activation_pending = candidate.activation_pending.saturating_sub(1);
+        candidate.activated |= activated;
+        candidate.rewired += rewired;
+        candidate.evicted += evicted;
+        let activation_complete = was_pending && candidate.activation_pending == 0;
+        if activation_complete {
+            // SPF may have completed while the RIB was still atomically
+            // switching the protection group. In that case its native route
+            // snapshot was deliberately left unpublished below. Enter the
+            // ordinary throttle-aware scheduler now that activation has a
+            // definitive outcome. This also preserves ordering with the
+            // self-LSP generation scheduled by adjacency teardown; an
+            // immediate SpfCalc here could still see the pre-failure LSP.
+            let mut top = self.top();
+            super::rib::spf_schedule_top(&mut top, level);
+        }
+    }
+
+    pub(crate) fn microloop_force_release(&mut self, level: Level, timed: bool) {
+        let (hold, had_candidate) = {
+            let state = self.microloop.levels.get_mut(&level);
+            let had_candidate = state.candidate.take().is_some();
+            state.candidate_watchdog = None;
+            (state.hold.take(), had_candidate)
+        };
+        let Some(hold) = hold else {
+            if had_candidate && !timed {
+                self.microloop.levels.get_mut(&level).aborts += 1;
+            }
+            return;
+        };
+        let elapsed_ms = hold.started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        if timed {
+            let state = self.microloop.levels.get_mut(&level);
+            state.releases += 1;
+            state.last_hold_duration_ms = Some(elapsed_ms);
+            state.max_hold_duration_ms = state.max_hold_duration_ms.max(elapsed_ms);
+        } else {
+            let state = self.microloop.levels.get_mut(&level);
+            state.aborts += 1;
+            state.last_hold_duration_ms = Some(elapsed_ms);
+            state.max_hold_duration_ms = state.max_hold_duration_ms.max(elapsed_ms);
+        }
+        tracing::info!(
+            level = %level,
+            failure_id = hold.failure.id,
+            timed,
+            elapsed_ms,
+            ipv4 = hold.held_v4.len(),
+            ipv6 = hold.held_v6.len(),
+            "isis micro-loop avoidance: releasing held routes"
+        );
+        super::rib::publish_microloop_routes(self, level, hold.pending_v4, hold.pending_v6);
+    }
+
+    fn microloop_cancel(&mut self, level: Level) {
+        let state = self.microloop.levels.get_mut(&level);
+        let active = state.candidate.take().is_some() || state.hold.take().is_some();
+        state.candidate_watchdog = None;
+        if active {
+            state.aborts += 1;
+            tracing::info!(
+                level = %level,
+                "isis micro-loop avoidance: cancelled by overlapping failure"
+            );
+        }
+    }
+
+    pub(crate) fn microloop_expire(&mut self, level: Level, token: u64) {
+        if self
+            .microloop
+            .levels
+            .get(&level)
+            .hold
+            .as_ref()
+            .is_some_and(|hold| hold.token == token)
+        {
+            self.microloop_force_release(level, true);
+        }
+    }
+
+    pub(crate) fn microloop_candidate_expire(&mut self, level: Level, failure_id: u64) {
+        let timed_out = self
+            .microloop
+            .levels
+            .get(&level)
+            .candidate
+            .as_ref()
+            .is_some_and(|candidate| candidate.id == failure_id);
+        if !timed_out {
+            return;
+        }
+
+        let state = self.microloop.levels.get_mut(&level);
+        let failure = state.candidate.take().unwrap();
+        state.candidate_watchdog = None;
+        state.topology_timeouts += 1;
+        state.aborts += 1;
+        tracing::warn!(
+            level = %level,
+            failure_id,
+            required_self_lsp_generation = failure.required_self_lsp_generation,
+            current_self_lsp_generation = state.self_lsp_generation,
+            last_spf_generation = state.last_spf_generation,
+            "isis micro-loop avoidance: topology gate timed out; converging normally"
+        );
+
+        // Recompute an authoritative ordinary snapshot. Any in-flight SPF is
+        // allowed to publish too now that the candidate has failed open.
+        let mut top = self.top();
+        super::rib::spf_schedule_top(&mut top, level);
+    }
+
+    pub(crate) fn microloop_abort_ifindex(&mut self, ifindex: u32) {
+        for level in [Level::L1, Level::L2] {
+            let matches = {
+                let state = self.microloop.levels.get(&level);
+                state
+                    .candidate
+                    .as_ref()
+                    .is_some_and(|failure| failure.ifindex == ifindex)
+                    || state
+                        .hold
+                        .as_ref()
+                        .is_some_and(|hold| hold.failure.ifindex == ifindex)
+            };
+            if matches {
+                self.microloop_force_release(level, false);
+            }
+        }
+    }
+
+    pub(crate) fn microloop_abort_all(&mut self) {
+        for level in [Level::L1, Level::L2] {
+            self.microloop_force_release(level, false);
+        }
+    }
+}
+
+fn failure_matches<F: IsisRibFamily>(
+    addr: F::Addr,
+    nhop: &super::rib::SpfNexthop<F>,
+    failure: &Failure,
+) -> bool {
+    nhop.ifindex == failure.ifindex
+        || nhop
+            .sys_id
+            .is_some_and(|sys_id| failure.peers.contains(&sys_id))
+        || failure.nexthops.contains(&F::addr_to_ip(addr))
+}
+
+fn primary_equal<F: IsisRibFamily>(a: &SpfRoute<F>, b: &SpfRoute<F>) -> bool {
+    a.metric == b.metric
+        && a.sid == b.sid
+        && a.prefix_sid == b.prefix_sid
+        && a.no_php == b.no_php
+        && a.dest_vertex == b.dest_vertex
+        && a.backup_as_primary == b.backup_as_primary
+        && a.nhops.len() == b.nhops.len()
+        && a.nhops.iter().all(|(addr, a_nhop)| {
+            b.nhops.get(addr).is_some_and(|b_nhop| {
+                a_nhop.ifindex == b_nhop.ifindex
+                    && a_nhop.adjacency == b_nhop.adjacency
+                    && a_nhop.sys_id == b_nhop.sys_id
+            })
+        })
+}
+
+fn eligible<F: IsisRibFamily>(old: &SpfRoute<F>, desired: &SpfRoute<F>, failure: &Failure) -> bool {
+    if old.backup_as_primary || old.nhops.len() != 1 || desired.nhops.is_empty() {
+        return false;
+    }
+    let (&old_addr, old_nhop) = old.nhops.iter().next().unwrap();
+    old_nhop.backup.is_some()
+        && failure_matches::<F>(old_addr, old_nhop, failure)
+        && desired
+            .nhops
+            .iter()
+            .all(|(&addr, nhop)| !failure_matches::<F>(addr, nhop, failure))
+        && !primary_equal(old, desired)
+}
+
+fn candidate_prerequisites_ready(failure: &Failure, spf_self_lsp_generation: u64) -> bool {
+    failure.activation_pending == 0
+        && spf_self_lsp_generation >= failure.required_self_lsp_generation
+}
+
+fn defer_candidate<F: IsisRibFamily>(
+    current: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    desired: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    failure: &Failure,
+) -> (PrefixMap<F::Prefix, SpfRoute<F>>, BTreeSet<F::Prefix>) {
+    let mut published = desired.clone();
+    let mut held = BTreeSet::new();
+    for (prefix, old) in current.iter() {
+        let Some(next) = desired.get(&prefix) else {
+            continue;
+        };
+        if eligible::<F>(old, next, failure) {
+            published.insert(prefix, old.clone());
+            held.insert(prefix);
+        }
+    }
+    (published, held)
+}
+
+/// Preserve affected protected routes while either the repair activation or
+/// the post-failure self-LSP SPF is pending. Unlike the ordinary hold
+/// classifier, this intentionally restores a route that is absent from the
+/// desired map: omission is exactly how the pre-commit graph manifests when
+/// its stale local edge no longer has a live adjacency-to-ifindex mapping.
+fn retain_waiting_candidate<F: IsisRibFamily>(
+    current: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    desired: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    failure: &Failure,
+) -> (PrefixMap<F::Prefix, SpfRoute<F>>, usize) {
+    let mut published = desired.clone();
+    let mut retained = 0;
+    for (prefix, old) in current.iter() {
+        let Some((&addr, nhop)) = old.nhops.iter().next() else {
+            continue;
+        };
+        if old.nhops.len() == 1
+            && nhop.backup.is_some()
+            && failure_matches::<F>(addr, nhop, failure)
+        {
+            published.insert(prefix, old.clone());
+            retained += 1;
+        }
+    }
+    (published, retained)
+}
+
+fn retain_held<F: IsisRibFamily>(
+    current: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    desired: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    held: &BTreeSet<F::Prefix>,
+) -> PrefixMap<F::Prefix, SpfRoute<F>> {
+    let mut published = desired.clone();
+    for prefix in held {
+        if desired.get(prefix).is_some()
+            && let Some(old) = current.get(prefix)
+        {
+            published.insert(*prefix, old.clone());
+        }
+    }
+    published
+}
+
+/// Select the native v4/v6 snapshot that may be published by this SPF.
+/// The desired maps are retained in the hold state when any prefix is
+/// deferred; the returned maps become the ordinary `Isis.rib{,_v6}` cache.
+pub(super) fn select_published_routes(
+    top: &mut IsisTop,
+    level: Level,
+    spf_self_lsp_generation: u64,
+    desired_v4: PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    desired_v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
+) -> (
+    PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    PrefixMap<Ipv6Net, SpfRoute<V6>>,
+) {
+    let state = top.microloop.levels.get_mut(&level);
+    state.last_spf_generation = spf_self_lsp_generation;
+
+    if let Some(hold) = state.hold.as_mut() {
+        let published_v4 = retain_held(top.rib.get(&level), &desired_v4, &hold.held_v4);
+        let published_v6 = retain_held(top.rib_v6.get(&level), &desired_v6, &hold.held_v6);
+        hold.pending_v4 = desired_v4;
+        hold.pending_v6 = desired_v6;
+        return (published_v4, published_v6);
+    }
+
+    let Some(candidate) = state.candidate.as_ref() else {
+        return (desired_v4, desired_v6);
+    };
+    if candidate.activation_pending == 0 && !candidate.activated {
+        // No repair was actually activated. Retaining the old primary while
+        // waiting for topology commit would turn a failed adjacency into a
+        // potentially long black hole, so this is an immediate fail-open.
+        let failure = state.candidate.take().unwrap();
+        state.candidate_watchdog = None;
+        state.activation_failures += 1;
+        tracing::info!(
+            level = %level,
+            failure_id = failure.id,
+            pending = failure.activation_pending,
+            "isis micro-loop avoidance: repair activation unavailable; converging normally"
+        );
+        return (desired_v4, desired_v6);
+    }
+    let topology_ready = spf_self_lsp_generation >= candidate.required_self_lsp_generation;
+    if !candidate_prerequisites_ready(candidate, spf_self_lsp_generation) {
+        // RIB activation, self-LSP origination, and SPF run on independent
+        // tasks. Preserve only routes protected against this failure while a
+        // prerequisite is missing; unrelated additions/changes/withdrawals
+        // from the desired snapshot remain publishable. Crucially this also
+        // restores affected routes omitted by a pre-commit SPF snapshot.
+        let (published_v4, retained_v4) =
+            retain_waiting_candidate::<V4>(top.rib.get(&level), &desired_v4, candidate);
+        let (published_v6, retained_v6) =
+            retain_waiting_candidate::<V6>(top.rib_v6.get(&level), &desired_v6, candidate);
+        let failure_id = candidate.id;
+        let required_self_lsp_generation = candidate.required_self_lsp_generation;
+        let activation_pending = candidate.activation_pending;
+        if !topology_ready {
+            state.topology_waits += 1;
+            let first_wait = state.last_topology_wait_failure_id != Some(failure_id);
+            state.last_topology_wait_failure_id = Some(failure_id);
+            if first_wait {
+                tracing::info!(
+                    level = %level,
+                    failure_id,
+                    spf_self_lsp_generation,
+                    required_self_lsp_generation,
+                    retained_ipv4 = retained_v4,
+                    retained_ipv6 = retained_v6,
+                    "isis micro-loop avoidance: awaiting self-LSP generation"
+                );
+            } else {
+                tracing::debug!(
+                    level = %level,
+                    failure_id,
+                    spf_self_lsp_generation,
+                    required_self_lsp_generation,
+                    retained_ipv4 = retained_v4,
+                    retained_ipv6 = retained_v6,
+                    "isis micro-loop avoidance: still awaiting self-LSP generation"
+                );
+            }
+        } else {
+            tracing::debug!(
+                level = %level,
+                failure_id,
+                pending = activation_pending,
+                retained_ipv4 = retained_v4,
+                retained_ipv6 = retained_v6,
+                "isis micro-loop avoidance: awaiting repair activation before route publication"
+            );
+        }
+        return (published_v4, published_v6);
+    }
+
+    let failure = state.candidate.take().unwrap();
+    state.candidate_watchdog = None;
+
+    let (published_v4, held_v4) = defer_candidate::<V4>(top.rib.get(&level), &desired_v4, &failure);
+    let (published_v6, held_v6) =
+        defer_candidate::<V6>(top.rib_v6.get(&level), &desired_v6, &failure);
+    let held_count = held_v4.len() + held_v6.len();
+    if held_count == 0 {
+        state.no_eligible_routes += 1;
+        tracing::info!(
+            level = %level,
+            failure_id = failure.id,
+            spf_self_lsp_generation,
+            "isis micro-loop avoidance: no eligible protected routes; converging normally"
+        );
+        return (desired_v4, desired_v6);
+    }
+
+    // End the per-level borrow before allocating the global timer token,
+    // then reacquire it to install the hold.
+    let _ = state;
+    let token = top.microloop.alloc_token();
+    let delay_ms = top.config.microloop_rib_update_delay_ms;
+    let started = Instant::now();
+    let held_v4_count = held_v4.len();
+    let held_v6_count = held_v6.len();
+    let tx = top.tx.clone();
+    let timer = Timer::once_ms(delay_ms as u64, move || {
+        let tx = tx.clone();
+        async move {
+            let _ = tx.send(Message::MicroloopExpire { level, token });
+        }
+    });
+    let state = top.microloop.levels.get_mut(&level);
+    state.holds_started += 1;
+    state.prefixes_deferred += held_count as u64;
+    state.hold = Some(Hold {
+        token,
+        failure,
+        started,
+        held_v4,
+        held_v6,
+        pending_v4: desired_v4,
+        pending_v6: desired_v6,
+        timer,
+    });
+    tracing::info!(
+        level = %level,
+        token,
+        delay_ms,
+        ipv4 = held_v4_count,
+        ipv6 = held_v6_count,
+        "isis micro-loop avoidance: route publication hold armed"
+    );
+    (published_v4, published_v6)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::net::Ipv4Addr;
+
+    use super::super::rib::SpfNexthop;
+    use super::super::tilfa::RepairPathMpls;
+
+    fn route(addr: Ipv4Addr, ifindex: u32, backup: bool) -> SpfRoute<V4> {
+        let mut nhops = BTreeMap::new();
+        nhops.insert(
+            addr,
+            SpfNexthop {
+                ifindex,
+                adjacency: true,
+                sys_id: None,
+                backup: backup.then_some(RepairPathMpls {
+                    addr: Ipv4Addr::new(192, 0, 2, 2),
+                    ifindex: 9,
+                    labels: Vec::new(),
+                }),
+            },
+        );
+        SpfRoute {
+            metric: 10,
+            nhops,
+            sid: None,
+            prefix_sid: None,
+            no_php: false,
+            dest_vertex: Some(1),
+            backup_as_primary: false,
+        }
+    }
+
+    fn failure(failed: Ipv4Addr) -> Failure {
+        Failure {
+            id: 1,
+            revision: 1,
+            required_self_lsp_generation: 1,
+            cause: FailureCause::BfdDown,
+            ifindex: 7,
+            peers: BTreeSet::new(),
+            nexthops: BTreeSet::from([IpAddr::V4(failed)]),
+            activation_pending: 0,
+            activated: true,
+            rewired: 1,
+            evicted: 0,
+        }
+    }
+
+    #[test]
+    fn holds_only_changed_route_protected_by_failed_resource() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, true));
+        let mut desired = PrefixMap::new();
+        desired.insert(prefix, route(Ipv4Addr::new(192, 0, 2, 3), 8, true));
+        let failure = failure(failed);
+
+        let (published, held) = defer_candidate::<V4>(&current, &desired, &failure);
+        assert!(held.contains(&prefix));
+        assert_eq!(
+            published.get(&prefix).unwrap().nhops.keys().next(),
+            Some(&failed)
+        );
+    }
+
+    #[test]
+    fn withdrawal_is_never_held() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, true));
+        let desired = PrefixMap::new();
+        let failure = Failure {
+            id: 1,
+            revision: 1,
+            required_self_lsp_generation: 1,
+            cause: FailureCause::LinkDown,
+            ifindex: 7,
+            peers: BTreeSet::new(),
+            nexthops: BTreeSet::new(),
+            activation_pending: 0,
+            activated: true,
+            rewired: 0,
+            evicted: 0,
+        };
+
+        let (published, held) = defer_candidate::<V4>(&current, &desired, &failure);
+        assert!(held.is_empty());
+        assert!(published.get(&prefix).is_none());
+    }
+
+    #[test]
+    fn new_prefix_is_never_held() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let current = PrefixMap::new();
+        let mut desired = PrefixMap::new();
+        desired.insert(prefix, route(Ipv4Addr::new(192, 0, 2, 3), 8, true));
+
+        let (published, held) = defer_candidate::<V4>(&current, &desired, &failure(failed));
+        assert!(held.is_empty());
+        assert!(published.get(&prefix).is_some());
+    }
+
+    #[test]
+    fn unprotected_old_route_is_never_held() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, false));
+        let mut desired = PrefixMap::new();
+        desired.insert(prefix, route(Ipv4Addr::new(192, 0, 2, 3), 8, true));
+
+        let (published, held) = defer_candidate::<V4>(&current, &desired, &failure(failed));
+        assert!(held.is_empty());
+        assert_eq!(
+            published.get(&prefix).unwrap().nhops.keys().next(),
+            Some(&Ipv4Addr::new(192, 0, 2, 3))
+        );
+    }
+
+    #[test]
+    fn route_still_using_failed_resource_is_not_held() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, true));
+        let mut desired = PrefixMap::new();
+        let mut changed = route(failed, 7, true);
+        changed.metric = 20;
+        desired.insert(prefix, changed);
+
+        let (_, held) = defer_candidate::<V4>(&current, &desired, &failure(failed));
+        assert!(held.is_empty());
+
+        let (published, retained) =
+            retain_waiting_candidate::<V4>(&current, &desired, &failure(failed));
+        assert_eq!(retained, 1);
+        assert_eq!(published.get(&prefix), current.get(&prefix));
+    }
+
+    #[test]
+    fn unchanged_protected_route_survives_pre_failure_spf() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, true));
+        let desired = current.clone();
+
+        let (published, retained) =
+            retain_waiting_candidate::<V4>(&current, &desired, &failure(failed));
+        assert_eq!(retained, 1);
+        assert_eq!(published.get(&prefix), current.get(&prefix));
+    }
+
+    #[test]
+    fn protected_withdrawal_survives_pre_commit_spf() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, true));
+        let desired = PrefixMap::new();
+
+        let (published, retained) =
+            retain_waiting_candidate::<V4>(&current, &desired, &failure(failed));
+        assert_eq!(retained, 1);
+        assert_eq!(published.get(&prefix), current.get(&prefix));
+    }
+
+    #[test]
+    fn unprotected_withdrawal_remains_immediate_while_waiting() {
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut current = PrefixMap::new();
+        current.insert(prefix, route(failed, 7, false));
+        let desired = PrefixMap::new();
+
+        let (published, retained) =
+            retain_waiting_candidate::<V4>(&current, &desired, &failure(failed));
+        assert_eq!(retained, 0);
+        assert!(published.get(&prefix).is_none());
+    }
+
+    #[test]
+    fn self_lsp_generation_advances_once_per_complete_set() {
+        let mut state = MicroloopState::default();
+        assert_eq!(state.self_lsp_generation(Level::L2), 0);
+        assert_eq!(state.self_lsp_committed(Level::L2), 1);
+        assert_eq!(state.self_lsp_generation(Level::L2), 1);
+        assert_eq!(state.self_lsp_generation(Level::L1), 0);
+    }
+
+    #[test]
+    fn activation_and_topology_can_complete_in_either_order() {
+        let failed = Ipv4Addr::new(192, 0, 2, 1);
+        let mut candidate = failure(failed);
+        candidate.required_self_lsp_generation = 9;
+
+        candidate.activation_pending = 1;
+        assert!(!candidate_prerequisites_ready(&candidate, 8));
+        assert!(!candidate_prerequisites_ready(&candidate, 9));
+
+        candidate.activation_pending = 0;
+        assert!(!candidate_prerequisites_ready(&candidate, 8));
+        assert!(candidate_prerequisites_ready(&candidate, 9));
+        assert!(candidate_prerequisites_ready(&candidate, 10));
+    }
+
+    #[test]
+    fn pre_failure_spf_revision_is_stale() {
+        let mut state = MicroloopState::default();
+        state.levels.l2.revision = 3;
+        assert!(state.output_is_stale(Level::L2, 2));
+        assert!(!state.output_is_stale(Level::L2, 3));
+    }
+}

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -49,6 +49,8 @@ pub use flood::LspFlood;
 
 pub mod tilfa;
 
+pub mod microloop;
+
 pub mod graph;
 
 pub mod rib;

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -367,6 +367,20 @@ pub struct SpfRoute<F: IsisRibFamily> {
     pub backup_as_primary: bool,
 }
 
+impl<F: IsisRibFamily> Clone for SpfRoute<F> {
+    fn clone(&self) -> Self {
+        Self {
+            metric: self.metric,
+            nhops: self.nhops.clone(),
+            sid: self.sid,
+            prefix_sid: self.prefix_sid.clone(),
+            no_php: self.no_php,
+            dest_vertex: self.dest_vertex,
+            backup_as_primary: self.backup_as_primary,
+        }
+    }
+}
+
 impl<F: IsisRibFamily> std::fmt::Debug for SpfRoute<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SpfRoute")
@@ -1095,6 +1109,7 @@ pub(super) fn ipv6_capable_set(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
 fn apply_routing_updates(
     top: &mut IsisTop,
     level: Level,
+    spf_self_lsp_generation: u64,
     rib: PrefixMap<Ipv4Net, SpfRoute<V4>>,
     rib_v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
     ilm: BTreeMap<u32, SpfIlm>,
@@ -1109,6 +1124,21 @@ fn apply_routing_updates(
     }
     *top.ilm.get_mut(&level) = ilm;
 
+    let (rib, rib_v6) =
+        super::microloop::select_published_routes(top, level, spf_self_lsp_generation, rib, rib_v6);
+
+    publish_native_routes(top, level, rib, rib_v6);
+}
+
+/// Publish a complete native route snapshot. Kept separate from the SPF
+/// builder so the micro-loop hold timer can release its pending desired
+/// maps through exactly the same diff/cache/retention path.
+fn publish_native_routes(
+    top: &mut IsisTop,
+    level: Level,
+    rib: PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    rib_v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
+) {
     // The `fast-reroute backup-as-primary` flag is stamped onto each
     // `SpfRoute` at build time and read back in `make_rib_entry`, so
     // the metric ordering is decided by the route, not a separate
@@ -1137,6 +1167,16 @@ fn apply_routing_updates(
     *top.rib_v6.get_mut(&level) = rib_v6;
 }
 
+pub(super) fn publish_microloop_routes(
+    isis: &mut Isis,
+    level: Level,
+    rib: PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    rib_v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
+) {
+    let mut top = isis.top();
+    publish_native_routes(&mut top, level, rib, rib_v6);
+}
+
 /// Owned, `Send`-able inputs to a single IS-IS SPF run for one level.
 ///
 /// Built on the main task by [`build_spf_input`], which reads
@@ -1146,6 +1186,8 @@ fn apply_routing_updates(
 /// `tokio::task::spawn_blocking` without touching shared state.
 pub(super) struct SpfInput {
     level: Level,
+    microloop_revision: u64,
+    self_lsp_generation: u64,
     graph: spf::Graph,
     source: usize,
     adjacency_sids: BTreeMap<u32, IsisSysId>,
@@ -1186,6 +1228,8 @@ struct FlexAlgoInput {
 /// can ride on `Message::SpfDone` through the channel.
 pub struct SpfOutput {
     pub(super) level: Level,
+    pub(super) microloop_revision: u64,
+    pub(super) self_lsp_generation: u64,
     source: usize,
     adjacency_sids: BTreeMap<u32, IsisSysId>,
     spf_result: BTreeMap<usize, spf::Path>,
@@ -1310,6 +1354,8 @@ pub(super) fn build_spf_input(top: &mut IsisTop, level: Level) -> Option<SpfInpu
 
     Some(SpfInput {
         level,
+        microloop_revision: top.microloop.revision(level),
+        self_lsp_generation: top.microloop.self_lsp_generation(level),
         graph: legacy_graph,
         source,
         adjacency_sids,
@@ -1327,6 +1373,8 @@ pub(super) fn build_spf_input(top: &mut IsisTop, level: Level) -> Option<SpfInpu
 pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
     let SpfInput {
         level,
+        microloop_revision,
+        self_lsp_generation,
         graph: legacy_graph,
         source,
         adjacency_sids,
@@ -1416,6 +1464,8 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
 
     SpfOutput {
         level,
+        microloop_revision,
+        self_lsp_generation,
         source,
         adjacency_sids,
         spf_result,
@@ -1801,6 +1851,8 @@ fn register_mpls_protections(top: &IsisTop) {
 pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     let SpfOutput {
         level,
+        microloop_revision: _,
+        self_lsp_generation,
         source,
         adjacency_sids,
         spf_result,
@@ -2015,7 +2067,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     if !top.config.sr_mpls_enabled {
         ilm.clear();
     }
-    apply_routing_updates(top, level, rib, rib_v6, ilm);
+    apply_routing_updates(top, level, self_lsp_generation, rib, rib_v6, ilm);
 }
 
 /// Build the per-algorithm IPv4 RIB from a Flex-Algo SPF result.

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -31,6 +31,8 @@ impl Isis {
             .set(show_isis_route_detail)
             .path("/show/isis/fast-reroute/summary")
             .set(show_isis_fast_reroute_summary)
+            .path("/show/isis/micro-loop-avoidance")
+            .set(show_isis_microloop_avoidance)
             .path("/show/isis/fast-reroute/prefix/detail")
             .set(show_isis_fast_reroute_prefix_detail)
             .path("/show/isis/egress-protection")
@@ -1033,6 +1035,199 @@ fn show_isis_fast_reroute_summary(
     }
     if !wrote_any {
         writeln!(buf, "  (no IS-IS RIB entries yet)")?;
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct MicroloopLevelView {
+    level: &'static str,
+    state: &'static str,
+    failure_id: Option<u64>,
+    failure_revision: Option<u64>,
+    required_self_lsp_generation: Option<u64>,
+    self_lsp_generation: u64,
+    last_spf_generation: u64,
+    topology_ready: bool,
+    cause: Option<String>,
+    ifindex: Option<u32>,
+    activation_pending: usize,
+    activated: bool,
+    remaining_ms: Option<u128>,
+    candidate_timeout_remaining_ms: Option<u128>,
+    held_ipv4: usize,
+    held_ipv6: usize,
+    events: u64,
+    holds_started: u64,
+    prefixes_deferred: u64,
+    releases: u64,
+    aborts: u64,
+    activation_failures: u64,
+    topology_waits: u64,
+    topology_timeouts: u64,
+    no_eligible_routes: u64,
+    suppressed_events: u64,
+    last_hold_duration_ms: Option<u64>,
+    max_hold_duration_ms: u64,
+}
+
+#[derive(Serialize)]
+struct MicroloopView {
+    enabled: bool,
+    operational: bool,
+    inactive_reason: Option<&'static str>,
+    rib_update_delay_ms: u32,
+    levels: Vec<MicroloopLevelView>,
+}
+
+fn microloop_level_view(isis: &Isis, level: Level) -> MicroloopLevelView {
+    let state = isis.microloop.levels.get(&level);
+    let (name, failure, remaining_ms, held_ipv4, held_ipv6) = if let Some(hold) = &state.hold {
+        (
+            "holding",
+            Some(&hold.failure),
+            Some(hold.timer.remaining().as_millis()),
+            hold.held_v4.len(),
+            hold.held_v6.len(),
+        )
+    } else if let Some(candidate) = &state.candidate {
+        ("candidate", Some(candidate), None, 0, 0)
+    } else {
+        ("idle", None, None, 0, 0)
+    };
+    MicroloopLevelView {
+        level: match level {
+            Level::L1 => "Level-1",
+            Level::L2 => "Level-2",
+        },
+        state: name,
+        failure_id: failure.map(|f| f.id),
+        failure_revision: failure.map(|f| f.revision),
+        required_self_lsp_generation: failure.map(|f| f.required_self_lsp_generation),
+        self_lsp_generation: state.self_lsp_generation,
+        last_spf_generation: state.last_spf_generation,
+        topology_ready: failure
+            .is_none_or(|f| state.last_spf_generation >= f.required_self_lsp_generation),
+        cause: failure.map(|f| f.cause.to_string()),
+        ifindex: failure.map(|f| f.ifindex),
+        activation_pending: failure.map_or(0, |f| f.activation_pending),
+        activated: failure.is_some_and(|f| f.activated),
+        remaining_ms,
+        candidate_timeout_remaining_ms: state
+            .candidate_watchdog
+            .as_ref()
+            .map(|timer| timer.remaining().as_millis()),
+        held_ipv4,
+        held_ipv6,
+        events: state.events,
+        holds_started: state.holds_started,
+        prefixes_deferred: state.prefixes_deferred,
+        releases: state.releases,
+        aborts: state.aborts,
+        activation_failures: state.activation_failures,
+        topology_waits: state.topology_waits,
+        topology_timeouts: state.topology_timeouts,
+        no_eligible_routes: state.no_eligible_routes,
+        suppressed_events: state.suppressed_events,
+        last_hold_duration_ms: state.last_hold_duration_ms,
+        max_hold_duration_ms: state.max_hold_duration_ms,
+    }
+}
+
+/// `show isis micro-loop-avoidance` — current local
+/// convergence-delay phase and lifetime counters per level.
+fn show_isis_microloop_avoidance(
+    isis: &Isis,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let inactive_reason = if !isis.config.microloop_avoidance_enabled {
+        Some("not configured")
+    } else if !isis.config.ti_lfa_enabled {
+        Some("ti-lfa disabled")
+    } else if isis.config.fast_reroute_backup_as_primary {
+        Some("backup-as-primary enabled")
+    } else if !isis.config.distribute.rib {
+        Some("RIB distribution disabled")
+    } else if isis.restarting.is_some() {
+        Some("graceful restart active")
+    } else {
+        None
+    };
+    let view = MicroloopView {
+        enabled: isis.config.microloop_avoidance_enabled,
+        operational: inactive_reason.is_none(),
+        inactive_reason,
+        rib_update_delay_ms: isis.config.microloop_rib_update_delay_ms,
+        levels: [Level::L1, Level::L2]
+            .into_iter()
+            .map(|level| microloop_level_view(isis, level))
+            .collect(),
+    };
+    if json {
+        return Ok(serde_json::to_string_pretty(&view)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        "IS-IS micro-loop avoidance: {}",
+        if view.operational {
+            "operational"
+        } else {
+            view.inactive_reason.unwrap_or("inactive")
+        }
+    )?;
+    writeln!(buf, "  RIB update delay: {} ms", view.rib_update_delay_ms)?;
+    for level in view.levels {
+        writeln!(buf, "  {}: {}", level.level, level.state)?;
+        writeln!(
+            buf,
+            "    Self-LSP generation: committed {}, last SPF {}",
+            level.self_lsp_generation, level.last_spf_generation
+        )?;
+        if let Some(id) = level.failure_id {
+            writeln!(
+                buf,
+                "    Failure: id {} {}, ifindex {}, activated {}, pending acks {}",
+                id,
+                level.cause.as_deref().unwrap_or("unknown"),
+                level.ifindex.unwrap_or_default(),
+                level.activated,
+                level.activation_pending
+            )?;
+            writeln!(
+                buf,
+                "    Topology gate: required generation {}, ready {}, timeout remaining {:?} ms",
+                level.required_self_lsp_generation.unwrap_or_default(),
+                level.topology_ready,
+                level.candidate_timeout_remaining_ms
+            )?;
+        }
+        if let Some(remaining) = level.remaining_ms {
+            writeln!(
+                buf,
+                "    Remaining: {} ms, held prefixes: IPv4 {}, IPv6 {}",
+                remaining, level.held_ipv4, level.held_ipv6
+            )?;
+        }
+        writeln!(
+            buf,
+            "    Counters: events {}, holds {}, deferred {}, releases {}, aborts {}, activation-failures {}, topology-waits {}, topology-timeouts {}, no-eligible {}, suppressed {}, last/max hold {:?}/{} ms",
+            level.events,
+            level.holds_started,
+            level.prefixes_deferred,
+            level.releases,
+            level.aborts,
+            level.activation_failures,
+            level.topology_waits,
+            level.topology_timeouts,
+            level.no_eligible_routes,
+            level.suppressed_events,
+            level.last_hold_duration_ms,
+            level.max_hold_duration_ms
+        )?;
     }
     Ok(buf)
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -6059,7 +6059,7 @@ impl Ospf<Ospfv2> {
         if link.ls_ack_delayed.is_empty() {
             return;
         }
-        let ack_headers: Vec<OspfLsaHeader> = link.ls_ack_delayed.drain(..).collect();
+        let ack_headers = std::mem::take(&mut link.ls_ack_delayed);
         ospf_packet_trace!(
             self.tracing,
             LsAck,

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -528,6 +528,18 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// config intent (`vrf_log`) and kernel info exist.
     pub rib_known_vrfs: BTreeMap<String, (u32, u32)>,
 
+    /// Durable per-interface configuration, keyed by interface name.
+    ///
+    /// `OspfLink` is operational state keyed by a kernel ifindex, so it is
+    /// deliberately destroyed on `LinkDel` and rebuilt on `LinkAdd`.  YANG
+    /// intent must outlive that object: an interface can be created after its
+    /// configuration is committed, receive a new ifindex after recreation, or
+    /// cross a VRF boundary as a `LinkDel` + `LinkAdd` pair.  Keep the original
+    /// Set/Delete stream here and replay it into each fresh `OspfLink`.  The
+    /// stream is in commit order, which also preserves replacement semantics
+    /// for keyed leaves (authentication keys, Prefix-SIDs, and so on).
+    pub interface_config_log: BTreeMap<String, Vec<(Vec<CommandPath>, ConfigOp)>>,
+
     /// BFD client handle, captured at spawn (BFD is eager-spawned
     /// before OSPF). `None` only if BFD failed to start. Used to
     /// Subscribe / Unsubscribe per-neighbor single-hop sessions; see
@@ -636,6 +648,72 @@ impl<'a, V: OspfVersion> OspfInterface<'a, V> {
             crypto_key: self.crypto_key.clone(),
             md5_seq: s,
         }
+    }
+}
+
+/// Return the interface-name key from an OSPF interface configuration
+/// request. The path parser places matched list keys in `Args` order, so the
+/// first two values are area-id and interface name for both schema versions.
+fn ospf_interface_config_name(proto: &str, paths: &[CommandPath]) -> Option<String> {
+    let (path, mut args) = path_from_command(paths);
+    let prefix = format!("/router/{proto}/area/interface");
+    if path != prefix && !path.starts_with(&format!("{prefix}/")) {
+        return None;
+    }
+    let _area_id = args.string()?;
+    args.string()
+}
+
+#[cfg(test)]
+mod interface_config_path_tests {
+    use super::*;
+
+    fn cp(name: &str, ymatch: i32) -> CommandPath {
+        CommandPath {
+            name: name.to_string(),
+            ymatch,
+            ..Default::default()
+        }
+    }
+
+    fn interface_leaf(proto: &str, name: &str) -> Vec<CommandPath> {
+        vec![
+            cp("router", 0),         // Dir
+            cp(proto, 0),            // Dir
+            cp("area", 2),           // Key
+            cp("0.0.0.0", 3),        // KeyMatched
+            cp("interface", 2),      // Key
+            cp(name, 3),             // KeyMatched
+            cp("network-type", 4),   // Leaf
+            cp("point-to-point", 5), // LeafMatched
+        ]
+    }
+
+    #[test]
+    fn extracts_v2_and_v3_interface_names() {
+        assert_eq!(
+            ospf_interface_config_name("ospf", &interface_leaf("ospf", "eth2")),
+            Some("eth2".to_string())
+        );
+        assert_eq!(
+            ospf_interface_config_name("ospfv3", &interface_leaf("ospfv3", "eth3")),
+            Some("eth3".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_other_protocol_and_non_interface_paths() {
+        assert_eq!(
+            ospf_interface_config_name("ospf", &interface_leaf("ospfv3", "eth3")),
+            None
+        );
+        assert_eq!(
+            ospf_interface_config_name(
+                "ospf",
+                &[cp("router", 0), cp("ospf", 0), cp("router-id", 4)]
+            ),
+            None
+        );
     }
 }
 
@@ -1243,6 +1321,7 @@ impl<V: OspfVersion> Ospf<V> {
         if self.links.contains_key(&link.index) {
             return;
         }
+        let name = link.name.clone();
         let link = OspfLink::from(
             self.tx.clone(),
             link,
@@ -1251,6 +1330,7 @@ impl<V: OspfVersion> Ospf<V> {
             self.ptx.clone(),
         );
         self.links.insert(link.index, link);
+        self.interface_config_replay(&name);
     }
 
     /// Mark a link operationally up and, if OSPF is enabled on it,
@@ -1273,8 +1353,14 @@ impl<V: OspfVersion> Ospf<V> {
         };
         link.link_flags |= LinkFlags::Up | LinkFlags::LowerUp;
 
-        if !link.enabled
-            && link.config.enable
+        // Drive the transition from desired state, not the possibly stale
+        // runtime `enabled` bit.  LinkDown and LinkUp arrive on the RIB
+        // channel while Disable/Enable are processed later on `self.tx`; a
+        // rapid Down -> Up can therefore reach here before the queued Disable
+        // clears `enabled`.  Always queue Enable for an administratively
+        // enabled link, giving the self-channel the correct Disable -> Enable
+        // ordering regardless of task scheduling.
+        if link.config.enable
             && let Some(area) = link.config.area
         {
             let _ = self.tx.send(Message::Enable(ifindex, area));
@@ -1295,8 +1381,13 @@ impl<V: OspfVersion> Ospf<V> {
         };
         link.link_flags &= !LinkFlags::LowerUp;
 
-        if link.enabled {
-            let area_id = link.area_id;
+        // As with link_up, queue from desired state.  RIB emits these only on
+        // real operational transitions, so a Down -> Up -> Down burst becomes
+        // Disable -> Enable -> Disable on the FIFO self-channel and converges
+        // to the final kernel state instead of consulting a lagging runtime
+        // bit at each step.
+        if link.config.enable || link.enabled {
+            let area_id = link.config.area.unwrap_or(link.area_id);
             let _ = self.tx.send(Message::Disable(ifindex, area_id));
         }
     }
@@ -1323,6 +1414,40 @@ impl<V: OspfVersion> Ospf<V> {
             let _ = self.tx.send(Message::Disable(ifindex, area_id));
         }
         self.links.remove(&ifindex);
+    }
+
+    /// Remember one interface-scoped Set/Delete independently of the runtime
+    /// link.  Both the default instance and per-VRF children receive paths in
+    /// the plain `/router/<proto>/area/<id>/interface/<name>/...` shape (the
+    /// parent strips the VRF selector before forwarding to a child), so the
+    /// same helper covers OSPFv2 and OSPFv3.
+    fn interface_config_record(&mut self, msg: &ConfigRequest) {
+        if !matches!(msg.op, ConfigOp::Set | ConfigOp::Delete) {
+            return;
+        }
+        let Some(name) = ospf_interface_config_name(V::PROTO, &msg.paths) else {
+            return;
+        };
+        self.interface_config_log
+            .entry(name)
+            .or_default()
+            .push((msg.paths.clone(), msg.op));
+    }
+
+    /// Apply the durable Set/Delete stream to a newly-created operational
+    /// link.  Invoke callbacks directly so replay does not append a second copy
+    /// to the log.  Callback function pointers are copied out of the table
+    /// before borrowing `self` mutably.
+    fn interface_config_replay(&mut self, name: &str) {
+        let Some(log) = self.interface_config_log.get(name).cloned() else {
+            return;
+        };
+        for (paths, op) in log {
+            let (path, args) = path_from_command(&paths);
+            if let Some(callback) = self.callbacks.get(&path).copied() {
+                callback(self, args, op);
+            }
+        }
     }
 
     /// Count Exchange/Loading neighbors across all links in the same area.
@@ -1686,6 +1811,7 @@ impl Ospf<Ospfv2> {
             vrf_log: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
+            interface_config_log: BTreeMap::new(),
             bfd_client_tx,
             bfd_event_tx,
             bfd_event_rx,
@@ -1721,6 +1847,8 @@ impl Ospf<Ospfv2> {
     }
 
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        self.interface_config_record(&msg);
+
         // CommitEnd: fan out to per-VRF children (run their reconcile)
         // and prune any whose `router ospf vrf <name>` block was fully
         // deleted, then apply this instance's own flex-algo / affinity
@@ -7009,6 +7137,7 @@ impl Ospf<Ospfv3> {
             vrf_log: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
+            interface_config_log: BTreeMap::new(),
             bfd_client_tx,
             bfd_event_tx,
             bfd_event_rx,
@@ -7036,6 +7165,8 @@ impl Ospf<Ospfv3> {
     /// `/router/ospfv3/area/interface/enable` is registered (stub
     /// path); more leaves land alongside the YANG schema expansion.
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        self.interface_config_record(&msg);
+
         // CommitEnd: fan out to per-VRF children and prune deleted
         // ones, then apply this instance's own staging (mirrors the v2
         // sibling).

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -20,9 +20,31 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::error::SendError;
+use tokio::sync::oneshot;
 
 use super::api::RibRx;
 use super::inst::Message;
+
+/// Result of one adjacency-scoped protection switchover request.
+///
+/// Protocols that need to retain the activated repair during
+/// convergence (IS-IS micro-loop avoidance) use this acknowledgement
+/// as the commit point: a zero result is a fail-open signal and must
+/// not start a route-publication hold.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProtectSwitchResult {
+    pub rewired: usize,
+    pub evicted: usize,
+}
+
+impl ProtectSwitchResult {
+    pub fn activated(self) -> bool {
+        // ECMP-leg eviction preserves reachability but is not evidence that
+        // a TI-LFA protection group was switched onto a repair. MLA may hold
+        // the old protected route only after at least one actual rewire.
+        self.rewired > 0
+    }
+}
 
 /// Opaque per-subscriber identifier minted by
 /// [`crate::config::ConfigManager`] and recorded in
@@ -137,7 +159,22 @@ impl RibClient {
     /// SPF, so traffic moves to the pre-installed TI-LFA repairs in
     /// O(adjacencies) while reconvergence runs.
     pub fn protect_switch(&self, addr: std::net::IpAddr) -> Result<(), SendError<RibInbound>> {
-        self.send(Message::ProtectSwitch { addr })
+        self.send(Message::ProtectSwitch { addr, reply: None })
+    }
+
+    /// Trigger a protection switchover and return a completion receiver.
+    /// A dropped receiver (including a RIB channel failure) is treated by
+    /// callers as activation failure and therefore normal convergence.
+    pub fn protect_switch_report(
+        &self,
+        addr: std::net::IpAddr,
+    ) -> oneshot::Receiver<ProtectSwitchResult> {
+        let (reply, rx) = oneshot::channel();
+        let _ = self.send(Message::ProtectSwitch {
+            addr,
+            reply: Some(reply),
+        });
+        rx
     }
 
     /// Undo the switchover's ECMP leg eviction for the adjacency at
@@ -314,6 +351,24 @@ impl ClientRegistry {
 mod tests {
     use super::*;
     use tokio::sync::mpsc::unbounded_channel;
+
+    #[test]
+    fn protect_switch_activation_requires_a_rewired_repair() {
+        assert!(
+            ProtectSwitchResult {
+                rewired: 1,
+                evicted: 0,
+            }
+            .activated()
+        );
+        assert!(
+            !ProtectSwitchResult {
+                rewired: 0,
+                evicted: 2,
+            }
+            .activated()
+        );
+    }
 
     #[test]
     fn register_with_id_records_subscriber_and_advances_next_id() {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -217,6 +217,9 @@ pub enum Message {
     // the construction inside keeps this variant live with it.
     ProtectSwitch {
         addr: IpAddr,
+        /// Optional activation acknowledgement used by IS-IS
+        /// micro-loop avoidance. Legacy callers deliberately omit it.
+        reply: Option<tokio::sync::oneshot::Sender<super::client::ProtectSwitchResult>>,
     },
     /// The inverse of [`Message::ProtectSwitch`]: the adjacency at
     /// `addr` is back (BFD Up while the link never went down). The
@@ -2226,8 +2229,17 @@ impl Rib {
             }
             return;
         }
-        // Link dump.
+        // Link dump. Match the steady-state dispatcher: an ordinary
+        // subscriber sees only links in its own VRF, while an explicit
+        // `global_links` subscriber sees every VRF. Sending every link here
+        // used to let a per-VRF OSPF instance configure an interface before
+        // the kernel had actually moved it into that VRF; the later VRF
+        // LinkAdd was then mistaken for a duplicate ifindex.
         for link in self.links.values() {
+            let link_vrf_id = self.master_vrf_id(link.master);
+            if !global_links && link_vrf_id != vrf_id {
+                continue;
+            }
             let msg = RibRx::LinkAdd(link.clone());
             if tx.send(msg).is_err() {
                 return;
@@ -2924,7 +2936,7 @@ impl Rib {
             Message::NexthopRegister { proto, nh, vrf_id } => {
                 self.nht_register(proto, vrf_id, nh);
             }
-            Message::ProtectSwitch { addr } => {
+            Message::ProtectSwitch { addr, reply } => {
                 let (rewired, evicted) =
                     super::route::protect_switch(&mut self.nmap, &self.fib_handle, table_id, addr)
                         .await;
@@ -2943,6 +2955,9 @@ impl Rib {
                 }
                 if rewired == 0 && evicted == 0 {
                     tracing::debug!("ProtectSwitch {addr} table {table_id}: no eligible groups");
+                }
+                if let Some(reply) = reply {
+                    let _ = reply.send(super::client::ProtectSwitchResult { rewired, evicted });
                 }
             }
             Message::ProtectRestore { addr } => {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3069,6 +3069,23 @@ module config {
               }
             }
           }
+          container micro-loop-avoidance {
+            ext:help "Delay IS-IS convergence after local TI-LFA activation";
+            presence "Enable IS-IS micro-loop avoidance";
+            description
+              "Retain eligible native IPv4 and IPv6 routes on their
+               activated TI-LFA repair for a fixed interval after a local
+               failure. Withdrawals, new prefixes, unrelated routes,
+               Flex-Algorithm routes, and MPLS ILM updates are not delayed.";
+            leaf rib-update-delay {
+              ext:help "Post-failure native RIB update delay (milliseconds)";
+              type uint32 {
+                range "1..60000";
+              }
+              units milliseconds;
+              default "5000";
+            }
+          }
           container backup-as-primary {
             ext:help "Install TI-LFA backup as the primary nexthop";
             // Swap the metric-sort offset between the SPF primary

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -903,6 +903,10 @@ module exec {
           }
         }
       }
+      leaf micro-loop-avoidance {
+        ext:help "IS-IS TI-LFA micro-loop avoidance state and counters";
+        type empty;
+      }
       leaf egress-protection {
         ext:help "Mirror SID egress-protection entries (SRv6/SR-MPLS)";
         type empty;


### PR DESCRIPTION
## Summary

- implement IS-IS TI-LFA micro-loop avoidance with protected RIB switching, delay state, configuration, operational output, and documentation
- extend the TI-LFA/BFD BDD coverage for ordered switchover and timer behavior
- preserve OSPFv2 and OSPFv3 interface intent across VRF/link recreation and make RIB subscription snapshots VRF-correct
- add OSPFv2 and OSPFv3 VRF detach/reattach regression scenarios

## Testing

- `cargo fmt --all`
- `cargo check -p zebra-rs`
- `cargo test -p zebra-rs` (2052 passed, 4 ignored)
- `cargo test --test cucumber -- --concurrency=2 --tags '@l3vpn_ospf_v4 or @l3vpn_ospf_v6'`
- `cargo test --test cucumber -- --concurrency=2 --tags '@ospfv2_bfd_frr or @ospfv3_bfd_frr'`
- `cargo test --test cucumber -- --concurrency=2 --tags '@ospfv2_tilfa or @ospfv3_tilfa'`

The full default-concurrency BDD run completed 285 of 286 features successfully. The remaining `ipsec_s2s` failure is an unrelated deterministic external-backend mismatch; all IS-IS and OSPF targets passed.
