### PR TITLE
isis: RFC 9666 Area Proxy phase 1 — TLV 20 and Area Leader sub-TLV codec

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -202,6 +202,7 @@ impl Display for IsisTlv {
             Ipv6GlobalIfAddr(v) => write!(f, "{}", v),
             Ipv6Reach(v) => write!(f, "{}", v),
             RouterCap(v) => write!(f, "{}", v),
+            AreaProxy(v) => write!(f, "{}", v),
             MultiTopology(v) => write!(f, "{}", v),
             MtIpReach(v) => write!(f, "{}", v),
             MtIpv6Reach(v) => write!(f, "{}", v),

--- a/crates/isis-packet/src/flags_serde.rs
+++ b/crates/isis-packet/src/flags_serde.rs
@@ -21,6 +21,7 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::parser::IsisLspTypes;
+use crate::sub::area_proxy::AreaSidFlags;
 use crate::sub::cap::{RouterCapFlags, SegmentRoutingCapFlags, Srv6Flags};
 use crate::sub::neigh::AdjSidFlags;
 use crate::sub::prefix::{
@@ -118,6 +119,12 @@ bitfield_serde!(RouterCapFlags {
 } reserved { resvd: u8 });
 
 bitfield_serde!(Srv6Flags { o_flag: bool } reserved { resvd1: bool, resvd2: u16 });
+
+bitfield_serde!(AreaSidFlags {
+    l_flag: bool,
+    v_flag: bool,
+    f_flag: bool,
+} reserved { resvd: u8 });
 
 bitfield_serde!(AdjSidFlags {
     p_flag: bool,

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -14,9 +14,10 @@ use super::checksum_calc;
 use super::error::{IsisIResult, IsisParseError};
 use super::util::{ParseBe, TlvEmitter, u32_u8_3};
 use super::{
-    IsisTlvExtIpReach, IsisTlvExtIsReach, IsisTlvIpv6Reach, IsisTlvIpv6Srlg, IsisTlvMtIpReach,
-    IsisTlvMtIpv6Reach, IsisTlvMtIsReach, IsisTlvMultiTopology, IsisTlvRestart, IsisTlvRouterCap,
-    IsisTlvSidLabelBinding, IsisTlvSrlg, IsisTlvSrv6, IsisTlvType, IsisType, many0_complete,
+    IsisTlvAreaProxy, IsisTlvExtIpReach, IsisTlvExtIsReach, IsisTlvIpv6Reach, IsisTlvIpv6Srlg,
+    IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvMtIsReach, IsisTlvMultiTopology, IsisTlvRestart,
+    IsisTlvRouterCap, IsisTlvSidLabelBinding, IsisTlvSrlg, IsisTlvSrv6, IsisTlvType, IsisType,
+    many0_complete,
 };
 
 // IS-IS discriminator.
@@ -528,6 +529,8 @@ pub enum IsisTlv {
     PurgeOrigId(IsisTlvPurgeOrigId),
     #[nom(Selector = "IsisTlvType::LspBufferSize")]
     LspBufferSize(IsisTlvLspBufferSize),
+    #[nom(Selector = "IsisTlvType::AreaProxy")]
+    AreaProxy(IsisTlvAreaProxy),
     #[nom(Selector = "IsisTlvType::ExtIsReach")]
     ExtIsReach(IsisTlvExtIsReach),
     #[nom(Selector = "IsisTlvType::MtIsReach")]
@@ -602,6 +605,7 @@ impl IsisTlv {
             MtIpv6Reach(v) => v.value_wire_len(),
             Srv6(v) => v.value_wire_len(),
             RouterCap(v) => v.value_wire_len(),
+            AreaProxy(v) => v.value_wire_len(),
             // Fixed-stride lists whose u8 `len()` would wrap.
             LspEntries(v) => v.entries.len() * 16,
             MultiTopology(v) => v.entries.len() * 2,
@@ -659,6 +663,7 @@ impl IsisTlv {
             MtIpv6Reach(v) => v.tlv_emit(buf),
             P2p3Way(v) => v.tlv_emit(buf),
             RouterCap(v) => v.tlv_emit(buf),
+            AreaProxy(v) => v.tlv_emit(buf),
             Restart(v) => v.tlv_emit(buf),
             Unknown(v) => v.tlv_emit(buf),
         }

--- a/crates/isis-packet/src/sub/area_proxy.rs
+++ b/crates/isis-packet/src/sub/area_proxy.rs
@@ -1,0 +1,265 @@
+use bitfield_struct::bitfield;
+use bytes::{BufMut, BytesMut};
+use ipnet::{Ipv4Net, Ipv6Net};
+use nom::IResult;
+use nom::number::complete::be_u8;
+use nom_derive::*;
+use serde::{Deserialize, Serialize};
+
+use crate::util::{ParseBe, TlvEmitter};
+use crate::{IsisSysId, IsisTlv, IsisTlvType, SidLabelValue, many0_complete};
+
+use super::prefix::{psize, ptake, ptakev6};
+use super::{IsisAreaProxyCode, IsisSubTlvUnknown};
+
+impl_parse_subs!(IsisAreaProxySub);
+
+// ─────────────────────────────────────────────────────────────────────
+// RFC 9666 — Area Proxy TLV (type 20) and its sub-TLVs. The TLV is a
+// bare sub-TLV container carried in fragment 0 of an L2 LSP: every
+// Inside Router (pseudonodes included) advertises an empty one to
+// signal Area Proxy readiness, and the elected Area Leader adds the
+// Proxy System Identifier sub-TLV (and optionally an Area SID) once
+// the whole area is ready. It MUST NOT appear in L1 LSPs, IIHs, or
+// SNPs (IANA: IIH:n, LSP:y, SNP:n).
+// ─────────────────────────────────────────────────────────────────────
+
+/// One sub-TLV of the Area Proxy TLV, dispatched by `IsisAreaProxyCode`
+/// (RFC 9666 §4.3).
+#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+#[nom(Selector = "IsisAreaProxyCode")]
+pub enum IsisAreaProxySub {
+    #[nom(Selector = "IsisAreaProxyCode::ProxySystemId")]
+    ProxySystemId(IsisSubProxySystemId),
+    #[nom(Selector = "IsisAreaProxyCode::AreaSid")]
+    AreaSid(IsisSubAreaSid),
+    #[nom(Selector = "_")]
+    Unknown(IsisSubTlvUnknown),
+}
+
+impl IsisAreaProxySub {
+    pub fn len(&self) -> u8 {
+        use IsisAreaProxySub::*;
+        match self {
+            ProxySystemId(v) => v.len(),
+            AreaSid(v) => v.len(),
+            Unknown(v) => v.len,
+        }
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        use IsisAreaProxySub::*;
+        match self {
+            ProxySystemId(v) => v.tlv_emit(buf),
+            AreaSid(v) => v.tlv_emit(buf),
+            Unknown(v) => v.tlv_emit(buf),
+        }
+    }
+}
+
+/// Area Proxy System Identifier sub-TLV (RFC 9666 §4.3.1, type 1).
+/// Advertised by the Area Leader to distribute the Proxy System ID —
+/// the system ID under which the Proxy LSP is originated and which
+/// Inside Edge Routers use as the source of IIHs and SNPs on Outside
+/// Circuits.
+#[derive(Debug, Default, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubProxySystemId {
+    pub sys_id: IsisSysId,
+}
+
+impl TlvEmitter for IsisSubProxySystemId {
+    fn typ(&self) -> u8 {
+        IsisAreaProxyCode::ProxySystemId.into()
+    }
+
+    fn len(&self) -> u8 {
+        6
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put(&self.sys_id.id[..]);
+    }
+}
+
+impl From<IsisSubProxySystemId> for IsisAreaProxySub {
+    fn from(sub: IsisSubProxySystemId) -> Self {
+        IsisAreaProxySub::ProxySystemId(sub)
+    }
+}
+
+// RFC 9666 §4.3.2 flags octet (IETF bit 0 is the MSB):
+//   0 1 2 3 4 5 6 7
+//  +-+-+-+-+-+-+-+-+
+//  |F|V|L|         |
+//  +-+-+-+-+-+-+-+-+
+// F = 0x80 (address family: 0 IPv4, 1 IPv6), V = 0x40, L = 0x20 per
+// RFC 8667 §2.1.1.1. `bitfield(u8)` is LSB-first — declare the five
+// reserved bits first so L, V, F land at 0x20/0x40/0x80.
+#[bitfield(u8, debug = true)]
+#[derive(PartialEq)]
+pub struct AreaSidFlags {
+    #[bits(5)]
+    pub resvd: u8,
+    pub l_flag: bool,
+    pub v_flag: bool,
+    pub f_flag: bool,
+}
+
+impl ParseBe<AreaSidFlags> for AreaSidFlags {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        Ok((input, flags.into()))
+    }
+}
+
+/// Prefix carried by the Area SID sub-TLV; family is selected by the
+/// F-flag (kept as a typed enum so consumers don't re-derive it).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AreaSidPrefix {
+    V4(Ipv4Net),
+    V6(Ipv6Net),
+}
+
+impl AreaSidPrefix {
+    pub fn prefix_len(&self) -> u8 {
+        match self {
+            AreaSidPrefix::V4(p) => p.prefix_len(),
+            AreaSidPrefix::V6(p) => p.prefix_len(),
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let plen = psize(self.prefix_len());
+        buf.put_u8(self.prefix_len());
+        match self {
+            AreaSidPrefix::V4(p) => buf.put(&p.addr().octets()[..plen]),
+            AreaSidPrefix::V6(p) => buf.put(&p.addr().octets()[..plen]),
+        }
+    }
+}
+
+/// Area SID sub-TLV (RFC 9666 §4.3.2, type 2). Advertised by the Area
+/// Leader: an anycast prefix + SID representing the entire Inside Area,
+/// installed by every Inside Edge Router and re-advertised as a Node
+/// SID in the Proxy LSP.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubAreaSid {
+    pub flags: AreaSidFlags,
+    pub sid: SidLabelValue,
+    pub prefix: AreaSidPrefix,
+}
+
+impl ParseBe<IsisSubAreaSid> for IsisSubAreaSid {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = AreaSidFlags::parse_be(input)?;
+        // RFC 9666 defers to RFC 8667 §2.1.1.1: the V/L flags decide
+        // the SID form — V=L=1 a 3-octet label, V=L=0 a 4-octet index,
+        // anything else invalid (the registry walk degrades the
+        // sub-TLV to Unknown). `SidLabelValue::parse_be_flags` can't
+        // be used here: it requires the SID to be the sub-TLV's final
+        // field, but the prefix follows it — so slice the width by
+        // flags and let the length-keyed parser handle the value.
+        let width = match (flags.v_flag(), flags.l_flag()) {
+            (true, true) => 3,
+            (false, false) => 4,
+            _ => {
+                return Err(nom::Err::Error(nom::error::make_error(
+                    input,
+                    nom::error::ErrorKind::Verify,
+                )));
+            }
+        };
+        let (input, sid_bytes) = packet_utils::safe_split_at(input, width)?;
+        let (_, sid) = SidLabelValue::parse_be(sid_bytes)?;
+        let (input, plen) = be_u8(input)?;
+        let (input, prefix) = if flags.f_flag() {
+            let (input, p) = ptakev6(input, plen)?;
+            (input, AreaSidPrefix::V6(p))
+        } else {
+            let (input, p) = ptake(input, plen)?;
+            (input, AreaSidPrefix::V4(p))
+        };
+        Ok((input, Self { flags, sid, prefix }))
+    }
+}
+
+impl TlvEmitter for IsisSubAreaSid {
+    fn typ(&self) -> u8 {
+        IsisAreaProxyCode::AreaSid.into()
+    }
+
+    fn len(&self) -> u8 {
+        // Flags: 1 + SID + Prefix Length: 1 + packed prefix.
+        1 + self.sid.len() + 1 + psize(self.prefix.prefix_len()) as u8
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        // Derive V/L from the SID form and F from the prefix family so
+        // the emitted flags can never disagree with the bytes that
+        // follow.
+        let flags = match self.sid {
+            SidLabelValue::Label(_) => self.flags.with_v_flag(true).with_l_flag(true),
+            SidLabelValue::Index(_) => self.flags.with_v_flag(false).with_l_flag(false),
+        };
+        let flags = flags.with_f_flag(matches!(self.prefix, AreaSidPrefix::V6(_)));
+        buf.put_u8(flags.into());
+        self.sid.emit(buf);
+        self.prefix.emit(buf);
+    }
+}
+
+impl From<IsisSubAreaSid> for IsisAreaProxySub {
+    fn from(sub: IsisSubAreaSid) -> Self {
+        IsisAreaProxySub::AreaSid(sub)
+    }
+}
+
+/// Area Proxy TLV (RFC 9666 §4.3, type 20). A bare sub-TLV container;
+/// an empty one is the readiness signal every Inside Router advertises
+/// in fragment 0 of its L2 LSP.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisTlvAreaProxy {
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub subs: Vec<IsisAreaProxySub>,
+}
+
+impl ParseBe<IsisTlvAreaProxy> for IsisTlvAreaProxy {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, subs) = many0_complete(IsisAreaProxySub::parse_subs).parse(input)?;
+        Ok((input, Self { subs }))
+    }
+}
+
+impl IsisTlvAreaProxy {
+    fn sub_len(&self) -> usize {
+        // 2 bytes (type + length) per sub-TLV header.
+        self.subs.iter().map(|sub| sub.len() as usize + 2).sum()
+    }
+
+    /// True value length in bytes, unsaturated (the u8 `len()`
+    /// saturates at 255) — used by `IsisTlv::wire_len`.
+    pub fn value_wire_len(&self) -> usize {
+        self.sub_len()
+    }
+}
+
+impl TlvEmitter for IsisTlvAreaProxy {
+    fn typ(&self) -> u8 {
+        IsisTlvType::AreaProxy.into()
+    }
+
+    fn len(&self) -> u8 {
+        self.sub_len().min(255) as u8
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        self.subs.iter().for_each(|sub| sub.emit(buf));
+    }
+}
+
+impl From<IsisTlvAreaProxy> for IsisTlv {
+    fn from(tlv: IsisTlvAreaProxy) -> Self {
+        IsisTlv::AreaProxy(tlv)
+    }
+}

