### PR TITLE
topology: add static snapshot export for GitHub Pages

### DIFF
--- a/ai/topology/README.md
+++ b/ai/topology/README.md
@@ -121,6 +121,12 @@ The export is convergence-guarded: it retries (up to
 every algorithm's graph and every source has a path to every other
 router, and refuses to write a partial topology.
 
+`--algorithms` restricts the export (comma-separated): `--algorithms 0`
+exports the plain-SPF view only — the Algorithm dropdown and the data
+files both omit everything else. That is how zebra.rs serves both
+`topology/` (full Flex-Algo snapshot) and `topology0/` (algorithm 0
+only, the pre-Flex-Algo view) from the same lab.
+
 Deploy by copying the output directory to any static host. For
 https://zebra.rs it goes into the `zebra-rs/zebra-rs.github.io` repo as
 `topology/`, serving at https://zebra.rs/topology/. Everything is

--- a/ai/topology/README.md
+++ b/ai/topology/README.md
@@ -90,11 +90,41 @@ reload and travels with a shared link.
 
 | flag         | default                                | meaning                        |
 |--------------|----------------------------------------|--------------------------------|
-| `--port`     | `8080`                                 | HTTP listen port               |
+| `--port`     | `8080`                                 | HTTP listen port (serve mode)  |
 | `--ontology` | `playset/isis-flexalgo/ontology.json`  | router ontology                |
 | `--vtyctl`   | auto (sibling → `target/debug` → PATH) | vtyctl binary for `vtyctl mcp` |
 | `--mcp-host` | `unix:zebra-rs/vty`                    | daemon endpoint inside each ns |
 | `--timeout`  | `15`                                   | per-MCP-call timeout (seconds) |
+
+## Static snapshot (GitHub Pages)
+
+The viewer also runs without any backend: `snapshot` pre-fetches every
+API response from the live lab and writes a self-contained static site.
+
+```shell
+# With the lab up (root required, same as serve mode)
+sudo ./target/debug/zebra-topology snapshot --out dist/topology
+```
+
+The export contains the frontend plus one JSON file per API response —
+`data/routers.json`, `data/algorithms-<src>.json` per router, and one
+all-destinations `data/topology-<src>-<algo>.json` per (source,
+algorithm). The destination filter is applied client-side (in live mode
+too), so those files cover every dropdown combination; only the Refresh
+button and live experiments (like downing a link) need the real
+backend. `data/manifest.js` sets `window.ZEBRA_SNAPSHOT`, which is how
+the frontend knows to read `data/` files instead of `/api/…`, hide
+Refresh, and show the snapshot timestamp in the status bar.
+
+The export is convergence-guarded: it retries (up to
+`--settle-timeout`, default 120 s) until every router is active in
+every algorithm's graph and every source has a path to every other
+router, and refuses to write a partial topology.
+
+Deploy by copying the output directory to any static host. For
+https://zebra.rs it goes into the `zebra-rs/zebra-rs.github.io` repo as
+`topology/`, serving at https://zebra.rs/topology/. Everything is
+relative-path, so any subdirectory works.
 
 ## HTTP API
 

--- a/ai/topology/src/main.rs
+++ b/ai/topology/src/main.rs
@@ -93,6 +93,11 @@ enum Command {
         /// giving up rather than exporting a partial topology.
         #[arg(long, default_value_t = 120)]
         settle_timeout: u64,
+        /// Only export these algorithms (comma-separated, e.g. `0` or
+        /// `0,128`). The exported Algorithm dropdown is filtered to
+        /// match. Default: every algorithm the lab runs.
+        #[arg(long, value_delimiter = ',')]
+        algorithms: Option<Vec<u8>>,
     },
 }
 
@@ -150,7 +155,16 @@ async fn main() -> Result<()> {
         Some(Command::Snapshot {
             out,
             settle_timeout,
-        }) => snapshot::run(&app, &out, Duration::from_secs(settle_timeout)).await,
+            algorithms,
+        }) => {
+            snapshot::run(
+                &app,
+                &out,
+                Duration::from_secs(settle_timeout),
+                algorithms.as_deref(),
+            )
+            .await
+        }
         None | Some(Command::Serve) => serve(app, cli.port).await,
     }
 }

