### PR TITLE
bgp: RFC 9234 OTC ingress/egress procedures — route-leak prevention

### DIFF
--- a/bdd/tests/configs/bgp_otc_local_role/z1-base.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z1-base.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_otc_local_role/z1-provider-strict.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z1-provider-strict.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: provider
+        strict: null
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_otc_local_role/z1-provider.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z1-provider.yaml
@@ -1,0 +1,28 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: provider
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_otc_local_role/z2-customer-customer.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z2-customer-customer.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: customer
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: customer
+

--- a/bdd/tests/configs/bgp_otc_local_role/z2-customer-norole.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z2-customer-norole.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: customer
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+

--- a/bdd/tests/configs/bgp_otc_local_role/z2-norole.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z2-norole.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+

--- a/bdd/tests/configs/bgp_otc_local_role/z2-provider.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z2-provider.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: provider
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+

--- a/bdd/tests/configs/bgp_otc_local_role/z3-base.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z3-base.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+

--- a/bdd/tests/configs/bgp_otc_local_role/z3-peer.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z3-peer.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: peer
+

--- a/bdd/tests/configs/bgp_otc_local_role/z3-provider.yaml
+++ b/bdd/tests/configs/bgp_otc_local_role/z3-provider.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: provider
+

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1539,6 +1539,38 @@ async fn verify_no_unknown_attr(world: &mut World, namespace: String, prefix: St
     );
 }
 