--- a/crates/isis-packet/src/sub/area_proxy_code.rs
+++ b/crates/isis-packet/src/sub/area_proxy_code.rs
@@ -1,0 +1,42 @@
+use nom::IResult;
+use nom::number::complete::be_u8;
+use nom_derive::*;
+
+/// Sub-TLV type codes of the Area Proxy TLV (RFC 9666 §4.3).
+#[repr(u8)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum IsisAreaProxyCode {
+    #[default]
+    ProxySystemId = 1,
+    AreaSid = 2,
+    Unknown(u8),
+}
+
+impl From<IsisAreaProxyCode> for u8 {
+    fn from(typ: IsisAreaProxyCode) -> Self {
+        use IsisAreaProxyCode::*;
+        match typ {
+            ProxySystemId => 1,
+            AreaSid => 2,
+            Unknown(v) => v,
+        }
+    }
+}
+
+impl From<u8> for IsisAreaProxyCode {
+    fn from(typ: u8) -> Self {
+        use IsisAreaProxyCode::*;
+        match typ {
+            1 => ProxySystemId,
+            2 => AreaSid,
+            v => Unknown(v),
+        }
+    }
+}
+
+impl IsisAreaProxyCode {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u8(input)?;
+        Ok((input, typ.into()))
+    }
+}

