### PR TITLE
isis: RFC 9666 Area Proxy phase 4 — Inside Edge boundary behavior

### DIFF
--- a/zebra-rs/src/isis/area_proxy.rs
+++ b/zebra-rs/src/isis/area_proxy.rs
@@ -114,6 +114,32 @@ fn proxy_id_sub(tlvs: &[IsisTlv]) -> Option<IsisSysId> {
     })
 }
 
+/// Per-circuit Area Proxy role override
+/// (`/router/isis/interface/<name>/area-proxy`). Absent ⇒ derive:
+/// an L2-only circuit on an area-proxy-enabled instance is an
+/// Outside Circuit (RFC 9666 §5.1: Outside Circuits "may be
+/// identified by explicit configuration or by the fact that they
+/// are not also Level 1 circuits").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AreaProxyCircuit {
+    Inside,
+    Outside,
+}
+
+/// RFC 9666 §5.2 boundary filter: true when this L2 LSP must NOT be
+/// flooded toward Outside Routers — its source system is an Inside
+/// Router (live router LSP in the L1 LSDB, pseudonode LSPs of inside
+/// DISes included via the sys-id portion), or it carries the Area
+/// Proxy TLV. The Proxy LSP matches neither and crosses the boundary.
+pub(super) fn boundary_filtered(l1: &Lsdb, l2: &Lsdb, lsp_id: &IsisLspId) -> bool {
+    let l1_router = IsisLspId::new(lsp_id.sys_id(), 0, 0);
+    if l1.get(&l1_router).is_some_and(|lsa| lsa.lsp.hold_time > 0) {
+        return true;
+    }
+    l2.get(lsp_id)
+        .is_some_and(|lsa| has_area_proxy_tlv(&lsa.lsp.tlvs))
+}
+
 /// The inside-router set: every system with a live router LSP in the
 /// L1 LSDB (RFC 9666 terminology — the L1 LSDB *is* the Inside Area).
 pub(super) fn inside_routers(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
@@ -448,6 +474,25 @@ struct AreaProxyBrief {
     originating_proxy_lsp: bool,
     proxy_lsp_fragments: usize,
     proxy_lsp_seq_number: Option<u32>,
+    outside_circuits: Vec<String>,
+}
+
+/// Names of this instance's Outside Circuits — same classification as
+/// `LinkTop::is_outside_circuit`, computed from the link table for
+/// show output.
+fn outside_circuit_names(isis: &Isis) -> Vec<String> {
+    if !isis.config.area_proxy {
+        return Vec::new();
+    }
+    isis.links
+        .iter()
+        .filter(|(_, link)| match link.config.area_proxy_circuit {
+            Some(AreaProxyCircuit::Inside) => false,
+            Some(AreaProxyCircuit::Outside) => true,
+            None => link.state.level() == isis_packet::IsLevel::L2,
+        })
+        .map(|(_, link)| link.state.name.clone())
+        .collect()
 }
 
 pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String, std::fmt::Error> {
@@ -487,6 +532,7 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
         originating_proxy_lsp: !owned.is_empty(),
         proxy_lsp_fragments: owned.len(),
         proxy_lsp_seq_number: frag0_seq,
+        outside_circuits: outside_circuit_names(isis),
     };
 
     if json {
@@ -560,6 +606,13 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
             owned.len(),
             if owned.len() == 1 { "" } else { "s" },
             frag0_seq.unwrap_or(0),
+        )?;
+    }
+    if !brief.outside_circuits.is_empty() {
+        writeln!(
+            buf,
+            "Outside Circuits: {}",
+            brief.outside_circuits.join(", ")
         )?;
     }
     Ok(buf)
@@ -656,6 +709,38 @@ mod tests {
             lsdb.map.insert(entry.0, entry.1);
         }
         assert_eq!(inside_routers(&lsdb), BTreeSet::from([sys(1)]));
