### PR TITLE
bgp: transmit BFD over IPv6-unnumbered interface-neighbor peers

### DIFF
--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z1-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z1-full.yaml
@@ -18,6 +18,12 @@ router:
     global:
       as: 65001
       router-id: 1.1.1.1
+    # BFD over the unnumbered link (regression for #2324): the
+    # blanket instance-level default enables single-hop BFD on the
+    # interface-neighbor, keyed on the RA-learned link-local and
+    # pinned to i1's ifindex.
+    bfd:
+      enabled: true
     interface-neighbor:
     - interface: i1
       remote-as: 65002

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z2-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z2-full.yaml
@@ -9,6 +9,12 @@ router:
     global:
       as: 65002
       router-id: 2.2.2.2
+    # BFD over the unnumbered link (regression for #2324): the
+    # blanket instance-level default enables single-hop BFD on the
+    # interface-neighbor, keyed on the RA-learned link-local and
+    # pinned to i1's ifindex.
+    bfd:
+      enabled: true
     interface-neighbor:
     - interface: i1
       remote-as: 65001

--- a/bdd/tests/features/bgp_unnumbered_neighbor.feature
+++ b/bdd/tests/features/bgp_unnumbered_neighbor.feature
@@ -72,6 +72,19 @@ Feature: BGP IPv6 unnumbered neighbor discovered via Router Advertisements
     And BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z1" has "10.0.0.2/32"
 
+  Scenario: BFD comes up over the unnumbered link and transmits both ways
+    Given the test topology exists
+    # Regression for #2324. `bfd { enabled true }` attaches a single-hop
+    # BFD session to the interface-keyed peer. The session must key on
+    # the RA-learned link-local (not `::`) and pin i1's ifindex — a v6
+    # link-local destination is unroutable without a pinned egress
+    # interface, so an ifindex-0 session transmits zero control packets
+    # and never leaves Down. Each end reaching Up therefore proves the
+    # *other* end is transmitting: this fails flat on the pre-fix build,
+    # where zebra1 ends up with no BFD session at all.
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z2" on interface "i1" should be up
+
   Scenario: IPv4 LAN prefixes forward over the IPv6 link-local next-hop
     Given the test topology exists
     # The ENHE-learned LAN prefix must make it past the BGP table:

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1291,7 +1291,15 @@ pub(super) fn bfd_apply_ident(bgp: &mut Bgp, ident: usize) -> Option<()> {
         // instance-level `router bgp { bfd {} }` default (blanket enable +
         // per-neighbor override). Hop-mode / min-ttl stay per-neighbor.
         let eff = peer.config.bfd.resolve(&bgp.bfd);
-        let enable = eff.enable;
+        // Never subscribe a session against an unspecified remote. An
+        // `interface-neighbor` peer materializes dormant with `address ==
+        // ::` before any RA surfaces its link-local (see
+        // `interface_neighbor::materialize`); a `::`-keyed session is
+        // meaningless and, worse, collides — two dormant unnumbered peers
+        // would collapse onto one `{local: ::, remote: ::, ifindex: 0}`
+        // entry. The RA path re-runs `bfd_apply_ident` once a real
+        // link-local lands, at which point this flips back to enabled.
+        let enable = eff.enable && !addr.is_unspecified();
         let local = peer
             .config
             .transport
@@ -1306,18 +1314,23 @@ pub(super) fn bfd_apply_ident(bgp: &mut Bgp, ident: usize) -> Option<()> {
         } else {
             255 // GTSM (RFC 5881 §5): single-hop accepts only TTL 255.
         };
-        // Key single-hop sessions by the connected interface when we know it
-        // (from `RibRx::AddrAdd`): the XDP data plane — the Echo
-        // reflector and the expiration watchdog — attaches by ifindex, so an
-        // ifindex-0 key can never bring it up. Unknown (no address info yet,
-        // or a v6 link-local peer) falls back to 0 — the session still works,
-        // helper-backed features stay off; the `RibRx::AddrAdd` hook
-        // re-reconciles once the interface is learned. Multihop has no single
-        // egress interface.
+        // Key single-hop sessions by the egress interface. `resolve_session_
+        // ifindex` picks the most precise source: the interface key itself
+        // for an unnumbered (`PeerOrigin::Interface`) peer, the link-local
+        // connect scope, the local socket's scope/subnet, then the subnet
+        // covering the peer address. This is mandatory for a v6 link-local
+        // remote: `write_packet_v6` needs a pinned egress ifindex to route to
+        // `fe80::`, and `ConnectedSubnets::ifindex_for` deliberately returns
+        // `None` for link-locals (fe80::/64 is on every v6 interface). It
+        // also feeds the XDP data plane (Echo reflector + expiration
+        // watchdog), which attaches by ifindex. Falls back to 0 when nothing
+        // is known yet; the `RibRx::AddrAdd` hook re-reconciles once the
+        // interface is learned. Multihop has no single egress interface.
         let ifindex = if multihop {
             0
         } else {
-            bgp.connected_subnets.ifindex_for(addr).unwrap_or(0)
+            peer.resolve_session_ifindex(&bgp.connected_subnets)
+                .unwrap_or(0)
         };
         let key = SessionKey {
             local,
@@ -6369,6 +6382,25 @@ mod neighbor_group_wiring_tests {
         )
     }
 
+    /// Like [`fresh_bgp`], but wires a real BFD `client_tx` and returns
+    /// its receiver so a test can assert what BGP subscribed to BFD.
+    fn fresh_bgp_with_bfd() -> (Bgp, mpsc::UnboundedReceiver<ClientReq>) {
+        let (ctx, rib_rx) = test_ctx();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        let (bfd_client_tx, bfd_client_rx) = mpsc::unbounded_channel();
+        let bgp = Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            Some(bfd_client_tx),
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        );
+        (bgp, bfd_client_rx)
+    }
+
     fn peer_addr() -> IpAddr {
         IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
     }
