### PR TITLE
bgp: RFC 7947 route-server mode — neighbor X route-server-client

### DIFF
--- a/bdd/tests/configs/bgp_route_server/rs-base.yaml
+++ b/bdd/tests/configs/bgp_route_server/rs-base.yaml
@@ -1,0 +1,27 @@
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+

--- a/bdd/tests/configs/bgp_route_server/rs-client-otc.yaml
+++ b/bdd/tests/configs/bgp_route_server/rs-client-otc.yaml
@@ -1,0 +1,33 @@
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+      route-server-client: {}
+      otc-local-role:
+      - role: route-server
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+      route-server-client: {}
+      otc-local-role:
+      - role: route-server
+

--- a/bdd/tests/configs/bgp_route_server/rs-client.yaml
+++ b/bdd/tests/configs/bgp_route_server/rs-client.yaml
@@ -1,0 +1,29 @@
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+      route-server-client: {}
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3
+      route-server-client: {}
+

--- a/bdd/tests/configs/bgp_route_server/z1-otc.yaml
+++ b/bdd/tests/configs/bgp_route_server/z1-otc.yaml
@@ -1,0 +1,24 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65000
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: route-server-client
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_route_server/z1.yaml
+++ b/bdd/tests/configs/bgp_route_server/z1.yaml
@@ -1,0 +1,22 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65000
+      timers:
+        connect-retry-time: 3
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_route_server/z3-otc.yaml
+++ b/bdd/tests/configs/bgp_route_server/z3-otc.yaml
@@ -1,0 +1,24 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65000
+      timers:
+        connect-retry-time: 3
+      otc-local-role:
+      - role: route-server-client
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.3/32

--- a/bdd/tests/configs/bgp_route_server/z3.yaml
+++ b/bdd/tests/configs/bgp_route_server/z3.yaml
@@ -1,0 +1,22 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65000
+      timers:
+        connect-retry-time: 3
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.3/32

--- a/bdd/tests/features/bgp_route_server.feature
+++ b/bdd/tests/features/bgp_route_server.feature
@@ -1,0 +1,99 @@
+@serial
+@bgp_route_server
+Feature: BGP route server (RFC 7947) — transparent re-advertisement to clients
+  As an IXP operator
+  I want `neighbor X route-server-client`
+  So my route server re-advertises members' routes to each other with the
+  originating member's AS_PATH and next-hop untouched.
+
+  Test Topology (one exchange LAN, all eBGP):
+  ```
+  ┌────────────────────────────────────────────────────────────┐
+  │                            br0                             │
+  └──────────┬──────────────────┬──────────────────┬───────────┘
+             │                  │                  │
+        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+        │   z1    │        │   rs    │        │   z3    │
+        │ AS65001 │        │ AS65000 │        │ AS65003 │
+        │  .0.1   │        │  .0.2   │        │  .0.3   │
+        └─────────┘        └─────────┘        └─────────┘
+   originates 10.0.0.1/32                originates 10.0.0.3/32
+  ```
+
+  z1 and z3 peer only with the route server `rs`. As a plain eBGP
+  speaker, rs prepends AS65000 and rewrites the next-hop to itself. With
+  `route-server-client` on both sessions it becomes transparent: z3 sees
+  10.0.0.1/32 with AS_PATH "65001" and next-hop 192.168.0.1 — z1 itself —
+  and forwards to z1 directly across the LAN. Combined with RFC 9234, the
+  server takes `otc-local-role route-server` and the members
+  `route-server-client`, so the server marks routes with OTC-AS 65000.
+
+  Config files:
+  - z1.yaml / z3.yaml:        members originating one prefix each
+  - z1-otc.yaml / z3-otc.yaml: same, with `otc-local-role route-server-client`
+  - rs-base.yaml:              plain eBGP toward both members
+  - rs-client.yaml:            `route-server-client` toward both
+  - rs-client-otc.yaml:        plus `otc-local-role route-server`
+
+  Scenario: Setup the exchange LAN with a plain eBGP "server"
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "rs" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "rs"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "rs-base.yaml" to namespace "rs"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "rs" to "192.168.0.1" should be "Established"
+    And BGP session in "rs" to "192.168.0.3" should be "Established"
+    And BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z3" to "192.168.0.2" should be "Established"
+
+  Scenario: A plain eBGP speaker prepends its AS and rewrites the next-hop
+    Given the test topology exists
+    Then BGP route in "z3" has "10.0.0.1/32" with "as_path" value "65000 65001"
+    And BGP route in "z3" has "10.0.0.1/32" with "next_hop" value "192.168.0.2"
+    And BGP route in "z1" has "10.0.0.3/32" with "as_path" value "65000 65003"
+
+  Scenario: route-server-client makes the server transparent both ways
+    Given the test topology exists
+    When I apply config "rs-client.yaml" to namespace "rs"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "rs" to "192.168.0.1" should be "Established"
+    And BGP session in "rs" to "192.168.0.3" should be "Established"
+    And show command "show bgp neighbor" in namespace "rs" should contain "Route-server client: enabled"
+    # RFC 7947 §2.2.2 / §2.2.1: the originating member's AS_PATH and
+    # next-hop reach the other member untouched.
+    And BGP route in "z3" has "10.0.0.1/32" with "as_path" value "65001"
+    And BGP route in "z3" has "10.0.0.1/32" with "next_hop" value "192.168.0.1"
+    And BGP route in "z1" has "10.0.0.3/32" with "as_path" value "65003"
+    And BGP route in "z1" has "10.0.0.3/32" with "next_hop" value "192.168.0.3"
+
+  Scenario: RFC 9234 route-server / route-server-client roles on top
+    Given the test topology exists
+    When I apply config "rs-client-otc.yaml" to namespace "rs"
+    And I apply config "z1-otc.yaml" to namespace "z1"
+    And I apply config "z3-otc.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "rs" to "192.168.0.1" should be "Established"
+    And BGP session in "rs" to "192.168.0.3" should be "Established"
+    And show command "show bgp neighbor" in namespace "rs" should contain "OTC Remote Role: Route Server Client (received)"
+    And show command "show bgp neighbor" in namespace "z3" should contain "OTC Remote Role: Route Server (received)"
+    # ER1 on the server (RS toward RS-client): OTC = the server's AS.
+    And BGP route in "z3" has "10.0.0.1/32" with "otc_as" value "65000"
+    And BGP route in "z3" has "10.0.0.1/32" with "as_path" value "65001"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "rs"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "rs"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -38,6 +38,7 @@
   - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)
   - [Enforce First AS](ch-02-15-bgp-enforce-first-as.md)
   - [BGP Roles & Only-to-Customer (RFC 9234)](ch-02-42-bgp-otc-local-role.md)
