### PR TITLE
topology: add ?ui=off globe-only mode to the viewer

### DIFF
--- a/ai/topology/static/app.js
+++ b/ai/topology/static/app.js
@@ -126,6 +126,8 @@ function syncUrl() {
     params.set('algorithm', document.getElementById('algorithm').value || '0');
     const globe = document.getElementById('globe').value;
     if (globe !== DEFAULT_DESIGN) params.set('globe', globe);
+    // keep the globe-only switch (index.html reads it in <head>)
+    if (initialParams.get('ui') === 'off') params.set('ui', 'off');
     history.replaceState(null, '', '?' + params.toString());
 }
 

--- a/ai/topology/static/index.html
+++ b/ai/topology/static/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>zebra-rs Traffic Path Visualizer</title>
     <link rel="stylesheet" href="./static/style.css" />
+    <script>
+        // ?ui=off hides the header, controls and status bar so only the
+        // globe remains — for sharing a link that focuses on the path.
+        // Runs in <head> so the chrome never flashes before hiding.
+        if (new URLSearchParams(location.search).get('ui') === 'off')
+            document.documentElement.classList.add('bare');
+    </script>
 </head>
 <body>
     <div class="header">zebra-rs Traffic Path Visualizer</div>

--- a/ai/topology/static/style.css
+++ b/ai/topology/static/style.css
@@ -109,6 +109,13 @@ body {
     background: #fdecea;
 }
 
+/* ?ui=off — globe-only mode: no header, controls or status bar */
+html.bare .header,
+html.bare .controls,
+html.bare .status-bar {
+    display: none;
+}
+
 .path-legend {
     display: flex;
     gap: 10px;


### PR DESCRIPTION
## Summary
- New optional URL parameter for the traffic-path visualizer: `?ui=off` hides the header, the Source/Destination/Algorithm/Globe controls, and the status bar, leaving only the globe area — for sharing links that focus on the actual path.
- Read in `<head>` so the chrome never flashes before hiding; `syncUrl` preserves the switch across its query rewrite, so it composes with the existing `source`/`destination`/`algorithm`/`globe` params.

## Test plan
- Snapshots re-exported against the live 11-router isis-flexalgo-ai lab (convergence-guarded, both `topology` and `--algorithms 0`).
- Headless chromium against the export: with `?ui=off` the chrome computes to `display:none` and the globe canvas fills `window.innerHeight` exactly; without it the full UI renders as before. zebra.rs pages update follows separately (frontend is embedded in the snapshot).

Generated with [Claude Code](https://claude.com/claude-code)