### PR TITLE
isis: keep interface config intent across the link lifecycle

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -396,6 +396,10 @@ isis_passive:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@isis_passive"
 
+isis_vrf_late_enslave:
+	mkdir -p allure-results
+	$(CUCUMBER) -- --concurrency=1 --tags "@isis_vrf_late_enslave"
+
 vrf_phantom_instance:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@vrf_phantom_instance"

--- a/bdd/tests/configs/isis_vrf_late_enslave/z1.yaml
+++ b/bdd/tests/configs/isis_vrf_late_enslave/z1.yaml
@@ -1,0 +1,28 @@
+# z1 — the VRF is declared and IS-IS is configured on i1 INSIDE the VRF,
+# but i1 itself is deliberately NOT yet enslaved to the VRF. The feature
+# moves it in with a second commit (`set interface i1 vrf vrf-a`), so the
+# per-VRF IS-IS child is guaranteed to have seen i1's config before its
+# RIB link dump contains i1 at all.
+vrf:
+- name: vrf-a
+interface:
+- if-name: i1
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    vrf:
+    - name: vrf-a
+      net: 49.0001.0000.0000.0011.00
+      is-type: level-2-only
+      # No circuit-type on purpose: the circuit's level must come from
+      # the instance's is-type even though i1 appears after it was set.
+      interface:
+      - if-name: i1
+        network-type: point-to-point
+        metric: 10
+        ipv4:
+          enabled: true

