### PR TITLE
bgp: RFC 8584 §3 HRW DF election (df-election algorithm hrw)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_es/z1-hrw.yaml
+++ b/bdd/tests/configs/bgp_evpn_es/z1-hrw.yaml
@@ -1,0 +1,26 @@
+# z1 — EVPN multihoming (RFC 7432). Configures Ethernet Segment es1 with a
+# shared ESI; originates a Type-4 ES route and discovers z2 (the other PE on
+# the same ES) from z2's Type-4. Control-plane only — no VXLAN dataplane is
+# needed for ES discovery.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: all-active
+        df-election:
+          algorithm: hrw
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_es/z2-hrw.yaml
+++ b/bdd/tests/configs/bgp_evpn_es/z2-hrw.yaml
@@ -1,0 +1,25 @@
+# z2 — EVPN multihoming (RFC 7432). The second PE on Ethernet Segment es1,
+# sharing the SAME ESI as z1 (the defining property of an ES). Originates its
+# own Type-4 and discovers z1.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: all-active
+        df-election:
+          algorithm: hrw
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_es.feature
+++ b/bdd/tests/features/bgp_evpn_es.feature
@@ -83,6 +83,24 @@ Feature: BGP EVPN Ethernet Segment discovery (RFC 7432 Type-4)
     Then show command "show bgp evpn" in namespace "z1" should eventually not contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
     And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Member VTEPs (1)"
 
+  Scenario: HRW election (RFC 8584 Alg 1) is negotiated and agreed on both PEs
+    Given the test topology exists
+    # Restore z2's ES and switch both PEs to `df-election algorithm hrw`.
+    When I apply config "z1-hrw.yaml" to namespace "z1"
+    And I apply config "z2-hrw.yaml" to namespace "z2"
+    # Both Type-4s now carry the DF Election EC with Alg 1, so the
+    # negotiated algorithm is HRW.
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "df-election:alg1"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "DF algorithm: hrw"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Member VTEPs (2)"
+    # The RFC 8584 §3.2 weights for ESI 00:11:…:99, tag 0 rank 192.168.0.1
+    # (1676836140) over 192.168.0.2 (1477024859); the same DF as carving
+    # here, but reached through the hash, and both PEs must agree.
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Designated Forwarder (tag 0): 192.168.0.1 (this node)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "DF algorithm: hrw"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Designated Forwarder (tag 0): 192.168.0.1"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should not contain "Designated Forwarder (tag 0): 192.168.0.2"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -285,6 +285,32 @@ This interoperates with IOS-XR `service-carving preference-based`, Junos
 `designated-forwarder election algorithm preference` and FRR
 `evpn mh es-df-pref`.
 
+**Highest Random Weight** (Alg 1, RFC 8584 §3) keeps a hash but fixes
+carving's two weaknesses — a PE joining or leaving renumbers every ordinal
+and so reshuffles *every* service on the segment, and the lowest address
+gets a disproportionate share. HRW gives each `<PE, tag>` pair a
+pseudo-random weight seeded by the ESI and the service identifier, and the
+highest weight is the DF; adding or removing a PE only moves the services
+that PE won or wins. Ask for it with:
+
+```
+  ethernet-segment ES1
+   esi 00:11:22:33:44:55:66:77:88:99
+   interface ce1
+   df-election
+    algorithm hrw
+```
+
+The Type-4 then carries `df-election:alg1`, and the same unanimity rule
+applies: any PE still advertising Alg 0 drops the segment back to carving. A
+`preference` on the same segment takes priority over `algorithm hrw` — a
+pinned DF is a stronger statement than a better hash. The weight is the
+RFC's formula bit for bit (CRC-32 of the tag and ESI, then the RFC's
+linear-congruential mix, modulo 2^31, ties to the lowest address), so a
+segment shared with Junos `df-election-type mod`/Arista `algorithm hrw`
+peers elects the same DF on every box. For the E-LAN election the tag is
+the VNI; for VPWS it is the service identifier.
+
 Because the candidate set comes from the Type-4 routes in the Loc-RIB, the
 role is re-elected whenever a PE joins or leaves the segment — a peer's
 Type-4 arriving or being withdrawn re-runs the election and re-advertises

