### PR TITLE
bgp: RFC 8584 §4 AC-influenced DF election + EVPN access link state

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-acdf-off.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-acdf-off.yaml
@@ -1,0 +1,48 @@
+# z1 — z1-acdf.yaml without the AC-DF capability: the negative control.
+# Same links, same explicit segment binding; an AC failure now leaves the
+# election over the full Type-4 set.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: ce1.100
+        ethernet-segment: es1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-acdf.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z1-acdf.yaml
@@ -1,0 +1,52 @@
+# z1 — the z1-1.yaml pair with RFC 8584 §4 AC-influenced DF election
+# (`df-election ac-df`) and a real attachment circuit: the E-Line's AC is
+# the VLAN sub-interface ce1.100 of the segment port ce1, bound to es1
+# explicitly. Taking ce1.100 down withdraws only this service's Type-1;
+# the segment itself (Type-4, per-ES A-D on ce1) stays up.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+        df-election:
+          ac-df: null
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: ce1.100
+        ethernet-segment: es1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-acdf-off.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-acdf-off.yaml
@@ -1,0 +1,48 @@
+# z2 — z2-acdf.yaml without the AC-DF capability: the negative control.
+# Same links, same explicit segment binding; an AC failure now leaves the
+# election over the full Type-4 set.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: ce1.100
+        ethernet-segment: es1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-acdf.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-acdf.yaml
@@ -1,0 +1,52 @@
+# z2 — the z2-1.yaml pair with RFC 8584 §4 AC-influenced DF election
+# (`df-election ac-df`) and a real attachment circuit: the E-Line's AC is
+# the VLAN sub-interface ce1.100 of the segment port ce1, bound to es1
+# explicitly. Taking ce1.100 down withdraws only this service's Type-1;
+# the segment itself (Type-4, per-ES A-D on ce1) stays up.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: ce1
+        df-election:
+          ac-df: null
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: ce1.100
+        ethernet-segment: es1
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
@@ -186,6 +186,52 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "Remote SID: fcbb:bbbb:2:"
     And show command "show bgp evpn vpws" in namespace "z3" should contain "(via 192.168.0.2)"
 
+  Scenario: AC-influenced DF election re-elects the service whose AC went down (RFC 8584 §4)
+    Given the test topology exists
+    # Real links this time. The segment port is a dummy ce1; the E-Line's
+    # attachment circuit is the VLAN sub-interface ce1.100 on it, bound to
+    # es1 explicitly. Taking the AC down then withdraws only the service's
+    # Type-1 while the segment (Type-4, per-ES A-D) stays up — the case
+    # AC-DF exists for. A segment *port* down is plain segment loss: the ES
+    # routes are withheld and every PE re-elects without AC-DF.
+    When I execute "ip link add ce1 type dummy" in namespace "z1"
+    And I execute "ip link add link ce1 name ce1.100 type vlan id 100" in namespace "z1"
+    And I execute "ip link set ce1 up" in namespace "z1"
+    And I execute "ip link set ce1.100 up" in namespace "z1"
+    And I execute "ip link add ce1 type dummy" in namespace "z2"
+    And I execute "ip link add link ce1 name ce1.100 type vlan id 100" in namespace "z2"
+    And I execute "ip link set ce1 up" in namespace "z2"
+    And I execute "ip link set ce1.100 up" in namespace "z2"
+    And I apply config "z1-acdf.yaml" to namespace "z1"
+    And I apply config "z2-acdf.yaml" to namespace "z2"
+    # Both Type-4s carry the capability, so it is in effect on the segment;
+    # the election itself is unchanged while every AC is up.
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "df-election:alg0+ac-df"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "AC-DF: advertised, in effect (2 of 2 PEs advertise it)"
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+    # z2's AC fails: its Type-1 is withdrawn, its Type-4 is not. Under
+    # AC-DF z1's candidate list for instance 101 shrinks to itself, so z1
+    # takes the primary role — with the segment still two members strong.
+    When I execute "ip link set ce1.100 down" in namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: primary (DF 192.168.0.1)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "Member VTEPs (2)"
+    And show command "show bgp evpn vpws" in namespace "z3" should eventually contain "(via 192.168.0.1)"
+    # The AC returns: z2 re-originates and the carving picks it again.
+    When I execute "ip link set ce1.100 up" in namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+    And show command "show bgp evpn vpws" in namespace "z3" should eventually contain "(via 192.168.0.2)"
+    # Negative control: without the capability the same AC failure leaves
+    # z1 a backup — z2 is still on the segment, so the carving still picks
+    # it — and the remote end rides z1's B route instead.
+    When I apply config "z1-acdf-off.yaml" to namespace "z1"
+    And I apply config "z2-acdf-off.yaml" to namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually not contain "+ac-df"
+    When I execute "ip link set ce1.100 down" in namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "(via 192.168.0.1, backup)"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Role: backup (DF 192.168.0.2)"
+    When I execute "ip link set ce1.100 up" in namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "(via 192.168.0.2)"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -311,6 +311,30 @@ segment shared with Junos `df-election-type mod`/Arista `algorithm hrw`
 peers elects the same DF on every box. For the E-LAN election the tag is
 the VNI; for VPWS it is the service identifier.
 
