### PR TITLE
bgp: RFC 9234 otc-local-role — Role capability exchange and Role Mismatch

### DIFF
--- a/docs/design/bgp-rfc9234-plan.md
+++ b/docs/design/bgp-rfc9234-plan.md
@@ -76,15 +76,15 @@ yields OTC=AS(z1) on z2 via ER1 on z1, and "z1 no role → z2 customer
    ingress rule 2: n`, `OTC-AS: <asn>` on a path, and the last-reset reason
    `OTC role mismatch`. FRR/VyOS `local-role` is **not** offered as an alias.
 2. **YANG shape** — `list otc-local-role { key role; max-elements 1; leaf role { enumeration customer|provider|peer|route-server-client|route-server }; leaf strict { type empty } }`
-   gives exactly the `otc-local-role customer [strict]` CLI (memory
-   `zebra-rs-exec-keyword-at-key-position` covers keyword-at-list-key).
-   Fallback if `max-elements` is not honoured by the libyang port: enforce
-   "one role per neighbor" in the callback (later set replaces). Fallback if
-   an enum list-key does not complete in the CLI: `leaf otc-local-role { enumeration }`
-   + `leaf otc-local-role-strict { empty }`. Prove the chosen shape with a
-   `config/manager.rs` parse test **first** (`bgp_neighbor_otc_local_role_paths_parse`).
+   gives exactly the `otc-local-role customer [strict]` CLI. **Proven in
+   PR 2** by `config/manager.rs::bgp_neighbor_otc_local_role_paths_parse`
+   (enum list-key + empty leaf parse on the neighbor, neighbor-group and
+   VRF neighbor). `max-elements` is not engine-enforced (same as
+   `local-as`): the staging helpers on `InheritableKnobs` refuse a second
+   role with a warning — delete the current role before setting another.
    Module `zebra-bgp-otc.yang`, prefix `zbotc`, grouping
-   `bgp-neighbor-otc-local-role-extension`.
+   `bgp-neighbor-otc-local-role-extension`; the VRF copy is inline in
+   `zebra-bgp-vrf.yang`.
 3. **Local AS for ER1** = `peer.open_local_as()` (the substitute when
    `local-as` is active — the AS the neighbor sees us as, and what its own
    IR3 would stamp). **Remote AS for IR2/IR3** = `peer.remote_as`.
@@ -121,7 +121,7 @@ yields OTC=AS(z1) on z2 via ER1 on z1, and "z1 no role → z2 customer
 * YANG `zebra-bgp-otc.yang` (prefix `zbotc`), grouping `bgp-neighbor-otc-local-role-extension`, augments for set/delete; import in `config.yang`; `uses` in `zebra-bgp-neighbor-group.yang`; inline list in `zebra-bgp-vrf.yang` next to `enforce-first-as`. `yang_load_tests` grammar pin + parse test.
 * `PeerConfig.otc_local_role: Option<OtcLocalRole { role: BgpRole, strict: bool }>`; `InheritableKnobs.otc_local_role` (compiler forces `apply_inherited`); `config_otc_local_role` (record→resolve→`apply_otc_local_role`), `config_neighbor_group_otc_local_role` **with `sweep_members_inherit`** (memory: forgetting the sweep is a silent bug), `config_vrf_neighbor_otc_local_role`; registrations under `/otc-local-role`. `apply_otc_local_role` bounces an Established/Open* session on change (`ConfigChange`; log line mirrors XR: "neighbor X Down - OTC local role changed").
 * `build_open_packet`: `if is_ebgp() && let Some(r) = config.otc_local_role { bgp_cap.role = Some(CapRole::new(r.role)) }`.
-* `fsm_bgp_open`: right after the `BadPeerAS`/AS4-consistency block (so it covers both `ConnTag::Primary` and `ConnTag::Collision` via the same `close_collision` / `peer_send_notification` split): `otc_role_check(local, &packet.bgp_cap)` → `Ok(Received(r) | Inferred(r) | None)` or `Err(RoleMismatch)` → NOTIFICATION 2/11, `State::Idle`, `PeerDownReason::OtcRoleMismatch` ("OTC role mismatch"). Store `peer.otc_remote_role: Option<(BgpRole, RoleSource)>` for show and for the OTC gates.
+* `fsm_bgp_open`: right after the `BadPeerAS`/AS4-consistency block (so it covers both `ConnTag::Primary` and `ConnTag::Collision` via the same `close_collision` / `peer_send_notification` split): `otc_role_check(local, is_ebgp, &packet.bgp_cap) -> Result<(), OtcRoleMismatch>` → NOTIFICATION 2/11 + `State::Idle` on `Err`. **As built:** no `PeerDownReason` variant — `last_reset` is only written when an *Established* session ends, and a role mismatch happens in OpenSent, so the reason lives in `Peer::otc_role_mismatch` (cleared by the next passing OPEN) and is rendered as `OTC Role Mismatch: …`. The remote role is not stored; `Peer::otc_remote_role()` derives it from `cap_recv` (received, while OpenConfirm/Established) or the local role's counterpart (inferred).
 * `show bgp neighbor` (text + JSON), Cisco strings verbatim:
   ```
    OTC Local Mode: Loose

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -109,6 +109,8 @@
 /router/bgp/neighbor-group/ebgp-multihop
 /router/bgp/neighbor-group/enforce-first-as
 /router/bgp/neighbor-group/ip-transparent
+/router/bgp/neighbor-group/otc-local-role
+/router/bgp/neighbor-group/otc-local-role/strict
 /router/bgp/neighbor-group/passive
 /router/bgp/neighbor-group/password
 /router/bgp/neighbor-group/policy/in
@@ -164,6 +166,8 @@
 /router/bgp/neighbor/local-as/replace-as
 /router/bgp/neighbor/local-identifier
 /router/bgp/neighbor/neighbor-group
+/router/bgp/neighbor/otc-local-role
+/router/bgp/neighbor/otc-local-role/strict
 /router/bgp/neighbor/password
 /router/bgp/neighbor/pic-retention
 /router/bgp/neighbor/port
@@ -264,6 +268,8 @@
 /router/bgp/vrf/neighbor/enforce-first-as
 /router/bgp/vrf/neighbor/ip-transparent
 /router/bgp/vrf/neighbor/neighbor-group
+/router/bgp/vrf/neighbor/otc-local-role
+/router/bgp/vrf/neighbor/otc-local-role/strict
 /router/bgp/vrf/neighbor/password
 /router/bgp/vrf/neighbor/port
 /router/bgp/vrf/neighbor/remote-as

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -23,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 339
-Handled: 324
+Total settable schema nodes: 345
+Handled: 330
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -113,6 +113,8 @@
 /router/bgp/neighbor-group/ebgp-multihop	leaf
 /router/bgp/neighbor-group/enforce-first-as	p-container
 /router/bgp/neighbor-group/ip-transparent	p-container
+/router/bgp/neighbor-group/otc-local-role	list keys=role
+/router/bgp/neighbor-group/otc-local-role/strict	leaf
 /router/bgp/neighbor-group/passive	leaf
 /router/bgp/neighbor-group/password	leaf
 /router/bgp/neighbor-group/policy	container
@@ -179,6 +181,8 @@
 /router/bgp/neighbor/local-as/replace-as	leaf
 /router/bgp/neighbor/local-identifier	leaf
 /router/bgp/neighbor/neighbor-group	leaf
+/router/bgp/neighbor/otc-local-role	list keys=role
+/router/bgp/neighbor/otc-local-role/strict	leaf
 /router/bgp/neighbor/password	leaf
 /router/bgp/neighbor/pic-retention	p-container
 /router/bgp/neighbor/port	leaf
@@ -359,6 +363,8 @@
 /router/bgp/vrf/neighbor/enforce-first-as	p-container
 /router/bgp/vrf/neighbor/ip-transparent	p-container
 /router/bgp/vrf/neighbor/neighbor-group	leaf
