### PR TITLE
isis: RFC 9666 Area Proxy phase 3 — Proxy LSP origination

### DIFF
--- a/zebra-rs/src/isis/area_proxy.rs
+++ b/zebra-rs/src/isis/area_proxy.rs
@@ -14,14 +14,19 @@
 //! The election is recomputed from the LSDB after every SPF completion
 //! and LSDB expiry — both already funnel every LSDB mutation — so no
 //! dedicated debounce timer is needed. Candidates are gated on a live
-//! (non-purged) L1 LSP; the RFC 9667 reachability refinement (drop
-//! candidates the L1 SPF cannot reach, closing the silently-dead-leader
-//! window until its LSP ages out) lands with the Proxy LSP phase, where
-//! leadership starts to carry real responsibilities. RFC 9667 accepts
-//! transient disagreement: "subsequent flooding will cause the entire
-//! area to converge".
+//! (non-purged) L1 LSP *and* on RFC 9667 reachability: a candidate the
+//! last L1 SPF could not reach is ineligible, so a silently dead
+//! leader is displaced as soon as SPF sees the partition rather than
+//! when its LSP ages out. RFC 9667 accepts transient disagreement:
+//! "subsequent flooding will cause the entire area to converge".
+//!
+//! The advertising leader also originates the Proxy LSP
+//! (`lsp::proxy_generate`) under the Proxy System ID, refreshed
+//! through the same funnels with a content-compare so unchanged
+//! settles are free; leadership loss abdicates (the successor's
+//! higher-seq regeneration supersedes), local disablement withdraws.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 
 use isis_packet::{IsisAreaProxySub, IsisLspId, IsisSubTlv, IsisSysId, IsisTlv};
@@ -29,8 +34,11 @@ use serde::Serialize;
 
 use crate::config::Args;
 use crate::isis::{Isis, Level, Message};
+use crate::spf;
 
-use super::lsdb::Lsdb;
+use super::graph::LspMap;
+use super::lsdb::{Lsdb, insert_self_originate};
+use super::lsp::{lsp_emit, proxy_generate};
 
 #[derive(Default)]
 pub struct AreaProxy {
@@ -51,8 +59,13 @@ pub struct AreaProxy {
     pub ready_count: usize,
     /// True while our own L2 LSP fragment 0 carries the Proxy System
     /// Identifier sub-TLV — we are the leader, the area is ready, and
-    /// a proxy-system-id is configured. Read by `lsp_generate`.
+    /// a proxy-system-id is configured. Read by `lsp_generate`. The
+    /// same condition makes us the Proxy LSP originator.
     pub advertise_proxy_id: bool,
+    /// The Proxy System ID our live Proxy LSP fragments were
+    /// originated under, kept so abdication / teardown can find them
+    /// after the config or election that named it has moved on.
+    pub owned_proxy_id: Option<IsisSysId>,
     /// Distinct Proxy System IDs seen in the L2 LSDB, kept to log each
     /// conflicting occurrence once (RFC 9666 §4.4.1: multiple unique
     /// Proxy System IDs are a misconfiguration) instead of on every
@@ -101,6 +114,34 @@ fn proxy_id_sub(tlvs: &[IsisTlv]) -> Option<IsisSysId> {
     })
 }
 