+**AC-influenced election** (RFC 8584 §4) changes *who is a candidate*
+rather than how they are ranked. Ordinarily the candidates are every PE
+that advertised the segment's Type-4, and that stays true even when one of
+them has lost the attachment circuit for a particular service: its Type-1
+for that instance is withdrawn, but its Type-4 is not, so the carving can
+still hand it the DF role for a circuit it cannot forward on. With `ac-df`
+on every PE of the segment, the election for each service instance counts
+only the PEs whose Type-1 for it (and per-ES A-D) is present — a PE whose
+AC went down withdraws that one route and drops out of that one election,
+and the others re-elect immediately. Nothing changes for the segment's
+other services. `show bgp evpn ethernet-segment` reports `AC-DF:
+advertised, in effect (2 of 2 PEs advertise it)`; as with the algorithm,
+one PE without the capability keeps the whole segment on the plain
+Type-4 election, and the show says so.
+
+The link state that drives this is the kernel's own: a VPWS service whose
+`interface` goes down withdraws its Type-1, and an Ethernet Segment whose
+`interface` goes down withholds its ES routes altogether — the RFC 7432
+mass withdraw — exactly as the startup delay does, and re-originates when
+the link returns. A VLAN sub-interface (`ce1.100`) as the service's
+`interface`, with `ethernet-segment` naming the segment on the parent
+port, is the shape that makes the two distinct: the E-Line's AC can fail
+while the segment stays up.
+
 Because the candidate set comes from the Type-4 routes in the Loc-RIB, the
 role is re-elected whenever a PE joins or leaves the segment — a peer's
 Type-4 arriving or being withdrawn re-runs the election and re-advertises

--- a/docs/design/bgp-evpn-ethernet-segment.md
+++ b/docs/design/bgp-evpn-ethernet-segment.md
@@ -280,6 +280,28 @@ kernel VXLAN backend stays single-homed.**
   algorithm; a `preference` still overrides `hrw`. Unit vectors computed
   independently from the formula guard interop. BDD: `bgp_evpn_es`
   (both PEs advertise `df-election:alg1` and agree on the DF).