--- a/ai/topology/src/main.rs
+++ b/ai/topology/src/main.rs
@@ -5,10 +5,14 @@
 //! state is obtained through the MCP framework (`vtyctl mcp`, one
 //! stateless session per call, per router namespace) — never by scraping
 //! vty/vtyctl CLI output.
+//!
+//! The `snapshot` subcommand exports the same frontend plus every API
+//! response as static files, for publishing on a static host.
 
 mod api;
 mod mcp;
 mod ontology;
+mod snapshot;
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -17,7 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use http_body_util::Full;
 use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
@@ -33,34 +37,63 @@ const INDEX_HTML: &str = include_str!("../static/index.html");
 const APP_JS: &str = include_str!("../static/app.js");
 const STYLE_CSS: &str = include_str!("../static/style.css");
 
+/// In live mode the manifest declares "no snapshot": the frontend probes
+/// `window.ZEBRA_SNAPSHOT` to decide between the live API and the static
+/// `data/` files a snapshot export writes in its place.
+const LIVE_MANIFEST_JS: &str = "window.ZEBRA_SNAPSHOT = null;\n";
+
 #[derive(Parser)]
 #[command(
     name = "zebra-topology",
     about = "3D traffic path visualizer for the isis-flexalgo playset (MCP-backed)"
 )]
 struct Cli {
-    /// HTTP server port.
-    #[arg(long, default_value_t = 8080)]
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// HTTP server port (serve mode).
+    #[arg(long, global = true, default_value_t = 8080)]
     port: u16,
 
     /// Path to the playset ontology (router names, cities, regions).
-    #[arg(long, default_value = "playset/isis-flexalgo/ontology.json")]
+    #[arg(
+        long,
+        global = true,
+        default_value = "playset/isis-flexalgo/ontology.json"
+    )]
     ontology: PathBuf,
 
     /// vtyctl binary providing `vtyctl mcp`. Defaults to $VTYCTL_BIN,
     /// then a vtyctl next to this executable, then target/debug/vtyctl,
     /// then plain `vtyctl` from PATH.
-    #[arg(long)]
+    #[arg(long, global = true)]
     vtyctl: Option<String>,
 
     /// VTY gRPC endpoint passed to `vtyctl mcp -H` (as seen from inside
     /// each router's namespace).
-    #[arg(long, default_value = "unix:zebra-rs/vty")]
+    #[arg(long, global = true, default_value = "unix:zebra-rs/vty")]
     mcp_host: String,
 
     /// Per-MCP-call timeout in seconds.
-    #[arg(long, default_value_t = 15)]
+    #[arg(long, global = true, default_value_t = 15)]
     timeout: u64,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Serve the viewer live against the running lab (the default).
+    Serve,
+    /// Export the viewer plus pre-fetched data for every source router ×
+    /// algorithm as a static site (for GitHub Pages and the like).
+    Snapshot {
+        /// Output directory for the static site.
+        #[arg(long, default_value = "dist/topology")]
+        out: PathBuf,
+        /// How long to wait (seconds) for the lab to converge before
+        /// giving up rather than exporting a partial topology.
+        #[arg(long, default_value_t = 120)]
+        settle_timeout: u64,
+    },
 }
 
 /// Resolve the vtyctl binary the same way the playset scripts do, plus an
