### PR TITLE
bgp: prove bond carrier loss withholds ES routes; show a down segment port

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-bond.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws_multihoming/z2-bond.yaml
@@ -1,0 +1,50 @@
+# z2 — z2-1.yaml with the segment port and the E-Line's attachment circuit
+# on a kernel bond (bond0, one veth member), the shape an Ethernet Segment
+# has in production. Taking the member's peer down leaves bond0
+# administratively up but without carrier (IFF_UP kept, IFF_LOWER_UP
+# cleared): the ES routes and the Type-1 must come off the wire on that
+# transition alone, and return when the carrier does.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      encapsulation: srv6
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: single-active
+        interface: bond0
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 103
+        interface: bond0
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
+++ b/bdd/tests/features/bgp_evpn_vpws_multihoming.feature
@@ -232,6 +232,40 @@ Feature: BGP EVPN VPWS multihoming — ESI and DF-elected P/B (RFC 8214 §5)
     When I execute "ip link set ce1.100 up" in namespace "z2"
     Then show command "show bgp evpn vpws" in namespace "z3" should eventually contain "(via 192.168.0.2)"
 
+  Scenario: A segment port on a bond that loses carrier withholds the ES routes (RFC 7432 §8.2)
+    Given the test topology exists
+    # z2's segment port becomes a bond with one veth member; the E-Line's
+    # AC is the bond itself. Bringing the member's *peer* down takes the
+    # bond's carrier away while it stays administratively up — the way a
+    # LAG toward the CE fails in the field, and the transition a plain
+    # `ip link set down` does not exercise. `miimon` matters: a bond only
+    # notices a member's carrier through its link monitor (the kernel
+    # default is none), so without it the bond would stay LOWER_UP.
+    When I execute "ip link add m0 type veth peer name m0p" in namespace "z2"
+    And I execute "ip link add bond0 type bond mode active-backup miimon 100" in namespace "z2"
+    And I execute "ip link set m0 down" in namespace "z2"
+    And I execute "ip link set m0 master bond0" in namespace "z2"
+    And I execute "ip link set m0 up" in namespace "z2"
+    And I execute "ip link set m0p up" in namespace "z2"
+    And I execute "ip link set bond0 up" in namespace "z2"
+    And I apply config "z2-bond.yaml" to namespace "z2"
+    Then show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Interface: bond0"
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+    # Carrier lost: bond0 is NO-CARRIER, still UP. z2 withholds its Type-4,
+    # per-ES A-D and Type-1 — the mass withdraw — and says why; z1 is alone
+    # on the segment and turns primary.
+    When I execute "ip link set m0p down" in namespace "z2"
+    Then show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Port bond0 is down: ES routes withheld"
+    And show command "show bgp evpn" in namespace "z1" should eventually not contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: primary (DF 192.168.0.1)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "Member VTEPs (1)"
+    # Carrier back: z2 rejoins the segment and the carving hands it the DF.
+    When I execute "ip link set m0p up" in namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Role: backup (DF 192.168.0.2)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually not contain "ES routes withheld"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -326,14 +326,27 @@ advertised, in effect (2 of 2 PEs advertise it)`; as with the algorithm,
 one PE without the capability keeps the whole segment on the plain
 Type-4 election, and the show says so.
 
-The link state that drives this is the kernel's own: a VPWS service whose
+The link state that drives this is the kernel's operational state —
+administratively up *and* carrier, so a bond toward the CE whose members
+all fail counts as down even though it stays `UP` (give the bond a link
+monitor, `miimon 100` or ARP monitoring — a bond with the kernel's
+default of none never notices a member's carrier and never reports the
+loss): a VPWS service whose
 `interface` goes down withdraws its Type-1, and an Ethernet Segment whose
 `interface` goes down withholds its ES routes altogether — the RFC 7432
 mass withdraw — exactly as the startup delay does, and re-originates when
 the link returns. A VLAN sub-interface (`ce1.100`) as the service's
 `interface`, with `ethernet-segment` naming the segment on the parent
 port, is the shape that makes the two distinct: the E-Line's AC can fail
-while the segment stays up.
+while the segment stays up. A segment whose port is down says so:
+
+```
+show bgp evpn ethernet-segment
+Ethernet Segment: es1
+  ESI: 00:11:22:33:44:55:66:77:88:99
+  Interface: bond0
+  Port bond0 is down: ES routes withheld
+```
 
 Because the candidate set comes from the Type-4 routes in the Loc-RIB, the
 role is re-elected whenever a PE joins or leaves the segment — a peer's

--- a/docs/design/bgp-evpn-ethernet-segment.md
+++ b/docs/design/bgp-evpn-ethernet-segment.md
@@ -296,9 +296,17 @@ kernel VXLAN backend stays single-homed.**
   (`evpn_originate_vpws` gate), an ES port down empties the port's per-EVI
   A-D set **and** withholds the ES routes through `es_holding` (the
   startup-hold path, RFC 7432 §8.2 mass withdraw), both restored on up.
-  `LinkDown` is the kernel's `IFF_UP` transition; a bond that keeps
-  `IFF_UP` while losing carrier does not trigger it (RUNNING/LOWER_UP are
-  not tracked — follow-up). Show: `AC-DF: advertised, in effect (2 of 2
+  `LinkDown` is the RIB's *operational* down — `LinkFlagsExt::is_up` is
+  `IFF_UP && IFF_LOWER_UP` — so a bond whose members all lose carrier
+  while it stays administratively up takes the same path (a kernel LAG
+  toward the CE failing is exactly this — provided the bond has a link
+  monitor: with the kernel default `miimon 0` a bond never learns its
+  members' carrier and stays `LOWER_UP`, a kernel fact, not ours), and so
+  does a VLAN sub-interface on it. `show bgp evpn ethernet-segment` names it: `Port
+  bond0 is down: ES routes withheld` (JSON `port_down`). BDD:
+  `bgp_evpn_vpws_multihoming` (one-member bond; the member's peer down =
+  NO-CARRIER with `IFF_UP` kept → Type-4/A-D/Type-1 withheld and the
+  survivor primary; carrier back → rejoined). Show: `AC-DF: advertised, in effect (2 of 2
   PEs advertise it)`. BDD: `bgp_evpn_vpws_multihoming` (AC = VLAN
   sub-interface of the segment port; AC down re-elects the survivor
   primary only with AC-DF, with the negative control).

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -18226,7 +18226,7 @@ impl Bgp {
     }
 
     /// Whether segment `es`'s access port is a link we know to be down.
-    fn es_port_down(&self, es: &super::ethernet_segment::EthernetSegment) -> bool {
+    pub(crate) fn es_port_down(&self, es: &super::ethernet_segment::EthernetSegment) -> bool {
         es.interface
             .as_ref()
             .is_some_and(|port| self.links_down.contains(port))

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2560,6 +2560,10 @@ struct EthernetSegmentJson {
     esi: Option<String>,
     redundancy_mode: String,
     interface: Option<String>,
+    /// The access port is operationally down (administratively down, or
+    /// no carrier — a bond whose members all failed), so this segment's
+    /// ES routes are withheld and it is DF nowhere (RFC 7432 §8.2).
+    port_down: bool,
     df_preference: Option<u16>,
     ac_df: bool,
     /// RFC 8584 §4 AC-Influenced DF election is in effect: every PE on
@@ -2623,6 +2627,7 @@ fn show_bgp_evpn_ethernet_segment(
                 esi: es.esi.map(|esi| bgp_packet::esi_display(&esi)),
                 redundancy_mode: es.redundancy_mode.as_str().to_string(),
                 interface: es.interface.clone(),
+                port_down: bgp.es_port_down(es),
                 df_preference: es.df_preference,
                 ac_df: es.ac_df,
                 ac_df_in_effect,
@@ -2653,6 +2658,11 @@ fn show_bgp_evpn_ethernet_segment(
         writeln!(buf, "  Redundancy mode: {}", es.redundancy_mode.as_str())?;
         if let Some(ifname) = &es.interface {
             writeln!(buf, "  Interface: {ifname}")?;
+            // Operationally down (admin down or no carrier): the ES routes
+            // are withheld and this PE is DF nowhere on the segment.
+            if bgp.es_port_down(es) {
+                writeln!(buf, "  Port {ifname} is down: ES routes withheld")?;
+            }
         }
         if let Some(rt) = es.es_import_rt() {
             writeln!(buf, "  ES-Import RT: {}", format_evpn_ecom_value(&rt))?;


### PR DESCRIPTION
## Summary
Follow-up to #2338, which recorded that a bond keeping `IFF_UP` while losing carrier would not trigger the EVPN access-side link path. **That caveat was wrong**: the RIB's `LinkDown` is operational — `LinkFlagsExt::is_up` is `IFF_UP && IFF_LOWER_UP` — so a bond whose members all lose carrier already withholds the ES routes. The kernel-side requirement is a link monitor: with the default `miimon 0` a bond never learns a member's carrier and stays `LOWER_UP` (probed in a scratch netns; with `miimon 100` it goes `NO-CARRIER` while staying `UP`).

- **BDD proof** (`bgp_evpn_vpws_multihoming`): z2's segment port and E-Line AC on a one-member bond (`miimon 100`); the member's veth *peer* down leaves bond0 UP/NO-CARRIER → z2 withholds Type-4, per-ES A-D and Type-1, z1 is alone on the segment and turns primary (`Member VTEPs (1)`); peer up → z2 rejoins, carving hands it the DF back.
- **Show**: `show bgp evpn ethernet-segment` prints `Port bond0 is down: ES routes withheld` for an operationally-down segment port (JSON `port_down`).
- **Docs**: ES design doc and book ch-02-38 corrected — operational state = admin up *and* carrier; bonds need `miimon`/ARP monitoring to report it.

No election-logic change; `es_port_down` made `pub(crate)` for the show.

## Test plan
- [x] Scratch-netns probe: bond `miimon 0` keeps `LOWER_UP` on member carrier loss; `miimon 100` → `NO-CARRIER`, carrier 0, back on peer up.
- [x] BDD `bgp_evpn_vpws_multihoming` (AC-DF + bond scenarios) after `make install`: 1/1 passed, every step ran.
- [x] `cargo test --workspace --exclude bdd`, clippy `-D warnings`, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6q8o75SyjrbRH3DqnrrXg