+/router/bgp/vrf/neighbor/otc-local-role	list keys=role
+/router/bgp/vrf/neighbor/otc-local-role/strict	leaf
 /router/bgp/vrf/neighbor/password	leaf
 /router/bgp/vrf/neighbor/port	leaf
 /router/bgp/vrf/neighbor/remote-as	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -18,7 +18,7 @@ use super::route_clean;
 use super::{
     AssistedReplicationRole, BGP_PORT, Bgp, EvpnBumTunnel,
     inst::{Callback, EvpnEncap},
-    peer::{AllowAsIn, LocalAs, PasswordEncoding, Peer, PeerType, RemovePrivateAs},
+    peer::{AllowAsIn, LocalAs, OtcLocalRole, PasswordEncoding, Peer, PeerType, RemovePrivateAs},
     timer,
 };
 
@@ -1076,6 +1076,106 @@ fn config_enforce_first_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 pub(super) fn apply_enforce_first_as(peer: &mut Peer, want: bool) -> bool {
     peer.config.enforce_first_as = want;
     false
+}
+
+/// `set router bgp neighbor X otc-local-role <role>` — the RFC 9234 list
+/// node (zebra-bgp-otc.yang, IOS XR syntax). Records the verbatim
+/// statement, resolves through the neighbor-group precedence and applies
+/// it. Roles are exchanged only in the OPEN, so a live session whose
+/// effective role changed is bounced with `Event::Stop` to renegotiate
+/// (IOS XR: "Down - OTC local role changed"); an Idle peer picks it up
+/// on its first connect. Single-instance: a second role is refused with
+/// a warning — delete the current one first (same rule as `local-as`).
+fn config_otc_local_role(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let key = args.string();
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        if op.is_set() {
+            let role = super::neighbor_group::parse_otc_role(&key?)?;
+            if !peer.config.knobs_explicit.stage_otc_local_role(role) {
+                tracing::warn!(
+                    peer = %peer.display_name(),
+                    "bgp: otc-local-role is single-instance (already {}); delete it before setting {}",
+                    peer.config
+                        .knobs_explicit
+                        .otc_local_role
+                        .map(|r| r.role.cli_name())
+                        .unwrap_or("?"),
+                    role.cli_name(),
+                );
+                return None;
+            }
+        } else {
+            peer.config.knobs_explicit.unstage_otc_local_role(
+                key.as_deref()
+                    .and_then(super::neighbor_group::parse_otc_role),
+            );
+        }
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.otc_local_role
+        });
+        (peer.ident, apply_otc_local_role(peer, want))
+    };
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor X otc-local-role <role> strict` — the strict
+/// modifier leaf. Strict changes what the next OPEN must carry, so it
+/// bounces a live session like the list node does.
+fn config_otc_local_role_strict(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let role = super::neighbor_group::parse_otc_role(&args.string()?)?;
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        if !peer
+            .config
+            .knobs_explicit
+            .stage_otc_local_role_strict(role, op.is_set())
+        {
+            tracing::warn!(
+                peer = %peer.display_name(),
+                "bgp: otc-local-role is single-instance; delete the current role before setting {} strict",
+                role.cli_name(),
+            );
+            return None;
+        }
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.otc_local_role
+        });
+        (peer.ident, apply_otc_local_role(peer, want))
+    };
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
+/// Write a resolved `otc-local-role` onto the peer and return whether a
+/// live session must be bounced: the role rides the OPEN (RFC 9234
+/// §4.1), so any change to the effective role or mode renegotiates.
+/// Diff-gated so re-resolving an unchanged value never disturbs a
+/// session. The knob is stored but inert on iBGP (roles are eBGP-only);
+/// `show bgp neighbor` says so rather than a warning here — within a
+/// commit this callback can run before `remote-as` has classified the
+/// session, so `peer_type` is not yet trustworthy. Shared by the
+/// per-neighbor callbacks, the neighbor-group sweep and VRF
+/// materialization.
+pub(super) fn apply_otc_local_role(peer: &mut Peer, want: Option<OtcLocalRole>) -> bool {
+    if peer.config.otc_local_role == want {
+        return false;
+    }
+    peer.config.otc_local_role = want;
+    peer.otc_role_mismatch = None;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
 }
 
 /// Parse the compact `attach-unknown-attribute` spec
@@ -4680,6 +4780,14 @@ impl Bgp {
             super::neighbor_group::config_neighbor_group_enforce_first_as,
         );
         self.callback_add(
+            "/router/bgp/neighbor-group/otc-local-role",
+            super::neighbor_group::config_neighbor_group_otc_local_role,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/otc-local-role/strict",
+            super::neighbor_group::config_neighbor_group_otc_local_role_strict,
+        );
+        self.callback_add(
             "/router/bgp/neighbor-group/route-reflector/client",
             super::neighbor_group::config_neighbor_group_route_reflector_client,
         );
@@ -4879,6 +4987,14 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/neighbor/enforce-first-as",
             super::vrf_config::config_vrf_neighbor_enforce_first_as,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/otc-local-role",
+            super::vrf_config::config_vrf_neighbor_otc_local_role,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/otc-local-role/strict",
+            super::vrf_config::config_vrf_neighbor_otc_local_role_strict,
         );
         self.callback_add(
             "/router/bgp/vrf/neighbor/route-reflector/client",
@@ -5537,6 +5653,12 @@ impl Bgp {
         // left-most AS_PATH segment begins with the neighbor's own AS
         // (eBGP only).
         self.callback_peer("/enforce-first-as", config_enforce_first_as);
+
+        // RFC 9234 BGP Role (zebra-bgp-otc.yang, IOS XR syntax):
+        // `otc-local-role <role> [strict]`. Advertised in the OPEN on
+        // eBGP; a change bounces the session.
+        self.callback_peer("/otc-local-role", config_otc_local_role);
+        self.callback_peer("/otc-local-role/strict", config_otc_local_role_strict);
         self.callback_peer("/pic-retention", config_pic_retention);
 
         // Per-neighbor capability advertisement (zebra-bgp-capability.yang):
@@ -6258,6 +6380,116 @@ mod bfd_wiring_tests {
         config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
         config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
         assert!(!peer_enforce_first_as(&bgp, "10.0.0.2"));
+    }
+
+    fn peer_otc(bgp: &Bgp, addr: &str) -> Option<OtcLocalRole> {
+        bgp.peers
+            .get(&addr.parse().unwrap())
+            .unwrap()
+            .config
+            .otc_local_role
+    }
+
+    /// `otc-local-role <role>` seeds a loose entry, `strict` toggles the
+    /// mode, a second role is refused, and deletes are keyed.
+    #[tokio::test]
+    async fn otc_local_role_set_strict_refuse_and_delete() {
+        use bgp_packet::BgpRole;
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert_eq!(peer_otc(&bgp, "10.0.0.2"), None);
+
+        config_otc_local_role(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "customer"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            peer_otc(&bgp, "10.0.0.2"),
+            Some(OtcLocalRole {
+                role: BgpRole::Customer,
+                strict: false
+            })
+        );
+
+        config_otc_local_role_strict(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "customer"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(peer_otc(&bgp, "10.0.0.2").map(|r| r.strict), Some(true));
+
+        // Single-instance: a different role is refused, the first stays.
+        assert!(
+            config_otc_local_role(
+                &mut bgp,
+                arg_words(&["10.0.0.2", "provider"]),
+                ConfigOp::Set
+            )
+            .is_none()
+        );
+        assert_eq!(
+            peer_otc(&bgp, "10.0.0.2").map(|r| r.role),
+            Some(BgpRole::Customer)
+        );
+
+        // Strict off again.
+        config_otc_local_role_strict(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "customer"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert_eq!(peer_otc(&bgp, "10.0.0.2").map(|r| r.strict), Some(false));
+
+        // A keyed delete naming another role is a no-op; the matching
+        // (or unkeyed) delete clears the entry.
+        config_otc_local_role(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "provider"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(peer_otc(&bgp, "10.0.0.2").is_some());
+        config_otc_local_role(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert_eq!(peer_otc(&bgp, "10.0.0.2"), None);
+    }
+
+    /// The `strict` leaf landing before the list node within a commit
+    /// seeds the entry; a strict delete on an absent entry seeds nothing.
+    #[tokio::test]
+    async fn otc_local_role_strict_leaf_seeds_but_never_resurrects() {
+        use bgp_packet::BgpRole;
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_otc_local_role_strict(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "provider"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            peer_otc(&bgp, "10.0.0.2"),
+            Some(OtcLocalRole {
+                role: BgpRole::Provider,
+                strict: true
+            })
+        );
+        config_otc_local_role(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "provider"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        config_otc_local_role_strict(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "provider"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert_eq!(peer_otc(&bgp, "10.0.0.2"), None);
     }
 
     fn peer_attach_unknown(bgp: &Bgp, addr: &str) -> Option<UnknownAttr> {
@@ -8563,7 +8795,8 @@ mod neighbor_group_wiring_tests {
         config_neighbor_group_allowas_in, config_neighbor_group_allowas_in_count,
         config_neighbor_group_allowas_in_origin, config_neighbor_group_as_override,
         config_neighbor_group_disable_connected_check, config_neighbor_group_ebgp_multihop,
-        config_neighbor_group_enforce_first_as, config_neighbor_group_passive,
+        config_neighbor_group_enforce_first_as, config_neighbor_group_otc_local_role,
+        config_neighbor_group_otc_local_role_strict, config_neighbor_group_passive,
         config_neighbor_group_port, config_neighbor_group_remove_private_as,
         config_neighbor_group_remove_private_as_all,
         config_neighbor_group_remove_private_as_replace_as,
@@ -8919,6 +9152,75 @@ mod neighbor_group_wiring_tests {
             drain_stop_events(&mut bgp).is_empty(),
             "enforce-first-as changes must never bounce the session",
         );
+    }
+
+    /// Group `otc-local-role` propagates, bounces a live member (the
+    /// role rides the OPEN), and the explicit per-neighbor role wins.
+    #[tokio::test]
+    async fn group_otc_local_role_propagates_explicit_wins_and_bounces_live() {
+        use crate::bgp::peer::{OtcLocalRole, State};
+        use bgp_packet::BgpRole;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_otc_local_role(
+            &mut bgp,
+            arg_words(&["G", "customer"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            member(&bgp).config.otc_local_role,
+            Some(OtcLocalRole {
+                role: BgpRole::Customer,
+                strict: false
+            }),
+            "group opinion must apply"
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "a changed role bounces a live member"
+        );
+
+        // Strict via the group, no role change on the member beyond mode.
+        config_neighbor_group_otc_local_role_strict(
+            &mut bgp,
+            arg_words(&["G", "customer"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            member(&bgp).config.otc_local_role.map(|r| r.strict),
+            Some(true)
+        );
+
+        // Explicit wins over the group and survives the group delete.
+        config_otc_local_role(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "provider"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            member(&bgp).config.otc_local_role.map(|r| r.role),
+            Some(BgpRole::Provider)
+        );
+        config_neighbor_group_otc_local_role(&mut bgp, arg_words(&["G"]), ConfigOp::Delete)
+            .unwrap();
+        assert_eq!(
+            member(&bgp).config.otc_local_role.map(|r| r.role),
+            Some(BgpRole::Provider),
+            "explicit statement survives the group delete",
+        );
+        config_otc_local_role(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert_eq!(member(&bgp).config.otc_local_role, None);
+
+        // Re-applying an unchanged value never bounces.
+        let _ = drain_stop_events(&mut bgp);
+        config_neighbor_group_otc_local_role(&mut bgp, arg_words(&["G"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(drain_stop_events(&mut bgp).is_empty());
     }
 
     /// Group `route-reflector client` flows to the member's

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -80,6 +80,10 @@ pub struct InheritableKnobs {
     pub as_override: Option<bool>,
     pub remove_private_as: Option<RemovePrivateAs>,
     pub enforce_first_as: Option<bool>,
+    /// RFC 9234 `otc-local-role <role> [strict]` (zebra-bgp-otc.yang).
+    /// Single-instance list: the staging helpers below refuse a second
+    /// role, mirroring `local-as`.
+    pub otc_local_role: Option<super::peer::OtcLocalRole>,
     pub route_reflector_client: Option<bool>,
     /// RFC 9572 §6.1 region identifier — the 8-octet, EC-formatted Region ID
     /// (`region_id_from_asn`). A peer-group carrying this *is* a region; a
@@ -91,6 +95,54 @@ pub struct InheritableKnobs {
 }
 
 impl InheritableKnobs {
+    /// `otc-local-role <role>` list node, Set: seed the entry (strict
+    /// off) or keep the existing one. Returns `false` — and leaves the
+    /// record untouched — when a *different* role is already staged:
+    /// the list is single-instance (YANG `max-elements 1` is not
+    /// engine-enforced), so the caller warns and refuses, like
+    /// `local-as`. Delete the current role before setting another.
+    pub fn stage_otc_local_role(&mut self, role: bgp_packet::BgpRole) -> bool {
+        match self.otc_local_role {
+            Some(existing) if existing.role != role => false,
+            Some(_) => true,
+            None => {
+                self.otc_local_role = Some(super::peer::OtcLocalRole {
+                    role,
+                    strict: false,
+                });
+                true
+            }
+        }
+    }
+
+    /// `otc-local-role [<role>]` Delete: a keyed delete only removes the
+    /// matching entry, an unkeyed one clears the lot (there is at most
+    /// one).
+    pub fn unstage_otc_local_role(&mut self, role: Option<bgp_packet::BgpRole>) {
+        if let Some(existing) = self.otc_local_role
+            && role.is_none_or(|r| r == existing.role)
+        {
+            self.otc_local_role = None;
+        }
+    }
+
+    /// `otc-local-role <role> strict` leaf. A Set seeds the entry when
+    /// the leaf lands before the list node within a commit (same
+    /// single-instance refusal as [`Self::stage_otc_local_role`]); a
+    /// Delete reverts to loose without seeding, so a flag delete never
+    /// resurrects an entry the same commit already removed.
+    pub fn stage_otc_local_role_strict(&mut self, role: bgp_packet::BgpRole, strict: bool) -> bool {
+        if strict && !self.stage_otc_local_role(role) {
+            return false;
+        }
+        if let Some(entry) = self.otc_local_role.as_mut()
+            && entry.role == role
+        {
+            entry.strict = strict;
+        }
+        true
+    }
+
     /// Staging state machines for the two structured knobs, factored so
     /// the per-neighbor callbacks (`config.rs`) and the per-VRF-neighbor
     /// callbacks (`vrf_config.rs`) share one definition rather than each
@@ -882,6 +934,75 @@ pub fn config_neighbor_group_enforce_first_as(
     Some(())
 }
 
+/// Decode an `otc-local-role` list key (IOS XR token) or warn.
+pub(super) fn parse_otc_role(token: &str) -> Option<bgp_packet::BgpRole> {
+    match token.parse::<bgp_packet::BgpRole>() {
+        Ok(role) => Some(role),
+        Err(e) => {
+            tracing::warn!("bgp: {e}; ignoring");
+            None
+        }
+    }
+}
+
+/// `set router bgp neighbor-group <name> otc-local-role <role>` — the
+/// RFC 9234 list node (zebra-bgp-otc.yang). Stores the opinion and
+/// re-resolves every member; a live member whose effective role changed
+/// is bounced (roles are exchanged only in OPEN).
+pub fn config_neighbor_group_otc_local_role(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let key = args.string();
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if op.is_set() {
+        let role = parse_otc_role(&key?)?;
+        if !knobs.stage_otc_local_role(role) {
+            tracing::warn!(
+                "bgp: neighbor-group {name}: otc-local-role is single-instance (already {}); delete it before setting {}",
+                knobs
+                    .otc_local_role
+                    .map(|r| r.role.cli_name())
+                    .unwrap_or("?"),
+                role.cli_name(),
+            );
+            return None;
+        }
+    } else {
+        knobs.unstage_otc_local_role(key.as_deref().and_then(parse_otc_role));
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.otc_local_role);
+        super::config::apply_otc_local_role(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> otc-local-role <role> strict`.
+pub fn config_neighbor_group_otc_local_role_strict(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let role = parse_otc_role(&args.string()?)?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if !knobs.stage_otc_local_role_strict(role, op.is_set()) {
+        tracing::warn!(
+            "bgp: neighbor-group {name}: otc-local-role is single-instance; delete the current role before setting {} strict",
+            role.cli_name(),
+        );
+        return None;
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.otc_local_role);
+        super::config::apply_otc_local_role(peer, want)
+    });
+    Some(())
+}
+
 /// `set router bgp neighbor-group <name> route-reflector client <bool>`.
 ///
 /// Stores the opinion and re-resolves every member. The effective