+    }
+
+    /// RFC 9666 §5.2 boundary filter: inside-sourced L2 LSPs and any
+    /// LSP carrying the Area Proxy TLV are suppressed toward Outside
+    /// Routers; the Proxy LSP (neither) crosses.
+    #[test]
+    fn boundary_filter_suppresses_inside_and_tlv20_lsps() {
+        let mut l1 = Lsdb::default();
+        let inside = lsa(1, 0, 0, 1200);
+        l1.map.insert(inside.0, inside.1);
+        let aged = lsa(2, 0, 0, 0); // purged L1 LSP — not inside
+        l1.map.insert(aged.0, aged.1);
+
+        let mut l2 = Lsdb::default();
+        // Outside router LSP carrying TLV 20 (bogus but the filter
+        // must still key on it).
+        let (id20, mut lsa20) = lsa(7, 0, 0, 1200);
+        lsa20.lsp.tlvs = vec![isis_packet::IsisTlvAreaProxy::default().into()];
+        l2.map.insert(id20, lsa20);
+        // Plain outside LSP.
+        let plain = lsa(8, 0, 0, 1200);
+        l2.map.insert(plain.0, plain.1);
+
+        // Inside-sourced: filtered, its pseudonode LSP too.
+        assert!(boundary_filtered(&l1, &l2, &IsisLspId::new(sys(1), 0, 0)));
+        assert!(boundary_filtered(&l1, &l2, &IsisLspId::new(sys(1), 3, 0)));
+        // Purged L1 entry does not define inside membership.
+        assert!(!boundary_filtered(&l1, &l2, &IsisLspId::new(sys(2), 0, 0)));
+        // TLV 20 carrier: filtered even though not inside.
+        assert!(boundary_filtered(&l1, &l2, &id20));
+        // Plain outside LSP (and the Proxy LSP shape): crosses.
+        assert!(!boundary_filtered(&l1, &l2, &plain.0));
     }
 
     /// The L1 reachability gate maps SPF vertex ids back to system

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -299,6 +299,10 @@ impl Isis {
         );
         self.callback_add("/router/isis/interface/passive", link::config_passive);
         self.callback_add(
+            "/router/isis/interface/area-proxy",
+            link::config_area_proxy_circuit,
+        );
+        self.callback_add(
             "/router/isis/interface/hello/interval",
             link::config_hello_interval,
         );

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -184,8 +184,29 @@ pub fn srm_advertise(top: &mut LinkTop, level: Level, ifindex: u32) {
         return;
     }
 
