### PR TITLE
ospf: re-originate redistribute-table externals on Router-ID change

### DIFF
--- a/bdd/tests/features/ospfv2_redist_table.feature
+++ b/bdd/tests/features/ospfv2_redist_table.feature
@@ -47,6 +47,26 @@ Feature: OSPFv2 redistributes routes from a kernel routing table
     Then show command "show ospf route" in namespace "r1" should eventually not contain "10.55.1.0/24"
     And show command "show ospf route" in namespace "r1" should contain "10.55.2.0/24"
 
+  Scenario: Router-ID change re-originates the table externals
+    # A Router-ID change flushes every LSA self-originated under the
+    # old identity. The table-sourced Type-5s have no trigger of their
+    # own to come back (the table store only re-fires on a kernel
+    # delta), so the identity change itself must re-originate them.
+    # This is the same hole the startup race opens: inside the initial
+    # commit the table replay (RIB channel) and `router-id` (config
+    # channel) are unordered, and when the replay lands first its
+    # Type-5 is originated under the provisional identity and then
+    # flushed by the Router-ID change — r1 never saw 10.55.1.0/24.
+    When I apply command "set router ospf router-id 10.0.0.22" in namespace "r2"
+    # The flush is flooded before the first Hello under the new
+    # identity, so once r1 lists the new neighbor the old external is
+    # already gone from its table; the settle makes that ordering
+    # certain, so the route assert below cannot pass on stale state.
+    Then show command "show ospf neighbor" in namespace "r1" should eventually contain "10.0.0.22"
+    And I wait 5 seconds
+    And show command "show ospf route" in namespace "r1" should eventually contain "10.55.2.0/24"
+    And show command "show ip route" in namespace "r1" should eventually contain "10.55.2.0/24"
+
   Scenario: Teardown topology
     # Separate scenario so cleanup still runs when a step above fails
     # (a failed step skips the rest of its own scenario only).

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -6159,6 +6159,18 @@ impl Ospf<Ospfv2> {
         // next route churn) `default-information originate always` and
         // the NSSA defaults have no later trigger.
         self.as_external_redist_resync_all();
+        // `redistribute table <id>` externals must be re-originated
+        // here too: the table store only re-fires on a kernel-table
+        // delta, so a route present before the daemon started (learned
+        // from the netlink dump and replayed when the watch registered)
+        // has no later trigger either. The replay rides the RIB
+        // channel while `router-id` rides the config channel, and the
+        // two are unordered within one commit — when the replay lands
+        // first, its Type-5 is originated under the provisional
+        // identity and the flush above withdraws it; without this
+        // resync it stayed withdrawn until the next table change
+        // (bit `@ospfv2_redist_table`: r1 never saw 10.55.1.0/24).
+        self.as_external_table_resync_all();
         self.default_originate_resync();
         let nssa_areas: Vec<Ipv4Addr> = self
             .areas


### PR DESCRIPTION
## Summary

`@ospfv2_redist_table` failed in tonight's c=16 full run (main `3b8e4c3e`) and then 1 of 3 solo runs at c=1: r1 reached Full with r2 and had r2's loopback, but the Type-5 for the pre-start kernel table-100 route never appeared.

**Mechanism.** OSPFv2 `router_id_update` flushes every LSA self-originated under the old identity (`flush_self_originated_under`, Type-5s included) and then re-originates the config-driven LSAs — `as_external_redist_resync_all`, `default_originate_resync`, NSSA defaults — but never `as_external_table_resync_all`. The table store only re-fires on a kernel-table delta, so a route that was present before the daemon started (netlink dump, replayed when the watch registered) has no later trigger: once flushed it stays withdrawn until the table changes.

Why intermittent: inside r2's initial commit the table replay rides the RIB channel (`RibRx::TableRouteAdd`) while `router-id` rides the config channel, and the OSPF task's `select!` gives them no order. Replay-first stamps the Type-5 with the provisional identity; the router-id callback then withdraws it for good. The flush-on-change (`efd7e5b1`) and the re-origination block (`126669f7`) both predate the table source (`b4f45130`), which never joined the list. OSPFv3 has no table source, so this is v2-only.

## Fix

One call to `as_external_table_resync_all()` in `router_id_update`, next to the other re-originations, with a comment explaining the window.

## Test

New scenario in `ospfv2_redist_table.feature` that reproduces the hole deterministically: after the table external exists, `set router ospf router-id 10.0.0.22` on r2, wait for r1 to list the new neighbor identity plus a 5 s settle (the MaxAge flush is flooded before the first Hello under the new identity, so the route assert cannot pass on stale state), then require `10.55.2.0/24` back in r1's `show ospf route` and `show ip route`.

- Unfixed binary: the new scenario fails every time (r1 Full with 10.0.0.22 for >1 min, no external).
- Fixed binary: 5/5 solo runs, all 29 steps executed.
- `cargo fmt --check`, workspace clippy (0 warnings), `cargo test --workspace --exclude bdd` (3048 passed).
- Full BDD at c=16 on this branch: 291 ran, 290 passed, 1 failed. The one failure is `stamp_v6_te_metric`, an unrelated IS-IS/STAMP feature (no OSPF instance in it): st1's v6 link-local sender socket hit `EADDRNOTAVAIL` (local link-local still tentative under DAD) and `stamp::inst::subscribe` never retries a failed `add_session`. Mechanism is in the daemon log; fix follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJPZzL9yXsyWn6L71g72pb