+/// Assert the route carries no RFC 9234 OTC attribute (`otc_as` absent
+/// from the `show bgp -j` row). Presence is asserted with the generic
+/// `... with "otc_as" value "<asn>"` step.
+#[then(expr = "BGP route in {string} has {string} without OTC")]
+async fn verify_no_otc(world: &mut World, namespace: String, prefix: String) {
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show bgp"])
+        .await
+        .expect("Failed to get BGP routes");
+    let routes: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
+    let route = routes
+        .as_array()
+        .and_then(|arr| {
+            arr.iter()
+                .find(|r| r.get("prefix").and_then(|p| p.as_str()) == Some(prefix.as_str()))
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "BGP route {} not found in namespace {}, got: {}",
+                prefix, scoped, output
+            )
+        });
+    assert!(
+        route.get("otc_as").is_none(),
+        "route {} in {} must carry no OTC, got: {}",
+        prefix,
+        scoped,
+        route
+    );
+    println!("✓ route {} in {} carries no OTC", prefix, scoped);
+}
+
 #[given("the test topology exists")]
 async fn test_topology_exists(world: &mut World) {
     let z1 = world.ns("z1");

--- a/bdd/tests/features/bgp_otc_local_role.feature
+++ b/bdd/tests/features/bgp_otc_local_role.feature
@@ -1,0 +1,155 @@
+@serial
+@bgp_otc_local_role
+Feature: BGP Roles and Only-to-Customer route-leak prevention (RFC 9234)
+  As a network operator
+  I want `neighbor X otc-local-role {customer|provider|peer|route-server-client} [strict]`
+  So route leaks are prevented and detected from the BGP Role negotiated
+  in the OPEN and the Only-to-Customer (OTC) attribute on the routes.
+
+  Test Topology (a line, all eBGP, distinct ASes):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65003 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+   originates 10.0.0.1/32
+  ```
+
+  z1 originates 10.0.0.1/32. The roles configured on each session decide
+  what happens to that route (RFC 9234 §5):
+
+    * ER1: z1 (provider) stamps OTC-AS 65001 toward its customer z2.
+    * ER2: z2 (customer toward z3, i.e. z3 is a provider) must not
+      advertise an OTC-marked route to z3.
+    * IR3: with no role on z1, z2 (customer, loose mode) infers z1 as a
+      provider and stamps OTC-AS 65001 on receipt itself.
+    * IR1: z3 (provider, so z2 is its customer) rejects an OTC-marked
+      route from z2 as a leak.
+    * IR2: z3 (peer) rejects an OTC-marked route from z2 whose OTC-AS
+      (65001) is not z2's AS (65002).
+    * Role Mismatch: provider/provider is not a valid pair — the session
+      is refused with a Role Mismatch NOTIFICATION; strict mode refuses a
+      neighbor that sends no role at all.
+
+  The IOS XR spellings are used throughout (`OTC Local Mode`, `OTC Remote
+  Role: X (received|inferred)`, `OTC-AS`).
+
+  Config files:
+  - z1-base.yaml / z1-provider.yaml / z1-provider-strict.yaml
+  - z2-customer-customer.yaml / z2-customer-norole.yaml / z2-provider.yaml / z2-norole.yaml
+  - z3-base.yaml / z3-provider.yaml / z3-peer.yaml
+
+  Scenario: Setup line topology, provider -> customer -> (customer toward) z3
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-provider.yaml" to namespace "z1"
+    And I apply config "z2-customer-customer.yaml" to namespace "z2"
+    And I apply config "z3-base.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.1.3" should be "Established"
+    And BGP session in "z3" to "192.168.1.2" should be "Established"
+
+  Scenario: Roles are exchanged in the OPEN and shown IOS XR style
+    Given the test topology exists
+    Then show command "show bgp neighbor" in namespace "z1" should contain "OTC Local Role : Provider"
+    And show command "show bgp neighbor" in namespace "z1" should contain "OTC Remote Role: Customer (received)"
+    And show command "show bgp neighbor" in namespace "z1" should contain "OTC Role: advertised (Provider) and received (Customer)"
+    And show command "show bgp neighbor" in namespace "z2" should contain "OTC Remote Role: Provider (received)"
+
+  Scenario: ER1 stamps OTC toward the customer and ER2 blocks it toward the next provider
+    Given the test topology exists
+    # z1 (provider) adds OTC-AS 65001 on egress toward its customer z2.
+    Then BGP route in "z2" has "10.0.0.1/32" with "otc_as" value "65001"
+    And show command "show bgp 10.0.0.1/32" in namespace "z2" should contain "OTC-AS: 65001"
+    # z2 is a customer of z3, so z3 is a provider: an OTC-marked route
+    # must not be advertised there (ER2).
+    And BGP route in "z3" does not have "10.0.0.1/32"
+
+  Scenario: IR3 stamps OTC on receipt from an inferred provider (loose mode)
+    Given the test topology exists
+    # Remove z1's role: it no longer sends a Role capability nor OTC. z2
+    # (customer, loose) infers z1 as a provider and stamps OTC-AS 65001
+    # itself on ingress.
+    When I apply config "z1-base.yaml" to namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp neighbor" in namespace "z2" should contain "OTC Remote Role: Provider (inferred)"
+    And BGP route in "z2" has "10.0.0.1/32" with "otc_as" value "65001"
+    And BGP route in "z3" does not have "10.0.0.1/32"
+
+  Scenario: IR1 rejects an OTC-marked route arriving from a customer
+    Given the test topology exists
+    # z2 drops its role toward z3, so it forwards the OTC-marked route
+    # untouched; z3 becomes a provider (z2 is its customer) and must treat
+    # the OTC-marked route as a leak (IR1).
+    When I apply config "z2-customer-norole.yaml" to namespace "z2"
+    And I apply config "z3-provider.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.1.2" should be "Established"
+    And BGP route in "z3" does not have "10.0.0.1/32"
+    And show command "show bgp neighbor" in namespace "z3" should not contain "By OTC ingress rule 1: 0,"
+
+  Scenario: IR2 rejects an OTC-marked route from a peer whose OTC-AS is not the peer's AS
+    Given the test topology exists
+    # z3 as a peer of z2: the route still carries OTC-AS 65001 (z1), not
+    # z2's 65002, so z3 rejects it (IR2).
+    When I apply config "z3-peer.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.1.2" should be "Established"
+    And BGP route in "z3" does not have "10.0.0.1/32"
+    And show command "show bgp neighbor" in namespace "z3" should not contain "By OTC ingress rule 2: 0"
+
+  Scenario: A route without OTC passes a peer and is stamped by ER1 toward it
+    Given the test topology exists
+    # No roles anywhere on z2: nothing is stamped on z2 and z2 forwards
+    # whatever z1 sends. With z1 role-less the route reaches z3 unmarked,
+    # and z3 (peer) stamps OTC-AS 65002 on ingress (IR3).
+    When I apply config "z2-norole.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.1.2" should be "Established"
+    And BGP route in "z2" has "10.0.0.1/32" without OTC
+    And BGP route in "z3" has "10.0.0.1/32" with "otc_as" value "65002"
+
+  Scenario: Provider/provider is a Role Mismatch and the session is refused
+    Given the test topology exists
+    When I apply config "z1-provider.yaml" to namespace "z1"
+    And I apply config "z2-provider.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
+    And show command "show bgp neighbor" in namespace "z1" should contain "OTC Role Mismatch: received Provider, local Provider"
+
+  Scenario: Strict mode refuses a neighbor that sends no role, loose accepts it
+    Given the test topology exists
+    When I apply config "z1-provider-strict.yaml" to namespace "z1"
+    And I apply config "z2-norole.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
+    And show command "show bgp neighbor" in namespace "z1" should contain "OTC Local Mode: Strict"
+    And show command "show bgp neighbor" in namespace "z1" should contain "no BGP Role capability received (strict mode)"
+    # Back to loose: the same role-less neighbor is accepted, inferred.
+    When I apply config "z1-provider.yaml" to namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And show command "show bgp neighbor" in namespace "z1" should contain "OTC Remote Role: Customer (inferred)"
+
+  # Pure P2P links (no bridge): deleting each namespace destroys the veth
+  # pair ends it holds, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean

--- a/docs/design/bgp-rfc9234-plan.md
+++ b/docs/design/bgp-rfc9234-plan.md
@@ -134,6 +134,20 @@ yields OTC=AS(z1) on z2 via ER1 on z1, and "z1 no role → z2 customer
 * Unit tests (`peer.rs` FSM tests already have an `open_packet(...)` helper): valid pair, invalid pair → 2/11, loose absent → OpenConfirm with inferred, strict absent → 2/11, conflicting duplicates → 2/11, unknown value → 2/11, iBGP → no cap sent; config tests mirroring `enforce_first_as_*` and `group_enforce_first_as_propagates_no_bounce` (this one *does* bounce).
 
 ### PR 3 — OTC procedures + BDD
+**As built (2026-08-28):** `route.rs` `otc_ingress_rule(local, remote_as, otc) -> OtcIngress
+{Pass|Stamp(Otc)|Deny(rule)}` (pure, table-tested) + `otc_ingress(&Peer, &BgpAttr)`
+(eBGP gate) + `otc_ingress_deny(&mut Peer, rule, what)` (counter `Peer::otc_denied[2]`
++ `bgp_adj_in_trace!`); `otc_egress(&EgressAs, &mut BgpAttr) -> suppress` with
+`EgressAs.otc_local_role` (set by `Peer::egress_as()` on eBGP only) and
+`EgressAs::otc_local_as()` = substitute-or-global. `inbound_attr_checks` now takes
+`&mut Peer` + `otc_unicast: bool` and returns the IR3-stamped attr as a 4th tuple
+element; both v4 callers rebind `attr` to it before the shard split. v6 threads
+`otc_stamp` out of its check block. Egress gates on `rib.nexthop.is_none()` (plain
+unicast rows only). `UpdateGroupSig.otc_local_role`, `SIGNATURE_VERSION = 7`.
+Show: `OTC-AS: N` (detail + path-attr printer), JSON `otc_as`, neighbor line
+`By OTC ingress rule 1: n, By OTC ingress rule 2: n`. BDD `bgp_otc_local_role.feature`
+(9 scenarios + teardown) reuses the generic `with "otc_as" value` JSON step; one new
+step `BGP route in X has P without OTC`.
 * Ingress (v4 unicast: `inbound_attr_checks` + the single-prefix `route_ipv4_update` path; v6 unicast: `route_ipv6_update` ~6896). Only these two families — **not** the other six `enforce-first-as` sites. IR1/IR2 → return `None` + counter + `bgp_packet_trace!`-style trace "DENIED by OTC ingress rule N". IR3 mutates the attr: clone the UPDATE's attr once *before* the batch/shard split (N>1 runs policy in the shard, so the stamp must be main-side and shared by all prefixes).
 * Egress: `SyncCtx.otc_local_role` (from `Peer::sync_ctx`) and `EgressAs`-adjacent helper `otc_egress(role, local_as, &mut attrs) -> bool /*suppress*/` called in `route_update_ipv4` right after `ebgp_egress_aspath` (ER2 → `return None`, which already flows into `AdvertiseOutcome::Withdraw`); same in `route_update_ipv6` (takes `&mut Peer`, read `peer.config` directly).
 * `UpdateGroupSig.otc_local_role`, `SIGNATURE_VERSION = 7`, extend `signature_fields_each_distinguish`.

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1096,6 +1096,10 @@ pub struct Peer {
     /// the check. Surfaced by `show bgp neighbor`, since a session that
     /// never reaches Established leaves no `last_reset`.
     pub otc_role_mismatch: Option<OtcRoleMismatch>,
+    /// RFC 9234 §5 ingress rejections on this session, indexed by rule
+    /// (`[0]` = IR1 leak from a Customer / RS-Client, `[1]` = IR2 OTC ≠
+    /// remote AS from a Peer). Shown as "By OTC ingress rule 1/2".
+    pub otc_denied: [u64; 2],
     pub peer_type: PeerType,
     /// RFC 9572 §6.1 region identifier, resolved from this peer's
     /// neighbor-group (`region-id`) by `apply_inherited`. `Some` marks the
@@ -1331,6 +1335,7 @@ impl Peer {
             down_reason: None,
             last_reset: None,
             otc_role_mismatch: None,
+            otc_denied: [0; 2],
             peer_type: PeerType::IBGP,
             region_id: None,
             state: State::Idle,
@@ -1757,6 +1762,13 @@ impl Peer {
             remove_private_as: self.config.remove_private_as,
             local_as_substitute: self.change_local_as(),
             local_as_replace: self.config.local_as.is_some_and(|la| la.replace_as),
+            // Roles are defined for eBGP only (RFC 9234 §4): an iBGP
+            // session never runs the OTC egress procedures.
+            otc_local_role: if self.is_ebgp() {
+                self.config.otc_local_role.map(|r| r.role)
+            } else {
+                None
+            },
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -161,6 +161,18 @@ pub struct EgressAs {
     pub remove_private_as: Option<super::peer::RemovePrivateAs>,
     pub local_as_substitute: Option<u32>, // resolved peer.change_local_as()
     pub local_as_replace: bool,           // config.local_as.is_some_and(replace_as)
+    /// RFC 9234 `otc-local-role` on this eBGP session (`None` when unset
+    /// or iBGP) — drives the OTC egress procedures in [`otc_egress`].
+    pub otc_local_role: Option<BgpRole>,
+}
+
+impl EgressAs {
+    /// The AS number the neighbor sees us as — the `local-as` substitute
+    /// when one is active, else the router's AS. RFC 9234 ER1 stamps this
+    /// into OTC, matching what the neighbor's own IR3 would stamp.
+    pub fn otc_local_as(&self) -> u32 {
+        self.local_as_substitute.unwrap_or(self.local_as)
+    }
 }
 
 /// Per-session egress snapshot for the IPv4-unicast advertise build (A2).
@@ -318,6 +330,7 @@ impl SyncCtx {
                 remove_private_as: None,
                 local_as_substitute: None,
                 local_as_replace: false,
+                otc_local_role: None,
             },
             out_policy: Arc::new(super::policy::OutPolicy::default()),
             packet_tx: None,
@@ -378,6 +391,106 @@ fn ebgp_egress_aspath(eas: &EgressAs, attrs: &mut BgpAttr) {
             aspath.prepend_mut(As4Path::from(vec![substitute]));
         }
         None => aspath.prepend_mut(As4Path::from(vec![eas.local_as])),
+    }
+}
+
+/// Outcome of the RFC 9234 §5 ingress procedures for one received
+/// route (IPv4 / IPv6 unicast only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OtcIngress {
+    /// No role configured, iBGP, or nothing to do: keep the route as is.
+    Pass,
+    /// IR3: OTC was absent on a route from a Provider / Peer / RS — add
+    /// it with the remote AS. The stored route carries the stamp.
+    Stamp(Otc),
+    /// IR1 (rule 1) or IR2 (rule 2): a route leak. The route is
+    /// ineligible — not selected, not re-advertised, not stored.
+    Deny(u8),
+}
+
+/// RFC 9234 §5 ingress procedures, as a pure function of the local role,
+/// the neighbor's AS and the received OTC:
+///
+/// * IR1 — OTC present on a route from a **Customer** (we are Provider)
+///   or an **RS-Client** (we are RS): leak, ineligible.
+/// * IR2 — OTC present on a route from a **Peer** (we are Peer) with a
+///   value other than the remote AS: leak, ineligible.
+/// * IR3 — OTC absent on a route from a **Provider** (we are Customer),
+///   a **Peer** (we are Peer) or an **RS** (we are RS-Client): add OTC =
+///   remote AS.
+///
+/// Everything else passes unchanged; an OTC already present is never
+/// rewritten ("once set, preserved").
+pub(super) fn otc_ingress_rule(
+    local: Option<BgpRole>,
+    remote_as: u32,
+    otc: Option<Otc>,
+) -> OtcIngress {
+    let Some(local) = local else {
+        return OtcIngress::Pass;
+    };
+    match (local, otc) {
+        (BgpRole::Provider | BgpRole::RouteServer, Some(_)) => OtcIngress::Deny(1),
+        (BgpRole::Peer, Some(otc)) if otc.asn != remote_as => OtcIngress::Deny(2),
+        (BgpRole::Customer | BgpRole::Peer | BgpRole::RouteServerClient, None) => {
+            OtcIngress::Stamp(Otc::new(remote_as))
+        }
+        _ => OtcIngress::Pass,
+    }
+}
+
+/// [`otc_ingress_rule`] for a live session: roles apply to eBGP only.
+pub(super) fn otc_ingress(peer: &Peer, attr: &BgpAttr) -> OtcIngress {
+    if !peer.is_ebgp() {
+        return OtcIngress::Pass;
+    }
+    otc_ingress_rule(
+        peer.config.otc_local_role.map(|r| r.role),
+        peer.remote_as,
+        attr.otc,
+    )
+}
+
+/// Account and trace an RFC 9234 ingress rejection (`rule` = 1 or 2).
+/// `what` names the rejected unit — a prefix, or "UPDATE" when the whole
+/// batch shares the attribute.
+pub(super) fn otc_ingress_deny(peer: &mut Peer, rule: u8, what: &str) {
+    peer.otc_denied[usize::from(rule.saturating_sub(1)).min(1)] += 1;
+    let reason = match rule {
+        1 => "route leak from Customer/RS-Client",
+        _ => "OTC AS mismatch from Peer",
+    };
+    bgp_adj_in_trace!(
+        peer,
+        "{what} received from {} DENIED due to OTC ingress rule {rule}: {reason}",
+        peer.address,
+    );
+}
+
+/// RFC 9234 §5 egress procedures, applied to the outbound attribute copy
+/// of an IPv4 / IPv6 unicast route toward an eBGP neighbor with a local
+/// role. Returns `true` when the route must **not** be advertised:
+///
+/// * ER2 — OTC present and the neighbor is a **Provider** (we are
+///   Customer), a **Peer** (we are Peer) or an **RS** (we are RS-Client):
+///   suppress.
+/// * ER1 — OTC absent and the neighbor is a **Customer** (we are
+///   Provider), a **Peer** (we are Peer) or an **RS-Client** (we are RS):
+///   add OTC = local AS (`EgressAs::otc_local_as`).
+///
+/// No role (or iBGP, where `otc_local_role` is `None`): nothing happens
+/// and an OTC already on the route rides through untouched.
+pub(super) fn otc_egress(eas: &EgressAs, attrs: &mut BgpAttr) -> bool {
+    let Some(role) = eas.otc_local_role else {
+        return false;
+    };
+    match (role, attrs.otc) {
+        (BgpRole::Customer | BgpRole::Peer | BgpRole::RouteServerClient, Some(_)) => true,
+        (BgpRole::Provider | BgpRole::Peer | BgpRole::RouteServer, None) => {
+            attrs.otc = Some(Otc::new(eas.otc_local_as()));
+            false
+        }
+        _ => false,
     }
 }
 
@@ -3883,12 +3996,13 @@ pub fn route_ipv4_update(
     stale: bool,
 ) {
     let checks = {
-        let peer = peers.get_by_idx(ident).expect("peer must exist");
-        inbound_attr_checks(peer, attr, bgp.router_id)
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        inbound_attr_checks(peer, attr, bgp.router_id, rd.is_none() && label.is_none())
     };
-    let Some((peer_ident, peer_router_id, typ)) = checks else {
+    let Some((peer_ident, peer_router_id, typ, otc_stamped)) = checks else {
         return;
     };
+    let attr = otc_stamped.as_ref().unwrap_or(attr);
     let stale = stale || attr_has_llgr_stale(attr);
     // Per-AFI inbound policy: a route carrying an RD is VPNv4, otherwise
     // it is IPv4 unicast (the RFC 8950 IPv4-over-IPv6 path also lands
@@ -3924,13 +4038,17 @@ pub fn route_ipv4_update(
 }
 
 /// Per-attr inbound checks shared by every prefix in an UPDATE (AS-path
-/// loop, enforce-first-as, route-reflection). Returns the peer identity
-/// or `None` if the UPDATE is dropped; the batch path runs it once.
+/// loop, enforce-first-as, route-reflection, RFC 9234 OTC). Returns the
+/// peer identity — plus the attribute rewritten by OTC ingress rule 3,
+/// when it applied — or `None` if the UPDATE is dropped; the batch path
+/// runs it once. `otc_unicast` is true for plain IPv4 unicast, the only
+/// v4 family the RFC 9234 procedures cover (§6).
 fn inbound_attr_checks(
-    peer: &Peer,
+    peer: &mut Peer,
     attr: &BgpAttr,
     local_router_id: &Ipv4Addr,
-) -> Option<(usize, Ipv4Addr, BgpRibType)> {
+    otc_unicast: bool,
+) -> Option<(usize, Ipv4Addr, BgpRibType, Option<BgpAttr>)> {
     if let Some(ref aspath) = attr.aspath
         && aspath_own_as_loop(peer, aspath)
     {
@@ -3949,12 +4067,30 @@ fn inbound_attr_checks(
     {
         return None;
     }
+    // RFC 9234 §5 ingress: a leak is dropped here (ineligible, never
+    // stored); IR3 hands back a stamped copy the callers ingest instead.
+    let otc_stamped = if otc_unicast {
+        match otc_ingress(peer, attr) {
+            OtcIngress::Pass => None,
+            OtcIngress::Stamp(otc) => {
+                let mut stamped = attr.clone();
+                stamped.otc = Some(otc);
+                Some(stamped)
+            }
+            OtcIngress::Deny(rule) => {
+                otc_ingress_deny(peer, rule, "UPDATE");
+                return None;
+            }
+        }
+    } else {
+        None
+    };
     let typ = if peer.is_ibgp() {
         BgpRibType::IBGP
     } else {
         BgpRibType::EBGP
     };
-    Some((peer.ident, peer.remote_id, typ))
+    Some((peer.ident, peer.remote_id, typ, otc_stamped))
 }
 
 /// Parallel ingest for a packet's plain IPv4-unicast NLRIs (RIB
@@ -3973,12 +4109,15 @@ pub fn route_ipv4_update_batch(
     stale: bool,
 ) {
     let checks = {
-        let peer = peers.get_by_idx(ident).expect("peer must exist");
-        inbound_attr_checks(peer, attr, bgp.router_id)
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        inbound_attr_checks(peer, attr, bgp.router_id, true)
     };
-    let Some((peer_ident, peer_router_id, typ)) = checks else {
+    let Some((peer_ident, peer_router_id, typ, otc_stamped)) = checks else {
         return;
     };
+    // IR3 stamped once for the whole UPDATE, main-side, before the shard
+    // split — every prefix (and the N>1 batch clone) sees the same attr.
+    let attr = otc_stamped.as_ref().unwrap_or(attr);
     let stale = stale || attr_has_llgr_stale(attr);
 
     // N>1 (RIB sharding Phase C + RouteBatch): inbound policy runs in the
@@ -6921,7 +7060,7 @@ pub fn route_ipv6_update(
         attr
     };
 
-    let (peer_ident, peer_router_id, typ) = {
+    let (peer_ident, peer_router_id, typ, otc_stamp) = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         // RFC 4271 / 4456 loop detection — identical to the v4 path.
@@ -6935,6 +7074,20 @@ pub fn route_ipv6_update(
         if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
             return;
         }
+        // RFC 9234 §5 ingress procedures — IPv6 unicast only (VPNv6 rows
+        // carry an RD and are exempt per §6).
+        let otc_stamp = if rd.is_none() {
+            match otc_ingress(peer, attr) {
+                OtcIngress::Pass => None,
+                OtcIngress::Stamp(otc) => Some(otc),
+                OtcIngress::Deny(rule) => {
+                    otc_ingress_deny(peer, rule, &nlri.prefix.to_string());
+                    return;
+                }
+            }
+        } else {
+            None
+        };
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
         {
@@ -6965,7 +7118,18 @@ pub fn route_ipv6_update(
         } else {
             BgpRibType::EBGP
         };
-        (peer.ident, peer.remote_id, typ)
+        (peer.ident, peer.remote_id, typ, otc_stamp)
+    };
+
+    // IR3: ingest the stamped copy so the stored route carries OTC.
+    let otc_stamped_attr;
+    let attr = if let Some(otc) = otc_stamp {
+        let mut a = attr.clone();
+        a.otc = Some(otc);
+        otc_stamped_attr = a;
+        &otc_stamped_attr
+    } else {
+        attr
     };
 
     let stale = stale || attr_has_llgr_stale(attr);
@@ -12162,6 +12326,16 @@ pub fn route_update_ipv4(
         return None;
     }
 
+    // RFC 9234 §5 egress procedures — plain IPv4 unicast only (VPNv4 rows
+    // carry a VPN next-hop and are exempt per §6). ER2 suppresses an
+    // OTC-marked route toward a Provider / Peer / RS; ER1 stamps OTC =
+    // local AS toward a Customer / Peer / RS-Client. Keyed by
+    // `UpdateGroupSig::otc_local_role`, so the canonical-member memo is
+    // safe.
+    if rib.nexthop.is_none() && otc_egress(&ctx.egress_as, &mut attrs) {
+        return None;
+    }
+
     // 3. NEXT_HOP
     //
     // eBGP and self-originated routes always get a v4 rewrite. ENHE-
@@ -12344,6 +12518,12 @@ pub fn route_update_ipv6(
     // AS_PATH prepend for eBGP.
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
     if as_sets_withdraw_suppresses_egress(bgp.as_sets_withdraw, &attrs) {
+        return None;
+    }
+
+    // RFC 9234 §5 egress procedures — plain IPv6 unicast only (VPNv6 rows
+    // are exempt per §6); see `route_update_ipv4`.
+    if rib.nexthop.is_none() && otc_egress(&peer.egress_as(), &mut attrs) {
         return None;
     }
 
@@ -23348,6 +23528,7 @@ mod as_sets_withdraw_tests {
                 remove_private_as: None,
                 local_as_substitute: None,
                 local_as_replace: false,
+                otc_local_role: None,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -23405,6 +23586,7 @@ mod as_sets_withdraw_tests {
                 remove_private_as: None,
                 local_as_substitute: None,
                 local_as_replace: false,
+                otc_local_role: None,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -23495,6 +23677,7 @@ mod as_sets_withdraw_tests {
                 remove_private_as: None,
                 local_as_substitute: None,
                 local_as_replace: false,
+                otc_local_role: None,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -23563,6 +23746,7 @@ mod as_sets_withdraw_tests {
                 remove_private_as: None,
                 local_as_substitute: None,
                 local_as_replace: false,
+                otc_local_role: None,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -25139,5 +25323,119 @@ mod rfc4456_reflect_stamp_tests {
             assert_eq!(attrs.originator_id, None);
             assert_eq!(attrs.cluster_list, None);
         });
+    }
+}
+
+#[cfg(test)]
+mod otc_procedure_tests {
+    use super::*;
+
+    const ALL: [Option<BgpRole>; 6] = [
+        None,
+        Some(BgpRole::Provider),
+        Some(BgpRole::RouteServer),
+        Some(BgpRole::RouteServerClient),
+        Some(BgpRole::Customer),
+        Some(BgpRole::Peer),
+    ];
+
+    /// RFC 9234 §5 ingress, every role × {absent, OTC = remote, OTC ≠ remote}.
+    #[test]
+    fn ingress_rules_cover_the_rfc_table() {
+        let remote = 65002;
+        for local in ALL {
+            let absent = otc_ingress_rule(local, remote, None);
+            let own = otc_ingress_rule(local, remote, Some(Otc::new(remote)));
+            let other = otc_ingress_rule(local, remote, Some(Otc::new(65099)));
+            match local {
+                None => {
+                    assert_eq!(absent, OtcIngress::Pass);
+                    assert_eq!(own, OtcIngress::Pass);
+                    assert_eq!(other, OtcIngress::Pass);
+                }
+                // From a Customer / RS-Client: any OTC is a leak (IR1).
+                Some(BgpRole::Provider | BgpRole::RouteServer) => {
+                    assert_eq!(absent, OtcIngress::Pass);
+                    assert_eq!(own, OtcIngress::Deny(1));
+                    assert_eq!(other, OtcIngress::Deny(1));
+                }
+                // From a Peer: OTC must equal the remote AS (IR2); absent → IR3.
+                Some(BgpRole::Peer) => {
+                    assert_eq!(absent, OtcIngress::Stamp(Otc::new(remote)));
+                    assert_eq!(own, OtcIngress::Pass);
+                    assert_eq!(other, OtcIngress::Deny(2));
+                }
+                // From a Provider / RS: absent → IR3, present → preserved.
+                Some(BgpRole::Customer | BgpRole::RouteServerClient) => {
+                    assert_eq!(absent, OtcIngress::Stamp(Otc::new(remote)));
+                    assert_eq!(own, OtcIngress::Pass);
+                    assert_eq!(other, OtcIngress::Pass);
+                }
+            }
+        }
+    }
+
+    fn eas(role: Option<BgpRole>, substitute: Option<u32>) -> EgressAs {
+        EgressAs {
+            is_ebgp: true,
+            local_as: 65001,
+            remote_as: 65002,
+            as_override: false,
+            remove_private_as: None,
+            local_as_substitute: substitute,
+            local_as_replace: false,
+            otc_local_role: role,
+        }
+    }
+
+    /// RFC 9234 §5 egress, every role × {absent, present}.
+    #[test]
+    fn egress_rules_cover_the_rfc_table() {
+        for role in ALL {
+            let mut absent = BgpAttr::new();
+            let suppress_absent = otc_egress(&eas(role, None), &mut absent);
+            let mut present = BgpAttr::new();
+            present.otc = Some(Otc::new(65099));
+            let suppress_present = otc_egress(&eas(role, None), &mut present);
+            match role {
+                None => {
+                    assert!(!suppress_absent && absent.otc.is_none());
+                    assert!(!suppress_present && present.otc == Some(Otc::new(65099)));
+                }
+                // Toward a Customer / RS-Client: stamp (ER1), never suppress.
+                Some(BgpRole::Provider | BgpRole::RouteServer) => {
+                    assert!(!suppress_absent);
+                    assert_eq!(absent.otc, Some(Otc::new(65001)));
+                    assert!(
+                        !suppress_present,
+                        "an existing OTC is preserved, not a leak"
+                    );
+                    assert_eq!(present.otc, Some(Otc::new(65099)));
+                }
+                // Toward a Peer: stamp when absent (ER1), suppress when present (ER2).
+                Some(BgpRole::Peer) => {
+                    assert!(!suppress_absent);
+                    assert_eq!(absent.otc, Some(Otc::new(65001)));
+                    assert!(suppress_present);
+                }
+                // Toward a Provider / RS: never stamp, suppress when present (ER2).
+                Some(BgpRole::Customer | BgpRole::RouteServerClient) => {
+                    assert!(!suppress_absent && absent.otc.is_none());
+                    assert!(suppress_present);
+                }
+            }
+        }
+    }
+
+    /// ER1 stamps the AS the neighbor sees — the `local-as` substitute
+    /// when active — so it agrees with the neighbor's own IR3 stamp.
+    #[test]
+    fn egress_stamp_uses_the_presented_local_as() {
+        let mut attrs = BgpAttr::new();
+        assert!(!otc_egress(
+            &eas(Some(BgpRole::Provider), Some(64999)),
+            &mut attrs
+        ));
+        assert_eq!(attrs.otc, Some(Otc::new(64999)));
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -592,6 +592,10 @@ struct BgpRouteJson {
     /// carried verbatim on this route. Empty for routes without any.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     unknown_attributes: Vec<UnknownAttrJson>,
+    /// RFC 9234 Only-to-Customer attribute: the AS that marked the route
+    /// as not to be propagated beyond customers. Absent when unmarked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    otc_as: Option<u32>,
 }
 
 /// Render the standard / extended / large COMMUNITIES attributes of a
@@ -681,6 +685,7 @@ fn bgp_route_json(prefix: String, rib: &BgpRib) -> BgpRouteJson {
         ext_community,
         large_community,
         unknown_attributes: show_unknown_attrs(&rib.attr),
+        otc_as: rib.attr.otc.map(|o| o.asn),
     }
 }
 
@@ -1003,6 +1008,7 @@ where
                     ext_community,
                     large_community,
                     unknown_attributes: show_unknown_attrs(&rib.attr),
+                    otc_as: rib.attr.otc.map(|o| o.asn),
                 });
             }
         }
@@ -1913,6 +1919,11 @@ fn write_bgp_entry_detail<V: BgpShowView>(
             writeln!(out, "    AIGP metric: {}", aigp.aigp)?;
         }
 
+        // RFC 9234 Only-to-Customer (IOS XR spelling).
+        if let Some(otc) = &rib.attr.otc {
+            writeln!(out, "    OTC-AS: {}", otc.asn)?;
+        }
+
         // Surface BGP Color extended communities (RFC 9012 §4.3). The
         // color-aware nexthop resolver consumes these; surfacing here
         // gives operators visibility into the CO bits.
@@ -2172,6 +2183,7 @@ pub(super) fn show_adj_rib_routes<P: std::fmt::Display>(
                     ext_community,
                     large_community,
                     unknown_attributes: show_unknown_attrs(&rib.attr),
+                    otc_as: rib.attr.otc.map(|o| o.asn),
                 });
             }
         }
@@ -3340,6 +3352,9 @@ struct OtcRoleView {
     remote_role_source: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mismatch: Option<String>,
+    /// RFC 9234 §5 ingress rejections (IR1 / IR2) on this session.
+    denied_rule1: u64,
+    denied_rule2: u64,
 }
 
 /// `show bgp neighbor` view of [`Peer::last_reset`].
@@ -3427,6 +3442,8 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
                 remote_role: remote.map(|(role, _)| role.as_str()),
                 remote_role_source: remote.map(|(_, source)| source),
                 mismatch: peer.otc_role_mismatch.map(|m| m.to_string()),
+                denied_rule1: peer.otc_denied[0],
+                denied_rule2: peer.otc_denied[1],
             }
         }),
         encapsulation_type_ipv6: peer
@@ -3689,6 +3706,11 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         if let (Some(role), Some(source)) = (otc.remote_role, otc.remote_role_source) {
             writeln!(out, "  OTC Remote Role: {role} ({source})")?;
         }
+        writeln!(
+            out,
+            "    By OTC ingress rule 1: {}, By OTC ingress rule 2: {}",
+            otc.denied_rule1, otc.denied_rule2
+        )?;
         if let Some(mismatch) = &otc.mismatch {
             writeln!(
                 out,
@@ -4477,6 +4499,9 @@ fn write_evpn_path_attrs(
     // Accumulated IGP metric (RFC 7311).
     if let Some(aigp) = &attr.aigp {
         writeln!(buf, "{PAD}AIGP metric: {}", aigp.aigp)?;
+    }
+    if let Some(otc) = &attr.otc {
+        writeln!(buf, "{PAD}OTC-AS: {}", otc.asn)?;
     }
 
     Ok(())

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -40,7 +40,7 @@ use crate::context::Timer;
 
 /// Bumped whenever a new field is added to `UpdateGroupSig`. Surfaced
 /// in `show bgp update-group` so a stale view is detectable.
-pub const SIGNATURE_VERSION: u32 = 6;
+pub const SIGNATURE_VERSION: u32 = 7;
 
 /// Address families the grouping logic considers — every family whose
 /// advertise pipeline consults `peer.update_group_id`. IPv6 unicast
@@ -146,6 +146,12 @@ pub struct UpdateGroupSig {
     /// different substitute (or none) cannot share canonical UPDATE
     /// bytes. `(substitute, replace_as)`.
     pub local_as_substitute: Option<(u32, bool)>,
+    /// RFC 9234 `otc-local-role` (eBGP only; `None` when unset or iBGP).
+    /// The egress procedures depend on it: toward a Customer / Peer /
+    /// RS-Client the OTC attribute is added (ER1), toward a Provider /
+    /// Peer / RS an OTC-marked route is suppressed (ER2). Two peers under
+    /// different roles must therefore never share canonical UPDATE bytes.
+    pub otc_local_role: Option<bgp_packet::BgpRole>,
     // Negotiated wire-format capabilities (intersection of cap_send
     // and cap_recv on the peer). Anything that changes encoded
     // UPDATE bytes belongs here.
@@ -433,6 +439,13 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         local_as_substitute: if peer.is_ebgp() {
             peer.change_local_as()
                 .map(|asn| (asn, peer.config.local_as.is_some_and(|la| la.replace_as)))
+        } else {
+            None
+        },
+        // RFC 9234 egress procedures are keyed by the local role (eBGP
+        // only — roles are undefined on iBGP and must not split groups).
+        otc_local_role: if peer.is_ebgp() {
+            peer.config.otc_local_role.map(|r| r.role)
         } else {
             None
         },
@@ -1481,6 +1494,7 @@ mod tests {
             as_override_target: None,
             remove_private_as: None,
             local_as_substitute: None,
+            otc_local_role: None,
             as4_negotiated: true,
             extended_message: true,
             addpath_send: false,
@@ -1684,6 +1698,15 @@ mod tests {
         let mut c = a.clone();
         c.local_as_substitute = Some((64999, true));
         assert_ne!(a, c);
+
+        // RFC 9234: the role selects whether OTC is added or the route
+        // suppressed on egress — every role is its own group.
+        let mut a = base.clone();
+        a.otc_local_role = Some(bgp_packet::BgpRole::Provider);
+        assert_ne!(base, a);
+        let mut b = a.clone();
+        b.otc_local_role = Some(bgp_packet::BgpRole::Customer);
+        assert_ne!(a, b);
 
         let mut a = base.clone();
         a.as4_negotiated = false;


### PR DESCRIPTION
## Summary

PR 3 of the RFC 9234 series (plan: `docs/design/bgp-rfc9234-plan.md`): the Only-to-Customer procedures, driven by the `otc-local-role` negotiated in PR 2. IPv4 and IPv6 unicast only, per §6 — VPN rows are exempt and iBGP carries OTC through untouched.

| Rule | Where | Behaviour |
|---|---|---|
| IR1 | ingress | OTC present on a route from a Customer / RS-Client → leak, dropped (never stored), counted |
| IR2 | ingress | OTC present on a route from a Peer with OTC ≠ peer AS → leak, dropped, counted |
| IR3 | ingress | OTC absent on a route from a Provider / Peer / RS → stamp OTC = remote AS (stored route carries it) |
| ER1 | egress | OTC absent toward a Customer / Peer / RS-Client → add OTC = local AS (the `local-as` substitute when active) |
| ER2 | egress | OTC present toward a Provider / Peer / RS → not advertised |

* `route.rs`: `otc_ingress_rule` (pure, table-tested) behind `inbound_attr_checks` (now `&mut Peer`, returns the IR3-stamped attribute the v4 callers ingest **before** the shard split — one stamp per UPDATE); the v6 path threads its stamp the same way. `otc_egress` on `EgressAs.otc_local_role` right after the AS_PATH transform in both unicast builders.
* **`UpdateGroupSig.otc_local_role`, `SIGNATURE_VERSION` 6→7** — the role decides stamp-or-suppress on egress, so peers under different roles never share canonical bytes (regression guard extended).
* Per-peer `Peer::otc_denied[2]` + adj-in trace `... DENIED due to OTC ingress rule N: ...`.
* show: `OTC-AS: N` on a path (detail + path-attr printer), `otc_as` in route JSON, `By OTC ingress rule 1: n, By OTC ingress rule 2: n` in `show bgp neighbor` (IOS XR wording).

## Test plan

- [x] Unit: RFC §5 ingress and egress truth tables (every role × {absent, OTC = remote, OTC ≠ remote} / {absent, present}), substitute-AS stamp, `signature_fields_each_distinguish`
- [x] `cargo test --workspace --exclude bdd`, `cargo fmt --check`, workspace clippy `-D warnings`, lua clippy
- [x] **BDD `@bgp_otc_local_role` — 10/10 scenarios green** (3-node eBGP line z1–z2–z3): roles shown XR-style; ER1 stamp on z2 (`otc_as` 65001) + ER2 block toward z3; IR3 stamp with `(inferred)` provider; IR1 rejection with the rule-1 counter; IR2 rejection with the rule-2 counter; unmarked route stamped by a peer on ingress; provider/provider Role Mismatch; strict refuses a role-less neighbor, loose accepts it

Next: PR 4 — book chapter, RFC appendix row, update-groups design note, changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g1SgtRd4VA3tj5dit9uqr