+    // RFC 9666 §5.2: toward Outside Routers, L2 LSPs of Inside
+    // Routers (or any LSP carrying the Area Proxy TLV) must not be
+    // flooded — only the Proxy LSP and other outside LSPs cross the
+    // boundary. This transmit choke point covers every SRM setter
+    // (origination fan-out, §7.3.15.1 re-flood, PSNP/CSNP-driven
+    // requests), so an outside peer requesting a suppressed LSP gets
+    // silence rather than a leak.
+    let boundary = level == Level::L2 && top.is_outside_circuit();
+
     // Send LSPs for each SRM entry.
     for lsp_id in srm_entries {
+        if boundary
+            && super::area_proxy::boundary_filtered(
+                top.lsdb.get(&Level::L1),
+                top.lsdb.get(&Level::L2),
+                &lsp_id,
+            )
+        {
+            if let Some(adj) = top.lsdb.get_mut(&level).adj.get_mut(&ifindex) {
+                adj.srm.0.remove(&lsp_id);
+            }
+            continue;
+        }
         let lsdb = top.lsdb.get(&level);
         if let Some(lsa) = lsdb.get(&lsp_id) {
             let hold_time = lsa.hold_timer.as_ref().map_or(0, |timer| timer.rem_sec()) as u16;
@@ -211,14 +232,50 @@ pub fn srm_advertise(top: &mut LinkTop, level: Level, ifindex: u32) {
 }
 
 pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
-    let Some(adj) = link.lsdb.get_mut(&level).adj.get_mut(&link.ifindex) else {
-        return;
+    // Drain the SSN set first so the boundary filter below can borrow
+    // the LSDB immutably.
+    let drained: Vec<IsisLspEntry> = {
+        let Some(adj) = link.lsdb.get_mut(&level).adj.get_mut(&link.ifindex) else {
+            return;
+        };
+        adj.ssn_timer = None;
+        if adj.ssn.0.is_empty() {
+            return;
+        }
+        let mut entries = Vec::new();
+        while let Some((_, entry)) = adj.ssn.0.pop_first() {
+            entries.push(entry);
+        }
+        entries
     };
-    adj.ssn_timer = None;
 
-    if adj.ssn.0.is_empty() {
+    // RFC 9666 §5.2: PSNPs toward Outside Routers must not reference
+    // boundary-filtered LSPs (an ack or request for a suppressed LSP
+    // would resurrect it); an emptied PSNP is not sent at all.
+    let boundary = level == Level::L2 && link.is_outside_circuit();
+    let drained: Vec<IsisLspEntry> = if boundary {
+        drained
+            .into_iter()
+            .filter(|entry| {
+                !super::area_proxy::boundary_filtered(
+                    link.lsdb.get(&Level::L1),
+                    link.lsdb.get(&Level::L2),
+                    &entry.lsp_id,
+                )
+            })
+            .collect()
+    } else {
+        drained
+    };
+    if drained.is_empty() {
         return;
     }
+
+    // §5.2: SNPs on an Outside Circuit are sourced from the Proxy
+    // System ID, like the IIHs that formed the adjacency.
+    let source_id = link
+        .hello_source_id()
+        .unwrap_or_else(|| link.up_config.net.sys_id());
 
     // Interface MTU.
     let mtu = link.state.mtu as usize;
@@ -267,7 +324,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
 
     let mut entry_size = 0;
 
-    while let Some((_, entry)) = adj.ssn.0.pop_first() {
+    for entry in drained {
         tlvs.entries.push(entry);
 
         entry_size += 1;
@@ -276,7 +333,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
             auth::append_auth_tlv(&mut psnp_tlvs, resolved.as_ref());
             let psnp = IsisPsnp {
                 pdu_len: 0,
-                source_id: link.up_config.net.sys_id(),
+                source_id,
                 source_id_circuit: 0,
                 tlvs: psnp_tlvs,
             };
@@ -291,7 +348,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
         auth::append_auth_tlv(&mut psnp_tlvs, resolved.as_ref());
         let psnp = IsisPsnp {
             pdu_len: 0,
-            source_id: link.up_config.net.sys_id(),
+            source_id,
             source_id_circuit: 0,
             tlvs: psnp_tlvs,
         };

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -139,7 +139,14 @@ fn helper_ra_tlvs(link: &LinkTop, level: Level, include_restarting_neighbor: boo
 }
 
 pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
-    let source_id = link.up_config.net.sys_id();
+    // Outside Circuits source IIHs from the Proxy System ID (RFC 9666
+    // §5.1) so the outside neighbor adjacencies — and its TLV 22 —
+    // terminate on the proxy node. The unwrap fallback never reaches
+    // the wire: `hello_send` suppresses outside IIHs until the id is
+    // learned.
+    let source_id = link
+        .hello_source_id()
+        .unwrap_or_else(|| link.up_config.net.sys_id());
     let lan_id = link
         .state
         .adj
@@ -221,7 +228,10 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
 }
 
 pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
-    let source_id = link.up_config.net.sys_id();
+    // Same Outside-Circuit proxy sourcing as `hello_generate`.
+    let source_id = link
+        .hello_source_id()
+        .unwrap_or_else(|| link.up_config.net.sys_id());
 
     // P2P Hello doesn't use LAN ID
     let mut hello = IsisP2pHello {
@@ -356,6 +366,19 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
     // immediate Hello on every enabled circuit once the identity lands.
     if link.up_config.net.sys_id().is_empty() {
         return Ok(());
+    }
+
+    // RFC 9666 §5.1: an Outside Circuit runs L2 only, and its IIHs are
+    // sourced from the Proxy System ID — a router that has not yet
+    // learned it MUST NOT send IIHs there, so the outside adjacency
+    // can never form under our real identity.
+    if link.is_outside_circuit() {
+        if level == Level::L1 {
+            return Ok(());
+        }
+        if link.hello_source_id().is_none() {
+            return Ok(());
+        }
     }
 
     let hello = if link.config.network_type() == NetworkType::P2p {

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -3323,6 +3323,7 @@ impl Isis {
             } else {
                 None
             },
+            area_proxy_learned: self.area_proxy.proxy_sys_id,
             restarting: self.restarting.as_ref(),
             tracing: &self.tracing,
             lsdb: &mut self.lsdb,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -202,6 +202,12 @@ pub struct LinkTop<'a> {
     /// advertising Area Leader. Read by `lsp_recv` so the §7.3.16.4
     /// self-reclaim applies to reflected Proxy LSP copies too.
     pub area_proxy_owned: Option<isis_packet::IsisSysId>,
+    /// The Proxy System ID in force for the area (our own when we are
+    /// the advertising leader, otherwise learned from the leader's L2
+    /// Area Proxy TLV) — `Isis::area_proxy.proxy_sys_id`. Sources L2
+    /// IIHs and SNPs on Outside Circuits; `None` gates them off
+    /// entirely (RFC 9666 §5.1).
+    pub area_proxy_learned: Option<isis_packet::IsisSysId>,
     /// Snapshot of the per-instance `Isis.restarting` state. `Some`
     /// only between `clear isis graceful-restart begin` and either
     /// `abort`, `restarter-enabled=false`, or successful exit.
@@ -289,6 +295,35 @@ impl<'a> LinkTop<'a> {
         !self.is_p2p()
     }
 
+    /// RFC 9666 §5.1 circuit classification. Only meaningful while the
+    /// instance participates in Area Proxy: an explicit per-interface
+    /// `area-proxy inside|outside` wins; otherwise a circuit that is
+    /// not also a Level 1 circuit (effective level L2-only) is an
+    /// Outside Circuit.
+    pub fn is_outside_circuit(&self) -> bool {
+        if !self.up_config.area_proxy {
+            return false;
+        }
+        use super::area_proxy::AreaProxyCircuit;
+        match self.config.area_proxy_circuit {
+            Some(AreaProxyCircuit::Inside) => false,
+            Some(AreaProxyCircuit::Outside) => true,
+            None => self.state.level() == IsLevel::L2,
+        }
+    }
+
+    /// The system ID this circuit's IIHs and SNPs are sourced from:
+    /// our own on inside circuits; the Proxy System ID on Outside
+    /// Circuits — `None` there until it is learned, which per RFC 9666
+    /// §5.1 MUST suppress L2 IIH (and with it SNP) transmission.
+    pub fn hello_source_id(&self) -> Option<isis_packet::IsisSysId> {
+        if self.is_outside_circuit() {
+            self.area_proxy_learned
+        } else {
+            Some(self.up_config.net.sys_id())
+        }
+    }
+
     /// A passive circuit runs no Hello protocol: it advertises its
     /// prefixes into the LSP but never sends or processes Hellos, so it
     /// forms no adjacency. True when the operator set `passive`, and
@@ -331,6 +366,12 @@ pub struct LinkConfig {
 
     /// Link type one of LAN or Point-to-point.
     pub network_type: Option<NetworkType>,
+
+    /// RFC 9666 circuit role override
+    /// (`/router/isis/interface/<name>/area-proxy`). Absent ⇒ derived:
+    /// an L2-only circuit on an area-proxy-enabled instance is
+    /// Outside. See `LinkTop::is_outside_circuit`.
+    pub area_proxy_circuit: Option<super::area_proxy::AreaProxyCircuit>,
 
     /// Passive circuit (`/router/isis/interface/<name>/passive`). When
     /// set, the interface's prefixes are still advertised into the LSP
@@ -1999,6 +2040,34 @@ pub fn config_passive(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<(
         isis.link_state_up(ifindex);
     }
 
+    Some(())
+}
+
+/// `set router isis interface X area-proxy inside|outside` — explicit
+/// RFC 9666 circuit-role override; absent ⇒ derived (an L2-only
+/// circuit on an area-proxy-enabled instance is Outside).
+pub fn config_area_proxy_circuit(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    use super::area_proxy::AreaProxyCircuit;
+    let name = args.string()?;
+    let role = args.string()?;
+    let ifindex = {
+        let link = isis.links.get_mut_by_name(&name)?;
+        link.config.area_proxy_circuit = if op == ConfigOp::Set {
+            match role.as_str() {
+                "inside" => Some(AreaProxyCircuit::Inside),
+                "outside" => Some(AreaProxyCircuit::Outside),
+                _ => return None,
+            }
+        } else {
+            None
+        };
+        link.ifindex
+    };
+    // Reclassification changes what this circuit puts on the wire (IIH
+    // source identity, boundary filters) — refresh the Hello now
+    // rather than at the next timer tick.
+    let msg = Message::Ifsm(IfsmEvent::HelloOriginate, ifindex, None);
+    let _ = isis.tx.send(msg);
     Some(())
 }
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1870,6 +1870,20 @@ pub fn lsp_emit(
 }
 
 pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
+    // RFC 9666 §5.2: an Outside Circuit runs no L1, its CSNPs
+    // summarize only the LSPs allowed to cross the boundary, they are
+    // sourced from the Proxy System ID, and none are sent before that
+    // id is learned (the IIH gate means no adjacency exists then
+    // anyway). Everything filtered ⇒ no CSNP at all — the entry-empty
+    // guards below already ensure that.
+    if link.is_outside_circuit() && level == Level::L1 {
+        return vec![];
+    }
+    let boundary = level == Level::L2 && link.is_outside_circuit();
+    let Some(source_id) = link.hello_source_id() else {
+        return vec![];
+    };
+
     // Interface MTU.
     let mtu = link.state.mtu as usize;
 
@@ -1927,6 +1941,15 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
 
     let mut entry_size = 0;
     for (_lsp_id, lsa) in link.lsdb.get(&level).iter() {
+        if boundary
+            && super::area_proxy::boundary_filtered(
+                link.lsdb.get(&Level::L1),
+                link.lsdb.get(&Level::L2),
+                &lsa.lsp.lsp_id,
+            )
+        {
+            continue;
+        }
         if start.is_none() {
             start = Some(lsa.lsp.lsp_id);
         }
@@ -1939,7 +1962,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
             auth::append_auth_tlv(&mut csnp_tlvs, resolved.as_ref());
             let csnp = IsisCsnp {
                 pdu_len: 0,
-                source_id: link.up_config.net.sys_id(),
+                source_id,
                 source_id_circuit: 0,
                 start: start.unwrap_or(IsisLspId::start()),
                 end: lsa.lsp.lsp_id,
@@ -1957,7 +1980,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
         auth::append_auth_tlv(&mut csnp_tlvs, resolved.as_ref());
         let csnp = IsisCsnp {
             pdu_len: 0,
-            source_id: link.up_config.net.sys_id(),
+            source_id,
             source_id_circuit: 0,
             start: start.unwrap_or(IsisLspId::start()),
             end: IsisLspId::end(),

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -385,6 +385,16 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         return;
     }
 
+    // RFC 9666: on an Outside Circuit our IIHs are sourced from the
+    // Proxy System ID, so a received IIH sourced from it is "self" too
+    // — another Inside Edge Router on the same boundary LAN (a
+    // topology §5.2 declares unsupported). Never key a neighbor under
+    // the proxy identity.
+    if link.is_outside_circuit() && Some(pdu.source_id) == link.area_proxy_learned {
+        isis_pdu_trace!(link, &level, "[Hello:Recv] proxy-sourced IIH — ignored");
+        return;
+    }
+
     // Check link type.
     if !link.is_lan() {
         isis_pdu_trace!(
@@ -407,6 +417,15 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         );
         return;
     }
+
+    // The identity the peer sees us as: the Proxy System ID on an
+    // Outside Circuit (RFC 9666 §5.1), our own everywhere else — the
+    // 3-way handshake's neighbor echo is validated against it.
+    // Snapshot before borrowing `nbr` (method calls on `link` borrow
+    // the whole struct).
+    let hello_src = link
+        .hello_source_id()
+        .unwrap_or_else(|| link.up_config.net.sys_id());
 
     // RFC 5882 §3.2 BFD hold-down: while this neighbour's attached BFD
     // session is Down we keep its adjacency from (re-)reaching Up even though
@@ -486,7 +505,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // RR (HelperEdge::Stay) to prevent a repetitive restart from
     // pinning the adjacency indefinitely.
     let mac = link.state.mac;
-    let sys_id = link.up_config.net.sys_id();
+    let sys_id = hello_src;
     let ifname = link.state.name.clone();
     let (has_mac, _, helper_edge) =
         nbr_hello_interpret(nbr, &pdu.tlvs, mac, sys_id, link.local_pool);
@@ -687,6 +706,17 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         return;
     }
 
+    // See `hello_recv`: a proxy-sourced IIH on an Outside Circuit is
+    // another Inside Edge Router speaking as the same proxy identity.
+    if link.is_outside_circuit() && Some(pdu.source_id) == link.area_proxy_learned {
+        isis_pdu_trace!(
+            link,
+            &Level::L2,
+            "[Hello P2P:Recv] proxy-sourced IIH — ignored"
+        );
+        return;
+    }
+
     // Process the Hello for each compatible level
     for level in [Level::L1, Level::L2] {
         // Check if both sender and receiver support this level
@@ -729,6 +759,13 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             continue;
         }
 
+        // See `hello_recv`: on an Outside Circuit the peer echoes the
+        // Proxy System ID back in its 3-way TLV, not our real one.
+        // Snapshot before borrowing `nbr`.
+        let hello_src = link
+            .hello_source_id()
+            .unwrap_or_else(|| link.up_config.net.sys_id());
+
         // RFC 5882 §3.2 BFD hold-down — see the LAN handler. Snapshot the flag
         // (per level) before borrowing `nbr` from `link.state.nbrs`.
         let held = link.config.bfd.resolve(&link.up_config.bfd).enable
@@ -756,7 +793,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // hold-timer refresh decision below. Matches the LAN ordering
         // — see hello_recv for the RFC 5306 §3.2(a) rationale.
         let mac = link.state.mac;
-        let sys_id = link.up_config.net.sys_id();
+        let sys_id = hello_src;
         let ifname = link.state.name.clone();
         let (_, has_my_sys_id, helper_edge) =
             nbr_hello_interpret(nbr, &pdu.tlvs, mac, sys_id, link.local_pool);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3552,6 +3552,24 @@ module config {
             }
           }
 
+          leaf area-proxy {
+            ext:help "Area Proxy circuit role (RFC 9666): inside / outside";
+            type enumeration {
+              enum inside;
+              enum outside;
+            }
+            description
+              "Explicit RFC 9666 circuit-role override, meaningful only
+               while the instance's area-proxy is enabled. Absent, the
+               role is derived per §5.1: a circuit that is not also a
+               Level 1 circuit (effective level L2-only) is an Outside
+               Circuit. On an Outside Circuit L2 IIHs and SNPs are
+               sourced from the Proxy System ID (suppressed until it is
+               learned), and inside L2 LSPs are filtered from flooding
+               and SNPs. Outside circuits should not be configured to
+               run Level 1.";
+          }
+
           leaf network-type {
             ext:help "Media type: LAN or point-to-point";
             type enumeration {


### PR DESCRIPTION
## Summary

Phase 4 of RFC 9666 Area Proxy, building on #2306/#2307/#2308. This is the phase that actually hides the area: Outside Routers now see a single node.

* **Circuit classification (§5.1)**: per-interface `area-proxy inside|outside` override; absent, an L2-only circuit on a participating instance is derived Outside. Surfaced in `show isis area-proxy`.
* **IIH proxy sourcing (§5.1)**: L2 IIHs on Outside Circuits use the Proxy System ID as source — suppressed entirely until it is learned, so the boundary adjacency can never form under the real identity — and L1 never crosses. The 3-way echo is validated against the proxy identity; a *received* proxy-sourced IIH is dropped as self (second edge router on a boundary LAN, unsupported per §5.2).
* **Flood filter (§5.2)**: one predicate at the `srm_advertise` transmit choke point — L2 LSPs of Inside Routers (live L1 router LSP) or carrying TLV 20 never cross; the Proxy LSP and outside LSPs do. Covers origination fan-out, re-floods, and snooped requests alike.
* **SNP filter (§5.2)**: CSNPs summarize only what may cross; PSNPs drop filtered references; emptied SNPs are not sent; both sourced from the Proxy System ID.

## Test plan

- [x] Unit test for the boundary predicate (inside-sourced, pseudonode, purged-L1, TLV-20-carrier, plain-outside cases) + existing suites
- [x] **Live three-node lab**: outside router's only neighbor is `zaparea`; its LSDB = own LSP + Proxy LSP only (phase 3 leaked all four); its TLV 22 names `0000.0000.00aa`; it installs `10.99.98.0/30` via the Proxy LSP; **ping from outside to an inside prefix succeeds**; LSDB stays clean across an edge-router restart
- [x] `cargo test --workspace --exclude bdd` green; workspace clippy clean; `cargo fmt`

Known transitional gap (documented in the commit): inside routers' L2 SPF now fails the two-way check on the boundary edge (the outside neighbor's TLV 22 names the proxy), so routes to destinations *beyond* the Outside Router are lost inside until phase 5 implements §6.2's inside L2 SPF computation (proxy-adjacency resolution + intra/inter-area metric precedence). Phase 5 also brings the BDD topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)