+- **AC-influenced DF election (RFC 8584 §4) ✅**: the `ac-df` bit was
+  advertised before; now it is consumed. `es_ac_df_in_effect` = every
+  selected Type-4 on the segment carries the bit (unanimity, as for the
+  algorithm). When in effect, `es_ac_df_candidates` narrows the Type-4 set
+  per `(EVI, Ethernet Tag)` to the PEs with a live per-ES A-D **and** a
+  selected per-EVI A-D for it (`ethernet_segment::ac_df_filter`, pure and
+  unit-tested); this PE always counts, since it elects only for EVIs it
+  advertises. Applied in `evpn_es_df_sync` per bridge domain (tag 0 in the
+  VNI's table) and in `vpws_elect_role` per service instance (tag =
+  service id in the EVI's table). Both Ethernet A-D install/withdraw arms
+  now mark the segment's election dirty. Link state feeds the producer
+  side: `Bgp::links_down` (by name, from `LinkAdd` flags / `LinkDown` /
+  `LinkUp` / `LinkDel`) — a VPWS AC down withdraws its Type-1
+  (`evpn_originate_vpws` gate), an ES port down empties the port's per-EVI
+  A-D set **and** withholds the ES routes through `es_holding` (the
+  startup-hold path, RFC 7432 §8.2 mass withdraw), both restored on up.
+  `LinkDown` is the kernel's `IFF_UP` transition; a bond that keeps
+  `IFF_UP` while losing carrier does not trigger it (RUNNING/LOWER_UP are
+  not tracked — follow-up). Show: `AC-DF: advertised, in effect (2 of 2
+  PEs advertise it)`. BDD: `bgp_evpn_vpws_multihoming` (AC = VLAN
+  sub-interface of the segment port; AC down re-elects the survivor
+  primary only with AC-DF, with the negative control).
 - **Open risk:** Linux VXLAN/bridge multihoming primitives are limited;
   local-bias + aliasing may need **eBPF/tc** assists (cf. the RFC 9524
   replication work, `zebra-rs-evpn-rfc9524-replication-plan`). Feasibility

--- a/docs/design/bgp-evpn-multihoming-dataplane.md
+++ b/docs/design/bgp-evpn-multihoming-dataplane.md
@@ -179,7 +179,7 @@ rows are C3 (modulus/HRW) and C9.
 | Type-4 ES, Type-1 A-D per ES (ESI-label EC), Type-1 A-D per EVI | ✅ originated | `bgp/route.rs:16968`, `:17034`, `:17082` |
 | DF election: modulus (Alg 0) + preference (Alg 2), RFC 8584 negotiation | ✅ | `bgp/ethernet_segment.rs:215-280` |
 | DF election: HRW (Alg 1) | ✅ `df-election algorithm hrw` (RFC 8584 §3) | `ethernet_segment.rs` `hrw_ranked` |
-| AC-DF behaviour (withdraw on AC down) | ❌ bit only | no `LinkDown` path touches `ethernet_segments` |
+| AC-DF behaviour (withdraw on AC down) | ✅ RFC 8584 §4: per-EVI candidate filter once every PE advertises it; an AC link-down withdraws the VPWS Type-1 / the port's per-EVI A-Ds; an ES port link-down withholds the ES routes | `route.rs` `es_ac_df_candidates`, `evpn_link_state` |
 | Where the DF result goes | `show` and the VPWS P/B bits only | `bgp/show.rs:2565-2698`, `route.rs:17389-17422` |
 | non-DF filter, SPH/local-bias | ❌ **nothing programmed anywhere** | `EvpnFloodState::desired` `route.rs:3046-3069` filters on P2MP/prune/AR only; zero `IFLA_BRPORT` in `fib/` |
 | Aliasing consumer | ❌ modelled in RIB, first dest installed | `rib/inst.rs:5037-5052`, `MacEntry::installed_dest` `:901` |

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -453,6 +453,36 @@ pub fn elan_df(
     !holding && elect_forwarders(candidates, esi, vni).0 == Some(me)
 }
 
+/// RFC 8584 §4 AC-Influenced DF election is in effect on a segment only
+/// when **every** PE on it advertises the capability (§4: a PE that does
+/// not support it would keep electing over the full Type-4 set, and the
+/// two views of the DF would diverge). `advertising` of `total` Type-4s
+/// carry the bit; an empty segment is not in effect.
+pub fn ac_df_in_effect(advertising: usize, total: usize) -> bool {
+    total > 0 && advertising == total
+}
+
+/// The AC-DF candidate list for one `(ES, EVI, Ethernet Tag)` (RFC 8584
+/// §4.1): of the segment's Type-4 `candidates`, a PE stays only if its
+/// per-ES A-D is `live` and it has a per-EVI A-D for this EVI/tag
+/// (`ad_evi`) — a PE that withdrew that route has the attachment circuit
+/// down. `me` always stays: the callers elect for EVIs this PE is itself
+/// advertising for, and our own routes are not in the sets (they are
+/// originated, not received). The relative order — and so the carving
+/// ordinals — is preserved.
+pub fn ac_df_filter(
+    candidates: &[DfCandidate],
+    me: IpAddr,
+    live: &std::collections::BTreeSet<IpAddr>,
+    ad_evi: &std::collections::BTreeSet<IpAddr>,
+) -> Vec<DfCandidate> {
+    candidates
+        .iter()
+        .filter(|(ip, _, _)| *ip == me || (live.contains(ip) && ad_evi.contains(ip)))
+        .copied()
+        .collect()
+}
+
 /// What the E-LAN DF tee last told the cradle datapath about one segment
 /// (`Bgp::es_df_sent`), so a re-sync emits only the deltas: the access port
 /// sent as the segment's port list (`None` = not sent, or must be re-sent
@@ -849,6 +879,60 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(es.df_election_ec().df_alg, DfElectionEc::ALG_PREF);
+    }
+
+    /// AC-DF is a unanimous capability: any PE without the bit keeps the
+    /// segment on the plain Type-4 election, and nobody is not a segment.
+    #[test]
+    fn ac_df_needs_every_pe() {
+        assert!(ac_df_in_effect(2, 2));
+        assert!(ac_df_in_effect(1, 1));
+        assert!(!ac_df_in_effect(1, 2));
+        assert!(!ac_df_in_effect(0, 1));
+        assert!(!ac_df_in_effect(0, 0));
+    }
+
+    /// RFC 8584 §4.1: a PE whose per-EVI A-D for the EVI is missing — its
+    /// attachment circuit is down — drops out of that EVI's candidate list,
+    /// and so does one whose per-ES A-D is gone; the local PE stays. The
+    /// election then runs over what is left: with the carved DF gone, the
+    /// survivor is DF for the service.
+    #[test]
+    fn ac_df_drops_the_pe_with_the_ac_down() {
+        use std::collections::BTreeSet;
+        let [a, b, c] = pes();
+        let cands: Vec<DfCandidate> = vec![
+            (a, DfElectionEc::ALG_DEFAULT, 0),
+            (b, DfElectionEc::ALG_DEFAULT, 0),
+            (c, DfElectionEc::ALG_DEFAULT, 0),
+        ];
+        // Tag 1 carves to ordinal 1 = b over the full set.
+        assert_eq!(elect_forwarders(&cands, &ESI_T, 1).0, Some(b));
+        let live: BTreeSet<IpAddr> = [b, c].into_iter().collect();
+        // b's per-EVI A-D for this EVI is gone; c's is up.
+        let ad_evi: BTreeSet<IpAddr> = [c].into_iter().collect();
+        let narrowed = ac_df_filter(&cands, a, &live, &ad_evi);
+        assert_eq!(
+            narrowed.iter().map(|(ip, _, _)| *ip).collect::<Vec<_>>(),
+            vec![a, c]
+        );
+        // Tag 1 now carves to ordinal 1 of [a, c] = c.
+        assert_eq!(elect_forwarders(&narrowed, &ESI_T, 1).0, Some(c));
+        // c's per-ES A-D withdrawn (mass withdraw) removes it even with the
+        // per-EVI A-D still selected.
+        let live: BTreeSet<IpAddr> = [b].into_iter().collect();
+        let ad_evi: BTreeSet<IpAddr> = [b, c].into_iter().collect();
+        let narrowed = ac_df_filter(&cands, a, &live, &ad_evi);
+        assert_eq!(
+            narrowed.iter().map(|(ip, _, _)| *ip).collect::<Vec<_>>(),
+            vec![a, b]
+        );
+        // The local PE is never filtered by its own (originated) routes.
+        let narrowed = ac_df_filter(&cands, a, &BTreeSet::new(), &BTreeSet::new());
+        assert_eq!(
+            narrowed.iter().map(|(ip, _, _)| *ip).collect::<Vec<_>>(),
+            vec![a]
+        );
     }
 
     #[test]

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -905,6 +905,15 @@ pub struct Bgp {
     /// The Ethernet Segment nexthop groups last teed to cradle per
     /// `(ESI, EVI)` (`evpn_es_nhg_sync` diffs against it, RFC 7432 §8.4).
     pub es_nhg_sent: BTreeMap<([u8; 10], u32), Vec<crate::rib::EsNhgMember>>,
+    /// Access-side links currently down, by name — maintained from
+    /// `RibRx::LinkAdd` (the link's flags), `LinkDown`, `LinkUp` and
+    /// `LinkDel`. An Ethernet Segment whose port is here withholds its ES
+    /// routes (RFC 7432 §8.2) and is never DF; a VPWS service whose
+    /// attachment circuit is here advertises no Type-1 (RFC 8214 §3 — and
+    /// the RFC 8584 §4 AC-DF trigger). By name rather than ifindex so a
+    /// link deleted and re-created under a new ifindex resolves the same
+    /// way.
+    pub links_down: std::collections::BTreeSet<String>,
     /// Local snooped IGMP/MLD membership shadow, keyed by
     /// `(vni, group, source)` → local VTEP IP. Populated from
     /// `RibRx::SnoopJoin`, removed on `RibRx::SnoopLeave`. Drives
@@ -1415,6 +1424,7 @@ impl Bgp {
             l2_port_evis: BTreeMap::new(),
             es_df_sent: BTreeMap::new(),
             es_nhg_sent: BTreeMap::new(),
+            links_down: std::collections::BTreeSet::new(),
             local_smet: BTreeMap::new(),
             ethernet_segments: BTreeMap::new(),
             hostname: None,
@@ -4343,6 +4353,11 @@ impl Bgp {
                     }
                     self.evpn_es_df_sync();
                 }
+                // The link's flags say whether the access side is usable:
+                // a segment port or VPWS attachment circuit that arrived
+                // down — or came back under a new ifindex — is handled
+                // exactly like a LinkDown / LinkUp on it.
+                self.evpn_link_state(&link.name, link.is_up());
             }
             // Fast external failover: a link going operationally down
             // (or disappearing) immediately resets the single-hop eBGP
