### PR TITLE
bgp-packet: RFC 9234 codec — BGP Role capability and OTC path attribute

### DIFF
--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -44,6 +44,8 @@ pub enum AttrType {
     // optional-transitive path: retained with the Partial bit and propagated.
     Aigp = 26,
     LargeCom = 32,
+    /// RFC 9234 Only-to-Customer.
+    Otc = 35,
     PrefixSid = 40,
     TunnelEncap = 23,
     BgpLsAttr = 29,
@@ -72,6 +74,7 @@ impl From<u8> for AttrType {
             22 => PmsiTunnel,
             26 => Aigp,
             32 => LargeCom,
+            35 => Otc,
             40 => PrefixSid,
             23 => TunnelEncap,
             29 => BgpLsAttr,
@@ -102,6 +105,7 @@ impl From<AttrType> for u8 {
             PmsiTunnel => 22,
             Aigp => 26,
             LargeCom => 32,
+            Otc => 35,
             PrefixSid => 40,
             TunnelEncap => 23,
             BgpLsAttr => 29,
@@ -155,6 +159,8 @@ pub enum Attr {
     Aigp(Aigp),
     #[nom(Selector = "AttrSelector(AttrType::LargeCom, None)")]
     LargeCom(LargeCommunity),
+    #[nom(Selector = "AttrSelector(AttrType::Otc, None)")]
+    Otc(Otc),
     #[nom(Selector = "AttrSelector(AttrType::PrefixSid, None)")]
     PrefixSid(PrefixSid),
     #[nom(Selector = "AttrSelector(AttrType::TunnelEncap, None)")]
@@ -184,6 +190,7 @@ impl Attr {
             Attr::PmsiTunnel(v) => v.attr_emit(buf),
             Attr::LargeCom(v) => v.attr_emit(buf),
             Attr::Aigp(v) => v.attr_emit(buf),
+            Attr::Otc(v) => v.attr_emit(buf),
             Attr::PrefixSid(v) => v.attr_emit(buf),
             Attr::TunnelEncap(v) => v.attr_emit(buf),
             Attr::BgpLs(v) => v.attr_emit(buf),
@@ -216,6 +223,7 @@ impl fmt::Display for Attr {
             Attr::PmsiTunnel(v) => write!(f, "{}", v),
             Attr::LargeCom(v) => write!(f, "{}", v),
             Attr::Aigp(v) => write!(f, "{}", v),
+            Attr::Otc(v) => write!(f, "{}", v),
             Attr::PrefixSid(v) => write!(f, "{}", v),
             Attr::TunnelEncap(v) => write!(f, "{}", v),
             Attr::BgpLs(v) => write!(f, "{}", v),
@@ -246,6 +254,7 @@ impl fmt::Debug for Attr {
             Attr::PmsiTunnel(v) => write!(f, "{:?}", v),
             Attr::LargeCom(v) => write!(f, "{:?}", v),
             Attr::Aigp(v) => write!(f, "{:?}", v),
+            Attr::Otc(v) => write!(f, "{:?}", v),
             Attr::PrefixSid(v) => write!(f, "{:?}", v),
             Attr::TunnelEncap(v) => write!(f, "{:?}", v),
             Attr::BgpLs(v) => write!(f, "{:?}", v),
@@ -370,6 +379,9 @@ fn attr_malformation_is_withdraw(attr_type: AttrType) -> bool {
             // RFC 7606 §7.5: same for AGGREGATOR (wrong length for the
             // session's negotiated ASN width).
             | AttrType::Aggregator
+            // RFC 9234 §5: an OTC attribute whose length is not 4 "SHALL be
+            // handled using the approach of 'treat-as-withdraw'".
+            | AttrType::Otc
     )
 }
 
@@ -587,6 +599,9 @@ pub fn parse_bgp_update_attribute(
             }
             Attr::Aigp(v) => {
                 bgp_attr.aigp = Some(v);
+            }
+            Attr::Otc(v) => {
+                bgp_attr.otc = Some(v);
             }
             Attr::LargeCom(v) => {
                 bgp_attr.lcom = Some(v);
@@ -1206,5 +1221,71 @@ mod tests {
         assert_eq!(parsed.unknown[0].type_code, 240);
         assert_eq!(parsed.unknown[0].value, vec![1, 2, 3, 4]);
         assert!(parsed.unknown[0].is_partial());
+    }
+}
+
+#[cfg(test)]
+mod otc_tests {
+    use super::*;
+    use crate::Otc;
+
+    /// ORIGIN=IGP, AS_PATH = AS_SEQUENCE [65001] (4-octet), NEXT_HOP, then
+    /// the OTC attribute under test.
+    fn attr_block(otc: &[u8]) -> Vec<u8> {
+        let mut attrs = vec![0x40u8, 0x01, 0x01, 0x00];
+        attrs.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfd, 0xe9]);
+        attrs.extend_from_slice(&[0x40, 0x03, 0x04, 192, 0, 2, 1]);
+        attrs.push(0xc0); // optional | transitive
+        attrs.push(35); // OTC
+        attrs.push(otc.len() as u8);
+        attrs.extend_from_slice(otc);
+        attrs
+    }
+
+    #[test]
+    fn otc_decodes_into_bgp_attr_and_round_trips() {
+        let attrs = attr_block(&[0x00, 0x01, 0x00, 0x04]); // AS 65540
+        let (_, bgp_attr, _, _, treat_as_withdraw) =
+            parse_bgp_update_attribute(&attrs, attrs.len() as u16, true, None).unwrap();
+        assert!(!treat_as_withdraw);
+        let bgp_attr = bgp_attr.expect("attributes");
+        assert_eq!(bgp_attr.otc, Some(Otc::new(65540)));
+        // Recognised now — it must not also land in the unknown-attribute
+        // passthrough (which would re-emit a second, Partial-flagged copy).
+        assert!(bgp_attr.unknown.is_empty());
+
+        let mut buf = BytesMut::new();
+        bgp_attr.attr_emit(&mut buf);
+        let (_, again, _, _, _) =
+            parse_bgp_update_attribute(&buf, buf.len() as u16, true, None).unwrap();
+        assert_eq!(again.unwrap().otc, Some(Otc::new(65540)));
+        // Emitted with Optional+Transitive and no Partial bit.
+        let pos = buf
+            .windows(2)
+            .position(|w| w == [0xc0, 35])
+            .expect("OTC header");
+        assert_eq!(&buf[pos..pos + 7], &[0xc0, 35, 4, 0x00, 0x01, 0x00, 0x04]);
+    }
+
+    /// RFC 9234 §5: a length other than 4 is malformed and handled as
+    /// treat-as-withdraw — the attribute is dropped, the UPDATE's NLRI are
+    /// withdrawn, the session stays up (no error is returned).
+    #[test]
+    fn malformed_otc_length_is_treat_as_withdraw() {
+        for bad in [
+            &[0x00u8, 0x01, 0x00][..],
+            &[0x00u8, 0x01, 0x00, 0x04, 0x00][..],
+        ] {
+            let attrs = attr_block(bad);
+            let (_, bgp_attr, _, _, treat_as_withdraw) =
+                parse_bgp_update_attribute(&attrs, attrs.len() as u16, true, None)
+                    .expect("malformed OTC must not reset the session");
+            assert!(treat_as_withdraw, "len {}", bad.len());
+            let bgp_attr = bgp_attr.expect("attributes");
+            assert_eq!(bgp_attr.otc, None);
+            assert!(bgp_attr.unknown.is_empty());
+            // The well-formed attributes before it are still decoded.
+            assert!(bgp_attr.aspath.is_some());
+        }
     }
 }

--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -61,6 +61,9 @@ pub use rd::*;
 pub mod aigp;
 pub use aigp::*;
 
+pub mod otc;
+pub use otc::*;
+
 pub mod emitter;
 pub use emitter::*;
 

--- a/crates/bgp-packet/src/attrs/otc.rs
+++ b/crates/bgp-packet/src/attrs/otc.rs
@@ -1,0 +1,105 @@
+//! RFC 9234 §5 Only-to-Customer (OTC) path attribute (type code 35).
+//!
+//! Optional transitive, four octets: the AS number of the speaker that
+//! marked the route as "only to be advertised to customers". Set by a
+//! Provider / Peer / Route Server on egress toward a Customer / Peer /
+//! RS-Client (or by the receiver on ingress from one of those), and never
+//! changed once present — a route carrying OTC must not be propagated to
+//! a Provider, Peer or RS, and receiving one from a Customer or RS-Client
+//! identifies a route leak. The procedures themselves live in the
+//! `zebra-rs` ingress/egress paths; this module is only the codec.
+
+use std::fmt;
+
+use bytes::{BufMut, BytesMut};
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::be_u32;
+
+use crate::{AttrEmitter, AttrFlags, AttrType, ParseBe};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Otc {
+    /// The AS number that marked the route.
+    pub asn: u32,
+}
+
+impl Otc {
+    pub fn new(asn: u32) -> Self {
+        Self { asn }
+    }
+}
+
+impl ParseBe<Otc> for Otc {
+    fn parse_be(input: &[u8]) -> nom::IResult<&[u8], Otc> {
+        // RFC 9234 §5: "The OTC Attribute is considered malformed if the
+        // length value is not 4." Reject short *and* long values — a
+        // plain `be_u32` would silently accept trailing octets. The
+        // caller maps this error to treat-as-withdraw
+        // (`attr_malformation_is_withdraw`), as the RFC requires.
+        if input.len() != 4 {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        let (input, asn) = be_u32(input)?;
+        Ok((input, Otc { asn }))
+    }
+}
+
+impl AttrEmitter for Otc {
+    fn attr_flags(&self) -> AttrFlags {
+        AttrFlags::new().with_optional(true).with_transitive(true)
+    }
+
+    fn attr_type(&self) -> AttrType {
+        AttrType::Otc
+    }
+
+    fn len(&self) -> Option<usize> {
+        Some(4)
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u32(self.asn);
+    }
+}
+
+impl fmt::Display for Otc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.asn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_optional_transitive_type_35_four_octets() {
+        let mut buf = BytesMut::new();
+        Otc::new(65540).attr_emit(&mut buf);
+        // flags: Optional|Transitive = 0xc0, type 35, length 4, 65540.
+        assert_eq!(&buf[..], &[0xc0u8, 35, 4, 0x00, 0x01, 0x00, 0x04]);
+    }
+
+    #[test]
+    fn parses_exactly_four_octets() {
+        let (rest, otc) = Otc::parse_be(&[0x00, 0x00, 0xfd, 0xe9]).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(otc, Otc::new(65001));
+    }
+
+    #[test]
+    fn rejects_short_and_long_values() {
+        assert!(Otc::parse_be(&[0x00, 0x00, 0xfd]).is_err());
+        assert!(Otc::parse_be(&[0x00, 0x00, 0x00, 0xfd, 0xe9]).is_err());
+        assert!(Otc::parse_be(&[]).is_err());
+    }
+
+    #[test]
+    fn round_trips_through_the_emitter() {
+        let mut buf = BytesMut::new();
+        Otc::new(4_200_000_000).attr_emit(&mut buf);
+        let (_, parsed) = Otc::parse_be(&buf[3..]).unwrap();
+        assert_eq!(parsed.asn, 4_200_000_000);
+        assert_eq!(parsed.to_string(), "4200000000");
+    }
+}

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -5,7 +5,7 @@ use bytes::BytesMut;
 use crate::{
     Aggregator, Aggregator2, Aigp, As2Path, As4Aggregator, As4Path, As4PathAttr, AtomicAggregate,
     AttrEmitter, BgpLsAttr, BgpNexthop, ClusterList, Color, Community, ExtCommunity,
-    LargeCommunity, LocalPref, Med, NexthopAttr, Origin, OriginatorId, PmsiTunnel, PrefixSid,
+    LargeCommunity, LocalPref, Med, NexthopAttr, Origin, OriginatorId, Otc, PmsiTunnel, PrefixSid,
     PrefixSidTlv, TunnelEncap, UnknownAttr,
 };
 
@@ -39,6 +39,10 @@ pub struct BgpAttr {
     pub pmsi_tunnel: Option<PmsiTunnel>,
     /// AIGP
     pub aigp: Option<Aigp>,
+    /// Only-to-Customer (RFC 9234): the AS that marked this route as not
+    /// to be propagated beyond customers. Preserved unchanged once set;
+    /// stamped / checked by the role-aware ingress and egress paths.
+    pub otc: Option<Otc>,
     /// Large Community
     pub lcom: Option<LargeCommunity>,
     /// BGP Prefix-SID (RFC 8669) — Label-Index, Originator-SRGB, and
@@ -142,6 +146,9 @@ impl BgpAttr {
             v.attr_emit(buf);
         }
         if let Some(v) = &self.aigp {
+            v.attr_emit(buf);
+        }
+        if let Some(v) = &self.otc {
             v.attr_emit(buf);
         }
         // Likewise RFC 8092 §3: a non-zero multiple of 12.
@@ -287,6 +294,9 @@ impl fmt::Display for BgpAttr {
         }
         if let Some(v) = &self.aigp {
             writeln!(f, " AIGP: {}", v)?;
+        }
+        if let Some(v) = &self.otc {
+            writeln!(f, " OTC: {}", v)?;
         }
         if let Some(v) = &self.lcom {
             writeln!(f, " LargeCommunity: {}", v)?;

--- a/crates/bgp-packet/src/bgp_cap.rs
+++ b/crates/bgp-packet/src/bgp_cap.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 use crate::{
     AddPathValue, AfiSafi, CapAddPath, CapAs4, CapDynamic, CapEmit, CapEnhancedRefresh,
     CapExtended, CapExtendedNextHop, CapFqdn, CapLlgr, CapMultiProtocol, CapPathLimit, CapRefresh,
-    CapRefreshCisco, CapRestart, CapVersion, CapabilityPacket, LlgrValue, PathLimitValue,
+    CapRefreshCisco, CapRestart, CapRole, CapVersion, CapabilityPacket, LlgrValue, PathLimitValue,
 };
 
 #[derive(Default, Debug, PartialEq, Clone)]
@@ -25,6 +25,15 @@ pub struct BgpCap {
     pub fqdn: Option<CapFqdn>,
     pub version: Option<CapVersion>,
     pub path_limit: BTreeMap<AfiSafi, PathLimitValue>,
+    /// RFC 9234 BGP Role (code 9). On the receive side this is the first
+    /// Role capability in the OPEN; see [`Self::role_conflict`].
+    pub role: Option<CapRole>,
+    /// RFC 9234 §4.2: "If multiple BGP Role Capabilities are received and
+    /// not all of them have the same value, then the BGP speaker MUST
+    /// reject the connection using the Role Mismatch Notification."
+    /// Set when a later Role capability disagreed with [`Self::role`];
+    /// identical duplicates are collapsed silently.
+    pub role_conflict: bool,
 }
 
 impl BgpCap {
@@ -81,6 +90,9 @@ impl BgpCap {
             for val in self.path_limit.values() {
                 v.values.push(val.clone());
             }
+            v.emit(buf, false);
+        }
+        if let Some(v) = &self.role {
             v.emit(buf, false);
         }
     }
@@ -148,6 +160,10 @@ impl BgpCap {
                             bgp_cap.llgr.insert(key, llgr);
                         }
                     }
+                    CapabilityPacket::Role(v) => match bgp_cap.role {
+                        Some(first) if first.value != v.value => bgp_cap.role_conflict = true,
+                        _ => bgp_cap.role = Some(v),
+                    },
                     CapabilityPacket::Unknown(_v) => {
                         // Ignore unknown capability.
                     }
@@ -211,6 +227,58 @@ impl fmt::Display for BgpCap {
             }
             writeln!(f, " {}", v)?;
         }
+        if let Some(v) = &self.role {
+            writeln!(f, " {}", v)?;
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BgpRole;
+
+    fn role(r: BgpRole) -> CapabilityPacket {
+        CapabilityPacket::Role(CapRole::new(r))
+    }
+
+    #[test]
+    fn single_role_capability_is_recorded() {
+        let cap = BgpCap::from(vec![vec![role(BgpRole::Provider)]]);
+        assert_eq!(cap.role.and_then(|r| r.role()), Some(BgpRole::Provider));
+        assert!(!cap.role_conflict);
+    }
+
+    /// RFC 9234 §4.2: identical duplicates count as one Role capability.
+    #[test]
+    fn identical_duplicate_roles_collapse() {
+        let cap = BgpCap::from(vec![
+            vec![role(BgpRole::Customer)],
+            vec![role(BgpRole::Customer)],
+        ]);
+        assert_eq!(cap.role.and_then(|r| r.role()), Some(BgpRole::Customer));
+        assert!(!cap.role_conflict);
+    }
+
+    /// RFC 9234 §4.2: differing duplicates are a Role Mismatch. The first
+    /// value is kept for display; the conflict flag carries the verdict.
+    #[test]
+    fn differing_duplicate_roles_flag_a_conflict() {
+        let cap = BgpCap::from(vec![vec![role(BgpRole::Customer), role(BgpRole::Provider)]]);
+        assert_eq!(cap.role.and_then(|r| r.role()), Some(BgpRole::Customer));
+        assert!(cap.role_conflict);
+    }
+
+    #[test]
+    fn role_capability_is_emitted_and_displayed() {
+        let cap = BgpCap {
+            role: Some(CapRole::new(BgpRole::Peer)),
+            ..Default::default()
+        };
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf);
+        assert_eq!(&buf[..], &[2u8, 3, 9, 1, 4]);
+        assert_eq!(cap.to_string(), " Role: Peer\n");
     }
 }

--- a/crates/bgp-packet/src/caps/mod.rs
+++ b/crates/bgp-packet/src/caps/mod.rs
@@ -43,5 +43,8 @@ pub use path_limit::{CapPathLimit, PathLimitValue};
 pub mod unknown;
 pub use unknown::CapUnknown;
 
+pub mod role;
+pub use role::{BgpRole, CapRole, ParseBgpRoleError};
+
 pub mod emit;
 pub use emit::CapEmit;

--- a/crates/bgp-packet/src/caps/packet.rs
+++ b/crates/bgp-packet/src/caps/packet.rs
@@ -55,6 +55,8 @@ pub enum CapabilityPacket {
     RouteRefreshCisco(CapRefreshCisco),
     #[nom(Selector = "CapCode::LlgrOld")]
     LlgrOld(CapLlgr),
+    #[nom(Selector = "CapCode::Role")]
+    Role(CapRole),
     #[nom(Selector = "_")]
     Unknown(CapUnknown),
 }
@@ -64,7 +66,17 @@ impl CapabilityPacket {
         let (input, cap_header) = CapabilityHeader::parse_be(input)?;
         let len = cap_header.length as usize;
         let (input, cap) = packet_utils::safe_split_at(input, len)?;
-        let (remaining, mut cap) = CapabilityPacket::parse_be(cap, cap_header.code.into())?;
+        // RFC 9234 §4.1: the Role capability value is exactly one octet.
+        // Any other length is malformed, but failing the whole OPEN over it
+        // would reset a session RFC 5492 says to keep (unusable
+        // capabilities are ignored). Route it through the opaque `Unknown`
+        // passthrough instead, so the session logic sees "no role
+        // received" — which strict mode then rejects on its own terms.
+        let mut code: CapCode = cap_header.code.into();
+        if code == CapCode::Role && len != 1 {
+            code = CapCode::Unknown(cap_header.code);
+        }
+        let (remaining, mut cap) = CapabilityPacket::parse_be(cap, code)?;
         if !remaining.is_empty() {
             return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
         }
@@ -118,6 +130,9 @@ impl CapabilityPacket {
             Self::PathLimit(m) => {
                 m.emit(buf, false);
             }
+            Self::Role(m) => {
+                m.emit(buf, false);
+            }
             Self::RouteRefreshCisco(m) => {
                 m.emit(buf, false);
             }
@@ -149,6 +164,7 @@ impl fmt::Display for CapabilityPacket {
             Self::PathLimit(v) => write!(f, "{}", v),
             Self::RouteRefreshCisco(v) => write!(f, "{}", v),
             Self::LlgrOld(v) => write!(f, "{}", v),
+            Self::Role(v) => write!(f, "{}", v),
             Self::Unknown(v) => write!(f, "{}", v),
         }
     }
@@ -159,20 +175,22 @@ mod tests {
     use super::*;
     use crate::CapEmit;
 
-    // RFC 9234 Role capability: code 9, length 1, one value octet. zebra-rs has
-    // no explicit `CapabilityPacket` arm for it, so it must fall through to the
-    // opaque `Unknown` passthrough and parse without error (RFC 5492 requires
-    // ignoring unknown capabilities). Regression: the old `CapUnknown` re-read a
-    // 2-byte header from the 1-byte value and failed the whole OPEN.
+    // A one-octet capability with an unassigned code (200) has no
+    // `CapabilityPacket` arm, so it must fall through to the opaque `Unknown`
+    // passthrough and parse without error (RFC 5492 requires ignoring unknown
+    // capabilities). Regression: the old `CapUnknown` re-read a 2-byte header
+    // from the 1-byte value and failed the whole OPEN. (This test used the
+    // RFC 9234 Role capability, code 9, as its example until that grew a
+    // typed arm — see `role_capability_parses_to_typed_variant`.)
     #[test]
     fn unknown_short_capability_parses_and_round_trips() {
-        let wire = [9u8, 1, 0x03]; // code=9 (Role), len=1, value=0x03
+        let wire = [200u8, 1, 0x03]; // code=200 (unassigned), len=1
         let (rest, cap) = CapabilityPacket::parse_cap(&wire).unwrap();
         assert!(rest.is_empty());
         let CapabilityPacket::Unknown(u) = &cap else {
             panic!("expected Unknown, got {cap:?}");
         };
-        assert_eq!(u.code, 9);
+        assert_eq!(u.code, 200);
         assert_eq!(u.data, vec![0x03]);
 
         // Grouped re-emit (code + length + value) preserves the code and value.
@@ -185,14 +203,46 @@ mod tests {
     // rather than error on the missing header.
     #[test]
     fn unknown_zero_length_capability_parses() {
-        let wire = [9u8, 0]; // code=9, len=0, no value
+        let wire = [200u8, 0]; // code=200, len=0, no value
         let (rest, cap) = CapabilityPacket::parse_cap(&wire).unwrap();
         assert!(rest.is_empty());
         let CapabilityPacket::Unknown(u) = &cap else {
             panic!("expected Unknown");
         };
-        assert_eq!(u.code, 9);
+        assert_eq!(u.code, 200);
         assert!(u.data.is_empty());
+    }
+
+    // RFC 9234 §4.1 Role capability: code 9, length 1, one value octet.
+    #[test]
+    fn role_capability_parses_to_typed_variant() {
+        let wire = [9u8, 1, 0x03]; // Customer
+        let (rest, cap) = CapabilityPacket::parse_cap(&wire).unwrap();
+        assert!(rest.is_empty());
+        let CapabilityPacket::Role(role) = &cap else {
+            panic!("expected Role, got {cap:?}");
+        };
+        assert_eq!(role.role(), Some(crate::BgpRole::Customer));
+
+        let mut buf = BytesMut::new();
+        cap.encode(&mut buf);
+        assert_eq!(&buf[..], &[2u8, 3, 9, 1, 0x03]);
+    }
+
+    // A Role capability whose length is not 1 is malformed (RFC 9234 §4.1).
+    // It must neither fail the OPEN nor surface as a role: it lands in the
+    // opaque `Unknown` passthrough with its code preserved.
+    #[test]
+    fn role_capability_wrong_length_falls_to_unknown() {
+        for wire in [&[9u8, 0][..], &[9u8, 2, 0x03, 0x00][..]] {
+            let (rest, cap) = CapabilityPacket::parse_cap(wire).unwrap();
+            assert!(rest.is_empty());
+            let CapabilityPacket::Unknown(u) = &cap else {
+                panic!("expected Unknown for {wire:?}, got {cap:?}");
+            };
+            assert_eq!(u.code, 9);
+            assert_eq!(u.data.len(), wire.len() - 2);
+        }
     }
 
     // A known capability still routes to its typed variant, and the Unknown

--- a/crates/bgp-packet/src/caps/role.rs
+++ b/crates/bgp-packet/src/caps/role.rs
@@ -1,0 +1,267 @@
+//! RFC 9234 §4.1 BGP Role capability (capability code 9).
+//!
+//! A speaker that has a locally configured BGP Role toward an eBGP
+//! neighbor advertises it in the OPEN message as a one-octet capability.
+//! The session logic (`zebra-rs` `fsm_bgp_open`) compares the received
+//! role against the local one per §4.2 and rejects the connection with a
+//! Role Mismatch NOTIFICATION (OPEN Message Error, subcode 11) when the
+//! pair is invalid, when strict mode is on and no role was received, or
+//! when several Role capabilities carry different values.
+
+use std::fmt;
+use std::str::FromStr;
+
+use bytes::{BufMut, BytesMut};
+use nom_derive::*;
+
+use super::{CapCode, CapEmit};
+
+/// The BGP Role of the local speaker toward one eBGP neighbor (RFC 9234
+/// §4.1, IANA "BGP Role Value" registry).
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum BgpRole {
+    /// The local AS provides transit to the remote AS.
+    Provider = 0,
+    /// The local speaker is a route server (RFC 7947).
+    RouteServer = 1,
+    /// The local AS is a client of a route server.
+    RouteServerClient = 2,
+    /// The local AS receives transit from the remote AS.
+    Customer = 3,
+    /// Lateral peering: the two ASes exchange routes without providing
+    /// transit to each other.
+    Peer = 4,
+}
+
+impl BgpRole {
+    /// Decode a wire value. `None` for the unassigned range 5–255.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Provider),
+            1 => Some(Self::RouteServer),
+            2 => Some(Self::RouteServerClient),
+            3 => Some(Self::Customer),
+            4 => Some(Self::Peer),
+            _ => None,
+        }
+    }
+
+    /// The role the remote speaker must announce for the pair to be valid
+    /// (RFC 9234 §4.2 Table 2): Provider↔Customer, RS↔RS-Client,
+    /// Peer↔Peer. Also the role a loose-mode speaker *infers* for a
+    /// neighbor that sent no Role capability.
+    pub fn counterpart(self) -> Self {
+        match self {
+            Self::Provider => Self::Customer,
+            Self::Customer => Self::Provider,
+            Self::RouteServer => Self::RouteServerClient,
+            Self::RouteServerClient => Self::RouteServer,
+            Self::Peer => Self::Peer,
+        }
+    }
+
+    /// Whether `remote` is the valid partner of this role (§4.2).
+    pub fn pairs_with(self, remote: Self) -> bool {
+        self.counterpart() == remote
+    }
+
+    /// Operator-facing spelling, matching Cisco IOS XR's `show bgp
+    /// neighbor` output ("OTC Local Role : Provider").
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Provider => "Provider",
+            Self::RouteServer => "Route Server",
+            Self::RouteServerClient => "Route Server Client",
+            Self::Customer => "Customer",
+            Self::Peer => "Peer",
+        }
+    }
+
+    /// Configuration token, IOS XR spelling
+    /// (`otc-local-role {customer|provider|peer|route-server-client}`;
+    /// `route-server` is the zebra-rs superset for the RS side).
+    pub fn cli_name(self) -> &'static str {
+        match self {
+            Self::Provider => "provider",
+            Self::RouteServer => "route-server",
+            Self::RouteServerClient => "route-server-client",
+            Self::Customer => "customer",
+            Self::Peer => "peer",
+        }
+    }
+}
+
+impl From<BgpRole> for u8 {
+    fn from(role: BgpRole) -> Self {
+        role as u8
+    }
+}
+
+impl fmt::Display for BgpRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A configuration token that names no BGP Role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseBgpRoleError(pub String);
+
+impl fmt::Display for ParseBgpRoleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unknown BGP role `{}` (expected customer, provider, peer, \
+             route-server-client or route-server)",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for ParseBgpRoleError {}
+
+impl FromStr for BgpRole {
+    type Err = ParseBgpRoleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "provider" => Ok(Self::Provider),
+            "route-server" => Ok(Self::RouteServer),
+            "route-server-client" => Ok(Self::RouteServerClient),
+            "customer" => Ok(Self::Customer),
+            "peer" => Ok(Self::Peer),
+            other => Err(ParseBgpRoleError(other.to_string())),
+        }
+    }
+}
+
+/// The Role capability as carried on the wire: code 9, length 1, one
+/// value octet. The raw value is kept (rather than a decoded [`BgpRole`])
+/// so an unassigned value 5–255 survives to the session logic, which
+/// treats it as a role that pairs with nothing — a Role Mismatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, NomBE)]
+pub struct CapRole {
+    pub value: u8,
+}
+
+impl CapRole {
+    pub fn new(role: BgpRole) -> Self {
+        Self { value: role.into() }
+    }
+
+    /// The decoded role, or `None` for an unassigned value.
+    pub fn role(&self) -> Option<BgpRole> {
+        BgpRole::from_u8(self.value)
+    }
+}
+
+impl CapEmit for CapRole {
+    fn code(&self) -> CapCode {
+        CapCode::Role
+    }
+
+    fn len(&self) -> u8 {
+        1
+    }
+
+    fn emit_value(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.value);
+    }
+}
+
+impl fmt::Display for CapRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.role() {
+            Some(role) => write!(f, "Role: {}", role),
+            None => write!(f, "Role: unassigned ({})", self.value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [BgpRole; 5] = [
+        BgpRole::Provider,
+        BgpRole::RouteServer,
+        BgpRole::RouteServerClient,
+        BgpRole::Customer,
+        BgpRole::Peer,
+    ];
+
+    #[test]
+    fn wire_values_match_iana_registry() {
+        assert_eq!(u8::from(BgpRole::Provider), 0);
+        assert_eq!(u8::from(BgpRole::RouteServer), 1);
+        assert_eq!(u8::from(BgpRole::RouteServerClient), 2);
+        assert_eq!(u8::from(BgpRole::Customer), 3);
+        assert_eq!(u8::from(BgpRole::Peer), 4);
+        for role in ALL {
+            assert_eq!(BgpRole::from_u8(role.into()), Some(role));
+        }
+        assert_eq!(BgpRole::from_u8(5), None);
+        assert_eq!(BgpRole::from_u8(255), None);
+    }
+
+    /// RFC 9234 §4.2 Table 2: exactly three valid pairs, symmetric, and
+    /// nothing else.
+    #[test]
+    fn role_pairs_are_the_rfc_table() {
+        for local in ALL {
+            for remote in ALL {
+                let valid = matches!(
+                    (local, remote),
+                    (BgpRole::Provider, BgpRole::Customer)
+                        | (BgpRole::Customer, BgpRole::Provider)
+                        | (BgpRole::RouteServer, BgpRole::RouteServerClient)
+                        | (BgpRole::RouteServerClient, BgpRole::RouteServer)
+                        | (BgpRole::Peer, BgpRole::Peer)
+                );
+                assert_eq!(local.pairs_with(remote), valid, "{local:?} vs {remote:?}");
+                assert_eq!(
+                    remote.pairs_with(local),
+                    valid,
+                    "symmetry {local:?}/{remote:?}"
+                );
+            }
+            assert!(local.pairs_with(local.counterpart()));
+            assert_eq!(local.counterpart().counterpart(), local);
+        }
+    }
+
+    #[test]
+    fn cli_tokens_round_trip() {
+        for role in ALL {
+            assert_eq!(role.cli_name().parse::<BgpRole>().unwrap(), role);
+        }
+        assert!("rs-server".parse::<BgpRole>().is_err());
+        assert!("Provider".parse::<BgpRole>().is_err());
+    }
+
+    #[test]
+    fn capability_emits_code_9_length_1() {
+        let cap = CapRole::new(BgpRole::Customer);
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf, true);
+        assert_eq!(&buf[..], &[9u8, 1, 3]);
+
+        // Classic optional-parameter framing around it.
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf, false);
+        assert_eq!(&buf[..], &[2u8, 3, 9, 1, 3]);
+    }
+
+    #[test]
+    fn capability_value_parses_and_decodes() {
+        let (rest, cap) = CapRole::parse_be(&[4u8]).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(cap.role(), Some(BgpRole::Peer));
+        assert_eq!(cap.to_string(), "Role: Peer");
+
+        let (_, cap) = CapRole::parse_be(&[7u8]).unwrap();
+        assert_eq!(cap.role(), None);
+        assert_eq!(cap.to_string(), "Role: unassigned (7)");
+    }
+}