@@ -1410,6 +1531,7 @@ pub(super) fn resolve_inherited_knobs(
         as_override: resolve_knob(groups, config, |k| k.as_override),
         remove_private_as: resolve_knob(groups, config, |k| k.remove_private_as),
         enforce_first_as: resolve_knob(groups, config, |k| k.enforce_first_as),
+        otc_local_role: resolve_knob(groups, config, |k| k.otc_local_role),
         route_reflector_client: resolve_knob(groups, config, |k| k.route_reflector_client),
         region_id: resolve_knob(groups, config, |k| k.region_id),
     }
@@ -1452,6 +1574,7 @@ pub(super) fn apply_resolved_session_knobs(peer: &mut Peer, want: &InheritableKn
     super::config::apply_as_override(peer, want.as_override.unwrap_or(false));
     super::config::apply_remove_private_as(peer, want.remove_private_as);
     super::config::apply_enforce_first_as(peer, want.enforce_first_as.unwrap_or(false));
+    bounce |= super::config::apply_otc_local_role(peer, want.otc_local_role);
     super::config::apply_route_reflector_client(peer, want.route_reflector_client.unwrap_or(false));
     // The BFD re-arm this returns is only meaningful for a live session.
     let _ = super::config::apply_update_source(peer, want.update_source);
@@ -1511,6 +1634,7 @@ pub(super) fn apply_inherited(
         as_override,
         remove_private_as,
         enforce_first_as,
+        otc_local_role,
         route_reflector_client,
         region_id,
     } = resolved;
@@ -1545,6 +1669,9 @@ pub(super) fn apply_inherited(
     super::config::apply_as_override(peer, as_override.unwrap_or(false));
     super::config::apply_remove_private_as(peer, remove_private_as);
     super::config::apply_enforce_first_as(peer, enforce_first_as.unwrap_or(false));
+    // Roles ride the OPEN, so a changed effective role bounces a live
+    // member like the transport knobs do.
+    bounce |= super::config::apply_otc_local_role(peer, otc_local_role);
     super::config::apply_route_reflector_client(peer, route_reflector_client.unwrap_or(false));
     outcome.bfd_reapply = super::config::apply_update_source(peer, update_source);
     outcome.mss_refresh = super::config::apply_tcp_mss(peer, tcp_mss);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -610,6 +610,12 @@ pub struct PeerConfig {
     /// that forwards routes without prepending its AS. Ignored for iBGP
     /// peers (which never prepend). Default `false`.
     pub enforce_first_as: bool,
+    /// RFC 9234 `otc-local-role` (zebra-bgp-otc.yang, IOS XR syntax):
+    /// the local BGP Role toward this neighbor and whether strict mode
+    /// is on. `None` = roles not configured (no Role capability sent,
+    /// no role check on the peer's OPEN, no OTC processing). Ignored on
+    /// iBGP sessions.
+    pub otc_local_role: Option<OtcLocalRole>,
     /// Per-neighbor `local-as` (zebra-bgp-local-as.yang). `None` runs
     /// the session under the router's global AS; `Some` presents the
     /// substitute AS to this neighbor (see [`LocalAs`]).
@@ -658,6 +664,91 @@ impl PeerConfig {
     }
 }
 
+/// RFC 9234 BGP Role configured toward one neighbor —
+/// `neighbor X otc-local-role <role> [strict]` (zebra-bgp-otc.yang,
+/// Cisco IOS XR syntax).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OtcLocalRole {
+    /// The local speaker's role, advertised in the OPEN as the Role
+    /// capability (code 9) on eBGP sessions.
+    pub role: BgpRole,
+    /// Strict mode (RFC 9234 §4.2): a neighbor that sends no Role
+    /// capability is rejected with a Role Mismatch NOTIFICATION instead
+    /// of having its role inferred from ours.
+    pub strict: bool,
+}
+
+impl OtcLocalRole {
+    /// IOS XR `show bgp neighbor` spelling of the mode.
+    pub fn mode_str(&self) -> &'static str {
+        if self.strict { "Strict" } else { "Loose" }
+    }
+}
+
+/// Why the peer's OPEN failed the RFC 9234 §4.2 role check. Kept on the
+/// peer after the Role Mismatch NOTIFICATION so `show bgp neighbor` can
+/// explain a session that never reaches Established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtcRoleMismatch {
+    /// Both sides sent a role and the pair is not one of
+    /// provider/customer, route-server/route-server-client, peer/peer.
+    Pair { local: BgpRole, received: BgpRole },
+    /// The peer sent a role value outside the IANA-assigned 0–4.
+    Unassigned(u8),
+    /// Strict mode and the peer sent no Role capability.
+    Absent,
+    /// The peer sent several Role capabilities with different values.
+    Conflict,
+}
+
+impl std::fmt::Display for OtcRoleMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pair { local, received } => {
+                write!(f, "received {received}, local {local} (not a valid pair)")
+            }
+            Self::Unassigned(v) => write!(f, "received unassigned role value {v}"),
+            Self::Absent => write!(f, "no BGP Role capability received (strict mode)"),
+            Self::Conflict => write!(f, "conflicting BGP Role capabilities received"),
+        }
+    }
+}
+
+/// RFC 9234 §4.2 role correctness of a received OPEN against the local
+/// `otc-local-role`. `Ok` when roles are not configured locally, on an
+/// iBGP session (roles are defined for eBGP only), when the received
+/// role forms a valid pair with ours, or — in loose mode — when the peer
+/// sent no Role capability at all (its role is then inferred from ours).
+/// Every `Err` is answered with a Role Mismatch NOTIFICATION (OPEN
+/// Message Error, subcode 11).
+pub fn otc_role_check(
+    local: Option<OtcLocalRole>,
+    is_ebgp: bool,
+    caps: &BgpCap,
+) -> Result<(), OtcRoleMismatch> {
+    let Some(local) = local else {
+        return Ok(());
+    };
+    if !is_ebgp {
+        return Ok(());
+    }
+    if caps.role_conflict {
+        return Err(OtcRoleMismatch::Conflict);
+    }
+    match caps.role {
+        Some(cap) => match cap.role() {
+            Some(received) if local.role.pairs_with(received) => Ok(()),
+            Some(received) => Err(OtcRoleMismatch::Pair {
+                local: local.role,
+                received,
+            }),
+            None => Err(OtcRoleMismatch::Unassigned(cap.value)),
+        },
+        None if local.strict => Err(OtcRoleMismatch::Absent),
+        None => Ok(()),
+    }
+}
+
 impl Default for PeerConfig {
     fn default() -> Self {
         Self {
@@ -685,6 +776,7 @@ impl Default for PeerConfig {
             as_override: false,
             remove_private_as: None,
             enforce_first_as: false,
+            otc_local_role: None,
             local_as: None,
             attach_unknown_attr: None,
             description: None,
@@ -999,6 +1091,11 @@ pub struct Peer {
     /// Survives re-establishment (FRR semantics: it describes the
     /// *last* reset, not the current session).
     pub last_reset: Option<(PeerDownReason, Instant)>,
+    /// Why the last received OPEN failed the RFC 9234 role check (a
+    /// Role Mismatch NOTIFICATION was sent). Cleared when an OPEN passes
+    /// the check. Surfaced by `show bgp neighbor`, since a session that
+    /// never reaches Established leaves no `last_reset`.
+    pub otc_role_mismatch: Option<OtcRoleMismatch>,
     pub peer_type: PeerType,
     /// RFC 9572 §6.1 region identifier, resolved from this peer's
     /// neighbor-group (`region-id`) by `apply_inherited`. `Some` marks the
@@ -1233,6 +1330,7 @@ impl Peer {
             session_ifindex: None,
             down_reason: None,
             last_reset: None,
+            otc_role_mismatch: None,
             peer_type: PeerType::IBGP,
             region_id: None,
             state: State::Idle,
@@ -1396,6 +1494,23 @@ impl Peer {
 
     pub fn is_ibgp(&self) -> bool {
         self.peer_type.is_ibgp()
+    }
+
+    /// The neighbor's RFC 9234 role as this session sees it, with its
+    /// provenance for `show bgp neighbor`: `"received"` when the peer
+    /// sent a Role capability on the current session, `"inferred"` (the
+    /// counterpart of our role, loose mode) otherwise. `None` unless an
+    /// `otc-local-role` is configured on an eBGP session.
+    pub fn otc_remote_role(&self) -> Option<(BgpRole, &'static str)> {
+        let local = self.config.otc_local_role?;
+        if !self.is_ebgp() {
+            return None;
+        }
+        let negotiated = self.state.is_established() || matches!(self.state, State::OpenConfirm);
+        match self.cap_recv.role.and_then(|cap| cap.role()) {
+            Some(received) if negotiated => Some((received, "received")),
+            _ => Some((local.role.counterpart(), "inferred")),
+        }
     }
 
     /// The active `local-as` substitute for this session, if any.
@@ -2259,6 +2374,37 @@ pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State
         );
         return State::Idle;
     }
+
+    // RFC 9234 §4.2 role correctness. Same connection-tag split as the
+    // AS check above: a failing collision conn is torn down alone, a
+    // failing primary conn takes the session to Idle.
+    if let Err(mismatch) =
+        otc_role_check(peer.config.otc_local_role, peer.is_ebgp(), &packet.bgp_cap)
+    {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            "bgp: OTC role mismatch — {mismatch}; sending Role Mismatch NOTIFICATION",
+        );
+        peer.otc_role_mismatch = Some(mismatch);
+        if conn == ConnTag::Collision
+            && let Some(collision) = peer.collision.take()
+        {
+            close_collision(
+                collision,
+                NotifyCode::OpenMsgError,
+                OpenError::RoleMismatch.into(),
+            );
+            return peer.state;
+        }
+        peer_send_notification(
+            peer,
+            NotifyCode::OpenMsgError,
+            OpenError::RoleMismatch.into(),
+            Vec::new(),
+        );
+        return State::Idle;
+    }
+    peer.otc_role_mismatch = None;
 
     if peer.state != State::OpenSent && peer.state != State::OpenConfirm {
         // OPEN in an unexpected state — discard.
@@ -3124,6 +3270,14 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
         // FQDN capability (draft-walton, code 73). Domain name is left
         // empty for now — operators have only asked for hostname.
         bgp_cap.fqdn = Some(CapFqdn::new(name, ""));
+    }
+    // RFC 9234 §4.1: "If the BGP Role is locally configured, the eBGP
+    // speaker MUST advertise the BGP Role Capability". Roles are
+    // defined for eBGP only, so an iBGP session never carries one.
+    if peer.is_ebgp()
+        && let Some(local) = peer.config.otc_local_role
+    {
+        bgp_cap.role = Some(CapRole::new(local.role));
     }
     for (key, addpath) in peer.config.addpath.iter() {
         // RFC 7911 §3: a negotiated Send obliges us to stamp a path-id
@@ -5331,5 +5485,204 @@ mod holdtimer_starvation_tests {
         assert_eq!(next, State::Idle, "stale UPDATE must not resurrect");
         assert!(matches!(effect, FsmEffect::None));
         assert_eq!(peer.counter[BgpType::Update as usize].rcvd, 0);
+    }
+}
+
+#[cfg(test)]
+mod otc_role_tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    /// Peer in OpenSent with the given `otc-local-role`. `remote_as`
+    /// 65002 makes it eBGP (local AS is 65001), 65001 makes it iBGP.
+    fn opensent_peer(remote_as: u32, role: Option<OtcLocalRole>) -> Peer {
+        let (tx, rx) = mpsc::channel::<Message>(64);
+        Box::leak(Box::new(rx));
+        let mut peer = Peer::new(
+            1,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            remote_as,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.config.otc_local_role = role;
+        // `Peer::new` leaves the session type to the `remote-as`
+        // callback; derive it here the way that callback would.
+        peer.peer_type = if remote_as == 65001 {
+            PeerType::IBGP
+        } else {
+            PeerType::EBGP
+        };
+        peer.state = State::OpenSent;
+        let _ = build_open_packet(&mut peer);
+        peer
+    }
+
+    fn open_from(my_as: u16, bgp_cap: BgpCap) -> OpenPacket {
+        let header = BgpHeader::new(BgpType::Open, BGP_HEADER_LEN + 10);
+        OpenPacket::new(header, my_as, 180, &Ipv4Addr::new(2, 2, 2, 2), bgp_cap)
+    }
+
+    /// An OPEN from the eBGP neighbor (AS 65002).
+    fn open_with(bgp_cap: BgpCap) -> OpenPacket {
+        open_from(65002, bgp_cap)
+    }
+
+    fn caps_with_role(role: BgpRole) -> BgpCap {
+        BgpCap {
+            role: Some(CapRole::new(role)),
+            ..Default::default()
+        }
+    }
+
+    fn customer(strict: bool) -> Option<OtcLocalRole> {
+        Some(OtcLocalRole {
+            role: BgpRole::Customer,
+            strict,
+        })
+    }
+
+    /// RFC 9234 §4.1: a configured role is advertised on eBGP.
+    #[tokio::test]
+    async fn ebgp_open_advertises_configured_role() {
+        let peer = opensent_peer(65002, customer(false));
+        assert_eq!(
+            peer.cap_send.role.and_then(|c| c.role()),
+            Some(BgpRole::Customer)
+        );
+    }
+
+    /// Roles are defined for eBGP only: an iBGP OPEN carries none even
+    /// when the knob is set, and the peer's role is never checked.
+    #[tokio::test]
+    async fn ibgp_session_neither_sends_nor_checks_roles() {
+        let mut peer = opensent_peer(65001, customer(true));
+        assert!(peer.cap_send.role.is_none());
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_from(65001, caps_with_role(BgpRole::Customer)),
+        );
+        assert_eq!(next, State::OpenConfirm);
+        assert_eq!(peer.otc_remote_role(), None);
+    }
+
+    /// Provider<->Customer is a valid pair (§4.2 Table 2).
+    #[tokio::test]
+    async fn valid_pair_proceeds_with_received_role() {
+        let mut peer = opensent_peer(65002, customer(true));
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_with(caps_with_role(BgpRole::Provider)),
+        );
+        assert_eq!(next, State::OpenConfirm);
+        assert_eq!(peer.otc_role_mismatch, None);
+        peer.state = State::OpenConfirm;
+        assert_eq!(
+            peer.otc_remote_role(),
+            Some((BgpRole::Provider, "received"))
+        );
+    }
+
+    /// Customer<->Customer is not: Role Mismatch, session to Idle.
+    #[tokio::test]
+    async fn invalid_pair_is_role_mismatch() {
+        let mut peer = opensent_peer(65002, customer(false));
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_with(caps_with_role(BgpRole::Customer)),
+        );
+        assert_eq!(next, State::Idle);
+        assert_eq!(
+            peer.otc_role_mismatch,
+            Some(OtcRoleMismatch::Pair {
+                local: BgpRole::Customer,
+                received: BgpRole::Customer,
+            })
+        );
+    }
+
+    /// Loose mode (§4.2 backward compatibility): no Role capability
+    /// from the peer is tolerated and its role inferred from ours.
+    #[tokio::test]
+    async fn loose_mode_infers_absent_role() {
+        let mut peer = opensent_peer(65002, customer(false));
+        let next = fsm_bgp_open(&mut peer, ConnTag::Primary, open_with(BgpCap::default()));
+        assert_eq!(next, State::OpenConfirm);
+        peer.state = State::OpenConfirm;
+        assert_eq!(
+            peer.otc_remote_role(),
+            Some((BgpRole::Provider, "inferred"))
+        );
+    }
+
+    /// Strict mode: a missing Role capability is a Role Mismatch.
+    #[tokio::test]
+    async fn strict_mode_rejects_absent_role() {
+        let mut peer = opensent_peer(65002, customer(true));
+        let next = fsm_bgp_open(&mut peer, ConnTag::Primary, open_with(BgpCap::default()));
+        assert_eq!(next, State::Idle);
+        assert_eq!(peer.otc_role_mismatch, Some(OtcRoleMismatch::Absent));
+    }
+
+    /// §4.2: differing duplicate Role capabilities are rejected.
+    #[tokio::test]
+    async fn conflicting_role_capabilities_rejected() {
+        let mut peer = opensent_peer(65002, customer(false));
+        let mut caps = caps_with_role(BgpRole::Provider);
+        caps.role_conflict = true;
+        let next = fsm_bgp_open(&mut peer, ConnTag::Primary, open_with(caps));
+        assert_eq!(next, State::Idle);
+        assert_eq!(peer.otc_role_mismatch, Some(OtcRoleMismatch::Conflict));
+    }
+
+    /// An unassigned role value pairs with nothing.
+    #[tokio::test]
+    async fn unassigned_role_value_rejected() {
+        let mut peer = opensent_peer(65002, customer(false));
+        let caps = BgpCap {
+            role: Some(CapRole { value: 7 }),
+            ..Default::default()
+        };
+        let next = fsm_bgp_open(&mut peer, ConnTag::Primary, open_with(caps));
+        assert_eq!(next, State::Idle);
+        assert_eq!(peer.otc_role_mismatch, Some(OtcRoleMismatch::Unassigned(7)));
+    }
+
+    /// Without a local role the peer's Role capability is simply
+    /// ignored — today's behaviour for every existing deployment.
+    #[tokio::test]
+    async fn no_local_role_ignores_peer_role() {
+        let mut peer = opensent_peer(65002, None);
+        assert!(peer.cap_send.role.is_none());
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_with(caps_with_role(BgpRole::Customer)),
+        );
+        assert_eq!(next, State::OpenConfirm);
+        assert_eq!(peer.otc_role_mismatch, None);
+        assert_eq!(peer.otc_remote_role(), None);
+    }
+
+    /// A mismatch recorded by one OPEN is cleared by a later good one.
+    #[tokio::test]
+    async fn passing_open_clears_recorded_mismatch() {
+        let mut peer = opensent_peer(65002, customer(true));
+        let _ = fsm_bgp_open(&mut peer, ConnTag::Primary, open_with(BgpCap::default()));
+        assert!(peer.otc_role_mismatch.is_some());
+        peer.state = State::OpenSent;
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_with(caps_with_role(BgpRole::Provider)),
+        );
+        assert_eq!(next, State::OpenConfirm);
+        assert_eq!(peer.otc_role_mismatch, None);
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3100,6 +3100,12 @@ struct Neighbor<'a> {
     /// UPDATE is dropped unless its AS_PATH begins with this neighbor's
     /// own AS.
     enforce_first_as: bool,
+    /// RFC 9234 `otc-local-role` (zebra-bgp-otc.yang): local mode/role,
+    /// the neighbor's role as negotiated or inferred, and the reason the
+    /// last OPEN failed the role check, if it did. `None` when the knob
+    /// is not configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    otc: Option<OtcRoleView>,
     /// `afi-safi ipv6 encapsulation-type` (ietf-bgp-neighbor): the SRv6
     /// encapsulation mode configured for the IPv6 unicast family on this
     /// neighbor. `None` = unset.
@@ -3321,6 +3327,21 @@ fn uptime(instant: &Option<Instant>) -> String {
     peer_uptime(instant, false).0
 }
 
+/// `show bgp neighbor` view of the RFC 9234 role state
+/// ([`crate::bgp::peer::PeerConfig::otc_local_role`]). Strings use the
+/// IOS XR spellings (`Loose`/`Strict`, `Provider`, `received`/`inferred`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct OtcRoleView {
+    local_mode: &'static str,
+    local_role: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_role: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_role_source: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mismatch: Option<String>,
+}
+
 /// `show bgp neighbor` view of [`Peer::last_reset`].
 #[derive(Debug, Serialize)]
 struct LastReset {
@@ -3398,6 +3419,16 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         local_as_config: peer.config.local_as,
         local_as_dual_fallback: peer.local_as_dual_fallback,
         enforce_first_as: peer.config.enforce_first_as,
+        otc: peer.config.otc_local_role.map(|local| {
+            let remote = peer.otc_remote_role();
+            OtcRoleView {
+                local_mode: local.mode_str(),
+                local_role: local.role.as_str(),
+                remote_role: remote.map(|(role, _)| role.as_str()),
+                remote_role_source: remote.map(|(_, source)| source),
+                mismatch: peer.otc_role_mismatch.map(|m| m.to_string()),
+            }
+        }),
         encapsulation_type_ipv6: peer
             .config
             .sub
@@ -3645,6 +3676,27 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         )?;
     }
 
