### PR TITLE
bdd: drop z1's dead enp0s7 stanzas from isis_srv6_base

### DIFF
--- a/bdd/tests/configs/isis_srv6_base/z1.conf
+++ b/bdd/tests/configs/isis_srv6_base/z1.conf
@@ -6,14 +6,6 @@ interface enp0s6 {
     address 2001:db8:ff00:10::1/64;
   }
 }
-interface enp0s7 {
-  ipv4 {
-    address 192.168.3.1/24;
-  }
-  ipv6 {
-    address 2001:db8:ff00:3::1/64;
-  }
-}
 interface lo {
   ipv4 {
     address 10.0.0.1/32;
@@ -37,7 +29,6 @@ router {
       }
       priority 63;
     }
-    interface enp0s7;
     interface lo {
       circuit-type level-2-only;
       ipv4 {


### PR DESCRIPTION
## Summary
- `isis_srv6_base` z1 is wired only via `enp0s6`; `enp0s7` exists on z2/z3/z4. z1.conf still carried an `interface enp0s7` address block (192.168.3.1/24, 2001:db8:ff00:3::1/64 — referenced nowhere else) and a bare `router isis interface enp0s7;`.
- Since #2322 an IS-IS interface line for a link that never appears is parked and logged instead of silently dropped — which is how this leftover surfaced in the 289/289 full-suite run. Removing it.

## Test plan
- [x] `make -C bdd isis_srv6_base`: 1 feature, passed; z1's daemon log shows no `not known yet` deferral for this run
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)