--- a/crates/isis-packet/src/sub/area_proxy_disp.rs
+++ b/crates/isis-packet/src/sub/area_proxy_disp.rs
@@ -1,0 +1,64 @@
+use std::fmt::{Display, Formatter, Result};
+
+use super::area_proxy::{
+    AreaSidFlags, AreaSidPrefix, IsisAreaProxySub, IsisSubAreaSid, IsisSubProxySystemId,
+    IsisTlvAreaProxy,
+};
+
+impl Display for IsisTlvAreaProxy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  Area Proxy:")?;
+        for sub in self.subs.iter() {
+            write!(f, "\n{}", sub)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for IsisAreaProxySub {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use IsisAreaProxySub::*;
+        match self {
+            ProxySystemId(v) => write!(f, "{}", v),
+            AreaSid(v) => write!(f, "{}", v),
+            Unknown(v) => write!(f, "   Unknown Code: {} Len: {}", v.code, v.len),
+        }
+    }
+}
+
+impl Display for IsisSubProxySystemId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "   Proxy System ID: {}", self.sys_id)
+    }
+}
+
+impl Display for AreaSidFlags {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "F:{} V:{} L:{}",
+            self.f_flag() as u8,
+            self.v_flag() as u8,
+            self.l_flag() as u8
+        )
+    }
+}
+
+impl Display for IsisSubAreaSid {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "   Area SID: {}, Prefix: {}, Flags: {}",
+            self.sid, self.prefix, self.flags
+        )
+    }
+}
+
+impl Display for AreaSidPrefix {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            AreaSidPrefix::V4(p) => write!(f, "{}", p),
+            AreaSidPrefix::V6(p) => write!(f, "{}", p),
+        }
+    }
+}

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -31,6 +31,8 @@ pub enum IsisSubTlv {
     Srv6(IsisSubSrv6),
     #[nom(Selector = "IsisCapCode::FlexAlgoDef")]
     FlexAlgoDef(IsisSubFlexAlgoDef),
+    #[nom(Selector = "IsisCapCode::AreaLeader")]
+    AreaLeader(IsisSubAreaLeader),
     #[nom(Selector = "_")]
     Unknown(IsisSubTlvUnknown),
 }