+  - [Route Server (RFC 7947)](ch-02-43-bgp-route-server.md)
   - [AS_SET / AS_CONFED_SET Withdrawal (RFC 9774)](ch-02-39-bgp-as-sets-withdraw.md)
   - [Well-Known Communities](ch-02-24-bgp-well-known-communities.md)
   - [Table-Map (Policy at the BGP→RIB Install Point)](ch-02-28-bgp-table-map.md)

--- a/book/src/appendix-b-supported-rfcs.md
+++ b/book/src/appendix-b-supported-rfcs.md
@@ -34,6 +34,7 @@ implementation; the corresponding features track the referenced draft revision.
 | RFC 9774 | Deprecation of AS_SET and AS_CONFED_SET in BGP (`as-sets-withdraw`, on by default). |
 | RFC 9234 | Route Leak Prevention and Detection Using Roles in UPDATE and OPEN Messages — `otc-local-role`, the BGP Role capability and the Only-to-Customer attribute. |
 | RFC 4456 | BGP Route Reflection — an alternative to full IBGP mesh. |
+| RFC 7947 | Internet Exchange BGP Route Server — `route-server-client` (transparent AS_PATH and next-hop toward clients; path hiding via ADD-PATH). |
 | RFC 2385 | Protection of BGP Sessions via the TCP MD5 Signature Option. |
 | RFC 5925 | The TCP Authentication Option (TCP-AO). |
 | RFC 5926 | Cryptographic Algorithms for the TCP Authentication Option. |

