### PR TITLE
bgp: single-active backup path — tee the (ESI, EVI) group DF-first (RFC 7432 §14.1.1)

### DIFF
--- a/docs/design/bgp-evpn-ethernet-segment.md
+++ b/docs/design/bgp-evpn-ethernet-segment.md
@@ -280,6 +280,20 @@ kernel VXLAN backend stays single-homed.**
   algorithm; a `preference` still overrides `hrw`. Unit vectors computed
   independently from the formula guard interop. BDD: `bgp_evpn_es`
   (both PEs advertise `df-election:alg1` and agree on the DF).
+- **Single-active backup path (RFC 7432 §14.1.1) ✅**: `evpn_es_nhg_sync`
+  no longer skips single-active ESIs. Their `(ESI, EVI)` group is teed with
+  `single_active` and ordered — `es_sa_primary` (the PE whose selected
+  Type-2s carry the ESI in that EVI, i.e. the DF, chosen among the group's
+  own live PEs; most MACs, ties to the lowest address) first, the rest
+  sorted behind it (`ethernet_segment::order_es_members`, pure). cradle
+  forwards to slot 0 alone (`ES_NHG_F_SINGLE_ACTIVE`). `Rib::mac_install`
+  therefore sends such MACs through the group, so a DF whose port fails —
+  ES routes withheld at once, its cradle-learned Type-2s lingering — is
+  replaced by the backup in one group update. `Message::EsNhg`,
+  `cradle_es_nhg`, `CradleMirror.es_nhg` and `es_nhg_sent` carry the flag.
+  `show bgp evpn ethernet-segment` ends with the teed groups (`… bd 100:
+  single-active primary 192.0.2.2, backup 192.0.2.3`), shown on a remote
+  PE with no segment of its own too. BDD: cradle `cradle_evpn_mh_sa_zebra`.
 - **AC-influenced DF election (RFC 8584 §4) ✅**: the `ac-df` bit was
   advertised before; now it is consumed. `es_ac_df_in_effect` = every
   selected Type-4 on the segment carries the bit (unanimity, as for the

--- a/docs/design/bgp-evpn-multihoming-dataplane.md
+++ b/docs/design/bgp-evpn-multihoming-dataplane.md
@@ -179,6 +179,7 @@ rows are C3 (modulus/HRW) and C9.
 | Type-4 ES, Type-1 A-D per ES (ESI-label EC), Type-1 A-D per EVI | ✅ originated | `bgp/route.rs:16968`, `:17034`, `:17082` |
 | DF election: modulus (Alg 0) + preference (Alg 2), RFC 8584 negotiation | ✅ | `bgp/ethernet_segment.rs:215-280` |
 | DF election: HRW (Alg 1) | ✅ `df-election algorithm hrw` (RFC 8584 §3) | `ethernet_segment.rs` `hrw_ranked` |
+| Single-active backup path (RFC 7432 §14.1.1 pre-install) | ✅ SA `(ESI, EVI)` groups teed DF-first with `single_active`; cradle forwards to slot 0, backup slots promoted on the DF's per-ES A-D withdrawal | `route.rs` `evpn_es_nhg_sync`/`es_sa_primary`, cradle `ES_NHG_F_SINGLE_ACTIVE` |
 | AC-DF behaviour (withdraw on AC down) | ✅ RFC 8584 §4: per-EVI candidate filter once every PE advertises it; an AC link-down withdraws the VPWS Type-1 / the port's per-EVI A-Ds; an ES port link-down withholds the ES routes | `route.rs` `es_ac_df_candidates`, `evpn_link_state` |
 | Where the DF result goes | `show` and the VPWS P/B bits only | `bgp/show.rs:2565-2698`, `route.rs:17389-17422` |
 | non-DF filter, SPH/local-bias | ❌ **nothing programmed anywhere** | `EvpnFloodState::desired` `route.rs:3046-3069` filters on P2MP/prune/AR only; zero `IFLA_BRPORT` in `fib/` |

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -81,6 +81,12 @@ message EsNhg {
   string esi = 1;
   uint32 bd = 2;
   repeated EsNhgMember members = 3;
+  // RFC 7432 §14.1.1 single-active: only members[0] — the Designated
+  // Forwarder, the PE that advertised the segment's MACs — forwards; the
+  // rest are the pre-installed backup path. A group update that drops the
+  // primary (its per-ES A-D withdrawn) fails every MAC over to the next
+  // member in one step, before any per-MAC route moves.
+  bool single_active = 4;
 }
 
 message PortDel {

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -453,6 +453,28 @@ pub fn elan_df(
     !holding && elect_forwarders(candidates, esi, vni).0 == Some(me)
 }
 
+/// Order an Ethernet Segment nexthop group's members for the datapath.
+/// `pairs` are `(advertising PE, member)`; the result is sorted by PE then
+/// member so it is stable across recomputes, except that a single-active
+/// segment's `primary` — the Designated Forwarder, the PE the segment's
+/// MACs were learned from — leads (RFC 7432 §14.1.1): the datapath
+/// forwards to slot 0 alone and holds the rest as the pre-installed backup
+/// path. `None` (no MAC advertised yet, or an all-active segment) leaves
+/// the sorted order; on a single-active segment that is the lowest PE,
+/// which is moot until a MAC exists to forward.
+pub fn order_es_members(
+    mut pairs: Vec<(IpAddr, crate::rib::EsNhgMember)>,
+    primary: Option<IpAddr>,
+) -> Vec<crate::rib::EsNhgMember> {
+    pairs.sort();
+    if let Some(primary) = primary {
+        // Stable: the primary's members keep their own order at the front.
+        let (front, back): (Vec<_>, Vec<_>) = pairs.into_iter().partition(|(pe, _)| *pe == primary);
+        pairs = front.into_iter().chain(back).collect();
+    }
+    pairs.into_iter().map(|(_, m)| m).collect()
+}
+
 /// RFC 8584 §4 AC-Influenced DF election is in effect on a segment only
 /// when **every** PE on it advertises the capability (§4: a PE that does
 /// not support it would keep electing over the full Type-4 set, and the
@@ -932,6 +954,44 @@ mod tests {
         assert_eq!(
             narrowed.iter().map(|(ip, _, _)| *ip).collect::<Vec<_>>(),
             vec![a]
+        );
+    }
+
+    /// The single-active group leads with the MAC advertiser and keeps the
+    /// rest, sorted, as the backup path; without a primary (all-active, or
+    /// no MAC yet) the order is the sorted one.
+    #[test]
+    fn single_active_group_leads_with_the_primary() {
+        use crate::rib::EsNhgMember;
+        let [a, b, c] = pes();
+        let pairs = vec![
+            (c, EsNhgMember::Vxlan(c)),
+            (a, EsNhgMember::Vxlan(a)),
+            (b, EsNhgMember::Vxlan(b)),
+        ];
+        assert_eq!(
+            order_es_members(pairs.clone(), None),
+            vec![
+                EsNhgMember::Vxlan(a),
+                EsNhgMember::Vxlan(b),
+                EsNhgMember::Vxlan(c)
+            ]
+        );
+        assert_eq!(
+            order_es_members(pairs.clone(), Some(b)),
+            vec![
+                EsNhgMember::Vxlan(b),
+                EsNhgMember::Vxlan(a),
+                EsNhgMember::Vxlan(c)
+            ]
+        );
+        // A primary that is not (any longer) a member — its per-ES A-D
+        // withdrawn — changes nothing: the survivors lead in sorted order,
+        // which is the failover.
+        let survivors: Vec<_> = pairs.into_iter().filter(|(pe, _)| *pe != b).collect();
+        assert_eq!(
+            order_es_members(survivors, Some(b)),
+            vec![EsNhgMember::Vxlan(a), EsNhgMember::Vxlan(c)]
         );
     }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -904,7 +904,8 @@ pub struct Bgp {
     pub es_df_sent: BTreeMap<[u8; 10], super::ethernet_segment::EsTeeState>,
     /// The Ethernet Segment nexthop groups last teed to cradle per
     /// `(ESI, EVI)` (`evpn_es_nhg_sync` diffs against it, RFC 7432 §8.4).
-    pub es_nhg_sent: BTreeMap<([u8; 10], u32), Vec<crate::rib::EsNhgMember>>,
+    /// `(ESI, EVI)` → `(single_active, ordered members)`.
+    pub es_nhg_sent: BTreeMap<([u8; 10], u32), (bool, Vec<crate::rib::EsNhgMember>)>,
     /// Access-side links currently down, by name — maintained from
     /// `RibRx::LinkAdd` (the link's flags), `LinkDown`, `LinkUp` and
     /// `LinkDel`. An Ethernet Segment whose port is here withholds its ES

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -17953,12 +17953,19 @@ impl Bgp {
     /// every group at once: the mass withdraw. Idempotent full recompute
     /// diffed against `es_nhg_sent`; a group that vanished is sent empty.
     pub fn evpn_es_nhg_sync(&mut self) {
-        let mut desired: BTreeMap<([u8; 10], u32), Vec<crate::rib::EsNhgMember>> = BTreeMap::new();
+        // `(ESI, EVI)` → the `(advertising PE, member)` pairs of the group.
+        #[allow(clippy::type_complexity)]
+        let mut desired: BTreeMap<([u8; 10], u32), Vec<(IpAddr, crate::rib::EsNhgMember)>> =
+            BTreeMap::new();
         let mut live_cache: BTreeMap<[u8; 10], BTreeSet<IpAddr>> = BTreeMap::new();
-        // Single-active segments (RFC 7432 §14.1.1) are not aliased: only
+        // Single-active segments (RFC 7432 §14.1.1) are not aliased — only
         // the DF forwards, and the DF is the PE that advertised the MAC —
-        // so its Type-2's own next hop is the whole answer. A segment is
-        // single-active when its per-ES A-D routes' ESI Label EC says so.
+        // but they do get a group: the DF first, the other attached PEs
+        // after it as the pre-installed backup path, so the DF's per-ES
+        // A-D withdrawal (its port failed) fails every MAC over to the
+        // backup in one update, while its stale Type-2s are still in the
+        // table. A segment is single-active when its per-ES A-D routes'
+        // ESI Label EC says so.
         let mut sa_esis: BTreeSet<[u8; 10]> = BTreeSet::new();
         for table in self.local_rib.evpn.values() {
             for (prefix, rib) in table.selected.iter() {
@@ -17981,11 +17988,7 @@ impl Bgp {
                 let EvpnPrefix::EthernetAd { esi, eth_tag } = prefix else {
                     continue;
                 };
-                if *eth_tag != 0
-                    || rib.typ == BgpRibType::Originated
-                    || *esi == ZERO_ESI
-                    || sa_esis.contains(esi)
-                {
+                if *eth_tag != 0 || rib.typ == BgpRibType::Originated || *esi == ZERO_ESI {
                     continue;
                 }
                 let Some(vni) = extract_vni_from_attr(&rib.attr) else {
@@ -18002,19 +18005,28 @@ impl Bgp {
                 }
                 let member = elan_es_member(rib, originator);
                 let members = desired.entry((*esi, vni)).or_default();
-                if !members.contains(&member) {
-                    members.push(member);
+                if !members.iter().any(|(_, m)| *m == member) {
+                    members.push((originator, member));
                 }
             }
         }
-        for members in desired.values_mut() {
-            members.sort();
+        let mut groups: BTreeMap<([u8; 10], u32), (bool, Vec<crate::rib::EsNhgMember>)> =
+            BTreeMap::new();
+        for ((esi, vni), pairs) in desired {
+            let single_active = sa_esis.contains(&esi);
+            let primary = if single_active {
+                self.es_sa_primary(&esi, vni, &pairs)
+            } else {
+                None
+            };
+            let members = super::ethernet_segment::order_es_members(pairs, primary);
+            groups.insert((esi, vni), (single_active, members));
         }
         let mut out: Vec<crate::rib::Message> = Vec::new();
         let gone: Vec<([u8; 10], u32)> = self
             .es_nhg_sent
             .keys()
-            .filter(|k| !desired.contains_key(*k))
+            .filter(|k| !groups.contains_key(*k))
             .copied()
             .collect();
         for (esi, bd) in gone {
@@ -18023,21 +18035,60 @@ impl Bgp {
                 esi,
                 bd,
                 members: Vec::new(),
+                single_active: false,
             });
         }
-        for ((esi, bd), members) in desired {
-            if self.es_nhg_sent.get(&(esi, bd)) != Some(&members) {
+        for ((esi, bd), group) in groups {
+            if self.es_nhg_sent.get(&(esi, bd)) != Some(&group) {
                 out.push(crate::rib::Message::EsNhg {
                     esi,
                     bd,
-                    members: members.clone(),
+                    members: group.1.clone(),
+                    single_active: group.0,
                 });
-                self.es_nhg_sent.insert((esi, bd), members);
+                self.es_nhg_sent.insert((esi, bd), group);
             }
         }
         for msg in out {
             let _ = self.ctx.rib.send(msg);
         }
+    }
+
+    /// The primary of a single-active segment's group for `vni` (RFC 7432
+    /// §14.1.1): the PE whose selected Type-2s carry this ESI in this EVI —
+    /// the Designated Forwarder, the only PE learning from the CE — chosen
+    /// among the group's own PEs (`pairs`), so a PE whose per-ES A-D is
+    /// gone cannot be primary however many stale MACs it still advertises.
+    /// Most MACs wins, ties to the lowest address; `None` when no MAC is
+    /// advertised yet.
+    fn es_sa_primary(
+        &self,
+        esi: &[u8; 10],
+        vni: u32,
+        pairs: &[(IpAddr, crate::rib::EsNhgMember)],
+    ) -> Option<IpAddr> {
+        let mut counts: BTreeMap<IpAddr, usize> = BTreeMap::new();
+        for table in self.local_rib.evpn.values() {
+            for (prefix, rib) in table.selected.iter() {
+                if !matches!(prefix, EvpnPrefix::MacIp { .. })
+                    || rib.typ == BgpRibType::Originated
+                    || rib.esi.as_ref() != Some(esi)
+                    || extract_vni_from_attr(&rib.attr) != Some(vni)
+                {
+                    continue;
+                }
+                let Some(BgpNexthop::Evpn(nh)) = rib.attr.nexthop else {
+                    continue;
+                };
+                if pairs.iter().any(|(pe, _)| *pe == nh) {
+                    *counts.entry(nh).or_default() += 1;
+                }
+            }
+        }
+        counts
+            .into_iter()
+            .max_by(|(ip_a, n_a), (ip_b, n_b)| n_a.cmp(n_b).then(ip_b.cmp(ip_a)))
+            .map(|(ip, _)| ip)
     }
 
     /// Tee the E-LAN DF election to the cradle datapath (RFC 7432 §8.5).

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2646,6 +2646,7 @@ fn show_bgp_evpn_ethernet_segment(
     let mut buf = String::new();
     if bgp.ethernet_segments.is_empty() {
         writeln!(buf, "No EVPN Ethernet Segments configured")?;
+        write_es_nhg_groups(&mut buf, bgp)?;
         return Ok(buf);
     }
     let local = std::net::IpAddr::V4(bgp.router_id);
@@ -2742,7 +2743,50 @@ fn show_bgp_evpn_ethernet_segment(
             }
         }
     }
+    write_es_nhg_groups(&mut buf, bgp)?;
     Ok(buf)
+}
+
+/// The Ethernet Segment nexthop groups this PE has teed to the datapath
+/// (`Bgp::es_nhg_sent`, from the peers' per-ES / per-EVI A-D routes) — a
+/// remote PE's view of every multihomed segment, configured here or not.
+/// A single-active group names its primary (the DF) and the backup path
+/// behind it (RFC 7432 §14.1.1); an all-active one lists the aliasing set.
+fn write_es_nhg_groups(buf: &mut String, bgp: &Bgp) -> std::fmt::Result {
+    use std::fmt::Write;
+    if bgp.es_nhg_sent.is_empty() {
+        return Ok(());
+    }
+    writeln!(
+        buf,
+        "Ethernet Segment nexthop groups (teed to the datapath):"
+    )?;
+    for ((esi, bd), (single_active, members)) in &bgp.es_nhg_sent {
+        let rendered: Vec<String> = members
+            .iter()
+            .map(|m| match m {
+                crate::rib::EsNhgMember::Srv6(sid) => sid.to_string(),
+                crate::rib::EsNhgMember::Vxlan(vtep) => vtep.to_string(),
+                crate::rib::EsNhgMember::Mpls { pe, label } => format!("{pe}/{label}"),
+            })
+            .collect();
+        let esi = bgp_packet::esi_display(esi);
+        if *single_active {
+            let (primary, backup) = rendered.split_first().expect("a sent group is non-empty");
+            let backup = if backup.is_empty() {
+                String::new()
+            } else {
+                format!(", backup {}", backup.join(" "))
+            };
+            writeln!(
+                buf,
+                "  {esi} bd {bd}: single-active primary {primary}{backup}"
+            )?;
+        } else {
+            writeln!(buf, "  {esi} bd {bd}: all-active {}", rendered.join(" "))?;
+        }
+    }
+    Ok(())
 }
 
 fn show_bgp_evpn_summary(

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -150,7 +150,8 @@ struct CradleMirror {
     es_peers: HashMap<String, Vec<IpAddr>>,
     /// EVPN multihoming aliasing: `(ESI, bridge domain)` → the nexthop
     /// group's members (`SetEsNhg`, replace semantics).
-    es_nhg: HashMap<(String, u32), Vec<crate::rib::EsNhgMember>>,
+    /// `(esi, bd)` → `(single_active, ordered members)`.
+    es_nhg: HashMap<(String, u32), (bool, Vec<crate::rib::EsNhgMember>)>,
     /// `(bd, mac)` → ESI: overlay FDB entries that resolve through the
     /// segment's group (`FdbRemote.esi`) rather than a single remote.
     fdb_es: HashMap<(u32, [u8; 6]), String>,
@@ -606,8 +607,8 @@ impl CradleFib {
         }
         // Aliasing groups (after the VNI bindings above), then the FDB
         // entries that resolve through them and the static local ones.
-        for ((esi, bd), members) in &m.es_nhg {
-            self.set_es_nhg(esi, *bd, members).await;
+        for ((esi, bd), (single_active, members)) in &m.es_nhg {
+            self.set_es_nhg(esi, *bd, members, *single_active).await;
         }
         for ((bd, mac), esi) in &m.fdb_es {
             self.fdb_add_es(*bd, *mac, esi).await;
@@ -2259,13 +2260,20 @@ impl CradleFib {
     /// aliasing; replace semantics, empty = no group). Mirrored; replayed
     /// after the VNI bindings (a VXLAN member takes the domain's VNI from
     /// them) and before the FDB entries that resolve through it.
-    pub async fn set_es_nhg(&self, esi: &str, bd: u32, members: &[crate::rib::EsNhgMember]) {
+    pub async fn set_es_nhg(
+        &self,
+        esi: &str,
+        bd: u32,
+        members: &[crate::rib::EsNhgMember],
+        single_active: bool,
+    ) {
         {
             let mut m = self.mirror.lock().await;
             if members.is_empty() {
                 m.es_nhg.remove(&(esi.to_string(), bd));
             } else {
-                m.es_nhg.insert((esi.to_string(), bd), members.to_vec());
+                m.es_nhg
+                    .insert((esi.to_string(), bd), (single_active, members.to_vec()));
             }
         }
         let pb_members = members
@@ -2298,6 +2306,7 @@ impl CradleFib {
                     esi: esi.to_string(),
                     bd,
                     members: pb_members,
+                    single_active,
                 })
                 .await?;
             anyhow::Ok(())

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1023,10 +1023,11 @@ impl FibHandle {
         esi: &[u8; 10],
         bd: u32,
         members: &[crate::rib::EsNhgMember],
+        single_active: bool,
     ) {
         if let Some(cradle) = &self.cradle {
             cradle
-                .set_es_nhg(&bgp_packet::esi_display(esi), bd, members)
+                .set_es_nhg(&bgp_packet::esi_display(esi), bd, members, single_active)
                 .await;
         }
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -516,7 +516,11 @@ pub enum Message {
     EsNhg {
         esi: [u8; 10],
         bd: u32,
+        /// Ordered: under `single_active` the first member is the primary
+        /// (the DF, the PE advertising the segment's MACs) and the rest
+        /// the backup path (RFC 7432 §14.1.1).
         members: Vec<EsNhgMember>,
+        single_active: bool,
     },
     /// MUP `dataplane gtp` downlink encap (`GTP4.E`): a GTP-U encap route teed
     /// to cradle — traffic to `prefix` in VRF `table_id` is wrapped in outer
@@ -3981,8 +3985,13 @@ impl Rib {
             Message::EsPeers { esi, vteps } => {
                 self.fib_handle.cradle_es_peers(&esi, &vteps).await;
             }
-            Message::EsNhg { esi, bd, members } => {
-                self.es_nhg_set(esi, bd, members).await;
+            Message::EsNhg {
+                esi,
+                bd,
+                members,
+                single_active,
+            } => {
+                self.es_nhg_set(esi, bd, members, single_active).await;
             }
             Message::CradleGtpEncapAdd {
                 prefix,
@@ -5187,13 +5196,21 @@ impl Rib {
     /// per-ES / per-EVI A-D view): tee it, remember whether the segment
     /// has one, and re-install every MAC on the segment in that domain so
     /// it moves between the group form and the single-destination form.
-    async fn es_nhg_set(&mut self, esi: [u8; 10], bd: u32, members: Vec<EsNhgMember>) {
+    async fn es_nhg_set(
+        &mut self,
+        esi: [u8; 10],
+        bd: u32,
+        members: Vec<EsNhgMember>,
+        single_active: bool,
+    ) {
         if members.is_empty() {
             self.es_groups.remove(&(esi, bd));
         } else {
             self.es_groups.insert((esi, bd));
         }
-        self.fib_handle.cradle_es_nhg(&esi, bd, &members).await;
+        self.fib_handle
+            .cradle_es_nhg(&esi, bd, &members, single_active)
+            .await;
         let macs: Vec<MacAddr> = self
             .mac_table
             .iter()


### PR DESCRIPTION
## Summary
The last EVPN-MH item from the ENOG91 analysis: the **single-active backup path** (RFC 7432 §14.1.1). Pairs with cradle-rs #189 (merged).

Single-active segments had no nexthop group: each MAC went to its advertiser alone, so when the DF's segment port failed, remote PEs kept sending to it until every one of its Type-2s was withdrawn — in cradle mode those are datapath-learned and never flushed, so that meant the FDB age. The per-ES A-D withdrawal (one message) arrives long before.

- `evpn_es_nhg_sync` now tees a group for single-active ESIs too, flagged `single_active` and **ordered**: primary first — `es_sa_primary`, the PE whose selected Type-2s carry the ESI in that EVI (the DF), chosen among the group's live PEs (most MACs, ties to lowest address) — then the other attached PEs, sorted, as the backup path (`ethernet_segment::order_es_members`, pure + unit-tested).
- cradle forwards such a group to slot 0 alone and never hashes it; dropping the primary promotes the backup for every MAC in one update.
- `Message::EsNhg`, the cradle tee, `CradleMirror` (replay) and `es_nhg_sent` carry the flag; vendored `proto/cradle.proto` gains `EsNhg.single_active = 4`.
- `show bgp evpn ethernet-segment` ends with the teed groups (`00:…:01 bd 100: single-active primary 192.0.2.2, backup 192.0.2.3`), on a remote PE with no segment of its own as well.
- Docs: ES design doc, dataplane analysis matrix row.

## Test plan
- [x] Unit: `single_active_group_leads_with_the_primary` (sorted without a primary; primary leads; a primary no longer a member = the failover order).
- [x] `cargo test --workspace --exclude bdd`, clippy `-D warnings`, fmt.
- [x] cradle-rs BDD `cradle_evpn_mh_sa_zebra` (88/88): pe1 shows the primary/backup group, known unicast rides it (`l2_es_nhg` non-zero), DF's port down → pe2 withholds ES routes while its stale Type-2 stays installed (asserted) → group flips to `primary 192.0.2.3` → CE stays reachable. Plus cradle regression 6/6.
- [x] zebra BDD regression (after `make install`): `bgp_evpn_es`, `srv6_macip_multihoming`, `vpws_multihoming`, `vpws_vxlan_multihoming`, `srv6_macip` — 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6q8o75SyjrbRH3DqnrrXg