### PR TITLE
bgp: honor next-hop-unchanged on the EVPN advertise path

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -904,8 +904,12 @@ pub struct PeerSubConfig {
     /// session between the route reflectors of an RR-based Inter-AS
     /// Option C — the RRs are outside the forwarding path, so the
     /// reflected route must keep the originating PE as the LSP endpoint.
+    /// EVPN routes likewise keep the originating VTEP: an EVPN transit
+    /// speaker is not a tunnel endpoint, and the receiver builds its
+    /// remote FDB from the Type-2 next-hop.
     /// Locally-originated routes still rewrite. Honored on the VPNv4
-    /// advertise path (`route_update_ipv4` / `vpnv4_service_label`).
+    /// (`route_update_ipv4` / `vpnv4_service_label`) and EVPN
+    /// (`route_update_evpn`) advertise paths.
     pub next_hop_unchanged: bool,
 }
 
@@ -1799,8 +1803,8 @@ impl Peer {
 
     /// Whether `afi-safi <name> next-hop-unchanged` is set for this
     /// neighbor in the given address family. Keeps the received next-hop
-    /// (and VPN label) on eBGP advertisement of forwarded VPN routes —
-    /// see [`PeerSubConfig::next_hop_unchanged`].
+    /// (and VPN label) on eBGP advertisement of forwarded VPN and EVPN
+    /// routes — see [`PeerSubConfig::next_hop_unchanged`].
     pub fn next_hop_unchanged(&self, afi: Afi, safi: Safi) -> bool {
         self.config
             .sub

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5813,6 +5813,20 @@ fn route_advertise_batch<A: BatchAfi>(
     }
 }
 
+/// Whether EVPN egress must replace the received next-hop with self.
+///
+/// Locally originated routes always use this speaker as their next-hop.
+/// Forwarded eBGP routes do so by default, unless the per-neighbor
+/// `afi-safi evpn next-hop-unchanged` knob asks to retain the originating
+/// VTEP — an EVPN transit speaker is not a tunnel endpoint.
+fn evpn_should_rewrite_nexthop(
+    peer_is_ebgp: bool,
+    rib_is_originated: bool,
+    next_hop_unchanged: bool,
+) -> bool {
+    rib_is_originated || (peer_is_ebgp && !next_hop_unchanged)
+}
+
 /// Per-peer EVPN advertise builder. Mirrors `route_update_ipv4`:
 /// applies split-horizon, the iBGP-iBGP / route-reflector filter,
 /// and fixes up AS_PATH / NEXT_HOP / LOCAL_PREF for the outgoing
@@ -6014,7 +6028,11 @@ pub fn route_update_evpn(
         return None;
     }
 
-    if peer.is_ebgp() || rib.is_originated() {
+    if evpn_should_rewrite_nexthop(
+        peer.is_ebgp(),
+        rib.is_originated(),
+        peer.next_hop_unchanged(Afi::L2vpn, Safi::Evpn),
+    ) {
         let nexthop: IpAddr = if let Some(ref local_addr) = peer.param.local_addr {
             local_addr.ip()
         } else {
@@ -6056,6 +6074,173 @@ pub fn route_update_evpn(
     }
 
     Some((route, attrs))
+}
+
+#[cfg(test)]
+mod evpn_nexthop_tests {
+    use super::evpn_should_rewrite_nexthop;
+
+    #[test]
+    fn plain_ebgp_forwarded_route_rewrites_to_self() {
+        assert!(evpn_should_rewrite_nexthop(true, false, false));
+    }
+
+    #[test]
+    fn next_hop_unchanged_preserves_forwarded_evpn_vtep() {
+        assert!(!evpn_should_rewrite_nexthop(true, false, true));
+    }
+
+    #[test]
+    fn locally_originated_route_always_rewrites_to_self() {
+        assert!(evpn_should_rewrite_nexthop(true, true, true));
+    }
+
+    #[test]
+    fn ibgp_forwarded_route_preserves_next_hop() {
+        assert!(!evpn_should_rewrite_nexthop(false, false, false));
+    }
+}
+
+/// The predicate above fixes the *rule*; these fix the *wiring* — that
+/// `route_update_evpn` actually reads the `(L2vpn, Evpn)` knob and puts
+/// the result on the outgoing attribute. Without this a caller passing a
+/// constant, or keying the lookup at the wrong AFI/SAFI, still passes
+/// every predicate test. That was exactly the original defect.
+#[cfg(test)]
+mod evpn_nexthop_wiring_tests {
+    use super::*;
+    use crate::bgp::peer::{PeerSubConfig, State};
+    use std::net::IpAddr;
+
+    const SPINE: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 101);
+    const VTEP: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 11);
+
+    /// EVPN transit speaker's eBGP peer toward a leaf. `local_addr` is
+    /// the session-local address `route_update_evpn` installs when it
+    /// rewrites the next-hop to self.
+    fn ebgp_peer(next_hop_unchanged: bool) -> Peer {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        Box::leak(Box::new(rx));
+        let mut peer = Peer::new(
+            1,
+            65001,
+            SPINE,
+            65002,
+            "10.0.0.12".parse::<IpAddr>().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = State::Established;
+        peer.peer_type = PeerType::EBGP;
+        peer.param.local_addr = Some("10.0.0.101:179".parse().unwrap());
+        if next_hop_unchanged {
+            peer.config.sub.insert(
+                AfiSafi::new(Afi::L2vpn, Safi::Evpn),
+                PeerSubConfig {
+                    next_hop_unchanged: true,
+                    ..Default::default()
+                },
+            );
+        }
+        peer
+    }
+
+    /// A Type-2 learned from another eBGP peer, carrying the originating
+    /// VTEP as its next-hop. ident 2 != peer.ident 1 (no split-horizon)
+    /// and `BgpRibType::EBGP` keeps `is_originated()` false.
+    fn forwarded_macip_rib() -> BgpRib {
+        let mut attr = BgpAttr::new();
+        attr.aspath = Some(As4Path::from(vec![65003]));
+        attr.nexthop = Some(BgpNexthop::Evpn(IpAddr::V4(VTEP)));
+        BgpRib::new(2, VTEP, BgpRibType::EBGP, 0, 0, &attr, None, None, false)
+    }
+
+    fn empty_top<'a>(
+        router_id: &'a Ipv4Addr,
+        local_rib: &'a mut LocalRib,
+        shard: &'a mut crate::bgp::shard::BgpShard,
+        attr_store: &'a mut crate::bgp::BgpAttrStore,
+        update_groups: &'a mut crate::bgp::update_group::UpdateGroupMap,
+        interface_addrs: &'a crate::bgp::interface_addrs::InterfaceAddrs,
+        rib_client: &'a crate::rib::client::RibClient,
+        tx: &'a tokio::sync::mpsc::Sender<crate::bgp::inst::Message>,
+    ) -> BgpTop<'a> {
+        BgpTop {
+            router_id,
+            srv6_ipv6_export: None,
+            local_rib,
+            shard,
+            tx,
+            rib_client,
+            attr_store,
+            update_groups,
+            interface_addrs,
+            vrf_export: None,
+            color_policy: None,
+            flex_algo_routes: None,
+            flex_algo_srv6_routes: None,
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+            as_sets_withdraw: false,
+        }
+    }
+
+    /// A forwarded EVPN route keeps the originating VTEP when the peer
+    /// carries `afi-safi evpn next-hop-unchanged`, and is rewritten to
+    /// this speaker's session-local address when it does not.
+    #[tokio::test]
+    async fn evpn_egress_honors_next_hop_unchanged() {
+        let router_id = SPINE;
+        let ctx = crate::context::ProtoContext::default_table_no_rib();
+        let mut local_rib = LocalRib::default();
+        let mut shard = crate::bgp::shard::BgpShard::default();
+        let mut attr_store = crate::bgp::BgpAttrStore::default();
+        let mut update_groups = crate::bgp::update_group::empty_map();
+        let interface_addrs = crate::bgp::interface_addrs::InterfaceAddrs::default();
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        Box::leak(Box::new(rx));
+
+        let rd = RouteDistinguisher::default();
+        let prefix = EvpnPrefix::MacIp {
+            eth_tag: 0,
+            mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x11],
+            ip: None,
+        };
+        let rib = forwarded_macip_rib();
+
+        let mut top = empty_top(
+            &router_id,
+            &mut local_rib,
+            &mut shard,
+            &mut attr_store,
+            &mut update_groups,
+            &interface_addrs,
+            &ctx.rib,
+            &tx,
+        );
+
+        let mut peer = ebgp_peer(true);
+        let (_, attrs) =
+            route_update_evpn(&mut peer, &rd, &prefix, &rib, &mut top, false).expect("advertise");
+        assert_eq!(
+            attrs.nexthop,
+            Some(BgpNexthop::Evpn(IpAddr::V4(VTEP))),
+            "next-hop-unchanged must keep the originating VTEP on eBGP egress"
+        );
+
+        let mut peer = ebgp_peer(false);
+        let (_, attrs) =
+            route_update_evpn(&mut peer, &rd, &prefix, &rib, &mut top, false).expect("advertise");
+        assert_eq!(
+            attrs.nexthop,
+            Some(BgpNexthop::Evpn(IpAddr::V4(SPINE))),
+            "without the knob an eBGP peer still gets next-hop-self"
+        );
+    }
 }
 
 /// Send a single EVPN withdraw to one peer. Mirrors