--- a/docs/design/bgp-evpn-ethernet-segment.md
+++ b/docs/design/bgp-evpn-ethernet-segment.md
@@ -271,6 +271,15 @@ kernel VXLAN backend stays single-homed.**
   `cradle_evpn_mh_sa_zebra` (BGP-driven).
 - **LAG as the segment port ✅ (slice 4, cradle-rs #187)**: the ES
   `interface` is a kernel bond; nothing zebra-side beyond naming it.
+- **HRW DF election (RFC 8584 §3, Alg 1) ✅**: `df-election algorithm hrw`.
+  `hrw_digest` = CRC-32 (IEEE/zlib) of `tag || ESI` with the top bit
+  dropped; `hrw_weight` = the RFC's LCG in wrapping 32-bit arithmetic mod
+  2^31 (IPv6 addresses by their low-order 32 bits); `hrw_ranked` orders by
+  weight then lowest address, DF first, backup second. `elect_forwarders`
+  now takes the ESI (HRW's salt) and dispatches on the negotiated
+  algorithm; a `preference` still overrides `hrw`. Unit vectors computed
+  independently from the formula guard interop. BDD: `bgp_evpn_es`
+  (both PEs advertise `df-election:alg1` and agree on the DF).
 - **Open risk:** Linux VXLAN/bridge multihoming primitives are limited;
   local-bias + aliasing may need **eBPF/tc** assists (cf. the RFC 9524
   replication work, `zebra-rs-evpn-rfc9524-replication-plan`). Feasibility

--- a/docs/design/bgp-evpn-multihoming-dataplane.md
+++ b/docs/design/bgp-evpn-multihoming-dataplane.md
@@ -178,7 +178,7 @@ rows are C3 (modulus/HRW) and C9.
 | ES config (Type-0 manual ESI, redundancy mode, one interface, DF preference, AC-DF bit, startup-delay) | ✅ | `yang/zebra-bgp-evpn.yang:208-296`, `bgp/config.rs:1891-2105`, `bgp/ethernet_segment.rs:100-126` |
 | Type-4 ES, Type-1 A-D per ES (ESI-label EC), Type-1 A-D per EVI | ✅ originated | `bgp/route.rs:16968`, `:17034`, `:17082` |
 | DF election: modulus (Alg 0) + preference (Alg 2), RFC 8584 negotiation | ✅ | `bgp/ethernet_segment.rs:215-280` |
-| DF election: HRW (Alg 1) | ❌ falls back to carving | `ethernet_segment.rs:267-280`, `show.rs:2687` |
+| DF election: HRW (Alg 1) | ✅ `df-election algorithm hrw` (RFC 8584 §3) | `ethernet_segment.rs` `hrw_ranked` |
 | AC-DF behaviour (withdraw on AC down) | ❌ bit only | no `LinkDown` path touches `ethernet_segments` |
 | Where the DF result goes | `show` and the VPWS P/B bits only | `bgp/show.rs:2565-2698`, `route.rs:17389-17422` |
 | non-DF filter, SPH/local-bias | ❌ **nothing programmed anywhere** | `EvpnFloodState::desired` `route.rs:3046-3069` filters on P2MP/prune/AR only; zero `IFLA_BRPORT` in `fib/` |

--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -12,6 +12,7 @@
 /router/bgp/afi-safi/encapsulation
 /router/bgp/afi-safi/ethernet-segment
 /router/bgp/afi-safi/ethernet-segment/df-election/ac-df
+/router/bgp/afi-safi/ethernet-segment/df-election/algorithm
 /router/bgp/afi-safi/ethernet-segment/df-election/preference
 /router/bgp/afi-safi/ethernet-segment/df-election/startup-delay
 /router/bgp/afi-safi/ethernet-segment/esi

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -23,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 348
-Handled: 333
+Total settable schema nodes: 349
+Handled: 334
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -12,6 +12,7 @@
 /router/bgp/afi-safi/ethernet-segment	list keys=name
 /router/bgp/afi-safi/ethernet-segment/df-election	p-container
 /router/bgp/afi-safi/ethernet-segment/df-election/ac-df	leaf
+/router/bgp/afi-safi/ethernet-segment/df-election/algorithm	leaf
 /router/bgp/afi-safi/ethernet-segment/df-election/preference	leaf
 /router/bgp/afi-safi/ethernet-segment/df-election/startup-delay	leaf
 /router/bgp/afi-safi/ethernet-segment/esi	leaf

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2187,6 +2187,24 @@ fn config_es_df_preference(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     Some(())
 }
 
+/// `router bgp afi-safi evpn ethernet-segment <name> df-election algorithm
+/// <default|hrw>` — elect with RFC 8584 §3 Highest Random Weight (Alg 1)
+/// instead of service carving. A configured preference (Alg 2) still takes
+/// precedence. The Type-4 is re-originated so peers see the algorithm, and
+/// the segment re-elects.
+fn config_es_df_algorithm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let hrw = op.is_set() && args.string()? == "hrw";
+    let es = bgp.ethernet_segments.entry(name).or_default();
+    es.hrw = hrw;
+    es_df_election_changed(bgp);
+    Some(())
+}
+
 /// `router bgp afi-safi evpn ethernet-segment <name> df-election ac-df` —
 /// advertise the RFC 8584 §2.2 AC-Influenced DF election capability bit.
 fn config_es_ac_df(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -5457,6 +5475,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/ethernet-segment/interface",
             config_ethernet_segment_interface,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment/df-election/algorithm",
+            config_es_df_algorithm,
         );
         self.callback_add(
             "/router/bgp/afi-safi/ethernet-segment/df-election/preference",

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -112,6 +112,10 @@ pub struct EthernetSegment {
     /// Advertise the RFC 8584 §2.2 AC-DF (AC-Influenced DF election)
     /// capability on this segment's Type-4.
     pub ac_df: bool,
+    /// Elect with the RFC 8584 §3 Highest Random Weight algorithm (Alg 1)
+    /// instead of service carving; a configured `df_preference` (Alg 2)
+    /// takes precedence.
+    pub hrw: bool,
     /// Seconds to stay out of this segment's DF election after joining it
     /// (IOS-XR `timers peering`, Junos
     /// `designated-forwarder-election-hold-time`, FRR
@@ -176,7 +180,11 @@ impl EthernetSegment {
                 pref,
             },
             None => DfElectionEc {
-                df_alg: DfElectionEc::ALG_DEFAULT,
+                df_alg: if self.hrw {
+                    DfElectionEc::ALG_HRW
+                } else {
+                    DfElectionEc::ALG_DEFAULT
+                },
                 bitmap: 0,
                 pref: 0,
             },
@@ -253,6 +261,70 @@ fn pref_ranked(candidates: &[DfCandidate]) -> Vec<IpAddr> {
     ranked.into_iter().map(|(ip, _, _)| ip).collect()
 }
 
+/// CRC-32 (IEEE 802.3 / ISO 3309: polynomial 0x04C11DB7 reflected, initial
+/// and final XOR all-ones — the CRC of zlib and Ethernet), as RFC 8584 §3.2
+/// uses for the HRW digest. Bitwise; the inputs are 14 bytes.
+pub fn crc32_ieee(bytes: &[u8]) -> u32 {
+    let mut crc: u32 = 0xffff_ffff;
+    for &b in bytes {
+        crc ^= b as u32;
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 {
+                (crc >> 1) ^ 0xedb8_8320
+            } else {
+                crc >> 1
+            };
+        }
+    }
+    !crc
+}
+
+/// RFC 8584 §3.2 `D(V, Es)`: the 31-bit digest of the 14-octet stream
+/// `Ethernet Tag (4, network order) || ESI (10)` — CRC-32 with the top bit
+/// discarded.
+pub fn hrw_digest(esi: &[u8; 10], tag: u32) -> u32 {
+    let mut stream = [0u8; 14];
+    stream[..4].copy_from_slice(&tag.to_be_bytes());
+    stream[4..].copy_from_slice(esi);
+    crc32_ieee(&stream) & 0x7fff_ffff
+}
+
+/// RFC 8584 §3.2 `Wrand(V, Es, Si)`:
+/// `(1103515245 · ((1103515245 · Si + 12345) ⊕ D) + 12345) mod 2^31`, with
+/// `Si` the PE's address as a 32-bit integer — an IPv4 address whole, an
+/// IPv6 address by its low-order 32 bits (the RFC notes only the low 31
+/// bits are significant). Computed in wrapping 32-bit arithmetic, which
+/// preserves the residue mod 2^31 the RFC defines.
+pub fn hrw_weight(addr: IpAddr, digest: u32) -> u32 {
+    let si: u32 = match addr {
+        IpAddr::V4(v4) => u32::from(v4),
+        IpAddr::V6(v6) => {
+            let o = v6.octets();
+            u32::from_be_bytes([o[12], o[13], o[14], o[15]])
+        }
+    };
+    let a = 1_103_515_245u32.wrapping_mul(si).wrapping_add(12_345);
+    1_103_515_245u32
+        .wrapping_mul(a ^ digest)
+        .wrapping_add(12_345)
+        & 0x7fff_ffff
+}
+
+/// The candidates ordered best-DF-first under HRW (RFC 8584 §3.2): highest
+/// weight wins, a tie goes to the numerically lowest address; the runner-up
+/// is the backup DF. Deterministic and order-independent, so every PE on
+/// the segment computes the same ranking from the same Type-4 set.
+fn hrw_ranked(candidates: &[DfCandidate], esi: &[u8; 10], tag: u32) -> Vec<IpAddr> {
+    let d = hrw_digest(esi, tag);
+    let mut ranked: Vec<(u32, IpAddr)> = candidates
+        .iter()
+        .map(|(ip, _, _)| (hrw_weight(*ip, d), *ip))
+        .collect();
+    ranked.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    ranked.dedup_by_key(|(_, ip)| *ip);
+    ranked.into_iter().map(|(_, ip)| ip).collect()
+}
+
 /// Elect the Designated Forwarder and its backup for one service instance,
 /// dispatching on the algorithm the segment's PEs agreed on.
 ///
@@ -264,11 +336,22 @@ fn pref_ranked(candidates: &[DfCandidate]) -> Vec<IpAddr> {
 ///
 /// `candidates` need not be sorted; carving sorts by address internally so
 /// the ordinal is stable across PEs.
-pub fn elect_forwarders(candidates: &[DfCandidate], tag: u32) -> (Option<IpAddr>, Option<IpAddr>) {
+pub fn elect_forwarders(
+    candidates: &[DfCandidate],
+    esi: &[u8; 10],
+    tag: u32,
+) -> (Option<IpAddr>, Option<IpAddr>) {
     let algs: Vec<u8> = candidates.iter().map(|(_, alg, _)| *alg).collect();
-    if negotiate_df_alg(&algs) == DfElectionEc::ALG_PREF {
-        let ranked = pref_ranked(candidates);
-        return (ranked.first().copied(), ranked.get(1).copied());
+    match negotiate_df_alg(&algs) {
+        DfElectionEc::ALG_PREF => {
+            let ranked = pref_ranked(candidates);
+            return (ranked.first().copied(), ranked.get(1).copied());
+        }
+        DfElectionEc::ALG_HRW => {
+            let ranked = hrw_ranked(candidates, esi, tag);
+            return (ranked.first().copied(), ranked.get(1).copied());
+        }
+        _ => {}
     }
     let mut vteps: Vec<IpAddr> = candidates.iter().map(|(ip, _, _)| *ip).collect();
     vteps.sort();
@@ -333,13 +416,14 @@ pub fn vpws_role(
     mode: EsRedundancyMode,
     candidates: &[DfCandidate],
     me: IpAddr,
+    esi: &[u8; 10],
     service_id: u32,
 ) -> VpwsRole {
     let on_segment = candidates.iter().any(|(ip, _, _)| *ip == me);
     if !matches!(mode, EsRedundancyMode::SingleActive) || !on_segment {
         return VpwsRole::Primary;
     }
-    let (df, backup) = elect_forwarders(candidates, service_id);
+    let (df, backup) = elect_forwarders(candidates, esi, service_id);
     if df == Some(me) {
         VpwsRole::Primary
     } else if backup == Some(me) {
@@ -359,8 +443,14 @@ pub fn vpws_role(
 /// is not DF either — unlike `vpws_role`'s primary fallback, a BUM copy
 /// delivered by a not-yet-elected PE is exactly the duplicate the filter
 /// exists to stop, while known unicast keeps flowing regardless.
-pub fn elan_df(candidates: &[DfCandidate], me: IpAddr, vni: u32, holding: bool) -> bool {
-    !holding && elect_forwarders(candidates, vni).0 == Some(me)
+pub fn elan_df(
+    candidates: &[DfCandidate],
+    me: IpAddr,
+    esi: &[u8; 10],
+    vni: u32,
+    holding: bool,
+) -> bool {
+    !holding && elect_forwarders(candidates, esi, vni).0 == Some(me)
 }
 
 /// What the E-LAN DF tee last told the cradle datapath about one segment
@@ -461,6 +551,9 @@ mod ac_esi_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The segment the election tests run on (its ESI is HRW's salt).
+    const ESI_T: [u8; 10] = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99];
 
     #[test]
     fn redundancy_mode_keyword_round_trip() {
@@ -580,7 +673,7 @@ mod tests {
         for me in [a, b, c] {
             for service_id in 0..4u32 {
                 assert_eq!(
-                    vpws_role(EsRedundancyMode::AllActive, &cands, me, service_id),
+                    vpws_role(EsRedundancyMode::AllActive, &cands, me, &ESI_T, service_id),
                     VpwsRole::Primary
                 );
             }
@@ -594,14 +687,20 @@ mod tests {
         let mode = EsRedundancyMode::SingleActive;
         // Service instance 0 carves to ordinal 0: a is DF, b backs it up,
         // c must not be used for this instance.
-        assert_eq!(vpws_role(mode, &cands, a, 0), VpwsRole::Primary);
-        assert_eq!(vpws_role(mode, &cands, b, 0), VpwsRole::Backup);
-        assert_eq!(vpws_role(mode, &cands, c, 0), VpwsRole::NonDesignated);
+        assert_eq!(vpws_role(mode, &cands, a, &ESI_T, 0), VpwsRole::Primary);
+        assert_eq!(vpws_role(mode, &cands, b, &ESI_T, 0), VpwsRole::Backup);
+        assert_eq!(
+            vpws_role(mode, &cands, c, &ESI_T, 0),
+            VpwsRole::NonDesignated
+        );
         // Instance 1 shifts the whole assignment by one — that spread is the
         // point of carving per <ESI, service instance>.
-        assert_eq!(vpws_role(mode, &cands, b, 1), VpwsRole::Primary);
-        assert_eq!(vpws_role(mode, &cands, c, 1), VpwsRole::Backup);
-        assert_eq!(vpws_role(mode, &cands, a, 1), VpwsRole::NonDesignated);
+        assert_eq!(vpws_role(mode, &cands, b, &ESI_T, 1), VpwsRole::Primary);
+        assert_eq!(vpws_role(mode, &cands, c, &ESI_T, 1), VpwsRole::Backup);
+        assert_eq!(
+            vpws_role(mode, &cands, a, &ESI_T, 1),
+            VpwsRole::NonDesignated
+        );
     }
 
     #[test]
@@ -610,10 +709,16 @@ mod tests {
         let mode = EsRedundancyMode::SingleActive;
         // Our own Type-4 not selected yet (or no segment at all): advertise
         // primary rather than blackhole the service while it converges.
-        assert_eq!(vpws_role(mode, &carving(&[a, b]), c, 0), VpwsRole::Primary);
-        assert_eq!(vpws_role(mode, &[], a, 0), VpwsRole::Primary);
+        assert_eq!(
+            vpws_role(mode, &carving(&[a, b]), c, &ESI_T, 0),
+            VpwsRole::Primary
+        );
+        assert_eq!(vpws_role(mode, &[], a, &ESI_T, 0), VpwsRole::Primary);
         // Sole PE on the segment is the DF.
-        assert_eq!(vpws_role(mode, &carving(&[a]), a, 3), VpwsRole::Primary);
+        assert_eq!(
+            vpws_role(mode, &carving(&[a]), a, &ESI_T, 3),
+            VpwsRole::Primary
+        );
     }
 
     #[test]
@@ -622,11 +727,11 @@ mod tests {
         // a is the lowest address but the lowest preference, so under Alg 2
         // it loses to both — the whole point of preference over carving.
         let cands = prefs(&[(a, 10), (b, 300), (c, 200)]);
-        assert_eq!(elect_forwarders(&cands, 0), (Some(b), Some(c)));
+        assert_eq!(elect_forwarders(&cands, &ESI_T, 0), (Some(b), Some(c)));
         // ... and the service instance no longer shifts the winner, unlike
         // carving: preference is per-segment, not per-service.
         for tag in 0..5u32 {
-            assert_eq!(elect_forwarders(&cands, tag).0, Some(b));
+            assert_eq!(elect_forwarders(&cands, &ESI_T, tag).0, Some(b));
         }
     }
 
@@ -636,7 +741,7 @@ mod tests {
         // draft-ietf-bess-evpn-pref-df, and FRR's comparison: equal pref ->
         // lowest IP wins. Both PEs must agree or they both forward.
         let cands = prefs(&[(c, 100), (a, 100), (b, 100)]);
-        assert_eq!(elect_forwarders(&cands, 0), (Some(a), Some(b)));
+        assert_eq!(elect_forwarders(&cands, &ESI_T, 0), (Some(a), Some(b)));
     }
 
     #[test]
@@ -648,10 +753,10 @@ mod tests {
         let mut cands = prefs(&[(a, 10), (b, 300)]);
         cands.push((c, DfElectionEc::ALG_DEFAULT, 0));
         // Carving on the address-sorted list [a, b, c], tag 1 -> ordinal 1.
-        assert_eq!(elect_forwarders(&cands, 1), (Some(b), Some(c)));
+        assert_eq!(elect_forwarders(&cands, &ESI_T, 1), (Some(b), Some(c)));
         // Whereas all-Alg-2 would have given b (highest pref) for every tag.
         let agreed = prefs(&[(a, 10), (b, 300), (c, 0)]);
-        assert_eq!(elect_forwarders(&agreed, 1).0, Some(b));
+        assert_eq!(elect_forwarders(&agreed, &ESI_T, 1).0, Some(b));
     }
 
     #[test]
@@ -663,24 +768,97 @@ mod tests {
         // must not be used — and unlike carving this holds for every
         // service instance.
         for tag in 0..4u32 {
-            assert_eq!(vpws_role(mode, &cands, b, tag), VpwsRole::Primary);
-            assert_eq!(vpws_role(mode, &cands, c, tag), VpwsRole::Backup);
-            assert_eq!(vpws_role(mode, &cands, a, tag), VpwsRole::NonDesignated);
+            assert_eq!(vpws_role(mode, &cands, b, &ESI_T, tag), VpwsRole::Primary);
+            assert_eq!(vpws_role(mode, &cands, c, &ESI_T, tag), VpwsRole::Backup);
+            assert_eq!(
+                vpws_role(mode, &cands, a, &ESI_T, tag),
+                VpwsRole::NonDesignated
+            );
         }
         // All-active still overrides the election entirely.
         for me in [a, b, c] {
             assert_eq!(
-                vpws_role(EsRedundancyMode::AllActive, &cands, me, 0),
+                vpws_role(EsRedundancyMode::AllActive, &cands, me, &ESI_T, 0),
                 VpwsRole::Primary
             );
         }
     }
 
+    /// The CRC-32 the HRW digest is built on is the IEEE/zlib one: its
+    /// standard check value.
+    #[test]
+    fn crc32_is_the_ieee_crc() {
+        assert_eq!(crc32_ieee(b"123456789"), 0xcbf4_3926);
+    }
+
+    /// RFC 8584 §3.2 vectors, computed independently from the formula
+    /// (`zlib.crc32` over `tag || ESI`, then the LCG in 32-bit wrapping
+    /// arithmetic, mod 2^31): for ESI 00:11:…:99 and tag 0 the digest is
+    /// 0x19981279, and 192.168.0.1 outweighs 192.168.0.2; for tag 100 the
+    /// order flips. Any implementation on the far end of the segment that
+    /// follows the RFC must agree on these, or two DFs forward.
+    #[test]
+    fn hrw_matches_the_rfc_8584_formula() {
+        use std::net::Ipv4Addr;
+        let a = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
+        let b = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2));
+        assert_eq!(hrw_digest(&ESI_T, 0), 0x1998_1279);
+        assert_eq!(hrw_weight(a, 0x1998_1279), 1_676_836_140);
+        assert_eq!(hrw_weight(b, 0x1998_1279), 1_477_024_859);
+        assert_eq!(hrw_digest(&ESI_T, 100), 0x7995_f7c3);
+        assert_eq!(hrw_weight(a, 0x7995_f7c3), 712_275_514);
+        assert_eq!(hrw_weight(b, 0x7995_f7c3), 2_110_888_649);
+        let cands: Vec<DfCandidate> =
+            vec![(a, DfElectionEc::ALG_HRW, 0), (b, DfElectionEc::ALG_HRW, 0)];
+        assert_eq!(elect_forwarders(&cands, &ESI_T, 0), (Some(a), Some(b)));
+        assert_eq!(elect_forwarders(&cands, &ESI_T, 100), (Some(b), Some(a)));
+        // Order-independent: every PE ranks the same set the same way.
+        let rev: Vec<DfCandidate> = cands.iter().rev().copied().collect();
+        assert_eq!(elect_forwarders(&rev, &ESI_T, 0), (Some(a), Some(b)));
+        // A single candidate is DF with nobody to back it up; none elects nobody.
+        assert_eq!(elect_forwarders(&cands[..1], &ESI_T, 0), (Some(a), None));
+        assert_eq!(elect_forwarders(&[], &ESI_T, 0), (None, None));
+    }
+
+    /// One PE asking for HRW while another asks for carving is a disagreed
+    /// segment: RFC 8584 negotiation falls back to carving, whose tag-0 DF
+    /// is the lowest address regardless of weights.
+    #[test]
+    fn hrw_needs_unanimity() {
+        let [a, b, _] = pes();
+        let mixed: Vec<DfCandidate> = vec![
+            (a, DfElectionEc::ALG_HRW, 0),
+            (b, DfElectionEc::ALG_DEFAULT, 0),
+        ];
+        assert_eq!(elect_forwarders(&mixed, &ESI_T, 0).0, Some(a));
+        assert_eq!(elect_forwarders(&mixed, &ESI_T, 1).0, Some(b));
+    }
+
+    /// The election the segment advertises follows the config: HRW when
+    /// asked for, but a preference still wins over it.
+    #[test]
+    fn segment_advertises_hrw_when_configured() {
+        let es = EthernetSegment {
+            hrw: true,
+            ..Default::default()
+        };
+        assert_eq!(es.df_election_ec().df_alg, DfElectionEc::ALG_HRW);
+        let es = EthernetSegment {
+            hrw: true,
+            df_preference: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(es.df_election_ec().df_alg, DfElectionEc::ALG_PREF);
+    }
+
     #[test]
     fn single_pe_wins_and_empty_elects_nobody() {
         let [a, _, _] = pes();
-        assert_eq!(elect_forwarders(&prefs(&[(a, 1)]), 0), (Some(a), None));
-        assert_eq!(elect_forwarders(&[], 0), (None, None));
+        assert_eq!(
+            elect_forwarders(&prefs(&[(a, 1)]), &ESI_T, 0),
+            (Some(a), None)
+        );
+        assert_eq!(elect_forwarders(&[], &ESI_T, 0), (None, None));
     }
 
     /// E-LAN DF per bridge domain: carving spreads consecutive VNIs across
@@ -691,20 +869,20 @@ mod tests {
         let [a, b, c] = pes();
         let cands: Vec<DfCandidate> = vec![(a, 0, 0), (b, 0, 0)];
         // VNI 100 % 2 == 0 → a; VNI 101 % 2 == 1 → b.
-        assert!(elan_df(&cands, a, 100, false));
-        assert!(!elan_df(&cands, b, 100, false));
-        assert!(!elan_df(&cands, a, 101, false));
-        assert!(elan_df(&cands, b, 101, false));
+        assert!(elan_df(&cands, a, &ESI_T, 100, false));
+        assert!(!elan_df(&cands, b, &ESI_T, 100, false));
+        assert!(!elan_df(&cands, a, &ESI_T, 101, false));
+        assert!(elan_df(&cands, b, &ESI_T, 101, false));
         // Holding trumps winning.
-        assert!(!elan_df(&cands, a, 100, true));
+        assert!(!elan_df(&cands, a, &ESI_T, 100, true));
         // Not a candidate: never DF.
-        assert!(!elan_df(&cands, c, 100, false));
-        assert!(!elan_df(&[], a, 100, false));
+        assert!(!elan_df(&cands, c, &ESI_T, 100, false));
+        assert!(!elan_df(&[], a, &ESI_T, 100, false));
         // Unanimous preference: the preferred PE is DF in every domain.
         let pref = prefs(&[(a, 10), (b, 200)]);
-        assert!(elan_df(&pref, b, 100, false));
-        assert!(elan_df(&pref, b, 101, false));
-        assert!(!elan_df(&pref, a, 100, false));
+        assert!(elan_df(&pref, b, &ESI_T, 100, false));
+        assert!(elan_df(&pref, b, &ESI_T, 101, false));
+        assert!(!elan_df(&pref, a, &ESI_T, 100, false));
     }
 
     #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -17660,9 +17660,9 @@ impl Bgp {
         let role = if self.es_holding(&esi) {
             VpwsRole::NonDesignated
         } else {
-            vpws_role(mode, &cands, me, local_id)
+            vpws_role(mode, &cands, me, &esi, local_id)
         };
-        let (df, _backup) = elect_forwarders(&cands, local_id);
+        let (df, _backup) = elect_forwarders(&cands, &esi, local_id);
         (esi, role, df)
     }
 
@@ -18080,7 +18080,10 @@ impl Bgp {
                         );
                         continue;
                     }
-                    roles.insert(vni, (elan_df(&cands, me, vni, holding), single_active));
+                    roles.insert(
+                        vni,
+                        (elan_df(&cands, me, &esi, vni, holding), single_active),
+                    );
                 }
             }
             desired.insert(esi, (port, roles, peers));

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2602,12 +2602,13 @@ fn show_bgp_evpn_ethernet_segment(
                 df_algorithm = Some(
                     match alg {
                         bgp_packet::DfElectionEc::ALG_DEFAULT => "service-carving",
+                        bgp_packet::DfElectionEc::ALG_HRW => "hrw",
                         bgp_packet::DfElectionEc::ALG_PREF => "preference-based",
                         _ => "unsupported (carving fallback)",
                     }
                     .to_string(),
                 );
-                designated_forwarder = super::ethernet_segment::elect_forwarders(&cands, 0)
+                designated_forwarder = super::ethernet_segment::elect_forwarders(&cands, &esi, 0)
                     .0
                     .map(|df| df.to_string());
             }
@@ -2694,13 +2695,14 @@ fn show_bgp_evpn_ethernet_segment(
                         None => "preference-based".to_string(),
                     }
                 }
+                bgp_packet::DfElectionEc::ALG_HRW => "hrw (RFC 8584 §3)".to_string(),
                 other => format!("alg {other} (unsupported; carving fallback)"),
             };
             writeln!(buf, "  DF algorithm: {alg_name}")?;
             if es.ac_df {
                 writeln!(buf, "  AC-DF capability: advertised")?;
             }
-            if let Some(df) = super::ethernet_segment::elect_forwarders(&cands, 0).0 {
+            if let Some(df) = super::ethernet_segment::elect_forwarders(&cands, &esi, 0).0 {
                 let tag = if df == local { " (this node)" } else { "" };
                 writeln!(buf, "  Designated Forwarder (tag 0): {df}{tag}")?;
             }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -258,6 +258,28 @@ module zebra-bgp-evpn {
            segment's Type-4 DF Election extended community (RFC 8584 §2.2).
            Absent = the RFC 7432 §8.5 default: service carving, no
            capabilities.";
+        leaf algorithm {
+          ext:help "DF election algorithm: default (service carving) or hrw";
+          type enumeration {
+            enum default {
+              description "RFC 7432 §8.5 service carving (RFC 8584 Alg 0).";
+            }
+            enum hrw {
+              description "RFC 8584 §3 Highest Random Weight (Alg 1).";
+            }
+          }
+          description
+            "The DF election algorithm this segment advertises in its Type-4
+             DF Election extended community and runs locally. `hrw` (RFC
+             8584 §3, Alg 1) ranks the segment's PEs by a pseudo-random
+             weight of (Ethernet Tag, ESI, PE address) — the highest wins,
+             ties go to the lowest address, the runner-up is the backup —
+             which spreads service instances across the PEs like carving
+             does but keeps every other instance's DF unchanged when a PE
+             joins or leaves. A configured `preference` overrides this leaf
+             (Alg 2). As with any algorithm, all PEs on the segment must
+             agree or the segment falls back to carving.";
+        }
         leaf preference {
           ext:help "DF preference; highest wins (selects Alg 2)";
           type uint16 {


### PR DESCRIPTION
## Summary
The last control-plane gap in the ENOG91 EVPN-MH matrix (`bgp-evpn-multihoming-dataplane.md`): **Highest Random Weight DF election, RFC 8584 §3 (Alg 1)**.

- New YANG leaf `df-election algorithm {default|hrw}` on the Ethernet Segment; `hrw` makes the Type-4 advertise `df-election:alg1`.
- `hrw_digest` = CRC-32 (IEEE) of `tag || ESI` with the top bit dropped; `hrw_weight` = the RFC's LCG in wrapping 32-bit arithmetic mod 2^31; `hrw_ranked` orders by weight, ties to the lowest address — DF first, backup second.
- `elect_forwarders` now takes the ESI (HRW's salt) and dispatches on the negotiated algorithm. A `preference` still overrides `hrw`; a mixed segment falls back to carving as before (RFC 8584 unanimity).
- Show output names the negotiated algorithm `hrw (RFC 8584 §3)` / JSON `hrw`.
- Docs: ES design doc, dataplane analysis matrix row (HRW ✅), book ch-02-38 HRW section; BGP config audit docs regenerated.

## Test plan
- [x] Unit: CRC-32 check value; RFC-formula vectors computed independently in Python (ESI 00:11:…:99 tag 0 → digest 0x19981279, 192.168.0.1 w=1676836140 beats 192.168.0.2 w=1477024859; tag 100 flips); order independence; unanimity fallback; preference > hrw.
- [x] `cargo test --workspace --exclude bdd`, clippy `-D warnings`, fmt.
- [x] BDD (after `make install`): `bgp_evpn_es` (new HRW scenario: both PEs advertise `alg1`, both report `DF algorithm: hrw` and agree on DF 192.168.0.1), `bgp_evpn_df_election`, `bgp_evpn_srv6_macip_multihoming`, `bgp_evpn_vpws_multihoming`, `bgp_evpn_vpws_vxlan_multihoming`, `bgp_evpn_vpws_startup_delay`, `bgp_evpn_srv6_macip` — 7/7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6q8o75SyjrbRH3DqnrrXg