### PR TITLE
bgp: tear down IPv6-unnumbered peers on BFD Down (#2343)

### DIFF
--- a/bdd/docs/bgp_unnumbered_neighbor.md
+++ b/bdd/docs/bgp_unnumbered_neighbor.md
@@ -48,7 +48,9 @@ interface-keyed peers), and the FIB assertion pins the substring
 |----------|--------|
 | Setup topology | |
 | RA discovery establishes the unnumbered session and exchanges IPv4 routes | |
+| BFD comes up over the unnumbered link and transmits both ways | |
 | IPv4 LAN prefixes forward over the IPv6 link-local next-hop | |
 | The unnumbered peer is listed in summaries and addressable by interface name | |
+| BFD going Down tears the unnumbered session down and withdraws its routes | |
 | Removing the interface-neighbor tears the session down | |
 | Teardown topology | |

--- a/bdd/tests/features/bgp_unnumbered_neighbor.feature
+++ b/bdd/tests/features/bgp_unnumbered_neighbor.feature
@@ -113,6 +113,45 @@ Feature: BGP IPv6 unnumbered neighbor discovered via Router Advertisements
     And show command "show bgp ipv4 summary" in namespace "z1" should contain "i1 "
     And show command "show bgp neighbor i1" in namespace "z1" should contain "BGP neighbor on i1: fe80::"
 
+  Scenario: BFD going Down tears the unnumbered session down and withdraws its routes
+    Given the test topology exists
+    # Regression for #2343. Drop inbound BFD control packets on z2 only:
+    # the link stays up and BGP's own TCP session keeps flowing, so the
+    # teardown can only come from BFD. z2's detect timer expires first;
+    # it then signals Down to z1 (z1 still receives z2's packets), so
+    # both ends see an Up→Down transition. Pre-fix, `process_bfd_event`
+    # looked the peer up by the link-local in the session key — an
+    # interface-keyed peer's map key is its ifindex, so the lookup
+    # missed, the event was dropped as "unknown peer", and the session
+    # stayed Established with its ENHE routes still in the kernel FIB
+    # (a blackhole under ECMP). The FIB assertions come right after the
+    # state checks: the idle-hold pacer restarts the session ~5 s after
+    # the teardown, so they must land inside that window. Both ends log
+    # the BFD-initiated teardown, but only z2's `Last reset` is
+    # deterministically "BFD down": z2 detects first and its NOTIFICATION
+    # / TCP close usually reaches z1 before z1's own BFD Down event, so
+    # z1 records the TCP failure and its parked BFD cause is discarded.
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And daemon log in namespace "z2" should eventually contain "tearing down peer on bfd-down"
+    And daemon log in namespace "z1" should eventually contain "tearing down peer on bfd-down"
+    And BGP session in namespace "z1" should eventually not be "Established"
+    And BGP session in namespace "z2" should eventually not be "Established"
+    And kernel route "10.10.2.0/24" in namespace "z1" should eventually be gone
+    And kernel route "10.10.1.0/24" in namespace "z2" should eventually be gone
+    And show command "show bgp neighbor i1" in namespace "z2" should eventually contain "due to BFD down"
+    # Recovery: with BFD packets flowing again the session comes back
+    # (BFD Up on both ends proves both are transmitting) and the
+    # v4-over-v6 routes return to the kernel, so the removal scenario
+    # below still has a live session to tear down.
+    When I restore bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z2" on interface "i1" should be up
+    And BGP session in namespace "z1" should eventually be "Established"
+    And BGP session in namespace "z2" should eventually be "Established"
+    And kernel route "10.10.2.0/24" in namespace "z1" should eventually contain "via inet6 fe80::"
+    And kernel route "10.10.1.0/24" in namespace "z2" should eventually contain "via inet6 fe80::"
+
   Scenario: Removing the interface-neighbor tears the session down
     Given the test topology exists
     When I apply config "z1-base.yaml" to namespace "z1"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -8495,6 +8495,103 @@ mod neighbor_group_wiring_tests {
         assert!(!key.multihop, "an unnumbered eBGP session is single-hop",);
     }
 