@@ -45,6 +47,7 @@ impl IsisSubTlv {
             NodeMaxSidDepth(v) => v.len(),
             Srv6(v) => v.len(),
             FlexAlgoDef(v) => v.len(),
+            AreaLeader(v) => v.len(),
             Unknown(v) => v.len,
         }
     }
@@ -58,6 +61,7 @@ impl IsisSubTlv {
             NodeMaxSidDepth(v) => v.tlv_emit(buf),
             Srv6(v) => v.tlv_emit(buf),
             FlexAlgoDef(v) => v.tlv_emit(buf),
+            AreaLeader(v) => v.tlv_emit(buf),
             Unknown(v) => v.tlv_emit(buf),
         }
     }
@@ -649,6 +653,43 @@ impl TlvEmitter for IsisSubFlexAlgoDef {
 impl From<IsisSubFlexAlgoDef> for IsisSubTlv {
     fn from(sub: IsisSubFlexAlgoDef) -> Self {
         IsisSubTlv::FlexAlgoDef(sub)
+    }
+}
+
+/// IS-IS Area Leader sub-TLV (RFC 9667 §5.1.1, IsisCapCode = 27).
+/// Advertising it signals eligibility for Area Leader election: the
+/// candidate with the numerically highest priority wins, ties broken by
+/// the highest system ID; unreachable nodes are ineligible. Reused by
+/// Area Proxy (RFC 9666) to elect the router that originates the Proxy
+/// LSP.
+#[derive(Debug, Default, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubAreaLeader {
+    /// Election priority, 0-255; higher wins.
+    pub priority: u8,
+    /// Flooding-topology algorithm (RFC 9667 §5.1.1): 0 = centralized
+    /// computation by the Area Leader, 1-127 standardized distributed,
+    /// 128-254 private distributed.
+    pub algorithm: u8,
+}
+
+impl TlvEmitter for IsisSubAreaLeader {
+    fn typ(&self) -> u8 {
+        IsisCapCode::AreaLeader.into()
+    }
+
+    fn len(&self) -> u8 {
+        2
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.priority);
+        buf.put_u8(self.algorithm);
+    }
+}
+
+impl From<IsisSubAreaLeader> for IsisSubTlv {
+    fn from(sub: IsisSubAreaLeader) -> Self {
+        IsisSubTlv::AreaLeader(sub)
     }
 }
 