+    // RFC 9234 roles — the IOS XR `show bgp neighbor detail` lines,
+    // spelling included, so XR-trained eyes and scripts find them.
+    if let Some(otc) = &neighbor.otc {
+        writeln!(out, "  OTC Local Mode: {}", otc.local_mode)?;
+        write!(out, "  OTC Local Role : {}", otc.local_role)?;
+        if otc.remote_role.is_none() && neighbor.peer_type == "internal" {
+            // Stored but inert: RFC 9234 defines roles for eBGP only.
+            write!(out, " (ignored on iBGP)")?;
+        }
+        writeln!(out)?;
+        if let (Some(role), Some(source)) = (otc.remote_role, otc.remote_role_source) {
+            writeln!(out, "  OTC Remote Role: {role} ({source})")?;
+        }
+        if let Some(mismatch) = &otc.mismatch {
+            writeln!(
+                out,
+                "  OTC Role Mismatch: {mismatch} (sent Role Mismatch NOTIFICATION)"
+            )?;
+        }
+    }
+
     if let Some(encap) = neighbor.encapsulation_type_ipv6 {
         writeln!(out, "  IPv6 Unicast encapsulation-type: {}", encap.as_str())?;
     }
@@ -3738,6 +3790,23 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                     write!(out, " and")?;
                 }
                 write!(out, " received")?;