--- a/bdd/tests/configs/isis_vrf_late_enslave/z2.yaml
+++ b/bdd/tests/configs/isis_vrf_late_enslave/z2.yaml
@@ -1,0 +1,24 @@
+# z2 — plain level-2-only IS-IS peer of z1's VRF instance over i1, with a
+# loopback so z1's VRF table has a prefix to learn.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -16,6 +16,12 @@ use serde_json::Value;
 pub struct World {
     topology_running: bool,
     feature_tag: String,
+    /// Byte length of `logs/<ns>.log` when this run started the daemon
+    /// in `<ns>` (0 when the file did not exist). Daemon logs append
+    /// across runs, so the log-content steps only look past this
+    /// offset — a line from an earlier run must never satisfy an
+    /// assertion about the daemon started now.
+    log_offsets: HashMap<String, u64>,
 }
 
 impl World {
@@ -30,6 +36,23 @@ impl World {
 
     fn ns(&self, logical: &str) -> String {
         format!("{}_{}", self.feature_tag, logical)
+    }
+
+    /// Remember where `logs/<scoped>.log` ends right now; called by every
+    /// daemon-start step so `daemon_log_since` reads only this run's lines.
+    fn mark_log_start(&mut self, scoped: &str) {
+        let len = fs::metadata(format!("logs/{}.log", scoped))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        self.log_offsets.insert(scoped.to_string(), len);
+    }
+
+    /// The daemon log of `scoped` from this run's start mark onward
+    /// (whole file if the daemon was started outside a start step).
+    fn daemon_log_since(&self, scoped: &str) -> String {
+        let content = fs::read_to_string(format!("logs/{}.log", scoped)).unwrap_or_default();
+        let offset = self.log_offsets.get(scoped).copied().unwrap_or(0) as usize;
+        content.get(offset..).unwrap_or("").to_string()
     }
 
     fn bridge(&self, _logical: &str) -> String {
@@ -478,6 +501,7 @@ async fn ping_should_fail(world: &mut World, namespace: String, target: String) 
 async fn start_zebra_rs(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
 
     // BFD Echo reflection off a bridge-enslaved veth needs generic (SKB) XDP:
@@ -523,6 +547,7 @@ async fn start_zebra_rs(world: &mut World, namespace: String) {
 async fn start_zebra_rs_sharded(world: &mut World, namespace: String, shards: usize) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
     let shards = shards.to_string();
 
@@ -555,6 +580,7 @@ async fn start_zebra_rs_sharded(world: &mut World, namespace: String, shards: us
 async fn start_zebra_rs_sharded_peer_task(world: &mut World, namespace: String, shards: usize) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
     let shards = shards.to_string();
 
@@ -591,6 +617,7 @@ async fn start_zebra_rs_sharded_peer_task(world: &mut World, namespace: String, 
 async fn start_zebra_rs_egress_group_task(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
 
     let _child = netns::spawn_in_netns_env(
@@ -627,6 +654,7 @@ async fn start_zebra_rs_sharded_egress_group_task(
 ) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
     let shards = shards.to_string();
 
@@ -663,6 +691,7 @@ async fn start_zebra_rs_sharded_egress_group_task(
 async fn start_zebra_rs_sync_chunk(world: &mut World, namespace: String, chunk: usize) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
     let chunk = chunk.to_string();
 
@@ -704,6 +733,7 @@ async fn start_zebra_rs_sync_chunk_egress(
 ) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
     let pid_file = world.pid_file(&namespace);
     let chunk = chunk.to_string();
     let egress_high = egress_high.to_string();
@@ -771,8 +801,10 @@ async fn stop_zebra_rs(world: &mut World, namespace: String) {
 async fn log_should_contain(world: &mut World, namespace: String, needle: String) {
     let scoped = world.ns(&namespace);
     let log_file = format!("logs/{}.log", scoped);
-    let contents = std::fs::read_to_string(&log_file)
-        .unwrap_or_else(|e| panic!("failed to read zebra-rs log {log_file}: {e}"));
+    if !Path::new(&log_file).exists() {
+        panic!("failed to read zebra-rs log {log_file}: no such file");
+    }
+    let contents = world.daemon_log_since(&scoped);
     assert!(
         contents.contains(&needle),
         "zebra-rs log {} for namespace {} does not contain {:?}",
@@ -913,6 +945,9 @@ async fn run_exec_command(world: &mut World, command: String, namespace: String)
 #[when(expr = "I spawn {string} in namespace {string}")]
 async fn spawn_background_command(world: &mut World, command: String, namespace: String) {
     let scoped = world.ns(&namespace);
+    // The spawned command may launch this namespace's daemon (e.g. the
+    // IPsec node script): log assertions must not see earlier runs.
+    world.mark_log_start(&scoped);
     let parts: Vec<&str> = command.split_whitespace().collect();
     let (cmd, args) = parts
         .split_first()
@@ -3056,7 +3091,7 @@ async fn daemon_log_eventually_contains(world: &mut World, namespace: String, ne
     const ATTEMPTS: u32 = 30;
     let mut last_len = 0usize;
     for i in 0..ATTEMPTS {
-        let content = fs::read_to_string(&path).unwrap_or_default();
+        let content = world.daemon_log_since(&scoped);
         if content.contains(&needle) {
             println!("✓ daemon log {} contains '{}'", path, needle);
             return;

--- a/bdd/tests/features/isis_vrf_late_enslave.feature
+++ b/bdd/tests/features/isis_vrf_late_enslave.feature
@@ -1,0 +1,60 @@
+@isis_vrf_late_enslave
+@isis
+Feature: IS-IS per-VRF interface config that precedes the VRF enslavement
+  As a network operator
+  I want `router isis vrf <name> interface <if>` config to take effect even
+  when the interface joins the VRF only after the per-VRF IS-IS instance has
+  already started, so that config order (or the kernel's timing) never
+  silently leaves a circuit unconfigured.
+
+  Mechanism under test: a per-VRF IS-IS child subscribes to the RIB with a
+  link dump limited to interfaces already enslaved to its VRF, then replays
+  its config. Every `interface <name> …` callback resolves the link by
+  name, so a line naming an interface the child has not seen yet used to
+  be dropped on the floor — the circuit never came up, or (when the
+  kernel's link update landed mid-replay) only the lines after it applied,
+  leaving e.g. `circuit-type level-2-only` unapplied. A link appearing
+  after `is-type` was set also kept the L1L2 link default, since only
+  `is-type` and `circuit-type` changes recomputed a circuit's level. The same window opens
+  inside a single commit: the RIB learns the enslavement from the netlink
+  echo on one channel while the child's subscribe arrives on another, with
+  no ordering between them. Deferred lines are now parked and replayed
+  when the link appears.
+
+  Test Topology:
+  ```
+     z1 [vrf-a: i1 10.0.12.1/30] ──── i1 10.0.12.2/30 [z2, lo 10.0.0.2/32]
+  ```
+  Commit 1 on z1 declares `vrf vrf-a` and the full `router isis vrf vrf-a`
+  block for i1 while i1 is still in the default VRF. Commit 2 enslaves i1.
+
+  Scenario: Setup z1 with IS-IS in a VRF whose interface is not yet enslaved
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    Then show command "show vrf" in namespace "z1" should eventually contain "vrf-a"
+    And show command "show isis vrf vrf-a interface" in namespace "z1" should eventually not contain "i1"
+
+  Scenario: Enslaving the interface afterwards brings the configured circuit up
+    Given the test topology exists
+    When I apply command "set interface i1 vrf vrf-a" in namespace "z1"
+    Then show command "show isis vrf vrf-a interface" in namespace "z1" should eventually contain "i1"
+    # The circuit runs at the instance's level-2-only, not the L1L2 link
+    # default — is-type was configured before i1 existed in the VRF.
+    And show command "show isis vrf vrf-a interface" in namespace "z1" should eventually not contain "L1L2"
+    And show command "show isis vrf vrf-a neighbor" in namespace "z1" should eventually contain "Up"
+    And show command "show ip route vrf vrf-a" in namespace "z1" should eventually contain "10.0.0.2/32"
+    And daemon log in namespace "z1" should eventually contain "replaying 4 deferred config line(s)"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -147,6 +147,26 @@ pub struct Isis {
     /// when IS-IS is enabled on an interface, released when it is
     /// disabled, read by `dis_becoming` to name the pseudonode LSP.
     pub circuit_ids: CircuitIdMap,
+
+    /// Durable per-interface configuration, keyed by interface name:
+    /// every `interface <name> …` Set/Delete line in commit order
+    /// (mirrors OSPF's `interface_config_log`).
+    ///
+    /// `IsisLink` is operational state keyed by ifindex — dropped on
+    /// `LinkDel`, rebuilt on `LinkAdd` — and the interface callbacks
+    /// resolve their link by name and drop the line when it is
+    /// missing. Intent must outlive the link: a per-VRF child
+    /// subscribes to the RIB while the kernel may still be moving the
+    /// interface into the VRF (so its initial link dump lacks the
+    /// interface its replayed config names), an interface can be
+    /// created after its config, re-created under a new ifindex, or
+    /// cross a VRF boundary as a `LinkDel` + `LinkAdd` pair. The log
+    /// is replayed into every fresh link from `link_add`.
+    pub interface_config_log: BTreeMap<String, Vec<(Vec<CommandPath>, ConfigOp)>>,
+    /// Set while `replay_interface_config` feeds logged lines back
+    /// through `process_cm_msg`, so they are applied without being
+    /// recorded a second time.
+    interface_config_replaying: bool,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
     pub config: IsisConfig,
@@ -818,6 +838,8 @@ impl Isis {
                 ctx,
                 links: IsisLinks::default(),
                 circuit_ids: CircuitIdMap::default(),
+                interface_config_log: BTreeMap::new(),
+                interface_config_replaying: false,
                 show: ShowChannel::new(),
                 show_cb: HashMap::new(),
                 config: IsisConfig::default(),
@@ -1109,6 +1131,22 @@ impl Isis {
             return;
         }
 
+        // Every `/router/isis/interface` callback resolves its link by
+        // name and silently drops the line when the link is unknown.
+        // Record interface lines durably (`interface_config_log`) and
+        // let a fresh link pick them up (`replay_interface_config`), so
+        // config that outruns the kernel — a per-VRF child spawned
+        // before the interface's VRF enslavement reached the RIB, an
+        // interface created after its config, or one re-created — still
+        // takes effect.
+        if path.starts_with("/router/isis/interface")
+            && let Some(name) = args.0.front().cloned()
+            && !self.interface_config_replaying
+            && !self.record_interface_config(name, &path, msg.paths.clone(), msg.op)
+        {
+            return;
+        }
+
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
         } else if path.starts_with("/router/isis/tracing") {
@@ -1118,6 +1156,62 @@ impl Isis {
             // OSPF's `config_tracing_dispatch`).
             super::tracing::config_tracing_dispatch(self, &path, args, msg.op);
         }
+    }
+
+    /// Record an `interface <name> …` line in `interface_config_log`.
+    /// Returns whether the line should also be applied now — false when
+    /// no link of that name exists yet (the replay applies it later).
+    /// Deleting the whole interface entry discards its log: nothing is
+    /// left to replay, and a live link takes the delete normally.
+    fn record_interface_config(
+        &mut self,
+        name: String,
+        path: &str,
+        paths: Vec<CommandPath>,
+        op: ConfigOp,
+    ) -> bool {
+        let known = self.links.contains_name(&name);
+        if op == ConfigOp::Delete && path == "/router/isis/interface" {
+            self.interface_config_log.remove(&name);
+            return known;
+        }
+        if !known && !self.interface_config_log.contains_key(&name) {
+            tracing::info!(
+                "isis: interface {name} is not known yet; deferring its config until the link appears"
+            );
+        }
+        self.interface_config_log
+            .entry(name)
+            .or_default()
+            .push((paths, op));
+        known
+    }
+
+    /// Replay `name`'s logged config into its (fresh) link. Outside a
+    /// commit the replay is wrapped in a synthetic CommitStart/CommitEnd
+    /// so the commit-time reconciles (SRLG fold, self-SID ILM, STAMP
+    /// sessions, gated LSP generation) run once for it; inside a live
+    /// commit the real CommitEnd covers it.
+    pub fn replay_interface_config(&mut self, name: &str) {
+        let Some(lines) = self.interface_config_log.get(name).cloned() else {
+            return;
+        };
+        tracing::info!(
+            "isis: link {name} appeared; replaying {} deferred config line(s)",
+            lines.len()
+        );
+        let wrap = !self.in_commit;
+        self.interface_config_replaying = true;
+        if wrap {
+            self.process_cm_msg(ConfigRequest::new(Vec::new(), ConfigOp::CommitStart));
+        }
+        for (paths, op) in lines {
+            self.process_cm_msg(ConfigRequest::new(paths, op));
+        }
+        if wrap {
+            self.process_cm_msg(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
+        }
+        self.interface_config_replaying = false;
     }
 
     /// Record a rewritten per-VRF config line (parent only). Appends to
@@ -4522,6 +4616,54 @@ mod commit_and_microloop_gate_tests {
 
     fn commit_end() -> ConfigRequest {
         ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd)
+    }
+
+    fn cp(name: &str, ymatch: i32) -> CommandPath {
+        CommandPath {
+            name: name.to_string(),
+            ymatch,
+            ..Default::default()
+        }
+    }
+
+    /// `/router/isis/interface[<name>]/<tail…>` as the manager would
+    /// deliver it (ymatch: 0 Dir, 2 Key, 3 KeyMatched, 4 Leaf, 5 LeafMatched).
+    fn if_line(name: &str, tail: &[(&str, i32)]) -> Vec<CommandPath> {
+        let mut paths = vec![
+            cp("router", 0),
+            cp("isis", 0),
+            cp("interface", 2),
+            cp(name, 3),
+        ];
+        paths.extend(tail.iter().map(|(n, m)| cp(n, *m)));
+        paths
+    }
+
+    #[tokio::test]
+    async fn interface_config_before_its_link_is_logged_not_dropped() {
+        let mut isis = fresh_isis();
+        assert!(!isis.links.contains_name("ce1"));
+
+        let enable = if_line("ce1", &[("ipv4", 0), ("enabled", 4), ("true", 5)]);
+        isis.process_cm_msg(ConfigRequest::new(enable, ConfigOp::Set));
+        let metric = if_line("ce1", &[("metric", 4), ("10", 5)]);
+        isis.process_cm_msg(ConfigRequest::new(metric, ConfigOp::Set));
+
+        // Logged in arrival order, and nothing was applied on the side:
+        // the enable never reserved a circuit id.
+        assert_eq!(isis.interface_config_log["ce1"].len(), 2);
+        assert!(isis.circuit_ids.get("ce1").is_none());
+
+        // A replay with the link still absent re-parks nothing and
+        // applies nothing — the log is left exactly as it was.
+        isis.replay_interface_config("ce1");
+        assert_eq!(isis.interface_config_log["ce1"].len(), 2);
+        assert!(isis.circuit_ids.get("ce1").is_none());
+
+        // Deleting the whole entry before the link ever appeared
+        // discards the log — there is nothing left to replay.
+        isis.process_cm_msg(ConfigRequest::new(if_line("ce1", &[]), ConfigOp::Delete));
+        assert!(!isis.interface_config_log.contains_key("ce1"));
     }
 
     /// The gate is seeded closed: the spawning commit's `CommitStart`

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -145,6 +145,10 @@ impl IsisLinks {
         self.map.values_mut().find(|link| link.state.name == name)
     }
 
+    pub fn contains_name(&self, name: &str) -> bool {
+        self.map.values().any(|link| link.state.name == name)
+    }
+
     pub fn insert(&mut self, key: u32, value: IsisLink) -> Option<IsisLink> {
         self.map.insert(key, value)
     }
@@ -1058,7 +1062,18 @@ impl Isis {
                 // existing reservation into the link's cache, should the
                 // name already hold one.
                 is_link.circuit_id = self.circuit_ids.get(&is_link.state.name).unwrap_or(0);
+                // The instance's `is-type` only reaches links that exist
+                // when it is configured (`config_is_type` walks the
+                // current links); a link appearing afterwards must not
+                // keep the L1L2 default, or a level-2-only instance runs
+                // L1 on it until a `circuit-type` line happens to
+                // recompute the level.
+                is_link.state.level =
+                    config_level_common(self.config.is_type(), is_link.config.circuit_type());
                 self.links.insert(is_link.ifindex, is_link);
+                // Intent outlives the link: replay everything ever
+                // configured for this interface name into the fresh link.
+                self.replay_interface_config(&name);
             }
             Err(e) => {
                 tracing::warn!(


### PR DESCRIPTION
## Summary
- **Fixes a regression shipped in v26.8.4**: `l3vpn_isis_v4`/`v6` failed in the post-release full-suite run. Every `/router/isis/interface` callback resolves its link by name and silently dropped the line when the link was unknown. Since e7b9c617 (#2304) the RIB's subscribe-time link dump is VRF-filtered, so a per-VRF IS-IS child that spawns (on the kernel `VrfAdd` echo) before the interface's enslavement reaches the RIB (netlink `RTM_NEWLINK`, a different channel — no ordering) replayed its config into an empty link set; the later `LinkAdd` built a bare link. Reproduces unloaded (~1 in 3). OSPF got a durable `interface_config_log` in that same commit; IS-IS did not.
- IS-IS now mirrors OSPF: a per-name `interface_config_log` recorded for every interface line and replayed into each fresh link from `link_add` (synthetic CommitStart/End when outside a commit), so intent outlives the link — late enslavement, an interface created after its config, a re-created ifindex, or a VRF crossing.
- Also seeds a fresh link's level from the instance `is-type` (only `is-type`/`circuit-type` ever recomputed it, so a late link kept `L1L2` on a level-2-only instance).
- Harness: daemon-log steps only read lines written by the current run (an `ipsec_s2s` step had passed on a 2026-08-10 line).
- New deterministic BDD feature `isis_vrf_late_enslave` (two-commit ordering): 26.8.3 fails it one way (lists the interface in the VRF instance before enslavement), 26.8.4 another (circuit never up); it now asserts the circuit comes up at L2 with neighbor, route, and the logged replay.

## Test plan
- [x] unit test `interface_config_before_its_link_is_logged_not_dropped`
- [x] `make -C bdd isis_vrf_late_enslave` ×3 and `l3vpn_isis_v4`/`v6` ×3 each — green; PE logs show `deferring` → `replaying N deferred config line(s)` inside a single-commit bring-up
- [x] pre-fix control on /usr/bin zebra-rs 26.8.3 fails the new feature; fixed binary passes
- [x] `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace --exclude bdd`
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)