@@ -8055,6 +8087,63 @@ mod neighbor_group_wiring_tests {
         assert_eq!(peer.remote_as, 65003);
         assert!(peer.config.remote_as_inherited);
         assert!(!peer.active, "still no RA — stays dormant");
+    }
+
+    /// Regression for #2324: an IPv6-unnumbered (`interface-neighbor`)
+    /// peer must subscribe its single-hop BFD session pinned to the
+    /// interface's ifindex, keyed on the RA-learned link-local — not on
+    /// `::`/ifindex-0. Two gaps caused the bug: the ND-materialize path
+    /// never re-ran `bfd_apply_ident`, and the ifindex derivation went
+    /// through `ConnectedSubnets::ifindex_for`, which returns `None` for
+    /// link-locals. Without a pinned ifindex `write_packet_v6` can't
+    /// route to `fe80::`, so the session transmits nothing.
+    #[tokio::test]
+    async fn interface_neighbor_bfd_subscribes_on_interface_ifindex_after_ra() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_remote_as, materialize_peer,
+        };
+
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        // Blanket `router bgp { bfd { enabled true } }`.
+        config_bgp_bfd_enable(&mut bgp, arg_words(&["true"]), ConfigOp::Set).unwrap();
+        // RIB announced the link; configure the unnumbered neighbor. The
+        // peer materializes dormant (`address == ::`).
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+
+        // A dormant peer must NOT subscribe a `::` session — the
+        // unspecified-remote guard suppresses it (which is also what
+        // keeps two dormant unnumbered peers from colliding onto one
+        // `{::, ::, 0}` entry).
+        assert!(
+            bfd_rx.try_recv().is_err(),
+            "no BFD subscribe while the peer is dormant (remote still ::)",
+        );
+
+        // RA surfaces the peer's link-local: the materialize path must
+        // re-reconcile BFD.
+        let link_local: std::net::Ipv6Addr = "fe80::2".parse().unwrap();
+        materialize_peer(&mut bgp, "i1", 7, link_local).expect("RA upgrades the peer");
+
+        let mut subscribe = None;
+        while let Ok(req) = bfd_rx.try_recv() {
+            if let ClientReq::Subscribe { key, .. } = req {
+                subscribe = Some(key);
+            }
+        }
+        let key = subscribe.expect("the RA must trigger a BFD Subscribe");
+        assert_eq!(
+            key.remote,
+            IpAddr::from(link_local),
+            "session must key on the RA-learned link-local, not ::",
+        );
+        assert_eq!(
+            key.ifindex, 7,
+            "single-hop session must pin the interface's ifindex (the #2324 fix)",
+        );
+        assert!(!key.multihop, "an unnumbered eBGP session is single-hop",);
     }
 
     // ---- whole-session knob inheritance (ttl-security exemplar) --

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -123,6 +123,7 @@ fn materialize(
     // the FSM alone — except a dormant peer (materialized at config
     // time, address still unspecified), which gets its first kick here.
     if let Some(existing) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex)) {
+        let ident = existing.ident;
         if let Some(link_local) = link_local {
             let incoming: std::net::IpAddr = link_local.into();
             let unspecified =
@@ -147,7 +148,20 @@ fn materialize(
             // a dormant one leaves Idle now that it can dial.
             existing.start();
         }
-        return Some(existing.ident);
+        // The `existing` borrow ends above; reconcile BFD now that the
+        // address may have been upgraded from `::` to the RA-learned
+        // link-local. `bfd_apply_ident` reads the remote and egress
+        // ifindex straight off the peer, so this is what finally
+        // subscribes (or re-keys) the session. The ND-materialize path
+        // is otherwise the one BFD reconcile trigger that never fires —
+        // config / `RibRx::AddrAdd` / `LinkDel` all route through
+        // `bfd_reconcile_all` — which left unnumbered peers with either
+        // no session or a stale `::` one that transmits nothing. Only on
+        // an RA upgrade (a dormant→dormant refresh changes nothing).
+        if link_local.is_some() {
+            let _ = super::config::bfd_apply_ident(bgp, ident);
+        }
+        return Some(ident);
     }
 
     let address: std::net::IpAddr = match link_local {
@@ -224,7 +238,14 @@ fn materialize(
     // OPEN-side validation) and ones materialized without a link-local
     // (no RA yet — the RA path upgrades them in place).
     peer.start();
-    Some(peer.ident)
+    let ident = peer.ident;
+    // Reconcile BFD for the freshly materialized peer (the `peer` borrow
+    // ends above). `bfd_apply_ident` no-ops while the address is still
+    // unspecified (dormant create) and subscribes the real single-hop
+    // session — pinned to this interface's ifindex — when the peer was
+    // created straight from an RA (`materialize_peer`).
+    let _ = super::config::bfd_apply_ident(bgp, ident);
+    Some(ident)
 }
 
 /// Stamp the initial ND discovery fields on a freshly created


### PR DESCRIPTION
Fixes #2324.

An `interface-neighbor` (IPv6 unnumbered, RA-discovered) peer with BFD enabled establishes BGP but never transmits a single BFD control packet, so the session never leaves Down. IPv4 numbered and IPv6 *global* numbered BFD are unaffected — the failure is specific to the link-local unnumbered path, identically against FRR and against another zebra-rs.

## Root cause — three coordinated gaps in the BGP→BFD apply path

1. **The ND-materialize path never re-ran the BFD reconcile.** `interface_neighbor::materialize` upgrades the peer's address from `::` to the RA-learned link-local but never called `bfd_apply_ident`. Config / `RibRx::AddrAdd` / `LinkDel` are the only reconcile triggers, and none fire on RA arrival — so the session was never created, or kept a stale `::` key.

2. **A `{local: ::, remote: ::, ifindex: 0}` key collision.** `bfd_apply_ident` subscribed a session even for a dormant peer whose remote is still `::`, which is meaningless and makes two dormant unnumbered peers collapse onto one entry.

3. **The transmit blocker — ifindex forced to 0.** The single-hop egress ifindex was resolved via `ConnectedSubnets::ifindex_for`, which deliberately returns `None` for link-locals (`fe80::/64` is on every v6 interface). With ifindex 0, `write_packet_v6` emits no `IPV6_PKTINFO` and the kernel cannot route to a link-local — so nothing is transmitted. `Peer::resolve_session_ifindex` already returns the interface ifindex for `PeerOrigin::Interface` peers; BGP even pins that same ifindex for its own TCP transport (`peer.scope_id`). Only the BFD side didn't consult it.

## The fix

- **`bgp/config.rs` `bfd_apply_ident`**: resolve the single-hop ifindex via `peer.resolve_session_ifindex(&bgp.connected_subnets)` instead of `connected_subnets.ifindex_for(addr)` (same result for numbered peers; also fixes v6-link-local *numbered* BFD via `scope_id`), and gate `enable` on a specified remote so a dormant peer never subscribes a `::` session.
- **`bgp/interface_neighbor.rs` `materialize`**: call `bfd_apply_ident` after the peer's address is set, on both the RA-upgrade and fresh-create paths.

## Tests

- New unit test `interface_neighbor_bfd_subscribes_on_interface_ifindex_after_ra`: the dormant peer sends no subscribe; the RA triggers a Subscribe keyed on the link-local with the interface's ifindex. Verified to fail if the ifindex fix is reverted.
- Extended the `@bgp_unnumbered_neighbor` BDD feature with `router bgp bfd { enabled true }` and a scenario asserting the single-hop BFD session comes up on **both** ends of the unnumbered link (each end reaching Up proves the other is transmitting). `make -C bdd bgp_unnumbered_neighbor` → 7 scenarios / 48 steps all pass.
- `cargo test -p zebra-rs` → 2066 passed, 0 failed. `cargo clippy --workspace --all-targets -- -D warnings` clean.

Out of scope: the per-VRF BFD path has a latent same-class gap for numbered v6-link-local CE peers, but it doesn't support RA-discovered interface-neighbors, so #2324 can't occur there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018psujAkjueTwnoXzgus1tB