--- a/crates/isis-packet/src/sub/cap_code.rs
+++ b/crates/isis-packet/src/sub/cap_code.rs
@@ -12,6 +12,9 @@ pub enum IsisCapCode {
     NodeMaxSidDepth = 23,
     Srv6 = 25,
     FlexAlgoDef = 26,
+    /// IS-IS Area Leader sub-TLV (RFC 9667 §5.1.1). Election machinery
+    /// shared by Dynamic Flooding and Area Proxy (RFC 9666).
+    AreaLeader = 27,
     Unknown(u8),
 }
 
@@ -25,6 +28,7 @@ impl From<IsisCapCode> for u8 {
             NodeMaxSidDepth => 23,
             Srv6 => 25,
             FlexAlgoDef => 26,
+            AreaLeader => 27,
             Unknown(v) => v,
         }
     }
@@ -40,6 +44,7 @@ impl From<u8> for IsisCapCode {
             23 => NodeMaxSidDepth,
             25 => Srv6,
             26 => FlexAlgoDef,
+            27 => AreaLeader,
             v => Unknown(v),
         }
     }

--- a/crates/isis-packet/src/sub/cap_disp.rs
+++ b/crates/isis-packet/src/sub/cap_disp.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter, Result};
 
-use super::cap::{FadSubTlv, IsisSubFlexAlgoDef, IsisSubSrv6, IsisSubTlv, RouterCapFlags};
+use super::cap::{
+    FadSubTlv, IsisSubAreaLeader, IsisSubFlexAlgoDef, IsisSubSrv6, IsisSubTlv, RouterCapFlags,
+};
 use super::{
     IsisSubNodeMaxSidDepth, IsisSubSegmentRoutingAlgo, IsisSubSegmentRoutingCap,
     IsisSubSegmentRoutingLB, IsisTlvRouterCap, SegmentRoutingCapFlags,
@@ -36,8 +38,19 @@ impl Display for IsisSubTlv {
             NodeMaxSidDepth(v) => write!(f, "{}", v),
             Srv6(v) => write!(f, "{}", v),
             FlexAlgoDef(v) => write!(f, "{}", v),
+            AreaLeader(v) => write!(f, "{}", v),
             Unknown(v) => write!(f, "   Unknown Code: {} Len: {}", v.code, v.len),
         }
+    }
+}
+
+impl Display for IsisSubAreaLeader {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "   Area Leader: Priority {}, Algorithm {}",
+            self.priority, self.algorithm
+        )
     }
 }
 

--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -37,12 +37,22 @@ macro_rules! impl_parse_subs {
     )+};
 }
 
+pub mod area_proxy;
+pub use area_proxy::{
+    AreaSidFlags, AreaSidPrefix, IsisAreaProxySub, IsisSubAreaSid, IsisSubProxySystemId,
+    IsisTlvAreaProxy,
+};
+pub mod area_proxy_code;
+pub use area_proxy_code::IsisAreaProxyCode;
+pub mod area_proxy_disp;
+
 pub mod cap;
 pub use cap::{
-    ExtAdminGroup, FadSubCode, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg,
-    IsisSubFadFlags, IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg, IsisSubFlexAlgoDef,
-    IsisSubNodeMaxSidDepth, IsisSubSegmentRoutingAlgo, IsisSubSegmentRoutingCap,
-    IsisSubSegmentRoutingLB, IsisSubSrv6, IsisSubTlv, IsisTlvRouterCap, SegmentRoutingCapFlags,
+    ExtAdminGroup, FadSubCode, FadSubTlv, IsisSubAreaLeader, IsisSubFadExcludeAg,
+    IsisSubFadExcludeSrlg, IsisSubFadFlags, IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg,
+    IsisSubFlexAlgoDef, IsisSubNodeMaxSidDepth, IsisSubSegmentRoutingAlgo,
+    IsisSubSegmentRoutingCap, IsisSubSegmentRoutingLB, IsisSubSrv6, IsisSubTlv, IsisTlvRouterCap,
+    SegmentRoutingCapFlags,
 };
 pub use packet_utils::SidLabelTlv;
 pub mod cap_code;