+            }
+            writeln!(out)?;
+        }
+
+        // RFC 9234 Role capability (IOS XR calls the row "OTC Role").
+        if neighbor.cap_send.role.is_some() || neighbor.cap_recv.role.is_some() {
+            let name =
+                |cap: &bgp_packet::CapRole| cap.role().map(|r| r.as_str()).unwrap_or("unassigned");
+            write!(out, "    OTC Role:")?;
+            if let Some(v) = &neighbor.cap_send.role {
+                write!(out, " advertised ({})", name(v))?;
+            }
+            if let Some(v) = &neighbor.cap_recv.role {
+                if neighbor.cap_send.role.is_some() {
+                    write!(out, " and")?;
+                }
+                write!(out, " received ({})", name(v))?;
             }
             writeln!(out)?;
         }
@@ -6229,6 +6298,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             local_as_config: None,
             local_as_dual_fallback: false,
             enforce_first_as: false,
+            otc: None,
             encapsulation_type_ipv6: None,
             ttl_security: false,
             ebgp_multihop: None,
@@ -7774,8 +7844,17 @@ struct NeighborGroupKnobsJson {
     remove_private_as: Option<RemovePrivateAs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     enforce_first_as: Option<bool>,
+    /// Serializes as `{"role":"customer","strict":bool}`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    otc_local_role: Option<OtcLocalRoleJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     route_reflector_client: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct OtcLocalRoleJson {
+    role: &'static str,
+    strict: bool,
 }
 
 impl NeighborGroupKnobsJson {
@@ -7798,6 +7877,10 @@ impl NeighborGroupKnobsJson {
             as_override: k.as_override,
             remove_private_as: k.remove_private_as,
             enforce_first_as: k.enforce_first_as,
+            otc_local_role: k.otc_local_role.map(|r| OtcLocalRoleJson {
+                role: r.role.cli_name(),
+                strict: r.strict,
+            }),
             route_reflector_client: k.route_reflector_client,
         }
     }