@@ -4351,9 +4366,11 @@ impl Bgp {
             // reconvergence.
             RibRx::LinkDown(ifindex) => {
                 self.link_down_failover(ifindex);
+                self.evpn_link_ifindex_state(ifindex, false);
             }
             RibRx::LinkDel(ifindex) => {
                 self.link_down_failover(ifindex);
+                self.evpn_link_ifindex_state(ifindex, false);
                 // A deleted link's addresses are not reliably withdrawn
                 // one by one (a veth moved into another netns emits only
                 // RTM_DELLINK), so sweep its contributions out of the
@@ -4370,6 +4387,7 @@ impl Bgp {
             }
             RibRx::LinkUp(ifindex) => {
                 self.link_up_kick(ifindex);
+                self.evpn_link_ifindex_state(ifindex, true);
             }
             RibRx::AddrAdd(addr) => {
                 self.interface_addrs.record(&addr);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8378,7 +8378,14 @@ fn route_evpn_export_selected(
             // multihomed, losing the primary must fail the service over to
             // the backup, not tear it down. `vpws_rebind` unbinds only when
             // the re-scan genuinely finds nothing usable.
-            EvpnPrefix::EthernetAd { eth_tag, .. } => {
+            EvpnPrefix::EthernetAd { esi, eth_tag } => {
+                // Under AC-DF (RFC 8584 §4) a per-EVI A-D gone is an
+                // attachment circuit down, and a per-ES A-D gone is the
+                // segment gone: either shrinks a candidate list, so the
+                // segment re-elects once this borrow ends.
+                if *esi != ZERO_ESI {
+                    vpws_mark_df_dirty(bgp.local_rib, esi);
+                }
                 let scope = if *eth_tag == MAX_ET {
                     None
                 } else {
@@ -8588,11 +8595,16 @@ fn route_evpn_export_selected(
         // re-selects. Either way the decision itself lives in
         // `vpws_rebind` — arrival never binds directly, because the route
         // that just arrived may lose to one already in the Loc-RIB.
-        EvpnPrefix::EthernetAd { eth_tag, .. } => {
+        EvpnPrefix::EthernetAd { esi, eth_tag } => {
             // A PE joined the segment (per-ES A-D) or an EVI on it (per-EVI
             // A-D): the aliasing nexthop groups gain a member — re-derived
-            // once this borrow ends (`Bgp::evpn_es_nhg_sync`).
+            // once this borrow ends (`Bgp::evpn_es_nhg_sync`) — and under
+            // AC-DF (RFC 8584 §4) that EVI's candidate list grows, so the
+            // segment re-elects.
             bgp.local_rib.es_nhg_dirty = true;
+            if *esi != ZERO_ESI {
+                vpws_mark_df_dirty(bgp.local_rib, esi);
+            }
             let scope = if *eth_tag == MAX_ET {
                 None
             } else {
@@ -17433,8 +17445,14 @@ impl Bgp {
         else {
             return;
         };
-        let wanted: std::collections::BTreeSet<u32> =
-            self.l2_port_evis.get(&ifindex).cloned().unwrap_or_default();
+        // A down port has no usable attachment circuit in any EVI: every
+        // per-EVI A-D comes off (RFC 8584 §4.1.2), its bridge membership
+        // notwithstanding, and goes back with the link.
+        let wanted: std::collections::BTreeSet<u32> = if self.links_down.contains(&port) {
+            Default::default()
+        } else {
+            self.l2_port_evis.get(&ifindex).cloned().unwrap_or_default()
+        };
         let segments: Vec<[u8; 10]> = self
             .ethernet_segments
             .values()
@@ -17529,6 +17547,14 @@ impl Bgp {
         if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
             svc.role = role;
             svc.df = df;
+        }
+        // RFC 8214 §3 / RFC 8584 §4.1.2: a service whose attachment circuit
+        // is down advertises nothing — the missing Type-1 is what tells the
+        // remote end, and the other PEs on the segment, to stop counting on
+        // it. `vpws_reconcile` withdrew it on the way here; `evpn_link_state`
+        // reconciles again when the link returns.
+        if self.vpws_ac_down(name) {
+            return;
         }
         // Per the afi-safi encapsulation: VXLAN advertises the service
         // VNI (the `vni` leaf, default the EVI); MPLS advertises a
@@ -17650,6 +17676,15 @@ impl Bgp {
             EsRedundancyMode::AllActive
         };
         let cands = self.es_df_candidates(&esi);
+        // RFC 8584 §4: with AC-DF in effect on the segment, a PE whose
+        // Type-1 for this service instance is missing has its attachment
+        // circuit down and is not a candidate for it.
+        let cands = match svc.evi {
+            Some(evi) if self.es_ac_df_in_effect(&esi) => {
+                self.es_ac_df_candidates(&cands, &esi, evi, local_id)
+            }
+            _ => cands,
+        };
         let me = self.evpn_local_source();
         // Inside the segment's startup hold this PE is deliberately missing
         // from `cands` — its Type-4 is suppressed — and `vpws_role` reads an
@@ -18069,6 +18104,7 @@ impl Bgp {
                 .and_then(|ifindex| self.l2_port_evis.get(ifindex));
             if let Some(vnis) = vnis {
                 let holding = self.es_holding(&esi);
+                let ac_df = self.es_ac_df_in_effect(&esi);
                 for &vni in vnis {
                     if u16::try_from(vni).is_err() {
                         // cradle's port bridge domain is a u16; the tee's
@@ -18080,9 +18116,19 @@ impl Bgp {
                         );
                         continue;
                     }
+                    // RFC 8584 §4: with AC-DF in effect this bridge
+                    // domain's candidates are only the PEs whose per-EVI
+                    // A-D for it is up.
+                    let narrowed;
+                    let bd_cands: &[super::ethernet_segment::DfCandidate] = if ac_df {
+                        narrowed = self.es_ac_df_candidates(&cands, &esi, vni, 0);
+                        &narrowed
+                    } else {
+                        &cands
+                    };
                     roles.insert(
                         vni,
-                        (elan_df(&cands, me, &esi, vni, holding), single_active),
+                        (elan_df(bd_cands, me, &esi, vni, holding), single_active),
                     );
                 }
             }
@@ -18167,13 +18213,194 @@ impl Bgp {
         self.evpn_originate_ethernet_ad_es(esi, vtep_local, single_active);
     }
 
-    /// True while the segment carrying `esi` is inside its startup hold
-    /// (`ethernet-segment <name> df-election startup-delay`).
+    /// True while the segment carrying `esi` is held out of the election:
+    /// inside its startup hold (`ethernet-segment <name> df-election
+    /// startup-delay`), or with its access port down (`links_down`). Both
+    /// withhold the ES routes and make this PE non-DF everywhere on the
+    /// segment.
     pub fn es_holding(&self, esi: &[u8; 10]) -> bool {
         let now = Instant::now();
-        self.ethernet_segments
+        self.ethernet_segments.values().any(|es| {
+            es.esi.as_ref() == Some(esi) && (es.is_holding_at(now) || self.es_port_down(es))
+        })
+    }
+
+    /// Whether segment `es`'s access port is a link we know to be down.
+    fn es_port_down(&self, es: &super::ethernet_segment::EthernetSegment) -> bool {
+        es.interface
+            .as_ref()
+            .is_some_and(|port| self.links_down.contains(port))
+    }
+
+    /// Whether VPWS service `name`'s attachment circuit is a link we know
+    /// to be down.
+    fn vpws_ac_down(&self, name: &str) -> bool {
+        self.local_rib
+            .evpn_vpws
+            .services
+            .get(name)
+            .and_then(|svc| svc.interface.as_ref())
+            .is_some_and(|ac| self.links_down.contains(ac))
+    }
+
+    /// `RibRx::LinkDown` / `LinkUp` / `LinkDel` by ifindex: resolve the name
+    /// and apply `evpn_link_state`. A link BGP never saw a `LinkAdd` for is
+    /// not ours to track.
+    pub fn evpn_link_ifindex_state(&mut self, ifindex: u32, up: bool) {
+        if let Some(name) =
+            super::ethernet_segment::ac_name_for_ifindex(ifindex, &self.link_index_by_name)
+        {
+            self.evpn_link_state(&name, up);
+        }
+    }
+
+    /// The EVPN access side of a link state change. An Ethernet Segment
+    /// whose port went down has lost the segment: its ES routes come off
+    /// the wire — the per-ES A-D withdrawal is the RFC 7432 §8.2 mass
+    /// withdraw, and the missing Type-4 takes this PE out of every other
+    /// PE's candidate set — exactly as the startup hold withholds them, and
+    /// they go back when the port returns. A VPWS service whose attachment
+    /// circuit went down withdraws its Type-1 (RFC 8214 §3); under RFC 8584
+    /// §4 AC-DF that withdrawal is what removes the PE from that service
+    /// instance's election on the other PEs. Idempotent: only a transition
+    /// does anything, so the `LinkAdd` re-publishes the RIB emits on every
+    /// flag change cost nothing.
+    pub fn evpn_link_state(&mut self, name: &str, up: bool) {
+        let changed = if up {
+            self.links_down.remove(name)
+        } else {
+            self.links_down.insert(name.to_string())
+        };
+        if !changed {
+            return;
+        }
+        let segments: Vec<([u8; 10], bool)> = self
+            .ethernet_segments
             .values()
-            .any(|es| es.esi.as_ref() == Some(esi) && es.is_holding_at(now))
+            .filter(|es| es.interface.as_deref() == Some(name))
+            .filter_map(|es| Some((es.esi?, es.redundancy_mode.single_active())))
+            .collect();
+        let services: Vec<String> = self
+            .local_rib
+            .evpn_vpws
+            .services
+            .iter()
+            .filter(|(_, svc)| svc.interface.as_deref() == Some(name))
+            .map(|(svc, _)| svc.clone())
+            .collect();
+        if segments.is_empty() && services.is_empty() {
+            return;
+        }
+        let me = self.evpn_local_source();
+        for (esi, single_active) in &segments {
+            if up {
+                // `evpn_originate_es_routes` still defers to a running
+                // startup hold; `es_hold_leave` originates then.
+                self.evpn_originate_es_routes(*esi, me, *single_active);
+                if let Some(ifindex) = self.link_index_by_name.get(name).copied() {
+                    self.evpn_reconcile_ad_evi_for_port(ifindex);
+                }
+            } else {
+                self.evpn_withdraw_es_routes(*esi, me);
+            }
+            vpws_mark_df_dirty(&mut self.local_rib, esi);
+            tracing::info!(
+                proto = "bgp",
+                category = "evpn",
+                port = %name,
+                esi = %bgp_packet::esi_display(esi),
+                "bgp: ethernet-segment port {}; ES routes {}",
+                if up { "up" } else { "down" },
+                if up { "re-originated" } else { "withdrawn" },
+            );
+        }
+        for svc in &services {
+            self.vpws_reconcile(svc);
+        }
+        self.vpws_df_drain();
+    }
+
+    /// RFC 8584 §4 AC-Influenced DF election: how many of the PEs on `esi`
+    /// — every selected Type-4, our own included — advertise the AC-DF
+    /// capability bit, and how many PEs there are. In effect only when the
+    /// two agree (`ethernet_segment::ac_df_in_effect`).
+    pub fn es_ac_df_bids(&self, esi: &[u8; 10]) -> (usize, usize) {
+        let (mut advertising, mut total) = (0usize, 0usize);
+        for table in self.local_rib.evpn.values() {
+            for (prefix, rib) in table.selected.iter() {
+                if let EvpnPrefix::EthernetSeg { esi: e, .. } = prefix
+                    && e == esi
+                {
+                    total += 1;
+                    let ac_df = rib
+                        .attr
+                        .ecom
+                        .as_ref()
+                        .and_then(|ec| ec.0.iter().find_map(|v| v.as_df_election()))
+                        .is_some_and(|d| d.ac_df());
+                    if ac_df {
+                        advertising += 1;
+                    }
+                }
+            }
+        }
+        (advertising, total)
+    }
+
+    /// Whether AC-DF is in effect on `esi`: every PE on it advertises it.
+    pub fn es_ac_df_in_effect(&self, esi: &[u8; 10]) -> bool {
+        let (advertising, total) = self.es_ac_df_bids(esi);
+        super::ethernet_segment::ac_df_in_effect(advertising, total)
+    }
+
+    /// The PEs whose per-EVI A-D for `(esi, evi, eth_tag)` is selected —
+    /// the attachment circuits that are up, in AC-DF terms. Identified the
+    /// way the aliasing sync identifies them: a received route's next hop
+    /// is the PE (its Type-4 Originating IP, the RFC 7432 §7.4 VTEP), and
+    /// our own originated route is `me`.
+    fn es_ad_evi_pes(
+        &self,
+        esi: &[u8; 10],
+        evi: u32,
+        eth_tag: u32,
+        me: IpAddr,
+    ) -> BTreeSet<IpAddr> {
+        let mut pes = BTreeSet::new();
+        for table in self.local_rib.evpn.values() {
+            for (prefix, rib) in table.selected.iter() {
+                let EvpnPrefix::EthernetAd { esi: e, eth_tag: t } = prefix else {
+                    continue;
+                };
+                if e != esi || *t != eth_tag || extract_vni_from_attr(&rib.attr) != Some(evi) {
+                    continue;
+                }
+                if rib.typ == BgpRibType::Originated {
+                    pes.insert(me);
+                } else if let Some(BgpNexthop::Evpn(nh)) = rib.attr.nexthop {
+                    pes.insert(nh);
+                }
+            }
+        }
+        pes
+    }
+
+    /// `cands` narrowed for one `(EVI, Ethernet Tag)` per RFC 8584 §4.1: a
+    /// PE stays a candidate only with a live per-ES A-D and a selected
+    /// per-EVI A-D for it. This PE always counts — the callers elect for
+    /// EVIs this PE is advertising for. Meaningful only once
+    /// `es_ac_df_in_effect`; a segment without unanimous AC-DF elects over
+    /// the plain Type-4 set.
+    pub fn es_ac_df_candidates(
+        &self,
+        cands: &[super::ethernet_segment::DfCandidate],
+        esi: &[u8; 10],
+        evi: u32,
+        eth_tag: u32,
+    ) -> Vec<super::ethernet_segment::DfCandidate> {
+        let me = self.evpn_local_source();
+        let live = vpws_es_live_pes(&self.local_rib, esi);
+        let ad_evi = self.es_ad_evi_pes(esi, evi, eth_tag, me);
+        super::ethernet_segment::ac_df_filter(cands, me, &live, &ad_evi)
     }
 
     /// Put segment `name` into its startup hold, if one is configured and is

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2562,6 +2562,9 @@ struct EthernetSegmentJson {
     interface: Option<String>,
     df_preference: Option<u16>,
     ac_df: bool,
+    /// RFC 8584 §4 AC-Influenced DF election is in effect: every PE on
+    /// the segment advertises the capability.
+    ac_df_in_effect: bool,
     es_import_rt: Option<String>,
     /// Configured `df-election startup-delay`, in seconds.
     startup_delay: Option<u16>,
@@ -2588,8 +2591,11 @@ fn show_bgp_evpn_ethernet_segment(
             let mut member_vteps = Vec::new();
             let mut df_algorithm = None;
             let mut designated_forwarder = None;
+            let mut ac_df_in_effect = false;
             if let Some(esi) = es.esi {
                 let cands = bgp.es_df_candidates(&esi);
+                let (advertising, total) = bgp.es_ac_df_bids(&esi);
+                ac_df_in_effect = super::ethernet_segment::ac_df_in_effect(advertising, total);
                 for (ordinal, (vtep, _, _)) in cands.iter().enumerate() {
                     member_vteps.push(EsMemberVtepJson {
                         ordinal,
@@ -2619,6 +2625,7 @@ fn show_bgp_evpn_ethernet_segment(
                 interface: es.interface.clone(),
                 df_preference: es.df_preference,
                 ac_df: es.ac_df,
+                ac_df_in_effect,
                 es_import_rt: es.es_import_rt().map(|rt| format_evpn_ecom_value(&rt)),
                 startup_delay: es.startup_delay,
                 startup_hold_remaining: es.hold_remaining_at(std::time::Instant::now()),
@@ -2699,8 +2706,25 @@ fn show_bgp_evpn_ethernet_segment(
                 other => format!("alg {other} (unsupported; carving fallback)"),
             };
             writeln!(buf, "  DF algorithm: {alg_name}")?;
-            if es.ac_df {
-                writeln!(buf, "  AC-DF capability: advertised")?;
+            // RFC 8584 §4 AC-DF: shown whenever anyone on the segment asks
+            // for it, with whether the segment as a whole has it — it takes
+            // every PE.
+            let (advertising, total) = bgp.es_ac_df_bids(&esi);
+            if es.ac_df || advertising > 0 {
+                let state = if super::ethernet_segment::ac_df_in_effect(advertising, total) {
+                    "in effect"
+                } else {
+                    "not in effect"
+                };
+                writeln!(
+                    buf,
+                    "  AC-DF: {}, {state} ({advertising} of {total} PEs advertise it)",
+                    if es.ac_df {
+                        "advertised"
+                    } else {
+                        "not advertised"
+                    }
+                )?;
             }
             if let Some(df) = super::ethernet_segment::elect_forwarders(&cands, &esi, 0).0 {
                 let tag = if df == local { " (this node)" } else { "" };

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -313,7 +313,17 @@ module zebra-bgp-evpn {
             "Advertise the AC-DF (AC-Influenced DF election) capability bit
              in the DF Election extended community (RFC 8584 §2.2), telling
              the other PEs on the segment that this PE excludes itself from
-             the election while its attachment circuit is down.";
+             the election while its attachment circuit is down.
+
+             Once every PE on the segment advertises it, the election for
+             each EVI (each VPWS service instance, each bridge domain)
+             counts only the PEs whose per-EVI Ethernet A-D route for it
+             is present alongside their per-ES A-D (RFC 8584 §4.1). A PE
+             whose attachment circuit for one EVI goes down withdraws that
+             per-EVI A-D and drops out of that EVI's election alone — the
+             other PEs re-elect at once, without the segment changing.
+             Any PE without the capability keeps the whole segment on the
+             plain Type-4 election.";
         }
         leaf startup-delay {
           ext:help "Seconds to stay out of the election after joining the segment";


### PR DESCRIPTION
## Summary
Closes the last control-plane item in the ENOG91 EVPN-MH matrix (`bgp-evpn-multihoming-dataplane.md`): **AC-influenced DF election, RFC 8584 §4** — and the kernel link-state plumbing it needs on the EVPN access side.

**Consumer (the election):** the `ac-df` bit was only advertised. Now, once *every* PE on a segment advertises it (RFC 8584 unanimity), each EVI's election runs over only the PEs whose per-ES A-D is live **and** whose per-EVI A-D for that EVI is selected (`ethernet_segment::ac_df_filter`, pure + unit-tested). Applied per bridge domain in the E-LAN DF tee (`evpn_es_df_sync`) and per service instance for VPWS (`vpws_elect_role`). Every Ethernet A-D install/withdraw now marks the segment's election dirty. `show bgp evpn ethernet-segment` reports `AC-DF: advertised, in effect (2 of 2 PEs advertise it)` (JSON `ac_df_in_effect`).

**Producer (link state):** new `Bgp::links_down` (by name, from `LinkAdd` flags / `LinkDown` / `LinkUp` / `LinkDel` → `evpn_link_state`):
- a VPWS service whose AC is down advertises no Type-1 (RFC 8214 §3 — the §4.1.2 AC-DF trigger);
- an Ethernet Segment whose port is down has its per-EVI A-Ds emptied and its ES routes withheld through the same `es_holding` path as the startup delay (RFC 7432 §8.2 mass withdraw); both restored on link up.
- `LinkDown` is the kernel's `IFF_UP` transition; a bond that keeps `IFF_UP` while losing carrier is a noted follow-up (RUNNING/LOWER_UP not tracked).

Docs: ES design doc, dataplane analysis row (AC-DF ✅), YANG description, book ch-02-38 AC-DF section.

## Test plan
- [x] Unit: `ac_df_needs_every_pe`, `ac_df_drops_the_pe_with_the_ac_down` (per-EVI A-D missing → dropped; per-ES A-D missing → dropped; local PE always kept; carving re-runs over the narrowed list).
- [x] `cargo test --workspace --exclude bdd`, clippy `-D warnings`, fmt.
- [x] BDD `bgp_evpn_vpws_multihoming` — new scenario with real links: the service AC is VLAN sub-interface `ce1.100` of segment port `ce1` (explicit `ethernet-segment: es1`), so taking it down withdraws only the Type-1 while the Type-4 stays. With AC-DF the survivor turns **primary** (`Member VTEPs (2)` still); AC up hands the DF back; negative control without `ac-df` leaves the survivor a backup and the remote riding the B route.
- [x] BDD regression (after `make install`): `bgp_evpn_es`, `srv6_macip_multihoming`, `vpws`, `vpws_mpls`, `vpws_startup_delay`, `vpws_vxlan`, `vpws_vxlan_multihoming`, `df_election`, `srv6_macip` — 9/9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6q8o75SyjrbRH3DqnrrXg