--- a/book/src/ch-02-43-bgp-route-server.md
+++ b/book/src/ch-02-43-bgp-route-server.md
@@ -1,0 +1,177 @@
+# BGP Route Server (RFC 7947)
+
+At an Internet Exchange, members would rather not maintain a full mesh of
+bilateral eBGP sessions. A **route server** takes their routes and hands
+them to every other member — but unlike an ordinary transit router it
+must be **transparent**: the member receiving a route must see it exactly
+as the originating member sent it, so that the AS_PATH still reflects
+the real AS-level topology and traffic flows member-to-member across the
+exchange LAN, never through the server.
+
+`neighbor X route-server-client` makes zebra-rs behave as that server
+toward the named neighbor.
+
+```
+router bgp {
+  neighbor 192.168.0.1 {
+    remote-as 65001;
+    route-server-client;
+  }
+}
+```
+
+## What changes toward a route-server client
+
+RFC 7947 lists what a route server must *not* do to a route it
+re-advertises. Toward a `route-server-client` neighbor zebra-rs:
+
+| RFC 7947 | Ordinary eBGP advertisement | Toward a route-server client |
+|---|---|---|
+| §2.2.2 AS_PATH | prepend the local AS (after `remove-private-as` / `as-override` / `local-as` rewrites) | **leave it untouched** — no prepend, and none of the rewrites, which only exist to shape a prepended path |
+| §2.2.1 NEXT_HOP | rewrite to this router's address | **keep the received next-hop** on forwarded routes, so the client forwards straight to the originating member on the exchange LAN. Locally originated routes still carry this router's address |
+| §2.2.2.1 MED | pass through | pass through |
+| §2.2.2.2 communities | pass through | pass through |
+
+It applies to **IPv4 and IPv6 unicast** and to **eBGP** neighbors (an
+iBGP neighbor never prepends or rewrites anyway). Inbound processing from
+a client is ordinary eBGP — the server's own AS never appears in a
+client's AS_PATH, so the loop check is unaffected.
+
+### Path hiding
+
+With a single best path per prefix, a route server that has *two*
+members announcing the same prefix would advertise only its own winner
+to everyone — hiding the other path from members that would prefer it
+(RFC 7947 §2.3). The RFC's remedies are a per-client Loc-RIB or
+**ADD-PATH** (RFC 7911). zebra-rs takes the second: enable `add-path
+send` on the client sessions and every member path is advertised.
+
+```yaml
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        add-path: send
+```
+
+## Topology
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                       exchange LAN                         │
+└──────────┬──────────────────┬──────────────────┬───────────┘
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │        │   rs    │        │   z3    │
+      │ AS65001 │        │ AS65000 │        │ AS65003 │
+      │  .0.1   │        │  .0.2   │        │  .0.3   │
+      └─────────┘        └─────────┘        └─────────┘
+ originates 10.0.0.1/32                originates 10.0.0.3/32
+```
+
+Without the knob, `z3` receives `10.0.0.1/32` with AS_PATH `65000 65001`
+and next-hop `192.168.0.2` — the server is in the data path and in the
+AS path. With `route-server-client` on both of `rs`'s sessions, `z3`
+receives AS_PATH `65001` with next-hop `192.168.0.1` and forwards to
+`z1` directly.
+
+## Configuration
+
+On the route server, per member:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      route-server-client: {}
+    - remote-address: 192.168.0.3
+      remote-as: 65003
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      route-server-client: {}
+```
+
+`route-server-client: {}` is the YAML spelling of a presence container;
+the CLI form is
+
+```
+set router bgp neighbor 192.168.0.1 route-server-client
+```
+
+An exchange normally puts every member into one
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) and sets the knob once
+there; a statement on the neighbor itself wins. It is also available on
+[VRF](ch-02-04-bgp-l3vpn.md) neighbors.
+
+Setting or clearing the knob on a live session **resets the session**:
+every route already advertised to the client carries the old AS_PATH and
+next-hop, and the cleanest way to replace them all is to let the client
+re-receive the table.
+
+**On the member side**, do not enable
+[`enforce-first-as`](ch-02-15-bgp-enforce-first-as.md) toward a route
+server — every route it sends starts with *another member's* AS, so the
+check would drop all of them.
+
+## Verification
+
+```
+show bgp neighbor 192.168.0.1
+...
+  Route-server client: enabled (transparent AS_PATH and next-hop, RFC 7947)
+```
+
+On a member, `show bgp 10.0.0.1/32` shows the originating member's path
+and next-hop:
+
+```
+  65001
+    192.168.0.1 from 192.168.0.2
+```
+
+## With RFC 9234 roles
+
+The [BGP Role](ch-02-42-bgp-otc-local-role.md) pair for this topology is
+`otc-local-role route-server` on the server and `otc-local-role
+route-server-client` on each member. The server then marks every route it
+hands out with `OTC-AS: 65000` (ER1) and refuses an OTC-marked route a
+member tries to push back through it (IR1); a member refuses to leak a
+marked route toward the server (ER2). Note that the OTC value is the
+**server's** AS, exactly as RFC 9234 specifies — not the originating
+member's.
+
+## Interplay and precedence
+
+- `as-override`, `remove-private-as` and `local-as` are ignored toward a
+  route-server client (a warning is logged when they overlap): there is no
+  prepend for them to shape.
+- `afi-safi … next-hop-self` does not override the transparent next-hop
+  for forwarded routes; `next-hop-unchanged` is implied.
+- Outbound policy still applies per client — this is how an exchange
+  implements member-specific export filtering.
+- Update groups: route-server clients form their own update group (the
+  signature carries the knob), so they never share an encoded UPDATE with
+  ordinary eBGP neighbors.
+
+## Limitations
+
+- No per-client Loc-RIB (RFC 7947 §2.3.2.1); use ADD-PATH for path
+  hiding.
+- IPv4/IPv6 unicast only.
+
+## References
+
+- [RFC 7947](https://www.rfc-editor.org/rfc/rfc7947.html) — Internet
+  Exchange BGP Route Server.
+- [RFC 7948](https://www.rfc-editor.org/rfc/rfc7948.html) — Internet
+  Exchange BGP Route Server Operations (background on path hiding and
+  member filtering).

--- a/docs/design/bgp-route-server-plan.md
+++ b/docs/design/bgp-route-server-plan.md
@@ -1,8 +1,18 @@
 # BGP Route Server mode (RFC 7947) — design
 
-Status: **planned, not started** (2026-08-28). Split out of the RFC 9234
-plan (`bgp-rfc9234-plan.md`) so the OTC work can land first; this document
-is self-contained and can be picked up independently.
+Status: **implemented 2026-08-28** on branch `bgp-route-server` (one PR, as
+sized below): knob + inheritance + VRF, `EgressAs.route_server_client`
+early-return in `ebgp_egress_aspath`, next-hop-unchanged implied for
+forwarded unicast rows (v4 via `sync_ctx`, v6 in the builder),
+`UpdateGroupSig.route_server_client` (SIGNATURE_VERSION 8), show, BDD
+`bgp_route_server.feature` on a bridged LAN, book `ch-02-43`. Deviations
+from §3.2: incompatible AS_PATH knobs are *ignored with a warning* rather
+than rejected in the callback (callback order within a commit makes
+rejection unreliable); a change bounces the live session so the client
+re-receives the table in the new form.
+
+Originally split out of the RFC 9234 plan (`bgp-rfc9234-plan.md`) so the
+OTC work could land first.
 
 ## 1. Why
 

--- a/docs/design/bgp-update-groups.md
+++ b/docs/design/bgp-update-groups.md
@@ -88,6 +88,7 @@ Two peers belong to the same update-group for a given `(afi, safi)` iff
 | `config.as_override` + `remote_as` (eBGP only) | `as-override` rewrites the peer's remote-AS to `local_as` in the egress AS_PATH; the result depends on `remote_as`, so it joins the key as `as_override_target: Some(remote_as)` (else `None`). |
 | `config.remove_private_as` + `remote_as` (eBGP only) | `remove-private-as` strips (or, with `replace-as`, rewrites) private ASNs from the egress AS_PATH; the result depends on the two modifiers and on the kept AS (`remote_as`), so it joins the key as `remove_private_as: Some(RemovePrivateAsKey { all, replace_as, keep_as })` (else `None`). |
 | `config.otc_local_role` (eBGP only) | RFC 9234 egress: toward a Customer / Peer / RS-Client the OTC attribute is added (ER1), toward a Provider / Peer / RS an OTC-marked route is suppressed (ER2) — the role decides stamp-or-suppress, so it joins the key as `otc_local_role: Some(role)` (else `None`; iBGP never runs the procedures). |
+| `config.route_server_client` (eBGP only) | RFC 7947: the egress AS_PATH is left untouched (no prepend, no rewrites) and the forwarded next-hop preserved toward a route-server client, so it joins the key as `route_server_client: bool`. |
 | `is_afi_safi(afi, safi)` membership | Implicit — only members of the AFI/SAFI participate in that group. |
 | `addpath_send` for `(afi, safi)` | Different framing → different group. |
 

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -124,6 +124,7 @@
 /router/bgp/neighbor-group/remove-private-as/all
 /router/bgp/neighbor-group/remove-private-as/replace-as
 /router/bgp/neighbor-group/route-reflector/client
+/router/bgp/neighbor-group/route-server-client
 /router/bgp/neighbor-group/tcp-ao/include-tcp-options
 /router/bgp/neighbor-group/tcp-ao/key-chain
 /router/bgp/neighbor-group/tcp-mss
@@ -176,6 +177,7 @@
 /router/bgp/neighbor/remove-private-as/all
 /router/bgp/neighbor/remove-private-as/replace-as
 /router/bgp/neighbor/route-reflector/client
+/router/bgp/neighbor/route-server-client
 /router/bgp/neighbor/soft-reconfiguration/inbound
 /router/bgp/neighbor/tcp-ao/include-tcp-options
 /router/bgp/neighbor/tcp-ao/key-chain
@@ -277,6 +279,7 @@
 /router/bgp/vrf/neighbor/remove-private-as/all
 /router/bgp/vrf/neighbor/remove-private-as/replace-as
 /router/bgp/vrf/neighbor/route-reflector/client
+/router/bgp/vrf/neighbor/route-server-client
 /router/bgp/vrf/neighbor/tcp-ao/include-tcp-options
 /router/bgp/vrf/neighbor/tcp-ao/key-chain
 /router/bgp/vrf/neighbor/timers/advertisement-interval

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -23,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 345
-Handled: 330
+Total settable schema nodes: 348
+Handled: 333
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -131,6 +131,7 @@
 /router/bgp/neighbor-group/remove-private-as/replace-as	leaf
 /router/bgp/neighbor-group/route-reflector	container
 /router/bgp/neighbor-group/route-reflector/client	leaf
+/router/bgp/neighbor-group/route-server-client	p-container
 /router/bgp/neighbor-group/tcp-ao	p-container
 /router/bgp/neighbor-group/tcp-ao/include-tcp-options	leaf
 /router/bgp/neighbor-group/tcp-ao/key-chain	leaf
@@ -192,6 +193,7 @@
 /router/bgp/neighbor/remove-private-as/replace-as	leaf
 /router/bgp/neighbor/route-reflector	container
 /router/bgp/neighbor/route-reflector/client	leaf
+/router/bgp/neighbor/route-server-client	p-container
 /router/bgp/neighbor/tcp-ao	p-container
 /router/bgp/neighbor/tcp-ao/include-tcp-options	leaf
 /router/bgp/neighbor/tcp-ao/key-chain	leaf
@@ -373,6 +375,7 @@
 /router/bgp/vrf/neighbor/remove-private-as/replace-as	leaf
 /router/bgp/vrf/neighbor/route-reflector	container
 /router/bgp/vrf/neighbor/route-reflector/client	leaf
+/router/bgp/vrf/neighbor/route-server-client	p-container
 /router/bgp/vrf/neighbor/tcp-ao	p-container
 /router/bgp/vrf/neighbor/tcp-ao/include-tcp-options	leaf
 /router/bgp/vrf/neighbor/tcp-ao/key-chain	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1078,6 +1078,60 @@ pub(super) fn apply_enforce_first_as(peer: &mut Peer, want: bool) -> bool {
     false
 }
 
+/// `set router bgp neighbor X route-server-client` — the RFC 7947
+/// presence container (zebra-bgp-route-server.yang). Toward this eBGP
+/// neighbor this router behaves as a transparent route server: no
+/// local-AS prepend (and none of the prepend-time AS_PATH rewrites) and
+/// the received next-hop is kept on forwarded routes. `delete` restores
+/// ordinary eBGP advertisement. A live session is bounced either way so
+/// the client re-receives every route in the new form.
+fn config_route_server_client(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.knobs_explicit.route_server_client = op.is_set().then_some(true);
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.route_server_client
+        })
+        .unwrap_or(false);
+        (peer.ident, apply_route_server_client(peer, want))
+    };
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
+/// Write a resolved `route-server-client` value onto the peer and return
+/// whether a live session must be bounced. Diff-gated. The knob changes
+/// the AS_PATH and next-hop of every route already advertised to the
+/// client, so a live session renegotiates rather than leaving the client
+/// with the pre-change form until the next churn. The AS_PATH rewrites
+/// (as-override / remove-private-as / local-as) are meaningless toward a
+/// route-server client and are ignored while it is set — a warning says
+/// so at the moment they overlap. Shared by the per-neighbor callback,
+/// the neighbor-group sweep and VRF materialization.
+pub(super) fn apply_route_server_client(peer: &mut Peer, want: bool) -> bool {
+    if peer.config.route_server_client == want {
+        return false;
+    }
+    if want
+        && (peer.config.as_override
+            || peer.config.remove_private_as.is_some()
+            || peer.config.local_as.is_some())
+    {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            "bgp: route-server-client leaves the egress AS_PATH untouched; as-override / remove-private-as / local-as are ignored toward this neighbor",
+        );
+    }
+    peer.config.route_server_client = want;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
+}
+
 /// `set router bgp neighbor X otc-local-role <role>` — the RFC 9234 list
 /// node (zebra-bgp-otc.yang, IOS XR syntax). Records the verbatim
 /// statement, resolves through the neighbor-group precedence and applies