+/// The inside-router set: every system with a live router LSP in the
+/// L1 LSDB (RFC 9666 terminology — the L1 LSDB *is* the Inside Area).
+pub(super) fn inside_routers(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
+    lsdb.iter()
+        .filter_map(|(_, lsa)| {
+            let id = lsa.lsp.lsp_id;
+            live_frag0(&id, lsa.lsp.hold_time).then(|| id.sys_id())
+        })
+        .collect()
+}
+
+/// System IDs reached by the last L1 SPF run, or None when no run has
+/// completed yet (treat as "no filter" — better transiently permissive
+/// at startup than an area with no eligible leader). Callers should
+/// union in their own sys-id: the SPF result may omit its source
+/// vertex.
+pub(super) fn l1_reachable(
+    spf_result: &Option<BTreeMap<usize, spf::Path>>,
+    lsp_map: &LspMap,
+) -> Option<BTreeSet<IsisSysId>> {
+    spf_result.as_ref().map(|result| {
+        result
+            .keys()
+            .filter_map(|id| lsp_map.resolve(*id).copied())
+            .collect()
+    })
+}
+
 /// L2-LSDB scan for advertised Proxy System IDs: the leader's copy (if
 /// any) and the set of distinct values for misconfiguration detection.
 fn learned_proxy_ids(
@@ -135,16 +176,38 @@ fn learned_proxy_ids(
 /// advertise (the Proxy System Identifier sub-TLV appears or goes).
 pub fn refresh(isis: &mut Isis) {
     if !isis.config.area_proxy {
+        // Participation switched off while we were the Proxy LSP
+        // originator: purge our fragments — with area-proxy gone from
+        // this router nobody is guaranteed to supersede them, and a
+        // successor leader's regeneration reclaims past the purge
+        // anyway.
+        purge_owned(isis);
         isis.area_proxy = AreaProxy::default();
         return;
     }
     let self_sys_id = isis.config.net.sys_id();
+
+    // RFC 9667: unreachable nodes are not eligible. Gate candidacy on
+    // the last L1 SPF run so a silently dead leader is displaced as
+    // soon as SPF sees the partition, not when its LSP ages out.
+    let mut reachable = l1_reachable(
+        isis.spf_result.get(&Level::L1),
+        isis.lsp_map.get(&Level::L1),
+    );
+    if let Some(r) = reachable.as_mut() {
+        r.insert(self_sys_id);
+    }
 
     // Area Leader election over the L1 LSDB (our own LSP included —
     // it sits in the LSDB like any other).
     let leader = elect(isis.lsdb.get(&Level::L1).iter().filter_map(|(_, lsa)| {
         let id = lsa.lsp.lsp_id;
         if !live_frag0(&id, lsa.lsp.hold_time) {
+            return None;
+        }
+        if let Some(r) = reachable.as_ref()
+            && !r.contains(&id.sys_id())
+        {
             return None;
         }
         area_leader_priority(&lsa.lsp.tlvs).map(|priority| (priority, id.sys_id()))
@@ -215,6 +278,158 @@ pub fn refresh(isis: &mut Isis) {
     if prev_advertise != advertise_proxy_id {
         let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
     }
+
+    // Proxy LSP lifecycle. While we are the advertising leader, drive
+    // (re)origination — the handler is idempotent (content compare), so
+    // firing on every settle is churn-free. Origination is deferred
+    // out of commits: the commit's own LSP work schedules SPF, and the
+    // following SpfDone re-enters here.
+    if advertise_proxy_id {
+        if !isis.in_commit {
+            let _ = isis.tx.send(Message::ProxyOriginate(None));
+        }
+    } else if prev_advertise {
+        if leader.is_some() && !is_leader {
+            // Leadership moved: stop refreshing our fragments and let
+            // the successor's regeneration (RFC 9666 §5.1: the new
+            // leader MUST regenerate) supersede them at a higher seq.
+            abdicate(isis);
+        } else {
+            // No successor in sight (leadership retained but readiness
+            // or the configured identity is gone): tear the Proxy LSP
+            // down rather than leave it orphaned.
+            purge_owned(isis);
+        }
+    }
+}
+
+/// Stop being the Proxy LSP originator without withdrawing it: clear
+/// the `originated` mark (and the refresh timer it re-arms) on our
+/// fragments so the successor's higher-seq copies replace them via
+/// normal flooding.
+fn abdicate(isis: &mut Isis) {
+    let Some(proxy_id) = isis.area_proxy.owned_proxy_id.take() else {
+        return;
+    };
+    tracing::info!(
+        "isis: area-proxy: abdicating Proxy LSP origination for {}",
+        proxy_id
+    );
+    let lsdb = isis.lsdb.get_mut(&Level::L2);
+    for (_, lsa) in lsdb.map.iter_mut() {
+        if lsa.lsp.lsp_id.sys_id() == proxy_id && lsa.originated {
+            lsa.originated = false;
+            lsa.refresh_timer = None;
+        }
+    }
+}
+
+/// Withdraw the Proxy LSP: purge every fragment we originated.
+fn purge_owned(isis: &mut Isis) {
+    let Some(proxy_id) = isis.area_proxy.owned_proxy_id.take() else {
+        return;
+    };
+    tracing::info!("isis: area-proxy: withdrawing Proxy LSP for {}", proxy_id);
+    let keys: Vec<IsisLspId> = owned_fragments(isis.lsdb.get(&Level::L2), proxy_id);
+    for key in keys {
+        let _ = isis.tx.send(Message::LspPurge(Level::L2, key));
+    }
+}
+
+/// The Proxy LSP fragments this instance originated, ordered by
+/// fragment number.
+fn owned_fragments(lsdb: &Lsdb, proxy_id: IsisSysId) -> Vec<IsisLspId> {
+    lsdb.iter()
+        .filter(|(id, lsa)| id.sys_id() == proxy_id && lsa.originated)
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+/// `Message::ProxyOriginate` handler: build the Proxy LSP set and
+/// flood any fragment whose content actually changed. `base` carries
+/// the ISO 10589 §7.3.16.4 reclaim floor when a peer reflected our
+/// Proxy LSP at a higher sequence number.
+pub fn process_originate(isis: &mut Isis, base: Option<u32>) {
+    // A commit is mid-flight: half-applied config must not reach the
+    // wire. The commit's own origination path schedules SPF, and the
+    // SpfDone that follows re-fires this through `refresh`.
+    if isis.in_commit {
+        return;
+    }
+    if !isis.area_proxy.advertise_proxy_id {
+        return;
+    }
+    let Some(proxy_id) = isis.config.area_proxy_sys_id else {
+        return;
+    };
+    let hostname = isis.config.area_proxy_hostname.clone();
+
+    let mut top = isis.top();
+    let fragments = proxy_generate(&mut top, proxy_id, hostname, base);
+    if fragments.is_empty() {
+        return;
+    }
+
+    // Idempotency: `refresh` fires on every LSDB settle, so only bump
+    // sequences when the content differs from what we already
+    // originated. The stored copies carry the Auth TLV appended by
+    // `lsp_emit`; strip it from the comparison. A reclaim (`base`)
+    // must originate regardless.
+    if base.is_none() {
+        let sans_auth = |tlvs: &[IsisTlv]| -> Vec<IsisTlv> {
+            tlvs.iter()
+                .filter(|t| !matches!(t, IsisTlv::Auth(_)))
+                .cloned()
+                .collect()
+        };
+        let current: BTreeMap<u8, Vec<IsisTlv>> = top
+            .lsdb
+            .get(&Level::L2)
+            .iter()
+            .filter(|(id, lsa)| id.sys_id() == proxy_id && lsa.originated && lsa.lsp.hold_time > 0)
+            .map(|(id, lsa)| (id.fragment_id(), sans_auth(&lsa.lsp.tlvs)))
+            .collect();
+        let new: BTreeMap<u8, Vec<IsisTlv>> = fragments
+            .iter()
+            .map(|f| (f.lsp_id.fragment_id(), f.tlvs.clone()))
+            .collect();
+        if !current.is_empty() && new == current {
+            return;
+        }
+    }
+
+    let max_frag = fragments
+        .iter()
+        .map(|l| l.lsp_id.fragment_id())
+        .max()
+        .unwrap_or(0);
+
+    let auth_cfg = super::lsp::level_auth_cfg(top.config, Level::L2).clone();
+    let resolved = super::auth::resolve_send(&auth_cfg, top.key_chains, chrono::Utc::now());
+    for mut frag in fragments {
+        let buf = lsp_emit(&mut frag, Level::L2, resolved.as_ref());
+        let lsp_id = frag.lsp_id;
+        insert_self_originate(&mut top, Level::L2, frag, Some(buf.to_vec()));
+        top.lsdb
+            .get_mut(&Level::L2)
+            .srm_set_all(top.tx, Level::L2, &lsp_id);
+    }
+
+    // Tail-purge fragments that fell out of this generation.
+    let orphans: Vec<IsisLspId> = top
+        .lsdb
+        .get(&Level::L2)
+        .iter()
+        .filter(|(id, lsa)| {
+            id.sys_id() == proxy_id && lsa.originated && id.fragment_id() > max_frag
+        })
+        .map(|(id, _)| *id)
+        .collect();
+    for key in orphans {
+        let _ = top.tx.send(Message::LspPurge(Level::L2, key));
+    }
+
+    isis.area_proxy.owned_proxy_id = Some(proxy_id);
 }
 
 #[derive(Serialize)]
@@ -230,12 +445,32 @@ struct AreaProxyBrief {
     inside_routers: usize,
     ready_routers: usize,
     advertising_proxy_system_id: bool,
+    originating_proxy_lsp: bool,
+    proxy_lsp_fragments: usize,
+    proxy_lsp_seq_number: Option<u32>,
 }
 
 pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String, std::fmt::Error> {
     let cfg = &isis.config;
     let state = &isis.area_proxy;
     let self_sys_id = cfg.net.sys_id();
+
+    // Our live Proxy LSP fragments, when we are the originator.
+    let owned: Vec<(IsisLspId, u32)> = state
+        .owned_proxy_id
+        .map(|pid| {
+            isis.lsdb
+                .get(&Level::L2)
+                .iter()
+                .filter(|(id, lsa)| id.sys_id() == pid && lsa.originated && lsa.lsp.hold_time > 0)
+                .map(|(id, lsa)| (*id, lsa.lsp.seq_number))
+                .collect()
+        })
+        .unwrap_or_default();
+    let frag0_seq = owned
+        .iter()
+        .find(|(id, _)| id.fragment_id() == 0)
+        .map(|(_, seq)| *seq);
 
     let brief = AreaProxyBrief {
         enabled: cfg.area_proxy,
@@ -249,6 +484,9 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
         inside_routers: state.inside_count,
         ready_routers: state.ready_count,
         advertising_proxy_system_id: state.advertise_proxy_id,
+        originating_proxy_lsp: !owned.is_empty(),
+        proxy_lsp_fragments: owned.len(),
+        proxy_lsp_seq_number: frag0_seq,
     };
 
     if json {
@@ -314,6 +552,15 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
     )?;
     if state.advertise_proxy_id {
         writeln!(buf, "Advertising the Proxy System Identifier sub-TLV")?;
+    }
+    if !owned.is_empty() {
+        writeln!(
+            buf,
+            "Proxy LSP:       originating, {} fragment{}, seq 0x{:08x}",
+            owned.len(),
+            if owned.len() == 1 { "" } else { "s" },
+            frag0_seq.unwrap_or(0),
+        )?;
     }
     Ok(buf)
 }
@@ -382,6 +629,50 @@ mod tests {
         assert_eq!(area_leader_priority(&bare), None);
         assert!(has_area_proxy_tlv(&bare));
         assert_eq!(proxy_id_sub(&bare), None);
+    }
+
+    fn lsa(sys_b: u8, pseudo: u8, frag: u8, hold: u16) -> (IsisLspId, super::super::lsdb::Lsa) {
+        let lsp_id = IsisLspId::new(sys(sys_b), pseudo, frag);
+        let lsp = isis_packet::IsisLsp {
+            lsp_id,
+            hold_time: hold,
+            ..Default::default()
+        };
+        (lsp_id, super::super::lsdb::Lsa::new(lsp))
+    }
+
+    /// The inside-router census counts live router fragment-0 LSPs
+    /// only — purges, pseudonodes, and higher fragments don't define
+    /// area membership.
+    #[test]
+    fn inside_routers_counts_live_router_frag0_only() {
+        let mut lsdb = Lsdb::default();
+        for entry in [
+            lsa(1, 0, 0, 1200), // live router frag 0 — inside
+            lsa(2, 0, 0, 0),    // purged
+            lsa(3, 2, 0, 1200), // pseudonode
+            lsa(4, 0, 1, 1200), // higher fragment only
+        ] {
+            lsdb.map.insert(entry.0, entry.1);
+        }
+        assert_eq!(inside_routers(&lsdb), BTreeSet::from([sys(1)]));
+    }
+
+    /// The L1 reachability gate maps SPF vertex ids back to system
+    /// ids, and reports None (no filter) before the first SPF run.
+    #[test]
+    fn l1_reachable_maps_spf_vertices_to_sys_ids() {
+        let mut map = LspMap::default();
+        let a = map.get_sys(&sys(1));
+        let _b = map.get_sys(&sys(2));
+
+        assert_eq!(l1_reachable(&None, &map), None);
+
+        let mut result: BTreeMap<usize, spf::Path> = BTreeMap::new();
+        result.insert(a, spf::Path::new(a));
+        let reachable = l1_reachable(&Some(result), &map).expect("filter");
+        assert!(reachable.contains(&sys(1)));
+        assert!(!reachable.contains(&sys(2)));
     }
 
     /// Purged LSPs (hold_time 0), pseudonode LSPs, and higher

--- a/zebra-rs/src/isis/area_proxy.rs
+++ b/zebra-rs/src/isis/area_proxy.rs
@@ -316,7 +316,7 @@ fn abdicate(isis: &mut Isis) {
         proxy_id
     );
     let lsdb = isis.lsdb.get_mut(&Level::L2);
-    for (_, lsa) in lsdb.map.iter_mut() {
+    for lsa in lsdb.map.values_mut() {
         if lsa.lsp.lsp_id.sys_id() == proxy_id && lsa.originated {
             lsa.originated = false;
             lsa.refresh_timer = None;

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -58,6 +58,10 @@ impl Isis {
             "/router/isis/area-proxy/priority",
             config_area_proxy_priority,
         );
+        self.callback_add(
+            "/router/isis/area-proxy/hostname",
+            config_area_proxy_hostname,
+        );
         // Authentication storage. The runtime sign/verify paths
         // read these for Hello/SNP and LSP.
         self.callback_add("/router/isis/area-password", config_area_password);
@@ -482,6 +486,12 @@ pub struct IsisConfig {
     /// `/router/isis/area-proxy/priority` — RFC 9667 Area Leader
     /// election priority; None ⇒ DEFAULT_AREA_PROXY_PRIORITY.
     pub area_proxy_priority: Option<u8>,
+
+    /// `/router/isis/area-proxy/hostname` — Dynamic Hostname (TLV 137)
+    /// the Area Leader advertises in the Proxy LSP (RFC 9666 §5.3.7
+    /// RECOMMENDED). Preconfigure the same value on every candidate so
+    /// a leadership change keeps the proxy's name stable.
+    pub area_proxy_hostname: Option<String>,
     pub refresh_time: Option<u16>,
     pub hold_time: Option<u16>,
     pub min_lsp_arrival_time: Option<u32>,
@@ -823,6 +833,7 @@ impl Default for IsisConfig {
             area_proxy: false,
             area_proxy_sys_id: Default::default(),
             area_proxy_priority: Default::default(),
+            area_proxy_hostname: Default::default(),
             refresh_time: Default::default(),
             hold_time: Default::default(),
             min_lsp_arrival_time: Default::default(),
@@ -1175,6 +1186,16 @@ fn config_area_proxy_priority(isis: &mut Isis, mut args: Args, op: ConfigOp) -> 
     let priority = args.u8()?;
     isis.config.area_proxy_priority = if op == ConfigOp::Set {
         Some(priority)
+    } else {
+        None
+    };
+    area_proxy_config_changed(isis)
+}
+
+fn config_area_proxy_hostname(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let hostname = args.string()?;
+    isis.config.area_proxy_hostname = if op == ConfigOp::Set {
+        Some(hostname)
     } else {
         None
     };

--- a/zebra-rs/src/isis/graph.rs
+++ b/zebra-rs/src/isis/graph.rs
@@ -119,6 +119,13 @@ pub fn graph(
     // entry because LspMap keys by IsisNeighborId (no fragment byte).
     let mut nodes_to_process = Vec::new();
     for (_, lsa) in top.lsdb.get(&level).iter() {
+        // RFC 9666 §6.1: Inside Routers MUST ignore the Proxy LSP in
+        // their own SPF — they see the area's real topology, and
+        // consuming the abstraction alongside it could loop. (The
+        // Proxy LSP only exists at L2; the check is inert at L1.)
+        if top.config.area_proxy && top.area_proxy.proxy_sys_id == Some(lsa.lsp.lsp_id.sys_id()) {
+            continue;
+        }
         let neighbor_id = lsa.lsp.lsp_id.neighbor_id();
         let is_originated = lsa.originated;
         let lsp = lsa.lsp.clone();
@@ -282,6 +289,10 @@ pub fn graph_mt2(
 
     let mut nodes_to_process = Vec::new();
     for (_, lsa) in top.lsdb.get(&level).iter() {
+        // Same RFC 9666 §6.1 Proxy-LSP exclusion as `graph()`.
+        if top.config.area_proxy && top.area_proxy.proxy_sys_id == Some(lsa.lsp.lsp_id.sys_id()) {
+            continue;
+        }
         let neighbor_id = lsa.lsp.lsp_id.neighbor_id();
         let is_originated = lsa.originated;
         let is_pseudo = lsa.lsp.lsp_id.is_pseudo();

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2124,6 +2124,12 @@ impl Isis {
             Message::DisOriginate(level, neighbor_id, base) => {
                 self.schedule_dis_originate(level, neighbor_id, base);
             }
+            Message::ProxyOriginate(base) => {
+                // No dedicated throttle: fired from `area_proxy::refresh`,
+                // which is itself paced by the SPF backoff, and the
+                // handler's content compare makes repeats free.
+                super::area_proxy::process_originate(self, base);
+            }
             Message::DisGenFire(level, neighbor_id) => {
                 // Commit gate: same contract as LspGenFire — park the
                 // run (base stays accumulated, no mark_run) and let the
@@ -3312,6 +3318,11 @@ impl Isis {
             tx: &self.tx,
             ptx: &link.ptx,
             up_config: &self.config,
+            area_proxy_owned: if self.area_proxy.advertise_proxy_id {
+                self.config.area_proxy_sys_id
+            } else {
+                None
+            },
             restarting: self.restarting.as_ref(),
             tracing: &self.tracing,
             lsdb: &mut self.lsdb,
@@ -3974,6 +3985,10 @@ pub enum Message {
     /// throttle, and clears the timer slot.
     LspGenFire(Level),
     LspPurge(Level, IsisLspId),
+    /// (Re)originate the RFC 9666 Proxy LSP as the advertising Area
+    /// Leader. The payload is the §7.3.16.4 reclaim floor when a peer
+    /// reflected our Proxy LSP at a higher sequence number.
+    ProxyOriginate(Option<u32>),
     /// Re-originate the pseudonode LSP whose owner is the given
     /// `IsisNeighborId` (sys_id + pseudo_id). The handler resolves
     /// this back to the local ifindex by walking `top.links`; if no
@@ -4069,6 +4084,9 @@ impl Display for Message {
             }
             Message::DisOriginate(level, neighbor_id, _) => {
                 write!(f, "[Message::DisOriginate({}, {})]", level, neighbor_id)
+            }
+            Message::ProxyOriginate(floor) => {
+                write!(f, "[Message::ProxyOriginate(floor={:?})]", floor)
             }
             Message::DisGenFire(level, neighbor_id) => {
                 write!(f, "[Message::DisGenFire({}, {})]", level, neighbor_id)

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -197,6 +197,11 @@ pub struct LinkTop<'a> {
     pub lsdb: &'a mut Levels<Lsdb>,
     pub flags: &'a LinkFlags,
     pub up_config: &'a IsisConfig,
+    /// The Proxy System ID this instance currently originates the
+    /// RFC 9666 Proxy LSP under — `Some` only while we are the
+    /// advertising Area Leader. Read by `lsp_recv` so the §7.3.16.4
+    /// self-reclaim applies to reflected Proxy LSP copies too.
+    pub area_proxy_owned: Option<isis_packet::IsisSysId>,
     /// Snapshot of the per-instance `Isis.restarting` state. `Some`
     /// only between `clear isis graceful-restart begin` and either
     /// `abort`, `restarter-enabled=false`, or successful exit.

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -488,6 +488,196 @@ pub fn dis_generate(
     fragments
 }
 
+/// Build the RFC 9666 Proxy LSP set: the single L2 LSP (fragmented as
+/// needed) the Area Leader originates under the Proxy System ID to
+/// represent the entire Inside Area as one node.
+///
+/// Phase-3 contents (§5.3): Area Addresses, Protocols Supported, and
+/// the proxy hostname from the Inside Area config; Extended IS
+/// Reachability copied from the Inside Edge Routers' L2 LSPs, keeping
+/// only entries whose neighbor is *Outside* (its sys-id has no live L1
+/// router LSP) and deduplicating to the lowest metric per neighbor;
+/// Extended IP / IPv6 Reachability merged from the inside routers' L1
+/// LSPs at the lowest metric per prefix. LSPs of L1-unreachable nodes
+/// MUST NOT contribute (§5.3.9). Deliberately absent: the Area Proxy
+/// TLV (the boundary filter drops any LSP carrying it — the Proxy LSP
+/// must cross), and the SR/TE merges (SRGB intersection, prefix-SID /
+/// Adj-SID copy, Area SID node-SID), which land with the Area SID
+/// phase.
+pub fn proxy_generate(
+    top: &mut IsisTop,
+    proxy_id: IsisSysId,
+    hostname: Option<String>,
+    base: Option<u32>,
+) -> Vec<IsisLsp> {
+    let level = Level::L2;
+    let neighbor_id = IsisNeighborId::from_sys_id(&proxy_id, 0);
+    let frag0_id = IsisLspId::from_neighbor_id(neighbor_id, 0);
+    // The Proxy LSP represents the area, not this router: no OL bit
+    // (per-topology O/A merging is MT scope, out of the phase-3 core).
+    let types = IsisLspTypes::from(level.digit());
+
+    let mut anchors: Vec<IsisTlv> = Vec::new();
+    let mut distributable: Vec<IsisTlv> = Vec::new();
+
+    anchors.push(
+        IsisTlvAreaAddr {
+            area_addrs: vec![top.config.net.area_id()],
+        }
+        .into(),
+    );
+    let mut nlpids = vec![];
+    if top.config.enable.v4 > 0 {
+        nlpids.push(IsisProto::Ipv4.into());
+    }
+    if top.config.enable.v6 > 0 {
+        nlpids.push(IsisProto::Ipv6.into());
+    }
+    if !nlpids.is_empty() {
+        anchors.push(IsisTlvProtoSupported { nlpids }.into());
+    }
+    if let Some(hostname) = hostname {
+        // Mirror the proxy identity into the local hostname map so
+        // show views resolve it; other routers learn it from the
+        // flooded TLV via the regular LSDB rebuild.
+        top.hostname
+            .get_mut(&level)
+            .insert(proxy_id, hostname.clone());
+        anchors.push(IsisTlvHostname { hostname }.into());
+    }
+
+    // The inside-router set is the L1 LSDB; the L1-unreachable are
+    // excluded from every walk below (self counts as reachable — the
+    // SPF result may omit its own source vertex).
+    let inside = super::area_proxy::inside_routers(top.lsdb.get(&Level::L1));
+    let mut reachable = super::area_proxy::l1_reachable(
+        top.spf_result.get(&Level::L1),
+        top.lsp_map.get(&Level::L1),
+    );
+    if let Some(r) = reachable.as_mut() {
+        r.insert(top.config.net.sys_id());
+    }
+    let usable = |sys: &IsisSysId| -> bool {
+        inside.contains(sys) && reachable.as_ref().is_none_or(|r| r.contains(sys))
+    };
+
+    // Outside adjacencies (§5.3.4): every Extended IS Reachability
+    // entry an inside router advertises at L2 toward a neighbor that
+    // is not itself inside. Lowest metric wins when several edge
+    // routers reach the same outside neighbor. Sub-TLVs (Adj-SID, TE)
+    // are not copied in the phase-3 core.
+    let mut outside: BTreeMap<IsisNeighborId, u32> = BTreeMap::new();
+    for (_, lsa) in top.lsdb.get(&Level::L2).iter() {
+        if lsa.lsp.hold_time == 0 || !usable(&lsa.lsp.lsp_id.sys_id()) {
+            continue;
+        }
+        for tlv in &lsa.lsp.tlvs {
+            let IsisTlv::ExtIsReach(reach) = tlv else {
+                continue;
+            };
+            for entry in &reach.entries {
+                let nsys = entry.neighbor_id.sys_id();
+                if inside.contains(&nsys) || nsys == proxy_id {
+                    continue;
+                }
+                let metric = outside.entry(entry.neighbor_id).or_insert(entry.metric);
+                *metric = (*metric).min(entry.metric);
+            }
+        }
+    }
+    if !outside.is_empty() {
+        let mut is_reach = IsisTlvExtIsReach::default();
+        for (neighbor_id, metric) in outside {
+            is_reach.entries.push(IsisTlvExtIsReachEntry {
+                neighbor_id,
+                metric,
+                subs: vec![],
+            });
+        }
+        distributable.extend(split_distributable_at_255(IsisTlv::ExtIsReach(is_reach)));
+    }
+
+    // Prefix reachability (§5.3.6): merge the inside routers' L1
+    // advertisements, lowest metric per prefix. Sub-TLVs (Prefix-SID)
+    // join with the SR merge phase.
+    let mut v4: BTreeMap<Ipv4Net, u32> = BTreeMap::new();
+    let mut v6: BTreeMap<Ipv6Net, u32> = BTreeMap::new();
+    for (_, lsa) in top.lsdb.get(&Level::L1).iter() {
+        if lsa.lsp.hold_time == 0 || !usable(&lsa.lsp.lsp_id.sys_id()) {
+            continue;
+        }
+        for tlv in &lsa.lsp.tlvs {
+            match tlv {
+                IsisTlv::ExtIpReach(reach) => {
+                    for entry in &reach.entries {
+                        let metric = v4.entry(entry.prefix).or_insert(entry.metric);
+                        *metric = (*metric).min(entry.metric);
+                    }
+                }
+                IsisTlv::Ipv6Reach(reach) => {
+                    for entry in &reach.entries {
+                        let metric = v6.entry(entry.prefix).or_insert(entry.metric);
+                        *metric = (*metric).min(entry.metric);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    if !v4.is_empty() {
+        let mut reach = IsisTlvExtIpReach::default();
+        for (prefix, metric) in v4 {
+            reach.entries.push(ext_ip_reach_entry(prefix, metric));
+        }
+        distributable.extend(split_distributable_at_255(IsisTlv::ExtIpReach(reach)));
+    }
+    if !v6.is_empty() {
+        let mut reach = IsisTlvIpv6Reach::default();
+        for (prefix, metric) in v6 {
+            reach.entries.push(ipv6_reach_entry(prefix, metric, false));
+        }
+        distributable.extend(split_distributable_at_255(IsisTlv::Ipv6Reach(reach)));
+    }
+
+    let mut fragments = pack_into_fragments(
+        anchors,
+        distributable,
+        neighbor_id,
+        types,
+        top.config.hold_time(),
+        top.config.lsp_mtu_size(),
+        None,
+    );
+
+    // Per-fragment sequence resolution, mirroring `dis_generate`:
+    // fragment 0 honors `base` (a peer reflected our Proxy LSP at a
+    // higher seq, ISO 10589 §7.3.16.4) in addition to the LSDB seq.
+    for frag in fragments.iter_mut() {
+        if frag.lsp_id.fragment_id() == 0 {
+            let existing = top
+                .lsdb
+                .get(&level)
+                .get(&frag0_id)
+                .map(|x| x.lsp.seq_number);
+            frag.seq_number = match (existing, base) {
+                (Some(e), Some(b)) => e.max(b).saturating_add(1),
+                (Some(e), None) => e.saturating_add(1),
+                (None, Some(b)) => b.saturating_add(1),
+                (None, None) => 0x0001,
+            };
+        } else {
+            let existing = top
+                .lsdb
+                .get(&level)
+                .get(&frag.lsp_id)
+                .map(|x| x.lsp.seq_number);
+            frag.seq_number = existing.map(|e| e.saturating_add(1)).unwrap_or(0x0001);
+        }
+    }
+
+    fragments
+}
+
 /// SID Structure sub-sub-TLV (RFC 9352 §9) for one locator: the
 /// locator's behavior plus `[structure]` when it has a prefix, `None`
 /// when it doesn't (no structure to advertise). Geometry comes from

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -1161,6 +1161,12 @@ pub fn lsp_recv(link: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) 
     // our authoritative copy, not adopt the peer's view of "ours".
     let is_self = link.up_config.net.sys_id() == lsp.lsp_id.sys_id();
 
+    // RFC 9666: while we are the advertising Area Leader, the Proxy
+    // LSP is ours the same way our self-LSPs are — the §7.3.16.4
+    // reclaim below must hold the network on our authoritative copy
+    // rather than adopt a peer's.
+    let is_proxy_own = level == Level::L2 && link.area_proxy_owned == Some(lsp.lsp_id.sys_id());
+
     // 7.3.15.1 Action on receipt of a link state PDU
     match link
         .lsdb
@@ -1194,6 +1200,11 @@ pub fn lsp_recv(link: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) 
                     Message::LspOriginate(level, Some(lsp.seq_number))
                 };
                 let _ = link.tx.send(msg);
+            } else if is_proxy_own {
+                // §7.3.16.4 applied to the Proxy LSP: re-originate past
+                // the reflected sequence number instead of installing
+                // the peer's copy over our own.
+                let _ = link.tx.send(Message::ProxyOriginate(Some(lsp.seq_number)));
             } else {
                 // 7.3.15.1 e.1 — install + re-flood.
                 //

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2820,6 +2820,13 @@ module config {
             ext:help "Area Leader election priority (default 64)";
             type uint8;
           }
+          leaf hostname {
+            ext:help "Dynamic Hostname advertised in the Proxy LSP";
+            // Same RFC 1123-ish charset as the system hostname leaf.
+            type string {
+              pattern "[A-Za-z0-9][A-Za-z0-9.-]*";
+            }
+          }
         }
 
         container segment-routing {


### PR DESCRIPTION
## Summary

Phase 3 of RFC 9666 Area Proxy, building on #2306 (codec) and #2307 (signaling/election). The elected Area Leader now originates the **Proxy LSP** — the single L2 LSP representing the whole Inside Area.

* **Content** (`lsp::proxy_generate`, §5.3): Area Addresses, Protocols Supported, and a proxy Dynamic Hostname (new `area-proxy hostname` config, preconfigure the same on every candidate) from the area config; **outside adjacencies** copied from Inside Edge Routers' L2 TLV 22 (an entry is outside when its neighbor has no live L1 router LSP; lowest metric per neighbor); **prefixes** merged from inside routers' L1 LSPs at lowest metric per prefix. L1-unreachable nodes contribute nothing (§5.3.9). No Area Proxy TLV inside it — the phase-4 boundary filter keys on that TLV and the Proxy LSP must cross. SR/SRGB/TE merges are deferred to the Area SID phase per the plan.
* **Lifecycle**: driven from the existing `refresh` funnels with a content-compare (Auth TLV stripped) so unchanged settles never bump sequences; fragments flood via `insert_self_originate` + SRM; orphans tail-purge. Losing leadership **abdicates** — clears `originated` so the successor's mandatory regeneration (§5.1) supersedes at higher seq; disabling area-proxy locally **withdraws** (purges). The ISO 10589 §7.3.16.4 reclaim now also covers reflected Proxy LSP copies.
* **Reachability gate** (deferred from #2307, now needed since leadership carries real work): candidates the last L1 SPF cannot reach are ineligible, so a silently dead leader is displaced at SPF speed, not LSP-lifetime speed.
* **§6.1 SPF rule**: graph builders (main + MT2) skip the Proxy LSP — inside routers must never consume the abstraction they generate.

## Test plan

- [x] Unit tests: inside-router census filters, L1-reachability mapping (None before first SPF), plus the existing election/TLV-walk suites
- [x] **Live three-node lab** (2 inside + 1 outside L2-only in area 49.0002): leader originates `zaparea.00-00` with `Neighbor ID: 0000.0000.0003.00` (the outside router) and the merged inside prefix; outside router holds it; `show isis topology` on inside routers shows **no proxy vertex**; killing the leader (no purge) → reachability gate displaces it → the priority-50 successor re-originates at seq+1 and the outside router converges
- [x] `cargo test --workspace --exclude bdd` green; workspace clippy clean; `cargo fmt`

Remaining phases: 4 (inside-edge IIH proxy sourcing + boundary flood/SNP filtering), 5 (inside L2 SPF metric rules + BDD), 6 (Area SID + SR merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)