@@ -105,12 +138,6 @@ async fn main() -> Result<()> {
         },
     });
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], cli.port));
-    let listener = TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("failed to bind {addr}"))?;
-
-    println!("zebra-topology: http://localhost:{}", cli.port);
     println!(
         "  ontology : {} ({} routers)",
         cli.ontology.display(),
@@ -118,6 +145,23 @@ async fn main() -> Result<()> {
     );
     println!("  vtyctl   : {vtyctl}");
     println!("  mcp host : {}", cli.mcp_host);
+
+    match cli.command {
+        Some(Command::Snapshot {
+            out,
+            settle_timeout,
+        }) => snapshot::run(&app, &out, Duration::from_secs(settle_timeout)).await,
+        None | Some(Command::Serve) => serve(app, cli.port).await,
+    }
+}
+
+async fn serve(app: Arc<App>, port: u16) -> Result<()> {
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind {addr}"))?;
+
+    println!("zebra-topology: http://localhost:{port}");
 
     loop {
         let (stream, _) = listener.accept().await?;
@@ -181,6 +225,7 @@ async fn handle(
         "/" => respond(StatusCode::OK, "text/html; charset=utf-8", INDEX_HTML),
         "/static/app.js" => respond(StatusCode::OK, "application/javascript", APP_JS),
         "/static/style.css" => respond(StatusCode::OK, "text/css", STYLE_CSS),
+        "/data/manifest.js" => respond(StatusCode::OK, "application/javascript", LIVE_MANIFEST_JS),
         "/api/routers" => json_ok(app.api_routers()),
         "/api/algorithms" => api_algorithms(&req, &app).await,
         "/api/topology" => api_topology(&req, &app).await,

--- a/ai/topology/src/snapshot.rs
+++ b/ai/topology/src/snapshot.rs
@@ -39,10 +39,10 @@ struct Snapshot {
     topologies: Vec<(String, u8, Value)>,
 }
 
-pub async fn run(app: &App, out: &Path, settle: Duration) -> Result<()> {
+pub async fn run(app: &App, out: &Path, settle: Duration, filter: Option<&[u8]>) -> Result<()> {
     let deadline = tokio::time::Instant::now() + settle;
     let snapshot = loop {
-        match collect(app).await {
+        match collect(app, filter).await {
             Ok(s) => break s,
             Err(e) if tokio::time::Instant::now() < deadline => {
                 eprintln!("lab not ready: {e:#}; retrying...");
@@ -57,7 +57,7 @@ pub async fn run(app: &App, out: &Path, settle: Duration) -> Result<()> {
         }
     };
 
-    write(app, out, &snapshot)?;
+    write(app, out, &snapshot, filter)?;
     println!(
         "snapshot: {} — {} routers, {} topology file(s)",
         out.display(),
@@ -70,7 +70,7 @@ pub async fn run(app: &App, out: &Path, settle: Duration) -> Result<()> {
 /// Query every router and validate completeness. Any hole (router not
 /// yet in a graph, destination not yet reachable, flex-algo not yet
 /// advertised) is an error, so the caller can retry until convergence.
-async fn collect(app: &App) -> Result<Snapshot> {
+async fn collect(app: &App, filter: Option<&[u8]>) -> Result<Snapshot> {
     let names: BTreeSet<&str> = app.routers.iter().map(|r| r.name.as_str()).collect();
     let mut snapshot = Snapshot {
         algorithms: Vec::new(),
@@ -80,8 +80,11 @@ async fn collect(app: &App) -> Result<Snapshot> {
 
     for router in &app.routers {
         let source = router.name.as_str();
-        let algorithms = app.api_algorithms(source).await?;
+        let algorithms = filter_algorithms(app.api_algorithms(source).await?, filter);
         let ids = algorithm_ids(&algorithms);
+        if ids.is_empty() {
+            bail!("{source}: no algorithms left after the --algorithms filter");
+        }
         flex_seen |= ids.iter().any(|a| *a != 0);
 
         for algo in &ids {
@@ -97,10 +100,34 @@ async fn collect(app: &App) -> Result<Snapshot> {
 
     // This playset exists to show Flex-Algorithm; a lab where no router
     // advertises one yet has not finished loading its configuration.
-    if !flex_seen {
+    // Exporting algorithm 0 alone is a deliberate choice, not a hole —
+    // the check only applies when a flex-algo is in scope.
+    if !flex_seen && filter.is_none_or(|f| f.iter().any(|a| *a != 0)) {
         bail!("no router advertises a Flex-Algorithm yet");
     }
     Ok(snapshot)
+}
+
+/// Restrict an `/api/algorithms` response to the algorithms in `filter`,
+/// so the exported dropdown never offers an algorithm whose topology
+/// files the export does not contain.
+fn filter_algorithms(mut algorithms: Value, filter: Option<&[u8]>) -> Value {
+    let Some(filter) = filter else {
+        return algorithms;
+    };
+    if let Some(list) = algorithms
+        .get_mut("algorithms")
+        .and_then(Value::as_array_mut)
+    {
+        list.retain(|choice| {
+            choice
+                .get("algo")
+                .and_then(Value::as_u64)
+                .and_then(|a| u8::try_from(a).ok())
+                .is_some_and(|a| filter.contains(&a))
+        });
+    }
+    algorithms
 }
 
 /// The algorithm numbers in an `/api/algorithms` response (0 always
@@ -151,7 +178,7 @@ fn validate_topology(
     Ok(())
 }
 
-fn write(app: &App, out: &Path, snapshot: &Snapshot) -> Result<()> {
+fn write(app: &App, out: &Path, snapshot: &Snapshot, filter: Option<&[u8]>) -> Result<()> {
     let data = out.join("data");
     let assets = out.join("static");
     std::fs::create_dir_all(&data)
@@ -180,12 +207,15 @@ fn write(app: &App, out: &Path, snapshot: &Snapshot) -> Result<()> {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock is past the epoch")
         .as_secs();
-    let manifest = json!({
+    let mut manifest = json!({
         "generatedAtEpoch": generated,
         "playset": "isis-flexalgo",
         "routers": snapshot.algorithms.len(),
         "topologies": snapshot.topologies.len(),
     });
+    if let Some(filter) = filter {
+        manifest["algorithms"] = json!(filter);
+    }
     write_file(
         &data.join("manifest.js"),
         &format!("window.ZEBRA_SNAPSHOT = {manifest};\n"),
@@ -250,6 +280,23 @@ mod tests {
         topology["paths"].as_array_mut().unwrap().pop();
         let err = validate_topology(&names(), "tk", 0, &topology).unwrap_err();
         assert!(err.to_string().contains("no path to se"), "{err}");
+    }
+
+    #[test]
+    fn filter_restricts_the_dropdown_choices() {
+        let algorithms = json!({
+            "algorithms": [
+                {"algo": 0, "label": "0 — shortest path"},
+                {"algo": 128, "label": "128 — exclude-any: trans-pacific"},
+            ],
+        });
+        let only_zero = filter_algorithms(algorithms.clone(), Some(&[0]));
+        assert_eq!(algorithm_ids(&only_zero), vec![0]);
+        // No filter passes the response through untouched.
+        assert_eq!(
+            algorithm_ids(&filter_algorithms(algorithms, None)),
+            vec![0, 128]
+        );
     }
 
     #[test]

--- a/ai/topology/src/snapshot.rs
+++ b/ai/topology/src/snapshot.rs
@@ -1,0 +1,266 @@
+//! Static snapshot export: the same frontend the live server embeds,
+//! plus every API response pre-fetched into `data/` files, laid out so
+//! the site works from any static host (GitHub Pages included).
+//!
+//! The export is all-or-nothing behind a convergence guard: every
+//! ontology router must be active in every algorithm's graph and every
+//! source must have a path to every other router, retried until a
+//! deadline — a half-converged lab is never written to disk.
+//!
+//! Layout under `--out`:
+//!
+//! ```text
+//! index.html
+//! static/app.js, static/style.css
+//! data/manifest.js                  — window.ZEBRA_SNAPSHOT = {...}
+//! data/routers.json                 — /api/routers
+//! data/algorithms-<src>.json        — /api/algorithms?source=<src>
+//! data/topology-<src>-<algo>.json   — /api/topology?...&destination=__all__
+//! ```
+//!
+//! The frontend filters by destination client-side, so one `__all__`
+//! topology per (source, algorithm) covers every destination choice.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+use crate::api::App;
+
+/// One fully collected, validated lab state, ready to write.
+struct Snapshot {
+    /// Per source router: the `/api/algorithms` response.
+    algorithms: Vec<(String, Value)>,
+    /// Per (source, algorithm): the all-destinations `/api/topology`
+    /// response.
+    topologies: Vec<(String, u8, Value)>,
+}
+
+pub async fn run(app: &App, out: &Path, settle: Duration) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + settle;
+    let snapshot = loop {
+        match collect(app).await {
+            Ok(s) => break s,
+            Err(e) if tokio::time::Instant::now() < deadline => {
+                eprintln!("lab not ready: {e:#}; retrying...");
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+            Err(e) => {
+                return Err(e.context(format!(
+                    "lab did not converge within {}s; refusing to export a partial snapshot",
+                    settle.as_secs()
+                )));
+            }
+        }
+    };
+
+    write(app, out, &snapshot)?;
+    println!(
+        "snapshot: {} — {} routers, {} topology file(s)",
+        out.display(),
+        snapshot.algorithms.len(),
+        snapshot.topologies.len()
+    );
+    Ok(())
+}
+
+/// Query every router and validate completeness. Any hole (router not
+/// yet in a graph, destination not yet reachable, flex-algo not yet
+/// advertised) is an error, so the caller can retry until convergence.
+async fn collect(app: &App) -> Result<Snapshot> {
+    let names: BTreeSet<&str> = app.routers.iter().map(|r| r.name.as_str()).collect();
+    let mut snapshot = Snapshot {
+        algorithms: Vec::new(),
+        topologies: Vec::new(),
+    };
+    let mut flex_seen = false;
+
+    for router in &app.routers {
+        let source = router.name.as_str();
+        let algorithms = app.api_algorithms(source).await?;
+        let ids = algorithm_ids(&algorithms);
+        flex_seen |= ids.iter().any(|a| *a != 0);
+
+        for algo in &ids {
+            let topology = app.api_topology(source, *algo, None).await?;
+            validate_topology(&names, source, *algo, &topology)?;
+            snapshot
+                .topologies
+                .push((source.to_string(), *algo, topology));
+        }
+        println!("  {source}: algorithms {ids:?} ok");
+        snapshot.algorithms.push((source.to_string(), algorithms));
+    }
+
+    // This playset exists to show Flex-Algorithm; a lab where no router
+    // advertises one yet has not finished loading its configuration.
+    if !flex_seen {
+        bail!("no router advertises a Flex-Algorithm yet");
+    }
+    Ok(snapshot)
+}
+
+/// The algorithm numbers in an `/api/algorithms` response (0 always
+/// included by construction).
+fn algorithm_ids(algorithms: &Value) -> Vec<u8> {
+    algorithms
+        .get("algorithms")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|a| a.get("algo").and_then(Value::as_u64))
+        .filter_map(|a| u8::try_from(a).ok())
+        .collect()
+}
+
+/// A topology is complete when every ontology router is active in its
+/// graph and every other router is reachable from the source.
+fn validate_topology(
+    names: &BTreeSet<&str>,
+    source: &str,
+    algo: u8,
+    topology: &Value,
+) -> Result<()> {
+    let active: BTreeSet<&str> = topology
+        .get("nodes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|n| n.get("active").and_then(Value::as_bool) == Some(true))
+        .filter_map(|n| n.get("name").and_then(Value::as_str))
+        .collect();
+    let reachable: BTreeSet<&str> = topology
+        .get("paths")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|p| p.get("destination").and_then(Value::as_str))
+        .collect();
+
+    for name in names {
+        if !active.contains(name) {
+            bail!("algorithm {algo} from {source}: {name} not in the IS-IS graph");
+        }
+        if *name != source && !reachable.contains(name) {
+            bail!("algorithm {algo} from {source}: no path to {name}");
+        }
+    }
+    Ok(())
+}
+
+fn write(app: &App, out: &Path, snapshot: &Snapshot) -> Result<()> {
+    let data = out.join("data");
+    let assets = out.join("static");
+    std::fs::create_dir_all(&data)
+        .with_context(|| format!("failed to create {}", data.display()))?;
+    std::fs::create_dir_all(&assets)
+        .with_context(|| format!("failed to create {}", assets.display()))?;
+
+    // The frontend embedded in this binary — the deployed site always
+    // matches the code that produced its data.
+    write_file(&out.join("index.html"), crate::INDEX_HTML)?;
+    write_file(&assets.join("app.js"), crate::APP_JS)?;
+    write_file(&assets.join("style.css"), crate::STYLE_CSS)?;
+
+    write_json(&data.join("routers.json"), &app.api_routers())?;
+    for (source, algorithms) in &snapshot.algorithms {
+        write_json(&data.join(format!("algorithms-{source}.json")), algorithms)?;
+    }
+    for (source, algo, topology) in &snapshot.topologies {
+        write_json(
+            &data.join(format!("topology-{source}-{algo}.json")),
+            topology,
+        )?;
+    }
+
+    let generated = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock is past the epoch")
+        .as_secs();
+    let manifest = json!({
+        "generatedAtEpoch": generated,
+        "playset": "isis-flexalgo",
+        "routers": snapshot.algorithms.len(),
+        "topologies": snapshot.topologies.len(),
+    });
+    write_file(
+        &data.join("manifest.js"),
+        &format!("window.ZEBRA_SNAPSHOT = {manifest};\n"),
+    )
+}
+
+fn write_file(path: &Path, content: &str) -> Result<()> {
+    std::fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<()> {
+    let mut text = serde_json::to_string_pretty(value)?;
+    text.push('\n');
+    write_file(path, &text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names() -> BTreeSet<&'static str> {
+        BTreeSet::from(["tk", "sg", "se"])
+    }
+
+    /// A complete topology from `tk`: everyone active, everyone reached.
+    fn topology_fixture() -> Value {
+        json!({
+            "source": "tk",
+            "algorithm": 0,
+            "nodes": [
+                {"name": "tk", "active": true},
+                {"name": "sg", "active": true},
+                {"name": "se", "active": true},
+            ],
+            "edges": [],
+            "paths": [
+                {"destination": "sg", "hops": ["tk", "sg"]},
+                {"destination": "se", "hops": ["tk", "se"]},
+            ],
+        })
+    }
+
+    #[test]
+    fn complete_topology_validates() {
+        validate_topology(&names(), "tk", 0, &topology_fixture()).expect("complete");
+    }
+
+    #[test]
+    fn inactive_router_is_rejected() {
+        let mut topology = topology_fixture();
+        topology["nodes"][2]["active"] = json!(false);
+        let err = validate_topology(&names(), "tk", 128, &topology).unwrap_err();
+        assert!(
+            err.to_string().contains("se not in the IS-IS graph"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn unreached_destination_is_rejected() {
+        let mut topology = topology_fixture();
+        topology["paths"].as_array_mut().unwrap().pop();
+        let err = validate_topology(&names(), "tk", 0, &topology).unwrap_err();
+        assert!(err.to_string().contains("no path to se"), "{err}");
+    }
+
+    #[test]
+    fn algorithm_ids_flatten_the_choices() {
+        let algorithms = json!({
+            "algorithms": [
+                {"algo": 0, "label": "0 — shortest path"},
+                {"algo": 128, "label": "128 — exclude-any: trans-pacific"},
+            ],
+        });
+        assert_eq!(algorithm_ids(&algorithms), vec![0, 128]);
+        assert!(algorithm_ids(&json!({})).is_empty());
+    }
+}

--- a/ai/topology/static/app.js
+++ b/ai/topology/static/app.js
@@ -4,6 +4,35 @@
 // backend, which queries each router over MCP (vtyctl mcp). There is no
 // TE telemetry here — the lab carries connectivity, IGP metrics, and
 // per-algorithm SPF paths, so that is what the globe shows.
+//
+// The frontend also runs from a static snapshot (`zebra-topology
+// snapshot`): data/manifest.js sets window.ZEBRA_SNAPSHOT, and every
+// query becomes a fetch of a pre-baked data/ file instead of the live
+// API. Destination filtering is client-side in both modes, so one
+// all-destinations topology per (source, algorithm) covers everything.
+
+// Set by data/manifest.js: null when served live, snapshot metadata
+// ({generatedAtEpoch, ...}) when exported as a static site.
+const SNAPSHOT = window.ZEBRA_SNAPSHOT || null;
+
+function routersUrl() {
+    return SNAPSHOT ? './data/routers.json' : './api/routers';
+}
+
+function algorithmsUrl(source) {
+    return SNAPSHOT
+        ? './data/algorithms-' + encodeURIComponent(source) + '.json'
+        : './api/algorithms?source=' + encodeURIComponent(source);
+}
+
+function topologyUrl(source, algorithm) {
+    return SNAPSHOT
+        ? './data/topology-' + encodeURIComponent(source) + '-' +
+            encodeURIComponent(algorithm) + '.json'
+        : './api/topology?source=' + encodeURIComponent(source) +
+            '&algorithm=' + encodeURIComponent(algorithm) +
+            '&destination=__all__';
+}
 
 const COLORS = ['#e6194b', '#3cb44b', '#4363d8', '#f58231', '#911eb4', '#42d4f4', '#f032e6', '#bfef45'];
 
@@ -66,6 +95,10 @@ let currentAlgorithm = 0;
 // state a newer selection produced.
 let topologySeq = 0;
 let algorithmsSeq = 0;
+
+// The all-destinations topology for the current source|algorithm.
+// Flipping the destination re-renders from here — no re-query.
+let topologyCache = { key: null, data: null };
 
 // The camera auto-aims only when the vantage point changes (new source
 // or destination) — never on an algorithm flip or refresh, so the view
@@ -205,7 +238,7 @@ function escapeHtml(s) {
 async function loadRouters() {
     try {
         setStatus('Loading routers...');
-        const data = await apiFetch('/api/routers');
+        const data = await apiFetch(routersUrl());
         const routers = data.routers || [];
 
         const srcSel = document.getElementById('source');
@@ -256,7 +289,7 @@ async function loadAlgorithms(source, preferred) {
     const seq = ++algorithmsSeq;
     try {
         setStatus('Loading algorithms...');
-        const data = await apiFetch('/api/algorithms?source=' + encodeURIComponent(source));
+        const data = await apiFetch(algorithmsUrl(source));
         if (seq !== algorithmsSeq) return;
         const algorithms = data.algorithms || [];
         // Capture the selection at rebuild time — not at call time — so a
@@ -283,31 +316,52 @@ async function loadAlgorithms(source, preferred) {
     }
 }
 
-async function loadTopology() {
+// The destination filter is applied here, client-side, to the cached
+// all-destinations response. Paths are re-indexed after filtering so
+// colors and legend numbering always start from the first visible path.
+function filterPaths(data, destination) {
+    const paths = (data.paths || []).filter(p =>
+        destination === '__all__' || p.destination === destination);
+    return paths.map((p, i) => ({ ...p, index: i }));
+}
+
+async function loadTopology(opts) {
+    const force = !!(opts && opts.force);
     const source = document.getElementById('source').value;
-    const destination = document.getElementById('destination').value;
     const algorithm = document.getElementById('algorithm').value || '0';
 
     if (!source) return;
 
     syncUrl();
 
+    const key = source + '|' + algorithm;
+    if (!force && topologyCache.key === key && topologyCache.data) {
+        renderFromCache();
+        return;
+    }
+
     const seq = ++topologySeq;
     // Keep the current view (and the user's camera) on screen while the
     // routers are queried; the map is replaced only when new data lands.
-    setStatus('Querying ' + source + ' over MCP...');
+    setStatus(SNAPSHOT ? 'Loading snapshot data...' : 'Querying ' + source + ' over MCP...');
 
     try {
-        const url = '/api/topology?source=' + encodeURIComponent(source) +
-            '&algorithm=' + encodeURIComponent(algorithm) +
-            '&destination=' + encodeURIComponent(destination);
-        const data = await apiFetch(url);
+        const data = await apiFetch(topologyUrl(source, algorithm));
         if (seq !== topologySeq) return;
-        renderTopology(data, `${source}|${destination}`);
+        topologyCache = { key, data };
+        renderFromCache();
     } catch (e) {
         if (seq !== topologySeq) return;
         setStatus('Failed to load topology: ' + e.message, true);
     }
+}
+
+function renderFromCache() {
+    const data = topologyCache.data;
+    // The destination is read at render time, not fetch time, so a flip
+    // made while a fetch was in flight is what ends up on screen.
+    const destination = document.getElementById('destination').value;
+    renderTopology(data, filterPaths(data, destination), `${data.source}|${destination}`);
 }
 
 // --- Map rendering ---
@@ -319,7 +373,7 @@ function nodeLabel(n) {
         `IS-IS: ${n.active ? 'up' : 'not in topology'}`;
 }
 
-function renderTopology(data, focusKey) {
+function renderTopology(data, paths, focusKey) {
     clearMap();
 
     currentAlgorithm = data.algorithm || 0;
@@ -360,7 +414,6 @@ function renderTopology(data, focusKey) {
     });
 
     // Path arcs, one color per path, with a legend toggle each.
-    const paths = data.paths || [];
     const legendEl = document.getElementById('legend');
     legendEl.innerHTML = '';
     let allPathBtn = null;
@@ -467,8 +520,11 @@ function renderTopology(data, focusKey) {
 
     const unplotted = data.nodes.filter(n => n.lat == null || n.lng == null).map(n => n.name);
     const extra = unplotted.length > 0 ? ` (${unplotted.length} node(s) without coordinates: ${unplotted.join(', ')})` : '';
+    const snapNote = SNAPSHOT && SNAPSHOT.generatedAtEpoch
+        ? ` Snapshot of ${new Date(SNAPSHOT.generatedAtEpoch * 1000).toUTCString()}.`
+        : '';
     setStatus(`Algorithm ${currentAlgorithm} from ${data.source}: ` +
-        `${paths.length} path(s), ${data.nodes.length} node(s), ${plottedEdges} link(s)${extra}.`);
+        `${paths.length} path(s), ${data.nodes.length} node(s), ${plottedEdges} link(s)${extra}.${snapNote}`);
 }
 
 function refreshArcs() {
@@ -552,6 +608,14 @@ function populatePathDetail(idx) {
 document.addEventListener('DOMContentLoaded', () => {
     initGlobeSelect();
     initMap();
+
+    // A snapshot cannot re-query the routers — hide Refresh and let the
+    // status bar carry the snapshot timestamp instead.
+    if (SNAPSHOT) {
+        const refresh = document.getElementById('refresh');
+        (refresh.closest('label') || refresh).style.display = 'none';
+    }
+
     loadRouters();
 
     // A globe-design flip only restyles the earth — no router re-query.
@@ -569,5 +633,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('destination').addEventListener('change', () => loadTopology());
     document.getElementById('algorithm').addEventListener('change', () => loadTopology());
-    document.getElementById('refresh').addEventListener('click', () => loadTopology());
+    document.getElementById('refresh').addEventListener('click', () => loadTopology({ force: true }));
 });

--- a/ai/topology/static/index.html
+++ b/ai/topology/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>zebra-rs Traffic Path Visualizer</title>
-    <link rel="stylesheet" href="/static/style.css" />
+    <link rel="stylesheet" href="./static/style.css" />
 </head>
 <body>
     <div class="header">zebra-rs Traffic Path Visualizer</div>
@@ -70,12 +70,16 @@
 
     <div class="status-bar" id="status">Initializing...</div>
 
+    <!-- Live server: window.ZEBRA_SNAPSHOT = null. Snapshot export:
+         the same path carries the snapshot metadata instead, switching
+         app.js from the live API to the pre-fetched data/ files. -->
+    <script src="./data/manifest.js"></script>
     <script src="https://unpkg.com/three@0.160.0/build/three.min.js"
             integrity="sha384-qOkzR5Ke/XkQxuGVJ9hpFEpDlcoLtWwVYhnJf06cLIZa2vaIptSqaubivErzmD5O"
             crossorigin="anonymous"></script>
     <script src="https://unpkg.com/globe.gl@2.32.0/dist/globe.gl.min.js"
             integrity="sha384-Plx/0mhoQXLzFNQEcp4kULf6wOFgVaNISmr+3cNLjGb4U8Nq7d7/96ydYtbT0Wb6"
             crossorigin="anonymous"></script>
-    <script src="/static/app.js"></script>
+    <script src="./static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

`zebra-topology snapshot --out <dir>` exports the viewer as a self-contained static site: the embedded frontend plus every API response pre-fetched from the live lab. This is what will serve at https://zebra.rs/topology/ — the full interactive globe (source/destination/algorithm selection, path detail, globe designs, shareable URLs) with no backend.

## How it works

- **Data layout**: `data/routers.json`, `data/algorithms-<src>.json` per router, and one all-destinations `data/topology-<src>-<algo>.json` per (source, algorithm) — 11 routers × 2 algorithms → 35 small JSON files.
- **Mode switch**: `data/manifest.js` sets `window.ZEBRA_SNAPSHOT`. The live server serves a `null` stub there; a snapshot carries the export metadata, switching `app.js` to the `data/` files, hiding Refresh, and stamping the snapshot time in the status bar. `index.html` is byte-identical in both modes (all paths relative, so any subdirectory works).
- **Client-side destination filter**: the frontend now always fetches `destination=__all__` and filters/re-indexes paths in JS. This is what collapses the static data matrix, and in live mode it makes destination flips instant (no MCP round trip) via a per-(source|algorithm) cache. The HTTP API itself is unchanged.
- **Convergence guard**: the export retries (default 120 s) until every ontology router is active in every algorithm's graph and every source has a path to every other router — a half-converged lab is never written to disk.

## Testing

- `cargo test --workspace --exclude bdd` green (new unit tests cover the convergence validation and algorithm-id flattening); workspace clippy clean; `node --check` on `app.js`.
- Ran `snapshot` against the live 11-node lab: converged first try, 22 topology files. Spot-checked the flex-algo detour: algo 0 `tk→{sj,sg}→se` crosses the Pacific, algo 128 goes `tk→sg→fr→{ln,va}→ch→se`.
- Served the export from a `/topology/` subpath via a plain static file server — all relative fetches resolve.
- Live mode re-verified: `/`, `/data/manifest.js` stub, and `/api/topology?…&destination=__all__` all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)