+    /// Bring an `interface-neighbor i1` (ifindex 7) up to the point
+    /// where its RA-learned link-local has subscribed a BFD session, and
+    /// hand back the instance, the subscribed `SessionKey` and the peer's
+    /// ident. Shared by the #2343 teardown tests below.
+    fn interface_neighbor_with_bfd_session() -> (Bgp, SessionKey, usize) {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_remote_as, materialize_peer,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        config_bgp_bfd_enable(&mut bgp, arg_words(&["true"]), ConfigOp::Set).unwrap();
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+        let link_local: std::net::Ipv6Addr = "fe80::2".parse().unwrap();
+        materialize_peer(&mut bgp, "i1", 7, link_local).expect("RA upgrades the peer");
+
+        let mut subscribe = None;
+        while let Ok(req) = bfd_rx.try_recv() {
+            if let ClientReq::Subscribe { key, .. } = req {
+                subscribe = Some(key);
+            }
+        }
+        let key = subscribe.expect("the RA must trigger a BFD Subscribe");
+        let ident = bgp
+            .peers
+            .get_by_key(&PeerKey::Interface(7))
+            .expect("interface-keyed peer exists")
+            .ident;
+        // Materialization queued `Event::Start`; clear the channel so the
+        // tests below see only what the BFD event produces.
+        while bgp.rx.try_recv().is_ok() {}
+        (bgp, key, ident)
+    }
+
+    fn bfd_up_to_down(key: SessionKey) -> crate::bfd::inst::BfdEvent {
+        crate::bfd::inst::BfdEvent::StateChange {
+            key,
+            change: crate::bfd::session::StateChange {
+                from: bfd_packet::State::Up,
+                to: bfd_packet::State::Down,
+                diag: bfd_packet::Diag::ControlDetectionTimeExpired,
+            },
+        }
+    }
+
+    /// Regression for #2343: BFD going Down on an IPv6-unnumbered
+    /// (`interface-neighbor`) peer must tear the BGP session down, as it
+    /// does for an addressed peer. The event's `remote` is the RA-learned
+    /// link-local, which is NOT the peer's map key (that is
+    /// `PeerKey::Interface(ifindex)`), so `process_bfd_event` has to
+    /// resolve the peer through the session's pinned ifindex. Pre-fix
+    /// the address lookup missed, the event was logged as "unknown
+    /// peer" and dropped, and the session stayed Established.
+    #[tokio::test]
+    async fn interface_neighbor_bfd_down_tears_session_down() {
+        use super::super::peer::PeerDownReason;
+        let (mut bgp, key, ident) = interface_neighbor_with_bfd_session();
+        assert_eq!(key.ifindex, 7, "precondition: session pinned to i1");
+
+        bgp.process_bfd_event(bfd_up_to_down(key));
+
+        assert_eq!(
+            drain_stop_events(&mut bgp),
+            vec![ident],
+            "BFD Down must queue Event::Stop for the interface-keyed peer",
+        );
+        assert_eq!(
+            bgp.peers.get_by_idx(ident).unwrap().down_reason,
+            Some(PeerDownReason::BfdDown),
+            "the teardown must be attributed to BFD in `show bgp neighbor`",
+        );
+    }
+
+    /// The ifindex fallback must not fire for a session key the peer
+    /// does not own: a late Down for a session that was re-keyed (the
+    /// neighbour surfaced a new link-local) is stale, not a path
+    /// failure, and must leave the peer alone.
+    #[tokio::test]
+    async fn interface_neighbor_ignores_bfd_down_for_stale_session_key() {
+        let (mut bgp, key, ident) = interface_neighbor_with_bfd_session();
+        let stale = SessionKey {
+            remote: "fe80::3".parse().unwrap(),
+            ..key
+        };
+
+        bgp.process_bfd_event(bfd_up_to_down(stale));
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "a Down for a key the peer never subscribed must not stop it",
+        );
+        assert_eq!(bgp.peers.get_by_idx(ident).unwrap().down_reason, None);
+    }
+
     // ---- whole-session knob inheritance (ttl-security exemplar) --
 
     use super::super::neighbor_group::config_neighbor_group_ttl_security;

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -7076,10 +7076,9 @@ impl Bgp {
             return;
         }
 
