### PR TITLE
zebra: remove stale insomnia backend comment from main.rs

### DIFF
--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -284,12 +284,6 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
     config.subscribe_show("rib", rib.show.tx.clone());
     config.subscribe_show("policy", policy.show.tx.clone());
 
-    // The firewall and IPsec backends live in the external insomnia
-    // daemon: it consumes both subtrees over the zebra.config.v1 JSON
-    // subscription and serves `show firewall` / `show vpn ipsec` back
-    // through the zebra.show.v1 provider registration (the subtrees
-    // only exist with `--feature iso`).
-
     let cli = Cli::new(config.tx.clone());
 
     let vty_addr = config::VtyAddr::parse(&arg.vty_socket)?;


### PR DESCRIPTION
## Summary
- Remove an outdated comment block in `zebra-rs/src/main.rs` describing the external insomnia daemon's firewall/IPsec backends; the comment no longer reflects anything in this file.

## Test plan
- Comment-only deletion; CI (`cargo fmt` / `cargo clippy` / `cargo test`) covers it.

Generated with [Claude Code](https://claude.com/claude-code)