--- a/crates/isis-packet/src/tlv_type.rs
+++ b/crates/isis-packet/src/tlv_type.rs
@@ -25,6 +25,10 @@ pub enum IsisTlvType {
     /// systemId-anonymous zero-lifetime LSP.
     PurgeOrigId = 13,
     LspBufferSize = 14,
+    /// Area Proxy TLV (RFC 9666). Carried in fragment 0 of an L2 LSP;
+    /// signals Area Proxy readiness and, from the Area Leader, carries
+    /// the Proxy System Identifier and Area SID sub-TLVs.
+    AreaProxy = 20,
     ExtIsReach = 22,
     MtIsReach = 222,
     Srv6 = 27,
@@ -77,6 +81,7 @@ impl IsisTlvType {
                 | Auth
                 | PurgeOrigId
                 | LspBufferSize
+                | AreaProxy
                 | ExtIsReach
                 | MtIsReach
                 | Srv6
@@ -113,6 +118,7 @@ impl From<IsisTlvType> for u8 {
             Auth => 10,
             PurgeOrigId => 13,
             LspBufferSize => 14,
+            AreaProxy => 20,
             ExtIsReach => 22,
             MtIsReach => 222,
             Srv6 => 27,
@@ -150,6 +156,7 @@ impl From<u8> for IsisTlvType {
             10 => Auth,
             13 => PurgeOrigId,
             14 => LspBufferSize,
+            20 => AreaProxy,
             22 => ExtIsReach,
             222 => MtIsReach,
             27 => Srv6,

--- a/crates/isis-packet/tests/area_proxy.rs
+++ b/crates/isis-packet/tests/area_proxy.rs
@@ -1,0 +1,203 @@
+//! RFC 9666 Area Proxy TLV (20) and RFC 9667 Area Leader sub-TLV (242/27)
+//! codec tests: wire-byte layouts, round-trips, and malformed-value
+//! degradation.
+
+use bytes::BytesMut;
+use ipnet::{Ipv4Net, Ipv6Net};
+use isis_packet::*;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+fn round_trip_tlv(tlv: &IsisTlv) -> IsisTlv {
+    let mut buf = BytesMut::new();
+    tlv.emit(&mut buf);
+    let (rest, parsed) = IsisTlv::parse_tlv(&buf).expect("parse");
+    assert!(rest.is_empty(), "leftover bytes: {rest:?}");
+    parsed
+}
+
+/// The readiness signal every Inside Router advertises is an *empty*
+/// Area Proxy TLV — two bytes on the wire.
+#[test]
+fn empty_area_proxy_tlv_round_trips() {
+    let tlv: IsisTlv = IsisTlvAreaProxy::default().into();
+    let mut buf = BytesMut::new();
+    tlv.emit(&mut buf);
+    assert_eq!(&buf[..], &[20, 0]);
+    assert_eq!(tlv.wire_len(), 2);
+    assert_eq!(round_trip_tlv(&tlv), tlv);
+}
+
+#[test]
+fn proxy_system_id_sub_wire_layout() {
+    let tlv: IsisTlv = IsisTlvAreaProxy {
+        subs: vec![
+            IsisSubProxySystemId {
+                sys_id: IsisSysId {
+                    id: [0, 0, 0, 0, 0, 1],
+                },
+            }
+            .into(),
+        ],
+    }
+    .into();
+    let mut buf = BytesMut::new();
+    tlv.emit(&mut buf);
+    // TLV 20, len 8; sub-TLV 1, len 6, system ID.
+    assert_eq!(&buf[..], &[20, 8, 1, 6, 0, 0, 0, 0, 0, 1]);
+    assert_eq!(round_trip_tlv(&tlv), tlv);
+}
+
+/// Area SID in the label form: V=L=1 with a 3-octet label, IPv4 prefix
+/// (F clear). RFC 9666 §4.3.2 flags are F=0x80, V=0x40, L=0x20.
+#[test]
+fn area_sid_label_v4_wire_layout() {
+    let area_sid = IsisSubAreaSid {
+        flags: AreaSidFlags::new(),
+        sid: SidLabelValue::Label(16000),
+        prefix: AreaSidPrefix::V4(Ipv4Net::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
+    };
+    let tlv: IsisTlv = IsisTlvAreaProxy {
+        subs: vec![area_sid.into()],
+    }
+    .into();
+    let mut buf = BytesMut::new();
+    tlv.emit(&mut buf);
+    // Sub-TLV 2, len 6: flags V|L=0x60, label 16000 = 0x003E80,
+    // prefix length 8, one packed prefix octet.
+    assert_eq!(&buf[..], &[20, 8, 2, 6, 0x60, 0x00, 0x3E, 0x80, 8, 10]);
+    let parsed = round_trip_tlv(&tlv);
+    let IsisTlv::AreaProxy(ap) = &parsed else {
+        panic!("expected AreaProxy TLV, got {parsed:?}");
+    };
+    let IsisAreaProxySub::AreaSid(sid) = &ap.subs[0] else {
+        panic!("expected AreaSid sub-TLV");
+    };
+    assert!(sid.flags.v_flag() && sid.flags.l_flag() && !sid.flags.f_flag());
+    assert_eq!(sid.sid, SidLabelValue::Label(16000));
+    assert_eq!(
+        sid.prefix,
+        AreaSidPrefix::V4(Ipv4Net::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap())
+    );
+}
+
+/// Area SID in the index form: V=L=0 with a 4-octet index, IPv6 prefix
+/// (F set).
+#[test]
+fn area_sid_index_v6_round_trips() {
+    let prefix = Ipv6Net::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 48).unwrap();
+    let tlv: IsisTlv = IsisTlvAreaProxy {
+        subs: vec![
+            IsisSubAreaSid {
+                // Emit derives V/L from the SID form and F from the
+                // prefix family; construct the flags to match so the
+                // parsed value compares equal to the original.
+                flags: AreaSidFlags::new().with_f_flag(true),
+                sid: SidLabelValue::Index(100),
+                prefix: AreaSidPrefix::V6(prefix),
+            }
+            .into(),
+        ],
+    }
+    .into();
+    let mut buf = BytesMut::new();
+    tlv.emit(&mut buf);
+    // Flags F=0x80; index 100 as 4 octets; prefix length 48 packs to 6
+    // octets. Sub value length = 1 + 4 + 1 + 6 = 12.
+    assert_eq!(buf[2], 2);
+    assert_eq!(buf[3], 12);
+    assert_eq!(buf[4], 0x80);
+    let parsed = round_trip_tlv(&tlv);
+    assert_eq!(parsed, tlv);
+}
+
+/// RFC 8667 §2.1.1.1: V=1/L=0 is an invalid flag combination — the
+/// sub-TLV degrades to Unknown with its bytes preserved instead of
+/// aborting the TLV.
+#[test]
+fn area_sid_flag_width_mismatch_degrades_to_unknown() {
+    let bytes: &[u8] = &[
+        20,   // Area Proxy TLV
+        8,    // length
+        2,    // Area SID sub-TLV
+        6,    // length
+        0x40, // V=1, L=0: invalid
+        0x00, 0x3E, 0x80, // would-be label
+        8, 10, // prefix
+    ];
+    let (rest, parsed) = IsisTlv::parse_tlv(bytes).expect("parse");
+    assert!(rest.is_empty());
+    let IsisTlv::AreaProxy(ap) = &parsed else {
+        panic!("expected AreaProxy TLV, got {parsed:?}");
+    };
+    let IsisAreaProxySub::Unknown(u) = &ap.subs[0] else {
+        panic!("expected Unknown sub-TLV, got {:?}", ap.subs[0]);
+    };
+    assert_eq!(u.code, 2);
+    assert_eq!(u.len, 6);
+    let mut buf = BytesMut::new();
+    parsed.emit(&mut buf);
+    assert_eq!(&buf[..], bytes);
+}
+
+#[test]
+fn unknown_area_proxy_sub_preserved_on_round_trip() {
+    let bytes: &[u8] = &[20, 5, 99, 3, 0xDE, 0xAD, 0xBE];
+    let (rest, parsed) = IsisTlv::parse_tlv(bytes).expect("parse");
+    assert!(rest.is_empty());
+    let IsisTlv::AreaProxy(ap) = &parsed else {
+        panic!("expected AreaProxy TLV, got {parsed:?}");
+    };
+    assert!(matches!(&ap.subs[0], IsisAreaProxySub::Unknown(u) if u.code == 99));
+    let mut buf = BytesMut::new();
+    parsed.emit(&mut buf);
+    assert_eq!(&buf[..], bytes);
+}
+
+/// A TLV run containing TLV 20 dispatches to the typed variant — before
+/// RFC 9666 support it round-tripped as Unknown — and neighbors in the
+/// run still parse.
+#[test]
+fn area_proxy_parses_typed_within_tlv_run() {
+    let bytes: &[u8] = &[
+        20, 0, // empty Area Proxy TLV
+        137, 2, b'r', b'1', // Dynamic Hostname
+    ];
+    let (rest, tlvs) = IsisTlv::parse_tlvs(bytes).expect("parse");
+    assert!(rest.is_empty());
+    assert_eq!(tlvs.len(), 2);
+    assert!(matches!(&tlvs[0], IsisTlv::AreaProxy(ap) if ap.subs.is_empty()));
+    assert!(matches!(&tlvs[1], IsisTlv::Hostname(h) if h.hostname == "r1"));
+}
+
+/// RFC 9667 §5.1.1 Area Leader sub-TLV inside Router Capability TLV 242:
+/// type 27, length 2, priority then algorithm.
+#[test]
+fn area_leader_sub_wire_layout_and_round_trip() {
+    let cap = IsisTlvRouterCap {
+        router_id: Ipv4Addr::new(1, 1, 1, 1),
+        flags: 0u8.into(),
+        subs: vec![
+            IsisSubAreaLeader {
+                priority: 200,
+                algorithm: 0,
+            }
+            .into(),
+        ],
+    };
+    let tlv: IsisTlv = cap.into();
+    let mut buf = BytesMut::new();
+    tlv.emit(&mut buf);
+    // TLV 242, len 9: router-id(4) + flags(1) + sub 27 len 2.
+    assert_eq!(&buf[..], &[242, 9, 1, 1, 1, 1, 0, 27, 2, 200, 0]);
+    let parsed = round_trip_tlv(&tlv);
+    let IsisTlv::RouterCap(cap) = &parsed else {
+        panic!("expected RouterCap TLV, got {parsed:?}");
+    };
+    match &cap.subs[0] {
+        IsisSubTlv::AreaLeader(v) => {
+            assert_eq!(v.priority, 200);
+            assert_eq!(v.algorithm, 0);
+        }
+        other => panic!("expected AreaLeader variant, got {other:?}"),
+    }
+}

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -147,6 +147,10 @@ pub fn lsp_cap_view<'a>(tlv: &'a IsisTlvRouterCap) -> LspCapView<'a> {
             cap::IsisSubTlv::FlexAlgoDef(fad) => {
                 view.fads.push(fad);
             }
+            cap::IsisSubTlv::AreaLeader(_) => {
+                // Not surfaced in the view yet; the Area Proxy leader
+                // election reads it directly from the LSDB.
+            }
             cap::IsisSubTlv::Unknown(_) => {
                 // Simpply ignore unknown sub tlv.
             }


### PR DESCRIPTION
## Summary

Phase 1 of RFC 9666 IS-IS Area Proxy: wire-format (codec) support in the `isis-packet` crate, with no behavior change in the daemon.

* **Area Proxy TLV (type 20)** — sub-TLV container carried in fragment 0 of an L2 LSP. An empty TLV is the readiness signal every Inside Router advertises; the Area Leader adds:
  * **Proxy System Identifier sub-TLV (1)** — the 6-octet system ID the Proxy LSP is originated under and that Inside Edge Routers use as the IIH/SNP source on Outside Circuits.
  * **Area SID sub-TLV (2)** — F/V/L flags, RFC 8667 §2.1.1.1 label/index SID, packed v4/v6 prefix. Emit derives V/L from the SID form and F from the prefix family; a V/L mismatch on parse degrades to Unknown with bytes preserved.
* **Area Leader sub-TLV (27) of Router Capability TLV 242** (RFC 9667 §5.1.1) — priority + algorithm; the election machinery RFC 9666 reuses to pick the Proxy LSP originator.

The sub-TLV registry uses the shared `impl_parse_subs!` walk (malformed known sub-TLVs degrade to Unknown without aborting the TLV), `AreaSidFlags` serde goes through the `bitfield_serde!` table, and `lsp_cap_view` in the daemon gets a no-op arm for the new cap sub-TLV.

Previously TLV 20 round-tripped as `Unknown`; it now parses typed, proven by a TLV-run test alongside a Dynamic Hostname TLV.

## Follow-up phases (separate PRs)

2. YANG/config + Area Proxy TLV advertisement + Area Leader election + show command
3. Proxy LSP generation by the leader
4. Inside Edge behavior (proxy-sourced IIHs, flood/CSNP/PSNP filtering)
5. Inside L2 SPF rules + BDD topology
6. Area SID + SRGB merge (optional)

## Test plan

- [x] `cargo test -p isis-packet` — new `tests/area_proxy.rs`: wire-byte layout checks against hand-crafted sequences, label/index round-trips, V/L-mismatch and unknown-sub degradation, typed parse within a TLV run, Area Leader layout in TLV 242
- [x] `cargo test --workspace --exclude bdd` — full suite green
- [x] `cargo clippy --workspace --exclude bdd --all-targets` — clean
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)