@@ -4780,6 +4834,10 @@ impl Bgp {
             super::neighbor_group::config_neighbor_group_enforce_first_as,
         );
         self.callback_add(
+            "/router/bgp/neighbor-group/route-server-client",
+            super::neighbor_group::config_neighbor_group_route_server_client,
+        );
+        self.callback_add(
             "/router/bgp/neighbor-group/otc-local-role",
             super::neighbor_group::config_neighbor_group_otc_local_role,
         );
@@ -4987,6 +5045,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/neighbor/enforce-first-as",
             super::vrf_config::config_vrf_neighbor_enforce_first_as,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/neighbor/route-server-client",
+            super::vrf_config::config_vrf_neighbor_route_server_client,
         );
         self.callback_add(
             "/router/bgp/vrf/neighbor/otc-local-role",
@@ -5657,6 +5719,9 @@ impl Bgp {
         // RFC 9234 BGP Role (zebra-bgp-otc.yang, IOS XR syntax):
         // `otc-local-role <role> [strict]`. Advertised in the OPEN on
         // eBGP; a change bounces the session.
+        // RFC 7947 route-server behaviour toward this neighbor
+        // (zebra-bgp-route-server.yang): transparent AS_PATH + next-hop.
+        self.callback_peer("/route-server-client", config_route_server_client);
         self.callback_peer("/otc-local-role", config_otc_local_role);
         self.callback_peer("/otc-local-role/strict", config_otc_local_role_strict);
         self.callback_peer("/pic-retention", config_pic_retention);
@@ -6380,6 +6445,27 @@ mod bfd_wiring_tests {
         config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
         config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
         assert!(!peer_enforce_first_as(&bgp, "10.0.0.2"));
+    }
+
+    fn peer_rs_client(bgp: &Bgp, addr: &str) -> bool {
+        bgp.peers
+            .get(&addr.parse().unwrap())
+            .unwrap()
+            .config
+            .route_server_client
+    }
+
+    /// `route-server-client` defaults off; the presence container turns
+    /// it on and its delete turns it back off.
+    #[tokio::test]
+    async fn route_server_client_set_and_delete() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(!peer_rs_client(&bgp, "10.0.0.2"));
+        config_route_server_client(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(peer_rs_client(&bgp, "10.0.0.2"));
+        config_route_server_client(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert!(!peer_rs_client(&bgp, "10.0.0.2"));
     }
 
     fn peer_otc(bgp: &Bgp, addr: &str) -> Option<OtcLocalRole> {
@@ -8800,7 +8886,7 @@ mod neighbor_group_wiring_tests {
         config_neighbor_group_port, config_neighbor_group_remove_private_as,
         config_neighbor_group_remove_private_as_all,
         config_neighbor_group_remove_private_as_replace_as,
-        config_neighbor_group_route_reflector_client,
+        config_neighbor_group_route_reflector_client, config_neighbor_group_route_server_client,
     };
 
     /// Attach `10.0.0.1` to group `G` (which has a remote-as so the
@@ -9151,6 +9237,41 @@ mod neighbor_group_wiring_tests {
         assert!(
             drain_stop_events(&mut bgp).is_empty(),
             "enforce-first-as changes must never bounce the session",
+        );
+    }
+
+    /// Group `route-server-client` propagates, bounces a live member (its
+    /// advertised routes change shape), and the explicit statement wins.
+    #[tokio::test]
+    async fn group_route_server_client_propagates_explicit_wins_and_bounces_live() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_route_server_client(&mut bgp, arg_words(&["G"]), ConfigOp::Set)
+            .unwrap();
+        assert!(
+            member(&bgp).config.route_server_client,
+            "group opinion must apply"
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "a live member is bounced"
+        );
+
+        config_route_server_client(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_neighbor_group_route_server_client(&mut bgp, arg_words(&["G"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(
+            member(&bgp).config.route_server_client,
+            "explicit statement survives the group delete",
+        );
+        let _ = drain_stop_events(&mut bgp);
+        config_route_server_client(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert!(
+            !member(&bgp).config.route_server_client,
+            "dropping both clears it"
         );
     }
 

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -84,6 +84,8 @@ pub struct InheritableKnobs {
     /// Single-instance list: the staging helpers below refuse a second
     /// role, mirroring `local-as`.
     pub otc_local_role: Option<super::peer::OtcLocalRole>,
+    /// RFC 7947 `route-server-client` presence container.
+    pub route_server_client: Option<bool>,
     pub route_reflector_client: Option<bool>,
     /// RFC 9572 §6.1 region identifier — the 8-octet, EC-formatted Region ID
     /// (`region_id_from_asn`). A peer-group carrying this *is* a region; a
@@ -934,6 +936,28 @@ pub fn config_neighbor_group_enforce_first_as(
     Some(())
 }
 
+/// `set router bgp neighbor-group <name> route-server-client` — presence
+/// container (zebra-bgp-route-server.yang). Stores the opinion and
+/// re-resolves every member; a live member whose effective value changed
+/// is bounced so the client re-receives its routes transparently.
+pub fn config_neighbor_group_route_server_client(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .route_server_client = op.is_set().then_some(true);
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.route_server_client).unwrap_or(false);
+        super::config::apply_route_server_client(peer, want)
+    });
+    Some(())
+}
+
 /// Decode an `otc-local-role` list key (IOS XR token) or warn.
 pub(super) fn parse_otc_role(token: &str) -> Option<bgp_packet::BgpRole> {
     match token.parse::<bgp_packet::BgpRole>() {
@@ -1532,6 +1556,7 @@ pub(super) fn resolve_inherited_knobs(
         remove_private_as: resolve_knob(groups, config, |k| k.remove_private_as),
         enforce_first_as: resolve_knob(groups, config, |k| k.enforce_first_as),
         otc_local_role: resolve_knob(groups, config, |k| k.otc_local_role),
+        route_server_client: resolve_knob(groups, config, |k| k.route_server_client),
         route_reflector_client: resolve_knob(groups, config, |k| k.route_reflector_client),
         region_id: resolve_knob(groups, config, |k| k.region_id),
     }
@@ -1575,6 +1600,8 @@ pub(super) fn apply_resolved_session_knobs(peer: &mut Peer, want: &InheritableKn
     super::config::apply_remove_private_as(peer, want.remove_private_as);
     super::config::apply_enforce_first_as(peer, want.enforce_first_as.unwrap_or(false));
     bounce |= super::config::apply_otc_local_role(peer, want.otc_local_role);
+    bounce |=
+        super::config::apply_route_server_client(peer, want.route_server_client.unwrap_or(false));
     super::config::apply_route_reflector_client(peer, want.route_reflector_client.unwrap_or(false));
     // The BFD re-arm this returns is only meaningful for a live session.
     let _ = super::config::apply_update_source(peer, want.update_source);
@@ -1635,6 +1662,7 @@ pub(super) fn apply_inherited(
         remove_private_as,
         enforce_first_as,
         otc_local_role,
+        route_server_client,
         route_reflector_client,
         region_id,
     } = resolved;
@@ -1672,6 +1700,7 @@ pub(super) fn apply_inherited(
     // Roles ride the OPEN, so a changed effective role bounces a live
     // member like the transport knobs do.
     bounce |= super::config::apply_otc_local_role(peer, otc_local_role);
+    bounce |= super::config::apply_route_server_client(peer, route_server_client.unwrap_or(false));
     super::config::apply_route_reflector_client(peer, route_reflector_client.unwrap_or(false));
     outcome.bfd_reapply = super::config::apply_update_source(peer, update_source);
     outcome.mss_refresh = super::config::apply_tcp_mss(peer, tcp_mss);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -616,6 +616,13 @@ pub struct PeerConfig {
     /// no role check on the peer's OPEN, no OTC processing). Ignored on
     /// iBGP sessions.
     pub otc_local_role: Option<OtcLocalRole>,
+    /// RFC 7947 `route-server-client` (zebra-bgp-route-server.yang).
+    /// When `true`, routes advertised to this eBGP neighbor keep the
+    /// AS_PATH exactly as received (no local-AS prepend, and none of the
+    /// prepend-time rewrites) and forwarded routes keep the received
+    /// NEXT_HOP — this router acts as a transparent route server toward
+    /// it. IPv4/IPv6 unicast only; ignored on iBGP. Default `false`.
+    pub route_server_client: bool,
     /// Per-neighbor `local-as` (zebra-bgp-local-as.yang). `None` runs
     /// the session under the router's global AS; `Some` presents the
     /// substitute AS to this neighbor (see [`LocalAs`]).
@@ -777,6 +784,7 @@ impl Default for PeerConfig {
             remove_private_as: None,
             enforce_first_as: false,
             otc_local_role: None,
+            route_server_client: false,
             local_as: None,
             attach_unknown_attr: None,
             description: None,
@@ -1738,7 +1746,12 @@ impl Peer {
             vpnv4_next_hop_self: self.next_hop_self(Afi::Ip, Safi::MplsVpn),
             vpnv4_next_hop_unchanged: self.next_hop_unchanged(Afi::Ip, Safi::MplsVpn),
             unicast_next_hop_self: self.next_hop_self(Afi::Ip, Safi::Unicast),
-            unicast_next_hop_unchanged: self.next_hop_unchanged(Afi::Ip, Safi::Unicast),
+            // RFC 7947 §2.2.1: a route server never rewrites the next-hop
+            // of a forwarded route — the client must reach the originating
+            // member directly. Locally originated rows still rewrite
+            // (`route_update_ipv4` applies this to forwarded rows only).
+            unicast_next_hop_unchanged: self.next_hop_unchanged(Afi::Ip, Safi::Unicast)
+                || (self.is_ebgp() && self.config.route_server_client),
             egress_as: self.egress_as(),
             out_policy: self.out_policy.clone(),
             packet_tx: self.packet_tx.clone(),
@@ -1769,6 +1782,7 @@ impl Peer {
             } else {
                 None
             },
+            route_server_client: self.is_ebgp() && self.config.route_server_client,
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -164,6 +164,9 @@ pub struct EgressAs {
     /// RFC 9234 `otc-local-role` on this eBGP session (`None` when unset
     /// or iBGP) — drives the OTC egress procedures in [`otc_egress`].
     pub otc_local_role: Option<BgpRole>,
+    /// RFC 7947 `route-server-client` (eBGP only): the egress AS_PATH is
+    /// left exactly as received — no prepend, no rewrites.
+    pub route_server_client: bool,
 }
 
 impl EgressAs {
@@ -331,6 +334,7 @@ impl SyncCtx {
                 local_as_substitute: None,
                 local_as_replace: false,
                 otc_local_role: None,
+                route_server_client: false,
             },
             out_policy: Arc::new(super::policy::OutPolicy::default()),
             packet_tx: None,
@@ -365,6 +369,13 @@ impl SyncCtx {
 /// the transforms apply uniformly across address families.
 fn ebgp_egress_aspath(eas: &EgressAs, attrs: &mut BgpAttr) {
     if !eas.is_ebgp {
+        return;
+    }
+    // RFC 7947 §2.2.2: a route server is transparent — the client must
+    // see the originating member's AS_PATH untouched. No local-AS
+    // prepend, and none of the rewrites that only exist to shape a
+    // prepended path (remove-private-as, as-override, local-as).
+    if eas.route_server_client {
         return;
     }
     let Some(aspath) = attrs.aspath.as_mut() else {
@@ -12590,7 +12601,11 @@ pub fn route_update_ipv6(
     // (both eBGP and iBGP) and wins over next-hop-self; next-hop-self forces
     // self even iBGP→iBGP. Originated rows always rewrite (RFC 2545 §2 — the
     // originator is the only valid next-hop).
-    let nh_unchanged = !rib.is_originated() && peer.next_hop_unchanged(Afi::Ip6, Safi::Unicast);
+    // RFC 7947 §2.2.1: toward a route-server client a forwarded route
+    // keeps the received next-hop (same as the v4 `sync_ctx` rule).
+    let nh_unchanged = !rib.is_originated()
+        && (peer.next_hop_unchanged(Afi::Ip6, Safi::Unicast)
+            || (peer.is_ebgp() && peer.config.route_server_client));
     let needs_self = rib.is_originated()
         || (peer.is_ebgp() && !nh_unchanged)
         || (peer.next_hop_self(Afi::Ip6, Safi::Unicast) && !nh_unchanged);
@@ -23662,6 +23677,7 @@ mod as_sets_withdraw_tests {
                 local_as_substitute: None,
                 local_as_replace: false,
                 otc_local_role: None,
+                route_server_client: false,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -23720,6 +23736,7 @@ mod as_sets_withdraw_tests {
                 local_as_substitute: None,
                 local_as_replace: false,
                 otc_local_role: None,
+                route_server_client: false,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -23811,6 +23828,7 @@ mod as_sets_withdraw_tests {
                 local_as_substitute: None,
                 local_as_replace: false,
                 otc_local_role: None,
+                route_server_client: false,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -23880,6 +23898,7 @@ mod as_sets_withdraw_tests {
                 local_as_substitute: None,
                 local_as_replace: false,
                 otc_local_role: None,
+                route_server_client: false,
             },
             out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
             packet_tx: None,
@@ -25518,6 +25537,7 @@ mod otc_procedure_tests {
             local_as_substitute: substitute,
             local_as_replace: false,
             otc_local_role: role,
+            route_server_client: false,
         }
     }
 
@@ -25570,5 +25590,58 @@ mod otc_procedure_tests {
             &mut attrs
         ));
         assert_eq!(attrs.otc, Some(Otc::new(64999)));
+    }
+}
+
+#[cfg(test)]
+mod route_server_tests {
+    use super::*;
+
+    fn eas(rs_client: bool) -> EgressAs {
+        EgressAs {
+            is_ebgp: true,
+            local_as: 65000,
+            remote_as: 65003,
+            as_override: true,
+            remove_private_as: Some(super::super::peer::RemovePrivateAs {
+                all: true,
+                replace_as: false,
+            }),
+            local_as_substitute: Some(64999),
+            local_as_replace: false,
+            otc_local_role: None,
+            route_server_client: rs_client,
+        }
+    }
+
+    fn path(asns: &[u32]) -> BgpAttr {
+        let mut attrs = BgpAttr::new();
+        attrs.aspath = Some(As4Path::from(asns.to_vec()));
+        attrs
+    }
+
+    /// RFC 7947 §2.2.2: toward a route-server client the AS_PATH is the
+    /// originating member's, untouched — no prepend, and none of the
+    /// prepend-time rewrites even when they are configured.
+    #[test]
+    fn route_server_client_egress_aspath_is_transparent() {
+        let mut attrs = path(&[65001, 65100]);
+        ebgp_egress_aspath(&eas(true), &mut attrs);
+        assert_eq!(attrs.aspath, Some(As4Path::from(vec![65001, 65100])));
+    }
+
+    /// The same session without the knob behaves as ordinary eBGP: the
+    /// local-as substitute and real AS are prepended (as-override /
+    /// remove-private-as act as configured).
+    #[test]
+    fn plain_ebgp_still_prepends() {
+        let mut attrs = path(&[65001]);
+        ebgp_egress_aspath(&eas(false), &mut attrs);
+        let got = attrs.aspath.expect("aspath");
+        assert_eq!(got.neighboring_as(), Some(64999), "substitute first");
+        assert!(
+            got.to_string().contains("65000"),
+            "real AS prepended: {got}"
+        );
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3092,6 +3092,10 @@ struct Neighbor<'a> {
     /// replaced with the local AS in the AS_PATH of outbound eBGP
     /// UPDATEs (before the local-AS prepend).
     as_override: bool,
+    /// RFC 7947 `neighbor X route-server-client`
+    /// (zebra-bgp-route-server.yang): routes are advertised to this
+    /// neighbor with the AS_PATH and forwarded next-hop untouched.
+    route_server_client: bool,
     /// FRR-style `neighbor X remove-private-as`
     /// (zebra-bgp-remove-private-as.yang), if configured. `None` leaves
     /// the egress AS_PATH untouched; `Some` strips (or, with
@@ -3430,6 +3434,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         soft_reconfig_in: peer.config.soft_reconfig_in,
         allowas_in: peer.config.allowas_in,
         as_override: peer.config.as_override,
+        route_server_client: peer.config.route_server_client,
         remove_private_as: peer.config.remove_private_as,
         local_as_config: peer.config.local_as,
         local_as_dual_fallback: peer.local_as_dual_fallback,
@@ -3654,6 +3659,13 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
 
     if neighbor.as_override {
         writeln!(out, "  AS-Override enabled (outbound AS_PATH replacement)")?;
+    }
+
+    if neighbor.route_server_client {
+        writeln!(
+            out,
+            "  Route-server client: enabled (transparent AS_PATH and next-hop, RFC 7947)"
+        )?;
     }
 
     if let Some(rpa) = neighbor.remove_private_as {
@@ -6319,6 +6331,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             soft_reconfig_in: false,
             allowas_in: None,
             as_override: false,
+            route_server_client: false,
             remove_private_as: None,
             local_as_config: None,
             local_as_dual_fallback: false,
@@ -7863,6 +7876,8 @@ struct NeighborGroupKnobsJson {
     allowas_in: Option<AllowAsIn>,
     #[serde(skip_serializing_if = "Option::is_none")]
     as_override: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route_server_client: Option<bool>,
     /// Serializes as `{"all":bool,"replace_as":bool}`
     /// (RemovePrivateAs's own Serialize derive).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7900,6 +7915,7 @@ impl NeighborGroupKnobsJson {
             prefix_set_out: k.prefix_set_out.clone(),
             allowas_in: k.allowas_in,
             as_override: k.as_override,
+            route_server_client: k.route_server_client,
             remove_private_as: k.remove_private_as,
             enforce_first_as: k.enforce_first_as,
             otc_local_role: k.otc_local_role.map(|r| OtcLocalRoleJson {
@@ -8133,6 +8149,9 @@ fn show_bgp_neighbor_group_detail(
     }
     if k.as_override == Some(true) {
         writeln!(buf, "  As-override: enabled")?;
+    }
+    if k.route_server_client == Some(true) {
+        writeln!(buf, "  Route-server-client: enabled")?;
     }
     if let Some(rpa) = k.remove_private_as {
         let mut desc = "enabled".to_string();

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -40,7 +40,7 @@ use crate::context::Timer;
 
 /// Bumped whenever a new field is added to `UpdateGroupSig`. Surfaced
 /// in `show bgp update-group` so a stale view is detectable.
-pub const SIGNATURE_VERSION: u32 = 7;
+pub const SIGNATURE_VERSION: u32 = 8;
 
 /// Address families the grouping logic considers — every family whose
 /// advertise pipeline consults `peer.update_group_id`. IPv6 unicast
@@ -152,6 +152,11 @@ pub struct UpdateGroupSig {
     /// Peer / RS an OTC-marked route is suppressed (ER2). Two peers under
     /// different roles must therefore never share canonical UPDATE bytes.
     pub otc_local_role: Option<bgp_packet::BgpRole>,
+    /// RFC 7947 `route-server-client` (eBGP only). The egress AS_PATH is
+    /// left untouched and the forwarded next-hop preserved toward such a
+    /// peer, so it must never share canonical bytes with an ordinary
+    /// eBGP neighbor that gets the prepended / rewritten form.
+    pub route_server_client: bool,
     // Negotiated wire-format capabilities (intersection of cap_send
     // and cap_recv on the peer). Anything that changes encoded
     // UPDATE bytes belongs here.
@@ -449,6 +454,9 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         } else {
             None
         },
+        // route-server-client makes the egress AS_PATH transparent and
+        // keeps the forwarded next-hop (eBGP only — iBGP never prepends).
+        route_server_client: peer.is_ebgp() && peer.config.route_server_client,
         as4_negotiated: peer.as4,
         extended_message: peer.opt.extended_message,
         addpath_send: peer.opt.is_add_path_send(afi, safi),
@@ -1495,6 +1503,7 @@ mod tests {
             remove_private_as: None,
             local_as_substitute: None,
             otc_local_role: None,
+            route_server_client: false,
             as4_negotiated: true,
             extended_message: true,
             addpath_send: false,
@@ -1707,6 +1716,12 @@ mod tests {
         let mut b = a.clone();
         b.otc_local_role = Some(bgp_packet::BgpRole::Customer);
         assert_ne!(a, b);
+
+        // RFC 7947: a route-server client gets the untouched AS_PATH and
+        // next-hop — its own group.
+        let mut a = base.clone();
+        a.route_server_client = true;
+        assert_ne!(base, a);
 
         let mut a = base.clone();
         a.as4_negotiated = false;

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -1087,6 +1087,23 @@ pub fn config_vrf_neighbor_enforce_first_as(
     Some(())
 }
 
+/// `set router bgp vrf <NAME> neighbor <addr> route-server-client` —
+/// RFC 7947 presence container (zebra-bgp-vrf.yang mirrors
+/// zebra-bgp-route-server.yang). Staged verbatim; resolved and applied at
+/// materialization like the other inheritable knobs.
+pub fn config_vrf_neighbor_route_server_client(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let vrf = args.string()?;
+    let addr = args.addr()?;
+    let cfg = vrf_entry(bgp, vrf, op)?;
+    let nbr = neighbor_entry(cfg, addr, op)?;
+    nbr.config.knobs_explicit.route_server_client = op.is_set().then_some(true);
+    Some(())
+}
+
 /// `set router bgp vrf <NAME> neighbor <addr> otc-local-role <role>` —
 /// RFC 9234 list node (zebra-bgp-vrf.yang mirrors zebra-bgp-otc.yang).
 /// Staged verbatim; resolved and applied at materialization like the

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2929,6 +2929,36 @@ mod yang_load_tests {
         }
     }
 
+    /// RFC 7947 `route-server-client` (zebra-bgp-route-server.yang): the
+    /// presence container must be settable on the global neighbor and the
+    /// VRF neighbor (the group copy is pinned with the other group knobs).
+    #[test]
+    fn bgp_neighbor_route_server_client_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 192.168.1.3 route-server-client",
+            "set router bgp vrf RED neighbor 192.168.1.3 route-server-client",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// RFC 9234 `otc-local-role` (zebra-bgp-otc.yang): the list keyed by
     /// an enumeration and its `strict` empty leaf must parse as settable
     /// paths on the global neighbor, the neighbor-group and the VRF
@@ -4395,6 +4425,7 @@ mod yang_load_tests {
             "set router bgp neighbor-group G allowas-in count 5",
             "set router bgp neighbor-group G allowas-in origin",
             "set router bgp neighbor-group G as-override",
+            "set router bgp neighbor-group G route-server-client",
             "set router bgp neighbor-group G remove-private-as",
             "set router bgp neighbor-group G remove-private-as all",
             "set router bgp neighbor-group G remove-private-as replace-as",

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -167,6 +167,9 @@ module config {
   import zebra-bgp-otc {
     prefix zbotc;
   }
+  import zebra-bgp-route-server {
+    prefix zbrs;
+  }
   import zebra-bgp-capability {
     prefix zbcap;
   }

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -48,6 +48,10 @@ module zebra-bgp-neighbor-group {
     prefix zbotc;
   }
 
+  import zebra-bgp-route-server {
+    prefix zbrs;
+  }
+
   import config {
     prefix config;
   }
@@ -162,6 +166,7 @@ module zebra-bgp-neighbor-group {
       uses zbrpa:bgp-neighbor-remove-private-as-extension;
       uses zbef:bgp-neighbor-enforce-first-as-extension;
       uses zbotc:bgp-neighbor-otc-local-role-extension;
+      uses zbrs:bgp-neighbor-route-server-client-extension;
       /* TCP-AO for members, and — via a listen-range binding — for
          the whole range: a dynamic peer is materialized only after
          its SYN is accepted, so the MKT must already be on the

--- a/zebra-rs/yang/zebra-bgp-route-server.yang
+++ b/zebra-rs/yang/zebra-bgp-route-server.yang
@@ -1,0 +1,107 @@
+module zebra-bgp-route-server {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-route-server";
+  prefix "zbrs";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "RFC 7947 Internet Exchange route-server behaviour, per client:
+
+       router bgp {
+         neighbor 192.168.0.1 {
+           remote-as 65001;
+           route-server-client;
+         }
+       }
+
+     A route server re-advertises its clients' routes to each other
+     transparently. Toward a neighbor marked `route-server-client` this
+     router:
+
+       - does NOT prepend its own AS to the AS_PATH (§2.2.2) — nor apply
+         the AS_PATH rewrites that only make sense with a prepend
+         (as-override, remove-private-as, the local-as substitute);
+       - keeps the received NEXT_HOP on forwarded routes (§2.2.1), so a
+         client forwards straight to the originating member on the
+         exchange LAN; locally originated routes still carry this
+         router's address;
+       - passes MED and communities through unchanged (§2.2.2.1/2),
+         as it always does.
+
+     IPv4 and IPv6 unicast only. Inbound processing from a client is
+     ordinary eBGP. Path hiding (§2.3) is addressed with ADD-PATH on the
+     client sessions (`afi-safi ipv4 add-path send`), not with a
+     per-client Loc-RIB.
+
+     On the client side, do NOT enable `enforce-first-as` toward a
+     route server — every route it sends starts with another member's
+     AS. Together with RFC 9234 the pair is `otc-local-role route-server`
+     on the server and `otc-local-role route-server-client` on the
+     client (zebra-bgp-otc.yang).
+
+     Changing the knob on a live session resets it so the client
+     re-receives every route with the transparent AS_PATH and next-hop.";
+
+  revision 2026-08-28 {
+    description "Initial revision.";
+    reference
+      "RFC 7947: Internet Exchange BGP Route Server.
+       FRR / BIRD `route-server-client` / `rs client`.";
+  }
+
+  grouping bgp-neighbor-route-server-client-extension {
+    description
+      "`route-server-client` presence container on a BGP neighbor.";
+
+    container route-server-client {
+      ext:help "Treat this neighbor as a route-server client (RFC 7947)";
+      presence "Advertise routes to this neighbor transparently, as a route server";
+      description
+        "When present, routes advertised to this eBGP neighbor keep the
+         AS_PATH exactly as received (no local-AS prepend) and, for
+         forwarded routes, the received NEXT_HOP. No-op for iBGP.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach route-server-client to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-route-server-client-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X route-server-client` is path-valid.";
+    uses bgp-neighbor-route-server-client-extension;
+  }
+}

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -368,6 +368,14 @@ module zebra-bgp-vrf {
            segment begins with the CE's own AS. No-op for iBGP. Same as
            the global neighbor.";
       }
+      container route-server-client {
+        ext:help "Treat this CE as a route-server client (RFC 7947)";
+        presence "Advertise routes to this CE transparently, as a route server";
+        description
+          "Keep the AS_PATH (no local-AS prepend) and the received
+           NEXT_HOP on routes advertised to this eBGP CE. No-op for
+           iBGP. Same as the global neighbor (zebra-bgp-route-server.yang).";
+      }
       list otc-local-role {
         key "role";
         max-elements 1;


### PR DESCRIPTION
## Summary

Implements the design in `docs/design/bgp-route-server-plan.md` (split out of the RFC 9234 series): zebra-rs can now act as an Internet Exchange route server toward neighbors marked `route-server-client`.

```
router bgp {
  neighbor 192.168.0.1 {
    remote-as 65001;
    route-server-client;
  }
}
```

Toward such a neighbor (eBGP, IPv4/IPv6 unicast):

| RFC 7947 | before | now |
|---|---|---|
| §2.2.2 AS_PATH | local AS prepended (after as-override / remove-private-as / local-as) | **untouched** — no prepend, no rewrites |
| §2.2.1 NEXT_HOP | rewritten to self | **received next-hop kept** on forwarded routes (originated routes still self) |
| §2.2.2.1/2 MED, communities | pass through | pass through |
| §2.3 path hiding | — | ADD-PATH on the client sessions (no per-client Loc-RIB) |

* YANG presence container `route-server-client`, inheritable via neighbor-group, VRF copy; parse pins on all three paths.
* `EgressAs.route_server_client` → `ebgp_egress_aspath` early return; next-hop-unchanged implied for forwarded unicast rows (v4 `sync_ctx`, v6 builder).
* **`UpdateGroupSig.route_server_client`, `SIGNATURE_VERSION` 7→8** — clients form their own update group.
* `apply_route_server_client` bounces a live session on change (the already-advertised table has the old shape) and warns when as-override / remove-private-as / local-as overlap (ignored toward a client).
* `show bgp neighbor`: `Route-server client: enabled (transparent AS_PATH and next-hop, RFC 7947)`; group show/JSON.
* Book chapter `ch-02-43-bgp-route-server.md`; the RFC 7947 appendix row (removed in #2334 as unbacked) is restored; update-groups §3.1 row; plan doc marked implemented.

Deviation from the plan doc: incompatible AS_PATH knobs are ignored-with-warning rather than rejected in the callback (callback order within a commit makes rejection unreliable).

## Test plan

- [x] Unit: transparent AS_PATH toward a client with every rewrite knob set vs. plain eBGP still prepending; `signature_fields_each_distinguish`; per-neighbor and group wiring (explicit wins, live member bounced); YANG parse pins
- [x] `cargo test --workspace --exclude bdd`, `cargo fmt --check`, workspace clippy `-D warnings`, lua clippy; config-audit docs regenerated
- [x] **BDD `@bgp_route_server` — 5/5 scenarios green** on one bridged LAN (rs AS65000, members AS65001/AS65003): plain eBGP → `as_path "65000 65001"`, `next_hop 192.168.0.2`; with the knob → `as_path "65001"`, `next_hop 192.168.0.1` (and the mirror image for the other member); with `otc-local-role route-server` / `route-server-client` → roles `(received)` both ways and `otc_as 65000` on the member
- [x] `mdbook build` clean, chapter cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g1SgtRd4VA3tj5dit9uqr
