### PR TITLE
fib: IPv6 vtep-source is the SRv6 outer source (EVPN-MH split horizon)

### DIFF
--- a/book/src/ch-02-41-bgp-evpn-srv6.md
+++ b/book/src/ch-02-41-bgp-evpn-srv6.md
@@ -162,10 +162,14 @@ automatically when the engine restarts.
 
 - **Requires cradle** — without an engine the routes are advertised and
   received but nothing forwards (the kernel has no DT2U/DT2M action).
-- **Multihoming is signalled in full** (Type-1/Type-4, DF election, the
-  ESI on Type-2s); what remains open across all encapsulations is the
-  aliasing / mass-withdraw *consumer* side for E-LAN MACs, and ARP
-  suppression.
+- **Multihoming works over SRv6 on cradle** — DF election and the non-DF
+  filter, split horizon, aliasing / mass withdraw and single-active, the
+  same as over VXLAN (the aliasing group's members are the PEs' `End.DT2U`
+  SIDs). One rule: split horizon identifies a segment peer by the **outer
+  IPv6 source** of its MAC-in-SRv6 packets, which zebra-rs sets to the
+  PE's IPv6 EVPN source — the VNI declaration's `local-address` — so set
+  the afi-safi `vtep-source` to that same address, making it the Type-4
+  Originating IP the peers learn. ARP suppression remains open.
 - **EVPN-VPWS** (RFC 8214) over SRv6 — the point-to-point E-Line with
   `End.DX2`/`End.DX2V` — is covered in
   [EVPN VPWS](ch-02-38-bgp-evpn-vpws.md).

--- a/docs/design/bgp-evpn-ethernet-segment.md
+++ b/docs/design/bgp-evpn-ethernet-segment.md
@@ -236,8 +236,12 @@ kernel VXLAN backend stays single-homed.**
   the copy from the segment's ports (`l2_drop_sph`). **The Type-4
   Originating IP must be the VTEP** for the match — it is
   `evpn_local_source()`, so configure `vtep-source` (or let the router-id
-  double as the VTEP). SRv6 uses the outer source; MPLS has none (ESI
-  label: open). BDD: cradle-rs `cradle_evpn_mh_sph` (static),
+  double as the VTEP). SRv6 uses the outer IPv6 source of the MAC-in-SRv6
+  packet, which the tee sets to the PE's IPv6 EVPN source (the VNI
+  declaration's `local-address`, `FibHandle::set_vtep_source`) rather than
+  the first local SID — so `vtep-source` must be that same address for the
+  peers' match to hold (BDD: cradle-rs `cradle_evpn_mh_srv6_zebra`). MPLS
+  has none (ESI label: open). BDD: cradle-rs `cradle_evpn_mh_sph` (static),
   `cradle_evpn_mh_df_zebra` (BGP-driven; CE injects via the non-DF, the DF
   must not echo).
 - **Aliasing ✅ (slice 3)**: ECMP a remote MAC across all all-active PEs

--- a/docs/design/bgp-evpn-multihoming-dataplane.md
+++ b/docs/design/bgp-evpn-multihoming-dataplane.md
@@ -353,7 +353,7 @@ DF line. The deck's demo had to prove filtering with `bpf_printk`.
 | Aliasing / mass withdraw | kernel FDB NHG (5.9), FRR wires it | new ES NHG in cradle + zebra consumer | native |
 | LAG / LACP | kernel bonding, free | kernel bonding as a cradle port (option A) — new integration | native |
 | Control channel | Lua→exec→C; not transactional, not replayed on restart; needed an FRR patch | typed gRPC + mirror replay | vendor SDK |