--- a/crates/bgp-packet/src/caps/unknown.rs
+++ b/crates/bgp-packet/src/caps/unknown.rs
@@ -11,9 +11,10 @@ pub struct CapUnknown {
     /// stripped the code/length header. It is deliberately NOT parsed from the
     /// value: the slice handed to this parser already has the 2-byte header
     /// removed, so parsing a `CapabilityHeader` here would re-read two value
-    /// octets and fail on any capability (e.g. RFC 9234 Role, code 9 len 1)
-    /// whose value is shorter than two bytes — rejecting the whole OPEN instead
-    /// of ignoring the unknown capability as RFC 5492 requires.
+    /// octets and fail on any capability whose value is shorter than two
+    /// bytes (a one-octet unassigned capability, or a malformed-length RFC
+    /// 9234 Role that `parse_cap` routes here) — rejecting the whole OPEN
+    /// instead of ignoring the unknown capability as RFC 5492 requires.
     #[nom(Ignore)]
     pub code: u8,
     pub data: Vec<u8>,

--- a/docs/design/bgp-rfc9234-plan.md
+++ b/docs/design/bgp-rfc9234-plan.md
@@ -1,0 +1,185 @@
+# RFC 9234 — BGP Roles and the Only-to-Customer (OTC) attribute
+
+Plan for route-leak prevention/detection in zebra-rs BGP: the Role
+capability (OPEN, code 9), the Role Mismatch NOTIFICATION (OPEN error
+subcode 11), the OTC path attribute (type 35), and the five ingress/egress
+procedures. Reference implementations consulted: RFC 9234 itself, the
+Cisco IOS XR 26.4.1 implementation (xrdocs "RFC 9234 BGP Only-to-Customer
+(OTC) on IOS XR", 2026-08-13), FRR `local-role`, VyOS/TNSR `local-role`.
+
+## 0. What is already in the tree
+
+| Piece | Status |
+|---|---|
+| `CapabilityType::Role = 9` (`crates/bgp-packet/src/caps/typ.rs`) | code named, no typed capability — falls through to `CapUnknown` (a unit test in `caps/packet.rs` *asserts* this fallthrough; it must be re-pointed at another code) |
+| `OpenError::RoleMismatch = 11` (`notification.rs`) | present incl. Display string |
+| `iana-bgp-notification@2023-07-05.yang` `open-role-mismatch` | present |
+| OTC attribute (type 35) | not named in `AttrType` → parses as `Unknown(35)`, retained with the Partial bit and re-emitted verbatim (RFC 4271 §9). zebra-rs already *preserves* OTC transparently — good — but does not read or set it |
+| Per-neighbor knob template | `enforce-first-as` (YANG grouping + `config.rs` callback + `neighbor_group.rs` inheritance + `vrf_config.rs` + `show.rs`) — the shape to copy |
+| No `role`/`local-role` leaf in vendored `ietf-bgp-common` | verified by grep — no augment-name collision (see memory `zebra-rs-bgp-neighbor-yang-ietf-collision`) |
+
+## 1. Semantics to implement (normative summary)
+
+Roles: `provider(0) rs(1) rs-client(2) customer(3) peer(4)`; valid pairs
+provider↔customer, rs↔rs-client, peer↔peer.
+
+Session (RFC 9234 §4):
+* If a local role is configured on an eBGP session, advertise the Role
+  capability (code 9, length 1).
+* Both sides send: pair must be valid, else NOTIFICATION Open Message Error
+  / Role Mismatch (2/11) and the session does not come up.
+* Only we send (**loose**, the default): SHOULD proceed; treat the remote
+  role as *inferred* from ours (Cisco displays "(inferred)").
+* **strict**: no Role capability received → Role Mismatch.
+* Multiple Role caps with different values → Role Mismatch. Same value →
+  one.
+* Roles are only defined for eBGP. iBGP: knob is a no-op (same convention as
+  `enforce-first-as` / `as-override`); OTC still rides through iBGP and
+  route reflection unchanged because it is transitive.
+* A role change is exchanged only in OPEN → **bounce the session** on change
+  (Cisco: CEASE "configuration change"; zebra-rs: `PeerDownReason::ConfigChange`,
+  Cease subcode 6).
+
+Routes (RFC 9234 §5, §6) — **IPv4 unicast and IPv6 unicast only** (AFI 1/2,
+SAFI 1); MUST NOT be applied to other families by default; "the operator
+MUST NOT have the ability to modify the procedures":
+
+| Rule | Direction | Condition | Action |
+|---|---|---|---|
+| IR1 | in | OTC present, from customer or rs-client | leak → ineligible (not selected, not re-advertised) |
+| IR2 | in | OTC present, from peer, value ≠ remote AS | leak → ineligible |
+| IR3 | in | OTC absent, from provider / peer / rs | add OTC = **remote AS** |
+| ER1 | out | OTC absent, to customer / peer / rs-client | add OTC = **local AS** |
+| ER2 | out | OTC present, to provider / peer / rs | do not advertise |
+
+OTC malformed (length ≠ 4) → RFC 7606 treat-as-withdraw (the
+`UpdatePacket.treat_as_withdraw` path already exists). Once set, OTC is
+preserved unchanged (no policy `set otc`; Cloudflare found Tier-1s stripping
+it — we must not).
+
+Loose-mode detail worth copying from Cisco: only the *configured* side
+applies OTC processing; an inferred role never drives the unconfigured
+side (it has no role). So "z1 provider (configured) → z2 no role" still
+yields OTC=AS(z1) on z2 via ER1 on z1, and "z1 no role → z2 customer
+(configured)" yields OTC=AS(z1) via IR3 on z2.
+
+## 2. Decisions
+
+1. **CLI spelling — Cisco IOS XR compatible (decided 2026-08-28):**
+   `neighbor <X> otc-local-role {customer|provider|peer|route-server-client} [strict]`,
+   the exact 26.4.1 syntax. One superset value, `route-server` (RFC role 1),
+   is added so zebra-rs can take the RS side of an RS↔RS-Client pair; XR
+   omits it only because XR has no route-server function. Every user-visible
+   string follows Cisco too (see PR 2 / PR 3): `OTC Local Mode: Loose|Strict`,
+   `OTC Local Role : Provider`, `OTC Remote Role: Customer (received|inferred)`,
+   capability row `OTC Role: Yes/No`, `By OTC ingress rule 1: n, By OTC
+   ingress rule 2: n`, `OTC-AS: <asn>` on a path, and the last-reset reason
+   `OTC role mismatch`. FRR/VyOS `local-role` is **not** offered as an alias.
+2. **YANG shape** — `list otc-local-role { key role; max-elements 1; leaf role { enumeration customer|provider|peer|route-server-client|route-server }; leaf strict { type empty } }`
+   gives exactly the `otc-local-role customer [strict]` CLI (memory
+   `zebra-rs-exec-keyword-at-key-position` covers keyword-at-list-key).
+   Fallback if `max-elements` is not honoured by the libyang port: enforce
+   "one role per neighbor" in the callback (later set replaces). Fallback if
+   an enum list-key does not complete in the CLI: `leaf otc-local-role { enumeration }`
+   + `leaf otc-local-role-strict { empty }`. Prove the chosen shape with a
+   `config/manager.rs` parse test **first** (`bgp_neighbor_otc_local_role_paths_parse`).
+   Module `zebra-bgp-otc.yang`, prefix `zbotc`, grouping
+   `bgp-neighbor-otc-local-role-extension`.
+3. **Local AS for ER1** = `peer.open_local_as()` (the substitute when
+   `local-as` is active — the AS the neighbor sees us as, and what its own
+   IR3 would stamp). **Remote AS for IR2/IR3** = `peer.remote_as`.
+4. **"Ineligible"** = drop at the per-UPDATE inbound gate (same fate as an
+   `enforce-first-as` violation: no Loc-RIB entry, no advertise). Count it
+   per peer (`otc_denied_ir1`, `otc_denied_ir2`) and trace it. Cisco keeps a
+   received-only copy under soft-reconfiguration; zebra-rs replays the
+   stored UPDATEs through the same gate, so no special case.
+5. **Unknown role value (5–255) received** → treat as Role Mismatch (it can
+   form no valid pair). **Role cap with length ≠ 1** → parse as opaque
+   `Unknown` (ignored) so a malformed cap does not kill the whole OPEN; in
+   strict mode that then reads as "no role received" → mismatch.
+6. **Update-group signature** — ER1/ER2 depend on the local role (and on
+   local AS, already a sig field), so `local_role: Option<LocalRole>` joins
+   `UpdateGroupSig` and `SIGNATURE_VERSION` 6→7 (memory
+   `zebra-rs-bgp-update-group-signature-trap`). Not doing this is a silent
+   wrong-bytes bug the BDD cannot catch.
+7. Per-prefix role override via route-map (Cisco RPL `set otc-local-role`)
+   is **deferred** (§6 of the RFC discourages it; keep the first cut
+   session-scoped).
+
+## 3. Phases (one PR each, smallest first)
+
+### PR 1 — codec (`crates/bgp-packet`)
+* `caps/role.rs`: `CapRole { role: u8 }` + `BgpRole` enum (`Provider=0, Rs=1, RsClient=2, Customer=3, Peer=4`) with `counterpart()` and `pairs_with()`; `CapEmit` (`len()=1`); Display "Role: customer".
+* `CapabilityPacket::Role` arm (`Selector = "CapCode::Role"`), `encode` arm.
+* `BgpCap.role: Option<CapRole>` + `role_conflict: bool` (set when a second Role cap carries a different value); emit + Display.
+* Fix `caps/packet.rs::unknown_short_capability_parses_and_round_trips` (uses code 9 as the "unknown" example) → use an unassigned code; update the `CapUnknown` doc comment that cites RFC 9234.
+* `attrs/otc.rs`: `Otc { asn: u32 }`, flags Optional|Transitive, fixed len 4; `AttrType::Otc = 35` (+ both `From` impls), `Attr::Otc`, `BgpAttr.otc: Option<Otc>`, `attr_emit` arm, Display; length ≠ 4 → treat-as-withdraw (follow the existing RFC 7606 pattern in `update.rs`/`parser.rs`).
+* Follow `SECURITY_AUDIT.md` "Invariants to preserve" (bounded slice, reject remainder, fixed length).
+* Tests: cap round-trip, duplicate-cap collapse/conflict, OTC round-trip, OTC bad length → treat-as-withdraw, `Unknown(35)` no longer produced.
+
+### PR 2 — session: knob, OPEN exchange, mismatch
+* YANG `zebra-bgp-otc.yang` (prefix `zbotc`), grouping `bgp-neighbor-otc-local-role-extension`, augments for set/delete; import in `config.yang`; `uses` in `zebra-bgp-neighbor-group.yang`; inline list in `zebra-bgp-vrf.yang` next to `enforce-first-as`. `yang_load_tests` grammar pin + parse test.
+* `PeerConfig.otc_local_role: Option<OtcLocalRole { role: BgpRole, strict: bool }>`; `InheritableKnobs.otc_local_role` (compiler forces `apply_inherited`); `config_otc_local_role` (record→resolve→`apply_otc_local_role`), `config_neighbor_group_otc_local_role` **with `sweep_members_inherit`** (memory: forgetting the sweep is a silent bug), `config_vrf_neighbor_otc_local_role`; registrations under `/otc-local-role`. `apply_otc_local_role` bounces an Established/Open* session on change (`ConfigChange`; log line mirrors XR: "neighbor X Down - OTC local role changed").
+* `build_open_packet`: `if is_ebgp() && let Some(r) = config.otc_local_role { bgp_cap.role = Some(CapRole::new(r.role)) }`.
+* `fsm_bgp_open`: right after the `BadPeerAS`/AS4-consistency block (so it covers both `ConnTag::Primary` and `ConnTag::Collision` via the same `close_collision` / `peer_send_notification` split): `otc_role_check(local, &packet.bgp_cap)` → `Ok(Received(r) | Inferred(r) | None)` or `Err(RoleMismatch)` → NOTIFICATION 2/11, `State::Idle`, `PeerDownReason::OtcRoleMismatch` ("OTC role mismatch"). Store `peer.otc_remote_role: Option<(BgpRole, RoleSource)>` for show and for the OTC gates.
+* `show bgp neighbor` (text + JSON), Cisco strings verbatim:
+  ```
+   OTC Local Mode: Loose
+   OTC Local Role : Provider
+   OTC Remote Role: Customer (received)
+  Neighbor capabilities:            Adv         Rcvd
+    OTC Role:                       Yes         Yes
+  ```
+  rendered in the `as4`/`fqdn` style (`show.rs` ~3731/4012); `Last reset ... OTC role mismatch`. JSON: `otc_local_mode`, `otc_local_role`, `otc_remote_role`, `otc_remote_role_source`.
+* Unit tests (`peer.rs` FSM tests already have an `open_packet(...)` helper): valid pair, invalid pair → 2/11, loose absent → OpenConfirm with inferred, strict absent → 2/11, conflicting duplicates → 2/11, unknown value → 2/11, iBGP → no cap sent; config tests mirroring `enforce_first_as_*` and `group_enforce_first_as_propagates_no_bounce` (this one *does* bounce).
+
+### PR 3 — OTC procedures + BDD
+* Ingress (v4 unicast: `inbound_attr_checks` + the single-prefix `route_ipv4_update` path; v6 unicast: `route_ipv6_update` ~6896). Only these two families — **not** the other six `enforce-first-as` sites. IR1/IR2 → return `None` + counter + `bgp_packet_trace!`-style trace "DENIED by OTC ingress rule N". IR3 mutates the attr: clone the UPDATE's attr once *before* the batch/shard split (N>1 runs policy in the shard, so the stamp must be main-side and shared by all prefixes).
+* Egress: `SyncCtx.otc_local_role` (from `Peer::sync_ctx`) and `EgressAs`-adjacent helper `otc_egress(role, local_as, &mut attrs) -> bool /*suppress*/` called in `route_update_ipv4` right after `ebgp_egress_aspath` (ER2 → `return None`, which already flows into `AdvertiseOutcome::Withdraw`); same in `route_update_ipv6` (takes `&mut Peer`, read `peer.config` directly).
+* `UpdateGroupSig.otc_local_role`, `SIGNATURE_VERSION = 7`, extend `signature_fields_each_distinguish`.
+* `show bgp <prefix>` / detail: `OTC-AS: 65540` line beside AIGP (`show.rs` ~1912 and ~4409) + JSON `otc_as`.
+* `show bgp neighbor`: `By OTC ingress rule 1: n, By OTC ingress rule 2: n` (Cisco wording, under the prefix-denied counters); trace line `Prefix P received from X DENIED due to OTC ingress rule 1: route leak from Customer/RS-Client` / `... rule 2: OTC AS mismatch from Peer`.
+* BDD `bgp_otc_local_role.feature` (line z1 AS65001 — z2 AS65002 — z3 AS65003, z1 originates 10.0.0.1/32), scenarios:
+  1. z1 provider / z2 customer: Established, both show `OTC Remote Role: ... (received)` and `OTC Role: Yes Yes`; z2 has the route with `OTC-AS: 65001`.
+  2. ER2: z2 customer toward z3 (z3 provider) → z3 does **not** get 10.0.0.1/32.
+  3. IR3 + loose: z1 role removed, z2 customer → z2 still stamps OTC 65001, remote shown "(inferred)".
+  4. IR1: z2 role toward z3 removed (z2 forwards the OTC route), z3 provider → z3 drops, counter IR1 = 1.
+  5. IR2: z2/z3 peer/peer with an OTC ≠ 65002 arriving at z3 (route already OTC-marked by z1 = 65001) → dropped, counter IR2.
+  6. Mismatch: z1 provider + z2 provider → not Established, last reset contains `OTC role mismatch`.
+  7. Strict: z1 `otc-local-role customer strict`, z2 no role → not Established, `OTC Local Mode: Strict`; add z2 role → Established.
+  New cucumber steps: `BGP route in "z" has "p" with OTC-AS <asn>` / `without OTC`; `show command ... should contain` covers the rest (memory: literal `show`, literal `clear`). Session bounce via `clear bgp ipv4 neighbor` where needed.
+* Config-file (YAML) spelling that the BDD uses, for the record:
+  ```yaml
+  router:
+    bgp:
+      neighbor:
+        - address: 192.168.0.2
+          remote-as: 65002
+          otc-local-role:
+            - role: provider
+              strict: null      # omit for loose (see memory zebra-rs-bdd-empty-leaf-yaml)
+  ```
+
+### PR 4 — docs (can fold into PR 3)
+* `book/src/ch-02-42-bgp-otc-local-role.md` ("Route Leak Prevention: OTC Local Role (RFC 9234)") + `SUMMARY.md` (after Enforce First AS), `appendix-b-supported-rfcs.md` row for RFC 9234, `docs/design/bgp-update-groups.md` §3.1 (otc-local-role now a sig field), `CHANGELOG.yaml` note at release cut. The chapter should state the XR-compatible syntax and the one superset value (`route-server`).
+
+### PR 5 — optional follow-ups
+* Route-map `set otc-local-role <role>` (in/out) per-prefix override, Cisco RPL parity — only if asked.
+* Dynamic-neighbor (listen-range) members inherit via the group path already; verify with a scenario.
+* Interop run against FRR/BIRD (`local role`, `require roles`) and — when a lab is available — IOS XR 26.4.1.
+
+### Separate task — route-server mode (RFC 7947)
+zebra-rs has no RS mode today (always prepends; no `route-server-client`
+knob; the book's RFC 7947 appendix row is unbacked). That work is tracked
+in its own design, **`bgp-route-server-plan.md`**, and is not part of this
+arc. The `otc-local-role` enum still accepts `route-server` and
+`route-server-client` so the wire/OPEN side is complete; the RS role is
+simply not *useful* until that plan lands.
+
+## 4. Gotchas to carry into implementation
+* `route_update_ipv4` output must depend only on `UpdateGroupSig` fields — hence decision 6.
+* `remote_as` for `remote-as external` / interface peers is learned from OPEN; the OTC gates run post-Established so it is always known there.
+* iBGP transit: a leak that enters via iBGP is caught only at the *other* border's ER2 — OTC must survive `strip_ibgp_only_attrs` (it is not iBGP-only; do not add it there).
+* `soft-reconfiguration inbound` replay re-runs IR1–IR3; counters will double on replay — count per replay is acceptable, document it.
+* Group knob without a sweep = config-order-dependent bug (memory `zebra-rs-bgp-neighbor-group-inheritance`).
+* `cargo fmt` before every commit; full suite = `cargo test --workspace --exclude bdd`; BDD needs `make -C bdd stage` and YANG copied to `/usr/share/zebra-rs/yang/`.

--- a/docs/design/bgp-route-server-plan.md
+++ b/docs/design/bgp-route-server-plan.md
@@ -1,0 +1,95 @@
+# BGP Route Server mode (RFC 7947) — design
+
+Status: **planned, not started** (2026-08-28). Split out of the RFC 9234
+plan (`bgp-rfc9234-plan.md`) so the OTC work can land first; this document
+is self-contained and can be picked up independently.
+
+## 1. Why
+
+An Internet Exchange route server (RFC 7947) re-advertises its clients'
+routes to each other *transparently*: it does not prepend its own AS, does
+not rewrite NEXT_HOP, and passes MED and communities through unchanged, so a
+client sees exactly the path the originating member sent. zebra-rs has no
+such mode today. The RFC 9234 role `route-server` / `route-server-client`
+pair also only becomes meaningful once zebra-rs can be the RS.
+
+## 2. Current state (verified 2026-08-28)
+
+| RFC 7947 requirement | zebra-rs today |
+|---|---|
+| §2.2.1 NEXT_HOP unchanged | available per AFI: `afi-safi ipv4\|ipv6 next-hop-unchanged` (`SyncCtx.unicast_next_hop_unchanged`, `Peer::next_hop_unchanged`) |
+| §2.2.2 AS_PATH transparent (no RS AS prepend) | **missing** — `route.rs::ebgp_egress_aspath` prepends unconditionally for every eBGP peer (9 call sites; only the v4/v6 unicast ones matter here) |
+| §2.2.2.1 MED passthrough | already passthrough (`route_update_ipv4` "4. MED - Pass through") |
+| §2.2.2.2 communities passthrough | already passthrough |
+| §2.3 path hiding — §2.3.2.2 ADD-PATH | ADD-PATH **send** implemented for v4/v6 unicast (`cap::addpath_send_implemented`) |
+| §2.3 path hiding — §2.3.2.1 per-client Loc-RIB | not implemented; **not planned** (ADD-PATH covers it) |
+| client fan-in | `listen-range` dynamic neighbors, per-neighbor in/out policy, `enforce-first-as` (must be OFF on the *client* side toward an RS) |
+| book | `appendix-b-supported-rfcs.md:36` lists RFC 7947 as supported (commit f3f39061) — **not backed by code**; correct it or make it true here |
+
+No `route-server-client` knob, no RS-side attribute-transparency switch exists.
+
+## 3. Design
+
+### 3.1 Knob
+`neighbor <X> route-server-client` — presence container, FRR/BIRD spelling
+(Cisco IOS XR has no route-server function, so there is no XR syntax to
+match). Module `zebra-bgp-route-server.yang`, prefix `zbrs`, grouping
+`bgp-neighbor-route-server-client-extension`; `uses` in
+`zebra-bgp-neighbor-group.yang` (inheritable — an IXP configures one group
+for all members), inline container in `zebra-bgp-vrf.yang`. Parse test in
+`config/manager.rs` before anything else (memory
+`zebra-rs-bgp-neighbor-yang-ietf-collision`: check `ietf-bgp-common` for a
+same-named leaf first; grep today shows none).
+
+### 3.2 Egress transform (v4/v6 unicast only)
+* `PeerConfig.route_server_client: bool` → `EgressAs.route_server_client`.
+* `ebgp_egress_aspath`: return early when set — no local-AS prepend. The
+  transforms it would otherwise run (`remove-private-as`, `as-override`,
+  `local-as` substitute) are incompatible with a transparent RS: reject the
+  combination in the config callback (clearest) rather than silently
+  skipping.
+* NEXT_HOP: treat forwarded rows as `next-hop-unchanged` (OR the flag into
+  `unicast_next_hop_unchanged` in `Peer::sync_ctx` and the v6 builder's
+  `nh_unchanged`). Locally-originated rows still rewrite to self.
+* MED / communities / AIGP: nothing to do.
+* **`UpdateGroupSig.route_server_client`** + `SIGNATURE_VERSION` bump — an
+  RS client must never share canonical bytes with an ordinary eBGP peer
+  (memory `zebra-rs-bgp-update-group-signature-trap`); extend
+  `signature_fields_each_distinguish`.
+* Other families (labeled, VPN, EVPN, …): untouched, still prepend.
+
+### 3.3 Ingress
+Ordinary eBGP. The RS AS never appears in a client's AS_PATH, so the RFC
+4271 loop check is unaffected. Best-path selection stays global (one
+Loc-RIB); with `add-path send` on the client sessions every member path is
+advertised, which is the RFC 7947 §2.3.2.2 answer to path hiding.
+
+### 3.4 Interplay with RFC 9234 (once both exist)
+`otc-local-role route-server` on the RS, `route-server-client` on members:
+* RS: ER1 stamps `OTC-AS: <RS AS>` toward clients; IR1 rejects an
+  OTC-marked route received from a client.
+* Client: IR3 stamps OTC = RS AS when absent; ER2 blocks OTC-marked routes
+  toward the RS.
+* OTC carries the **RS's** AS, not the originating member's — RFC 9234 §5
+  as written; document it.
+
+### 3.5 Show / docs / tests
+* `show bgp neighbor` (text + JSON): "Route-server client: yes".
+* BDD `bgp_route_server.feature`: RS AS65000 with clients AS65001 and
+  AS65002 (three namespaces on one bridge or two P2P links). Client 2
+  receives 65001's prefix with AS_PATH `65001` (no 65000) and the original
+  next-hop; a control scenario without the knob shows `65000 65001`.
+  Optional: `add-path send` scenario with two members announcing the same
+  prefix. Later: RS↔RS-client OTC scenario.
+* Book `ch-02-43-bgp-route-server.md`; fix the appendix-b row; changelog.
+
+## 4. Out of scope
+* Per-client Loc-RIB (§2.3.2.1).
+* RS-side per-client export policy language beyond the existing route-map /
+  prefix-set / community machinery.
+* IRR/RPKI-driven filtering (separate feature).
+
+## 5. Estimated size
+One PR: YANG + callback/inheritance wiring, ~20 lines in `route.rs` /
+`update_group.rs`, show, one BDD feature, book chapter. Comparable to
+`enforce-first-as` (PR of 2026-06-08) plus the update-group sig change.


### PR DESCRIPTION
## Summary

PR 1 of the RFC 9234 (route-leak prevention via BGP Roles) series — the wire codec in `bgp-packet` only. No session or route behaviour changes yet; the plan for the rest is in `docs/design/bgp-rfc9234-plan.md` (added here).

* **Role capability (code 9, §4.1)** — `caps/role.rs`: `BgpRole` with the §4.2 pairing table (Provider↔Customer, RS↔RS-Client, Peer↔Peer), Cisco IOS XR-compatible display/CLI spellings, and `CapRole`. New `CapabilityPacket::Role` arm. A Role capability whose length ≠ 1 is routed to the opaque `Unknown` passthrough instead of failing the whole OPEN (RFC 5492), so the session logic simply sees "no role received".
* **`BgpCap.role` / `role_conflict`** — identical duplicate Role capabilities collapse to one; differing values set the conflict flag the FSM will turn into a Role Mismatch NOTIFICATION (§4.2).
* **OTC attribute (type 35, §5)** — `attrs/otc.rs`: optional transitive, exactly 4 octets, wired into `AttrType` / `Attr` / `BgpAttr` parse, emit and Display. Length ≠ 4 is treat-as-withdraw (`attr_malformation_is_withdraw`). Until now OTC transited as `Unknown(35)` with the Partial bit set; it is now decoded and re-emitted without Partial.
* Two existing "unknown short capability" tests used code 9 as their example — re-pointed at unassigned code 200.

Also adds `docs/design/bgp-route-server-plan.md`: RFC 7947 route-server mode was found to be absent (the book's appendix row is unbacked) and is split out as a separate task.

## Test plan

- [x] `cargo test -p bgp-packet` — 513 passed, including the new Role/OTC tests (pairing matrix, cap round-trip, wrong-length cap → Unknown, duplicate-cap collapse/conflict, OTC round-trip through a full attribute block, malformed OTC → `treat_as_withdraw` with the earlier attributes intact and no session error)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings`

Next: PR 2 — `otc-local-role` knob, OPEN exchange, Role Mismatch handling, show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g1SgtRd4VA3tj5dit9uqr