--- a/zebra-rs/yang/zebra-bgp-afi-knobs.yang
+++ b/zebra-rs/yang/zebra-bgp-afi-knobs.yang
@@ -166,12 +166,18 @@ module zebra-bgp-afi-knobs {
          endpoint — as its next-hop (and its original VPN label). The
          receiving PE resolves that PE loopback over BGP-LU.
 
-         Honored on the unicast (SAFI 1), VPNv4 (SAFI 128), and (for the
-         VPN next-hop) related advertise paths; for unicast it preserves
-         the received next-hop on both eBGP and iBGP advertisement and
-         takes precedence over next-hop-self. Locally-originated routes
-         always advertise with self as the next-hop (the originator is
-         the only valid next-hop).";
+         Required likewise on an EVPN (SAFI 70) session where this
+         speaker forwards EVPN between other speakers without being a
+         VXLAN tunnel endpoint itself: the receiving PE builds its
+         remote FDB from the Type-2 next-hop, so rewriting it points
+         the tunnel at a node that cannot decapsulate.
+
+         Honored on the unicast (SAFI 1), VPNv4 (SAFI 128), EVPN
+         (SAFI 70), and (for the VPN next-hop) related advertise paths;
+         for unicast it preserves the received next-hop on both eBGP and
+         iBGP advertisement and takes precedence over next-hop-self.
+         Locally-originated routes always advertise with self as the
+         next-hop (the originator is the only valid next-hop).";
     }
 
     container policy {


### PR DESCRIPTION
## Summary

A one-condition change in `route_update_evpn()`: honor the per-neighbor `afi-safi evpn
next-hop-unchanged` setting, which the IPv4/IPv6 unicast and VPNv4 advertise paths already
honor.

A zebra-rs speaker that forwards EVPN between two VTEPs without being one itself
rewrites the next-hop of forwarded Type-2 routes to its own address, so the receiving
leaf programs its remote FDB toward a node with no VXLAN device and leaf-to-leaf known
unicast blackholes — with every session Established and every route present. Type-3 is
unaffected, since the VXLAN flood destination comes from the Originating Router IP in
the NLRI rather than the next-hop, so BUM still gets through and only known unicast
drops. `afi-safi evpn next-hop-unchanged` is accepted and committed, but the EVPN
advertise path never reads it back. Found while building an eBGP EVPN/VXLAN fabric on
containerlab.

## Steps to reproduce

```
  h1 ──── leaf1 ──────────── spine1 ──────────── leaf2 ──── h2
          VTEP       EVPN transit (no VTEP)       VTEP
        4200000011         4200000000         4200000012
        10.0.0.11          10.0.0.101          10.0.0.12
```

VNI 10 is stretched across the two leaves; spine1 has no bridge or VXLAN device and
only relays EVPN. Underlay eBGP over the physical links is omitted below.

spine1:

```
set router bgp neighbor 10.0.0.11 afi-safi evpn enabled true
set router bgp neighbor 10.0.0.11 afi-safi evpn next-hop-unchanged true
```

The same block goes toward 10.0.0.12. Both leaves are ordinary VTEPs — `bridge` plus
`vxlan` for VNI 10, `afi-safi evpn advertise-all-vni true`, and the mirrored multihop
EVPN session back to 10.0.0.101.

- Expected: leaf2 receives leaf1's Type-2 with next-hop 10.0.0.11, the originating VTEP.
- Actual: 10.0.0.101, the transit spine.

## Cause / fix

`route_update_evpn()` rewrites the next-hop for every eBGP peer unconditionally,
without consulting the neighbor's `next-hop-unchanged` setting. Gate the rewrite on it,
via a named predicate so it can be unit-tested without standing up a peer:

```rust
rib_is_originated || (peer_is_ebgp && !next_hop_unchanged)
```

Unset, that reduces to the original condition, so the change is opt-in and the default
behavior is unchanged; locally originated routes still rewrite to self. No update-group
change is needed — EVPN has no group-level byte cache, and both advertise call sites run
per peer.

Unit tests cover the predicate, and one drives `route_update_evpn()` to catch a regression
in the missing wiring. On containerlab, the same commit built with and without the
patch: all leaf-crossing host-to-host checks fail without it and all pass with it, the
leaves' remote FDB moving from the spine to the originating VTEP.

## Behavior
| peer / route                                  | before                      | after                       |
| --------------------------------------------- | --------------------------- | --------------------------- |
| eBGP, forwarded, `next-hop-unchanged` unset   | next-hop rewritten to self  | unchanged                   |
| eBGP, forwarded, `next-hop-unchanged` enabled | next-hop rewritten to self  | *received next-hop preserved* |
| eBGP, locally originated                      | next-hop rewritten to self  | unchanged                   |
| iBGP, forwarded                               | received next-hop preserved | unchanged                   |

For reference, a spine running FRR 10.2.1 with `attribute-unchanged next-hop` shows the
same next-hop behavior as the patched zebra-rs case.