@@ -8038,6 +8121,10 @@ fn show_bgp_neighbor_group_detail(
     }
     if k.enforce_first_as == Some(true) {
         writeln!(buf, "  Enforce-first-as: enabled")?;
+    }
+    if let Some(r) = k.otc_local_role {
+        let mode = if r.strict { ", strict" } else { "" };
+        writeln!(buf, "  OTC local role: {}{mode}", r.role.as_str())?;
     }
     if let Some(v) = k.route_reflector_client {
         writeln!(buf, "  Route-reflector-client: {v}")?;

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -1087,6 +1087,63 @@ pub fn config_vrf_neighbor_enforce_first_as(
     Some(())
 }
 
+/// `set router bgp vrf <NAME> neighbor <addr> otc-local-role <role>` —
+/// RFC 9234 list node (zebra-bgp-vrf.yang mirrors zebra-bgp-otc.yang).
+/// Staged verbatim; resolved and applied at materialization like the
+/// other inheritable knobs.
+pub fn config_vrf_neighbor_otc_local_role(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let key = args.string();
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    if op.is_set() {
+        let role = super::neighbor_group::parse_otc_role(&key?)?;
+        if !nbr.config.knobs_explicit.stage_otc_local_role(role) {
+            tracing::warn!(
+                "bgp: vrf neighbor {addr}: otc-local-role is single-instance; delete the current role before setting {}",
+                role.cli_name(),
+            );
+            return None;
+        }
+    } else {
+        nbr.config.knobs_explicit.unstage_otc_local_role(
+            key.as_deref()
+                .and_then(super::neighbor_group::parse_otc_role),
+        );
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> neighbor <addr> otc-local-role <role> strict`.
+pub fn config_vrf_neighbor_otc_local_role_strict(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let role = super::neighbor_group::parse_otc_role(&args.string()?)?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    if !nbr
+        .config
+        .knobs_explicit
+        .stage_otc_local_role_strict(role, op.is_set())
+    {
+        tracing::warn!(
+            "bgp: vrf neighbor {addr}: otc-local-role is single-instance; delete the current role before setting {} strict",
+            role.cli_name(),
+        );
+        return None;
+    }
+    Some(())
+}
+
 pub fn config_vrf_neighbor_route_reflector_client(
     bgp: &mut Bgp,
     mut args: Args,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2929,6 +2929,59 @@ mod yang_load_tests {
         }
     }
 
+    /// RFC 9234 `otc-local-role` (zebra-bgp-otc.yang): the list keyed by
+    /// an enumeration and its `strict` empty leaf must parse as settable
+    /// paths on the global neighbor, the neighbor-group and the VRF
+    /// neighbor — in IOS XR spelling (`otc-local-role customer strict`).
+    /// Pinned because the module only reaches the schema through
+    /// config.yang's import list and the group / VRF copies are separate
+    /// YANG text that could drift.
+    #[test]
+    fn bgp_neighbor_otc_local_role_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 192.168.1.3 otc-local-role customer",
+            "set router bgp neighbor 192.168.1.3 otc-local-role provider strict",
+            "set router bgp neighbor 192.168.1.3 otc-local-role peer",
+            "set router bgp neighbor 192.168.1.3 otc-local-role route-server-client",
+            "set router bgp neighbor 192.168.1.3 otc-local-role route-server",
+            "set router bgp neighbor-group G otc-local-role customer strict",
+            "set router bgp vrf RED neighbor 192.168.1.3 otc-local-role customer",
+            "set router bgp vrf RED neighbor 192.168.1.3 otc-local-role provider strict",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+
+        // A token outside the enumeration must not parse.
+        let (code, _comps, _state) = parse(
+            "set router bgp neighbor 192.168.1.3 otc-local-role rs-server",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "rs-server is not an otc-local-role"
+        );
+    }
+
     /// Grammar-rot guard for the per-neighbor `capability four-octet`
     /// knob (zebra-bgp-capability.yang). The augment reaches the schema
     /// only through config.yang's import list — dropping the import
@@ -4346,6 +4399,8 @@ mod yang_load_tests {
             "set router bgp neighbor-group G remove-private-as all",
             "set router bgp neighbor-group G remove-private-as replace-as",
             "set router bgp neighbor-group G enforce-first-as",
+            "set router bgp neighbor-group G otc-local-role customer",
+            "set router bgp neighbor-group G otc-local-role provider strict",
             "set router bgp neighbor-group G policy in PL-IN",
             "set router bgp neighbor-group G policy out PL-OUT",
             "set router bgp neighbor-group G prefix-set in PS-IN",

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -164,6 +164,9 @@ module config {
   import zebra-bgp-enforce-first-as {
     prefix zbef;
   }
+  import zebra-bgp-otc {
+    prefix zbotc;
+  }
   import zebra-bgp-capability {
     prefix zbcap;
   }

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -44,6 +44,10 @@ module zebra-bgp-neighbor-group {
     prefix zbef;
   }
 
+  import zebra-bgp-otc {
+    prefix zbotc;
+  }
+
   import config {
     prefix config;
   }
@@ -157,6 +161,7 @@ module zebra-bgp-neighbor-group {
       uses zbao:bgp-neighbor-as-override-extension;
       uses zbrpa:bgp-neighbor-remove-private-as-extension;
       uses zbef:bgp-neighbor-enforce-first-as-extension;
+      uses zbotc:bgp-neighbor-otc-local-role-extension;
       /* TCP-AO for members, and — via a listen-range binding — for
          the whole range: a dynamic peer is materialized only after
          its SYN is accepted, so the MKT must already be on the

--- a/zebra-rs/yang/zebra-bgp-otc.yang
+++ b/zebra-rs/yang/zebra-bgp-otc.yang
@@ -1,0 +1,154 @@
+module zebra-bgp-otc {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-otc";
+  prefix "zbotc";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "RFC 9234 BGP Roles — route-leak prevention and detection using the
+     BGP Role capability and the Only-to-Customer (OTC) path attribute.
+     Cisco IOS XR compatible syntax:
+
+       router bgp {
+         neighbor 10.10.10.2 {
+           remote-as 65540;
+           otc-local-role customer;          // loose mode (default)
+           otc-local-role provider strict;   // strict mode
+         }
+       }
+
+     The local role describes this router's relationship to the
+     neighbor from the local AS's point of view: `provider` (the local
+     AS gives the neighbor transit), `customer` (the local AS buys
+     transit from the neighbor), `peer` (settlement-free lateral
+     peering), `route-server-client` (the neighbor is an IXP route
+     server) and — a zebra-rs superset over IOS XR, which has no
+     route-server function — `route-server` (this router is the route
+     server). The neighbor configures the matching role on its side:
+     provider<->customer, route-server<->route-server-client,
+     peer<->peer.
+
+     A configured role is advertised in the OPEN message as the BGP Role
+     capability (code 9) on eBGP sessions. If both sides send a role and
+     the pair is invalid, the session is rejected with a Role Mismatch
+     NOTIFICATION (OPEN Message Error, subcode 11). In the default loose
+     mode a neighbor that sends no role is tolerated and its role is
+     inferred from ours; `strict` requires the neighbor to send one.
+
+     Roles are exchanged only in OPEN, so changing the role (or strict
+     mode) on a live session resets it. The knob is ignored on iBGP
+     sessions (RFC 9234 defines roles for eBGP only). The OTC ingress /
+     egress procedures that use the negotiated role apply to IPv4 and
+     IPv6 unicast only.
+
+     The node is a list keyed by the role so the CLI reads
+     `otc-local-role customer [strict]` exactly like IOS XR, but it is
+     semantically single-instance: the config callback refuses a
+     second entry with a warning (max-elements is not engine-enforced) —
+     delete the current role before setting another.";
+
+  revision 2026-08-28 {
+    description "Initial revision.";
+    reference
+      "RFC 9234: Route Leak Prevention and Detection Using Roles in
+       UPDATE and OPEN Messages. Cisco IOS XR 26.4.1
+       `neighbor X otc-local-role {customer|provider|peer|route-server-client} [strict]`.";
+  }
+
+  grouping bgp-neighbor-otc-local-role-extension {
+    description
+      "IOS XR-style `otc-local-role` on a BGP neighbor: a single-entry
+       list keyed by the local BGP Role, with an optional `strict`
+       modifier.";
+
+    list otc-local-role {
+      key "role";
+      max-elements 1;
+      ext:help "RFC 9234 BGP Role toward this neighbor (route-leak prevention)";
+      description
+        "The local BGP Role for this eBGP session. Single-instance: a
+         second entry is rejected by the config callback.";
+
+      leaf role {
+        ext:help "Local role: customer, provider, peer, route-server-client or route-server";
+        type enumeration {
+          enum customer {
+            description "The local AS receives transit from the neighbor.";
+          }
+          enum provider {
+            description "The local AS provides transit to the neighbor.";
+          }
+          enum peer {
+            description
+              "Lateral peering: routes are exchanged without transit in
+               either direction.";
+          }
+          enum route-server-client {
+            description "The neighbor is a route server (RFC 7947).";
+          }
+          enum route-server {
+            description
+              "This router is a route server toward the neighbor
+               (zebra-rs superset; not configurable on IOS XR).";
+          }
+        }
+        description
+          "Value carried in the BGP Role capability of the OPEN message
+           (IANA BGP Role Value: provider 0, route-server 1,
+           route-server-client 2, customer 3, peer 4).";
+      }
+
+      leaf strict {
+        ext:help "Require the neighbor to send its BGP Role (strict mode)";
+        type empty;
+        description
+          "Strict mode: reject the session with a Role Mismatch
+           NOTIFICATION when the neighbor sends no BGP Role capability.
+           Without it (loose mode, the default) the neighbor's role is
+           inferred from the local one.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach otc-local-role to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-otc-local-role-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X otc-local-role [...]` is path-valid.";
+    uses bgp-neighbor-otc-local-role-extension;
+  }
+}

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -368,6 +368,32 @@ module zebra-bgp-vrf {
            segment begins with the CE's own AS. No-op for iBGP. Same as
            the global neighbor.";
       }
+      list otc-local-role {
+        key "role";
+        max-elements 1;
+        ext:help "RFC 9234 BGP Role toward this CE (route-leak prevention)";
+        description
+          "RFC 9234 local BGP Role for this eBGP session, IOS XR
+           `otc-local-role` syntax. Single-instance. Same as the global
+           neighbor (zebra-bgp-otc.yang).";
+        leaf role {
+          ext:help "Local role: customer, provider, peer, route-server-client or route-server";
+          type enumeration {
+            enum customer;
+            enum provider;
+            enum peer;
+            enum route-server-client;
+            enum route-server;
+          }
+        }
+        leaf strict {
+          ext:help "Require the CE to send its BGP Role (strict mode)";
+          type empty;
+          description
+            "Reject the session with a Role Mismatch NOTIFICATION when
+             the CE sends no BGP Role capability.";
+        }
+      }
       container route-reflector {
         ext:help "Route-reflector settings for this CE";
         leaf client {


### PR DESCRIPTION
## Summary

PR 2 of the RFC 9234 series (plan: `docs/design/bgp-rfc9234-plan.md`). The per-neighbor knob, the OPEN Role-capability exchange, and the §4.2 role check. No OTC route processing yet — that is PR 3.

**CLI — Cisco IOS XR 26.4.1 compatible:**
```
router bgp {
  neighbor 10.10.10.2 {
    remote-as 65540;
    otc-local-role customer;            # loose mode (default)
    otc-local-role provider strict;     # strict mode
  }
}
```
Roles: `customer | provider | peer | route-server-client`, plus `route-server` as a zebra-rs superset (XR has no route-server function). Also on `neighbor-group` (inheritable, explicit-wins) and VRF neighbors.

* **YANG** `zebra-bgp-otc.yang`: a list keyed by the role with `max-elements 1` and a `strict` empty leaf — the same single-instance shape as `local-as`, so the CLI reads exactly like XR. A second role is refused with a warning (delete the current one first). The enum-list-key + empty-leaf CLI shape is proven by a parse test covering neighbor, group and VRF paths.
* **Config plumbing**: `PeerConfig.otc_local_role` (`OtcLocalRole { role, strict }`), staged on `InheritableKnobs`, resolved explicit-wins-else-group, applied by `apply_otc_local_role` — which bounces a live session on change (roles ride the OPEN; XR does the same). Group callbacks sweep members; VRF neighbors stage for materialization.
* **OPEN**: `CapRole` advertised on eBGP when configured (§4.1). On receive, `otc_role_check` next to the Bad Peer AS check (so both connection tags are covered): invalid pair, unassigned value, conflicting duplicate capabilities, or — in strict mode — no Role capability → **Role Mismatch NOTIFICATION (2/11)**, Idle. Loose mode infers the neighbor's role from ours. iBGP: stored but inert.
* **show bgp neighbor** (text + JSON), XR spelling:
  ```
    OTC Local Mode: Strict
    OTC Local Role : Customer
    OTC Remote Role: Provider (received)
    ...
      OTC Role: advertised (Customer) and received (Provider)
  ```
  plus `OTC Role Mismatch: received Provider, local Provider (not a valid pair) (sent Role Mismatch NOTIFICATION)` for a session that never establishes (a mismatch happens in OpenSent, so `last_reset` never sees it).
* Config-audit docs regenerated (+6 settable / +6 handled, 3 orphans unchanged).

## Test plan

- [x] New unit tests: 9 FSM cases (valid pair, invalid pair, loose absent → inferred, strict absent, conflicting caps, unassigned value, iBGP neither sends nor checks, no local role ignores peer role, later good OPEN clears the mismatch), per-neighbor + strict-leaf seeding config tests, group propagation/explicit-wins/bounce test, YANG parse pins
- [x] `cargo test --workspace --exclude bdd` — 2081 passed
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings`
- [x] **Live, two daemons on loopback** (provider ↔ customer strict): Established with `(received)` roles both ways and the `OTC Role` capability row; reconfigured to provider/provider → Role Mismatch NOTIFICATION sent by both sides, sessions Idle, mismatch line shown; role removed on one side → Established again with `(inferred)` on the configured side; `show running-config` round-trips `otc-local-role provider;`

Next: PR 3 — OTC ingress/egress procedures (IR1–IR3, ER1–ER2), `OTC-AS` in `show bgp <prefix>`, per-peer denied counters, update-group signature, BDD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g1SgtRd4VA3tj5dit9uqr