-| Encapsulations | VXLAN only | VXLAN, SRv6 (End.DT2M/DT2U), MPLS — one gate for all | vendor |
+| Encapsulations | VXLAN only | VXLAN, SRv6 (End.DT2M/DT2U), MPLS — one gate for all. SRv6 proven end to end (BDD cradle-rs `cradle_evpn_mh_srv6`, `_zebra`; the split horizon needs the SRv6 outer source = the Type-4 Originating IP, which the tee now guarantees for an IPv6 `vtep-source`). MPLS: DF gate + aliasing only, no split horizon (ESI label open) | vendor |
 | Kernel version coupling | 6.5+ for `l2_miss`/`backup_nhid`; behaviour tied to bridge internals that upstream calls "natural" | eBPF/aya + verifier; BTF; no dependence on bridge internals | n/a |
 | Performance | kernel bridge + 2 extra tc hops per BUM frame | XDP decap + TC switch, `clone_redirect` fan-out (≤ 64 members) | line rate |
 | Debuggability | `bpf_printk`, `tc -s`, kernel drop reasons | cradle counters, `dump l2`, Hubble-style flow ring already exists | vendor |

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1323,25 +1323,34 @@ impl CradleFib {
         if let Err(e) = result {
             tracing::warn!("fib: cradle local_sid_install {} failed: {e}", sid.addr);
         }
-        // Best-effort: the SRv6 H.Encaps outer source (zebra has no explicit
-        // config for it). A local SID is in the node's locator, so its
-        // address is a routable node source; forwarding does not depend on it.
-        // Set it once, from the first local SID installed.
+        // Best-effort fallback for the SRv6 H.Encaps outer source: a local
+        // SID is in the node's locator, so its address is a routable node
+        // source; forwarding does not depend on it. Only until an IPv6 EVPN
+        // source arrives (`set_vtep_source`), which then takes over.
         if self.encap_src_set.swap(true, Ordering::Relaxed) {
             return;
         }
+        self.set_srv6_encap_source(IpAddr::V6(sid.addr)).await;
+    }
+
+    /// Set the outer IPv6 source cradle stamps on its SRv6 encapsulation
+    /// (H.Encaps and MAC-in-SRv6 alike). Best-effort; forwarding does not
+    /// depend on it, but EVPN multihoming's split horizon does: a peer PE
+    /// recognises our overlay BUM by this address, so it must be the one we
+    /// advertise as our EVPN source (Type-4 Originating IP, `vtep-source`).
+    async fn set_srv6_encap_source(&self, addr: IpAddr) {
         if let Err(e) = async {
             self.client()
                 .await?
                 .set_srv6_encap_source(pb::Srv6EncapSource {
-                    addr: sid.addr.to_string(),
+                    addr: addr.to_string(),
                 })
                 .await?;
             anyhow::Ok(())
         }
         .await
         {
-            tracing::debug!("fib: cradle set_srv6_encap_source failed: {e}");
+            tracing::debug!("fib: cradle set_srv6_encap_source {addr} failed: {e}");
         }
     }
 
@@ -2418,6 +2427,14 @@ impl CradleFib {
     /// Set the local VTEP source (VXLAN outer source + decap match) for
     /// `addr`'s address family — cradle keeps one slot per family, so a
     /// dual-stack fabric sets both. Idempotent; last write per family wins.
+    ///
+    /// An IPv6 source is also the outer source of our MAC-in-SRv6
+    /// encapsulation: an EVPN-over-SRv6 PE declares its VNIs with the same
+    /// device shape (an IPv6 `local-address`), and that address — the PE's
+    /// EVPN source, its Type-4 Originating IP under `vtep-source` — is what
+    /// a multihoming peer matches our overlay BUM against for split
+    /// horizon (RFC 8365 §8.3.1). It overrides the first-local-SID fallback
+    /// whichever arrives first.
     pub async fn set_vtep_source(&self, addr: IpAddr) {
         {
             let mut m = self.mirror.lock().await;
@@ -2425,6 +2442,10 @@ impl CradleFib {
                 IpAddr::V4(v4) => m.vtep_source = Some(v4),
                 IpAddr::V6(v6) => m.vtep_source6 = Some(v6),
             }
+        }
+        if addr.is_ipv6() {
+            self.encap_src_set.store(true, Ordering::Relaxed);
+            self.set_srv6_encap_source(addr).await;
         }
         let result = async {
             self.client()


### PR DESCRIPTION
## Summary
- **Bug**: cradle stamped the *first installed local SID* as the outer IPv6 source of its MAC-in-SRv6 encapsulation, while zebra teed each Ethernet Segment peer's Type-4 Originating IP (`vtep-source`) as the ES peer for split horizon. Under SRv6 the two never matched, so a peer's End.DT2M copies of the CE's own BUM were flooded back onto the segment (cradle-rs BDD `cradle_evpn_mh_srv6_zebra`: `l2_drop_sph` stayed 0 and the CE received its own frames).
- **Fix**: `FibHandle::set_vtep_source` also sets cradle's SRv6 encap source when the address is IPv6 — the VNI declaration's `local-address`, the PE's EVPN source — and marks it so the first-local-SID fallback no longer overrides it, whichever arrives first (replay included).
- Operator rule (same as VXLAN): `vtep-source` must be that address. Documented in `docs/design/bgp-evpn-ethernet-segment.md`, the dataplane matrix, and the SRv6 book chapter (whose stale "aliasing consumer open" bullet is replaced with the current multihoming-over-SRv6 status).

Companion: cradle-rs PR adding `cradle_evpn_mh_srv6` / `cradle_evpn_mh_srv6_zebra` (the latter requires this fix).

## Test plan
- [x] `cargo clippy --workspace --all-targets` clean; `cargo test --workspace --exclude bdd` green
- [x] cradle-rs BDD `cradle_evpn_mh_srv6_zebra`: fails before (`l2_drop_sph` never nonzero), passes after (2/2, 96 steps)
- [x] cradle-rs BDD regression on the new binary: `cradle_evpn_srv6_zebra`, `cradle_evpn_srv6_zebra_multi`, `cradle_evpn_vxlan6_zebra` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6q8o75SyjrbRH3DqnrrXg