-        // SessionKey.remote is the BGP neighbor address — direct
-        // lookup. A missing peer means the user removed the
-        // neighbor since BGP last subscribed; safe to ignore.
-        let Some(peer) = self.peers.get_mut(&key.remote) else {
+        // A missing peer means the user removed the neighbor since
+        // BGP last subscribed; safe to ignore.
+        let Some(peer) = self.bfd_session_peer_mut(&key) else {
             bgp_bfd_trace!(
                 self.tracing,
                 ?key,
@@ -7095,6 +7094,39 @@ impl Bgp {
             "bgp: tearing down peer on bfd-down (RFC 5882 §5)",
         );
         let _ = self.tx.try_send(Message::Event(peer_idx, Event::Stop));
+    }
+
+    /// Resolve the peer that owns a BFD session, for a `SessionKey`
+    /// handed back by BFD.
+    ///
+    /// `SessionKey.remote` is the BGP neighbor address, so an addressed
+    /// peer is a direct `PeerKey::Addr` lookup. An IPv6-unnumbered
+    /// (`interface-neighbor`) peer is keyed by its ifindex
+    /// (`PeerKey::Interface`), NOT by the RA-learned link-local that
+    /// sits in `key.remote`, so the address lookup can never find it —
+    /// which is exactly how #2343 left such peers Established after
+    /// BFD went Down. `bfd_apply_ident` pins a single-hop session to the
+    /// peer's egress ifindex (`Peer::resolve_session_ifindex` returns
+    /// the interface key itself for an unnumbered peer), so `key.ifindex`
+    /// is the map key to fall back to. The peer's recorded
+    /// `bfd_session_key` must match exactly: a stale event for a
+    /// session that has since been re-keyed (the neighbour moved to a
+    /// new link-local) must not tear down whatever peer now owns that
+    /// interface.
+    fn bfd_session_peer_mut(
+        &mut self,
+        key: &crate::bfd::session::SessionKey,
+    ) -> Option<&mut super::peer::Peer> {
+        if self.peers.get(&key.remote).is_some() {
+            return self.peers.get_mut(&key.remote);
+        }
+        if key.multihop || key.ifindex == 0 {
+            return None;
+        }
+        let peer = self
+            .peers
+            .get_mut_by_key(&super::peer_key::PeerKey::Interface(key.ifindex))?;
+        (peer.bfd_session_key == Some(*key)).then_some(peer)
     }
 }
 


### PR DESCRIPTION
## Summary

Refs #2343 (left open on purpose — the reporter's lab re-test is still pending, so no closing keyword).

BFD reaching Down did **not** tear down `interface-neighbor` (IPv6-unnumbered) BGP sessions; numbered v4/v6 peers tore down in ~0.8 s. `Bgp::process_bfd_event` resolved the peer with `peers.get_mut(&key.remote)` = `PeerKey::Addr(<link-local>)`, but an unnumbered peer is keyed `PeerKey::Interface(ifindex)`, so the lookup could never hit and the event was dropped as "unknown peer". The session stayed Established with its ENHE routes still in the kernel FIB — a blackhole under ECMP. The teardown path (2026-05-19) predates interface-neighbor by a day and was never wired for it; #2326 fixed only the BGP→BFD (subscribe/transmit) direction.

* `zebra-rs/src/bgp/inst.rs` — new `Bgp::bfd_session_peer_mut(&SessionKey)`: address lookup first, then for a single-hop key with a pinned ifindex `PeerKey::Interface(key.ifindex)`, accepted only when the peer's recorded `bfd_session_key` equals the event key (a stale Down for a re-keyed session can't stop whatever peer now owns the interface). Numbered-peer behaviour is unchanged.
* `zebra-rs/src/bgp/config.rs` — two unit tests on an RA-materialized interface peer: `interface_neighbor_bfd_down_tears_session_down` (Up→Down → `Event::Stop` for the peer's ident + `down_reason == BfdDown`; verified to fail with the fallback disabled) and `interface_neighbor_ignores_bfd_down_for_stale_session_key`.
* `bdd/tests/features/bgp_unnumbered_neighbor.feature` — new scenario "BFD going Down tears the unnumbered session down and withdraws its routes": drop UDP/3784 on z2 → `tearing down peer on bfd-down` logged on both ends → both sessions leave Established → both v4-over-v6 kernel routes gone → `Last reset … due to BFD down` on the detecting side → restore → BFD Up both ends → Established both ends → routes back. (`Last reset` is only deterministic on the detecting side: the other end receives the NOTIFICATION/TCP close ~180 ms before its own BFD event and correctly records the TCP failure — the scenario comments explain this.)
* `bdd/docs/bgp_unnumbered_neighbor.md` — regenerated via `docs/feature2md.sh` (also picks up the #2326 scenario, which had never been regenerated).

Not touched: the per-VRF `process_bfd_event` has the same address-only lookup, but VRF has no interface-neighbor support, so it is unreachable today. A CHANGELOG.yaml note is owed at the next release cut.

## Test plan

- [x] `cargo test -p zebra-rs interface_neighbor_` — 5 passed (3 existing + 2 new); the teardown test fails when the ifindex fallback is disabled
- [x] `make -C bdd bgp_unnumbered_neighbor` — 8/8 scenarios on the freshly staged binary (new scenario end-to-end incl. recovery)
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` — 3033 passed / 0 failed (zebra-rs crate 2098)
- [ ] Reporter's containerlab re-test on a nightly (frr1—zebra1—zebra2, three addressing modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ar8fvwP3WFqK8XgBxxo87p
