### PR TITLE
stamp: retry a session whose socket could not be created

### DIFF
--- a/bdd/tests/configs/stamp_v6_dad_retry/st1.yaml
+++ b/bdd/tests/configs/stamp_v6_dad_retry/st1.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ff61::1/128
+- if-name: st1-st2
+  ipv6:
+    address: 2001:db8:61::1/64
+
+router:
+  isis:
+    net: 49.0061.0000.0000.0001.00
+    hostname: st1
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: st1-st2
+      network-type: point-to-point
+      ipv6:
+        enabled: true
+      te-metric:
+        measurement:
+          enabled: true
+          interval: 100
+          damping-period: 2

--- a/bdd/tests/configs/stamp_v6_dad_retry/st2.yaml
+++ b/bdd/tests/configs/stamp_v6_dad_retry/st2.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ff61::2/128
+- if-name: st2-st1
+  ipv6:
+    address: 2001:db8:61::2/64
+
+router:
+  isis:
+    net: 49.0061.0000.0000.0002.00
+    hostname: st2
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: st2-st1
+      network-type: point-to-point
+      ipv6:
+        enabled: true
+      te-metric:
+        measurement:
+          enabled: true
+          interval: 100
+          damping-period: 2

--- a/bdd/tests/features/stamp_v6_dad_retry.feature
+++ b/bdd/tests/features/stamp_v6_dad_retry.feature
@@ -1,0 +1,64 @@
+@stamp_v6_dad_retry
+@isis
+Feature: STAMP session creation survives a tentative IPv6 link-local
+  As a network operator measuring IPv6-only links with STAMP, I want a
+  session whose sender socket could not be created at adjacency-up
+  time to be retried, so a link-local that is still tentative under
+  Duplicate Address Detection when IS-IS comes up does not leave the
+  link unmeasured for the life of the adjacency.
+
+  The v6 link-local STAMP session is keyed from the local and remote
+  link-locals the moment the IS-IS neighbor reaches Up. IS-IS runs
+  over L2, so the adjacency can form while the kernel is still running
+  DAD on the local link-local; binding the sender socket to a tentative
+  address fails with EADDRNOTAVAIL. The IGP never re-subscribes on its
+  own (its key is stable while the neighbor stays Up), so STAMP itself
+  must park the failed creation and retry it.
+
+  Seen live in a c=16 full run of @stamp_v6_te_metric: st1 logged
+  "cannot create session ... Cannot assign requested address" at the
+  instant st2 created its side, and st1 never had a session.
+
+  Topology (same as @stamp_v6_te_metric):
+
+    st1                                    st2
+      st1-st2  2001:db8:61::1/64 ---- 2001:db8:61::2/64  st2-st1
+      lo 2001:db8:0:ff61::1/128            lo 2001:db8:0:ff61::2/128
+
+  Config files: st1.yaml  st2.yaml
+
+  Scenario: Build the topology with a slow DAD on st1's link
+    Given a clean test environment
+    When I create namespace "st1"
+    And I create namespace "st2"
+    And I connect namespace "st1" interface "st1-st2" to namespace "st2" interface "st2-st1"
+    # Keep st1's link-local tentative for ~8 s: raise dad_transmits and
+    # bounce the link so DAD restarts under the new count. The daemons
+    # start and the IS-IS adjacency forms well inside that window.
+    And I execute "sysctl -w net.ipv6.conf.st1-st2.dad_transmits=8" in namespace "st1"
+    And I execute "ip link set st1-st2 down" in namespace "st1"
+    And I execute "ip link set st1-st2 up" in namespace "st1"
+    And I start zebra-rs in namespace "st1"
+    And I start zebra-rs in namespace "st2"
+    And I apply config "st1.yaml" to namespace "st1"
+    And I apply config "st2.yaml" to namespace "st2"
+    Then isis neighbor in namespace "st1" at level 2 on interface "st1-st2" should be up
+
+  Scenario: The first creation fails on the tentative address and is retried
+    Given the test topology exists
+    # Proof the failure path ran: the sender bind hit the tentative
+    # link-local (without this line a fast DAD would let the scenario
+    # pass without exercising the retry).
+    Then daemon log in namespace "st1" should eventually contain "cannot create session"
+    # ...and the retry brought the session up once DAD completed.
+    And daemon log in namespace "st1" should eventually contain "session created on retry"
+    And show command "show stamp" in namespace "st1" should eventually contain "fe80:"
+    And show command "show stamp" in namespace "st1" should eventually contain "Active"
+    And show command "show stamp" in namespace "st2" should eventually contain "fe80:"
+
+  Scenario: Teardown topology
+    When I stop zebra-rs in namespace "st1"
+    And I stop zebra-rs in namespace "st2"
+    And I delete namespace "st1"
+    And I delete namespace "st2"
+    Then the test environment should be clean

--- a/zebra-rs/src/stamp/inst.rs
+++ b/zebra-rs/src/stamp/inst.rs
@@ -26,6 +26,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
+use std::time::Duration;
 
 use stamp_packet::{ErrorEstimate, ReflectorPacket, SenderPacket, StampTimestamp};
 use tokio::io::unix::AsyncFd;
@@ -88,6 +89,10 @@ pub struct ReflectorStats {
     pub t2_userspace: u64,
 }
 
+/// How long a session whose socket could not be created waits before
+/// the next creation attempt (see [`Stamp::retry_pending`]).
+const SESSION_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
 #[derive(Debug)]
 pub enum Message {
     /// A Session-Sender probe arrived on the reflector socket. `rx_ts`
@@ -119,6 +124,8 @@ pub enum Message {
     TxTick { key: SessionKey },
     /// Export (damping-period) timer fired for `key`.
     ExportTick { key: SessionKey },
+    /// Retry timer fired: re-attempt every parked session creation.
+    RetryPending,
 }
 
 /// Top-level STAMP instance.
@@ -152,6 +159,14 @@ pub struct Stamp {
     /// `[::]:862` listener bound (so v6 probes can't be answered).
     reflect_tx_v6: Option<UnboundedSender<ReflectRequest>>,
     probers: HashMap<SessionKey, ProberHandle>,
+    /// Sessions whose creation failed (`add_session` error) while a
+    /// subscriber still wants them, with the params to retry with.
+    /// Retried on every [`Message::RetryPending`] tick until the socket
+    /// comes up or the last subscriber leaves.
+    pending: BTreeMap<SessionKey, SessionParams>,
+    /// One-shot timer that sends [`Message::RetryPending`]; `None`
+    /// while nothing is parked.
+    retry_timer: Option<Task<()>>,
     pub reflector_stats: ReflectorStats,
 }
 
@@ -230,6 +245,8 @@ impl Stamp {
             reflect_tx,
             reflect_tx_v6,
             probers: HashMap::new(),
+            pending: BTreeMap::new(),
+            retry_timer: None,
             reflector_stats: ReflectorStats::default(),
         };
         stamp.show_build();
@@ -297,10 +314,32 @@ impl Stamp {
         notifier: UnboundedSender<StampEvent>,
     ) {
         if self.sessions.get(&key).is_none() {
-            if let Err(e) = self.add_session(key, params) {
-                tracing::warn!(?key, error = %e, "stamp: cannot create session");
-                // Keep the subscription anyway: unsubscribe stays
-                // symmetric for the IGP, it just never hears updates.
+            match self.add_session(key, params) {
+                Ok(()) => {
+                    self.pending.remove(&key);
+                }
+                Err(e) => {
+                    // A transient socket failure must not strand the
+                    // subscriber for the life of the adjacency: the IGP
+                    // never re-subscribes on its own (its key is stable
+                    // while the neighbor stays Up), so a creation that
+                    // fails once used to leave the link unmeasured
+                    // forever. Seen live as EADDRNOTAVAIL binding a v6
+                    // link-local that was still tentative under DAD.
+                    // Keep the subscription (unsubscribe stays
+                    // symmetric), park the params, and retry on the
+                    // pending tick until the socket comes up or the
+                    // last subscriber leaves.
+                    if self.pending.insert(key, params).is_none() {
+                        tracing::warn!(
+                            ?key, error = %e,
+                            "stamp: cannot create session, will retry"
+                        );
+                    } else {
+                        tracing::debug!(?key, error = %e, "stamp: session retry failed");
+                    }
+                    self.arm_retry_timer();
+                }
             }
         } else {
             self.update_params(&key, params);
@@ -330,7 +369,50 @@ impl Stamp {
         };
         if now_empty {
             self.subscribers.remove(key);
+            self.pending.remove(key);
             self.remove_session(key);
+        }
+    }
+
+    /// Arm the one-shot [`Message::RetryPending`] timer unless one is
+    /// already running. The task handle is held so despawning the
+    /// instance aborts it.
+    fn arm_retry_timer(&mut self) {
+        if self.retry_timer.is_some() {
+            return;
+        }
+        let tx = self.main_tx.clone();
+        self.retry_timer = Some(Task::spawn(async move {
+            tokio::time::sleep(SESSION_RETRY_INTERVAL).await;
+            let _ = tx.send(Message::RetryPending);
+        }));
+    }
+
+    /// [`Message::RetryPending`]: re-attempt every parked session
+    /// creation. Entries whose subscribers have all left (or that got
+    /// created meanwhile) are dropped; the timer is re-armed while
+    /// anything remains parked.
+    fn retry_pending(&mut self) {
+        self.retry_timer = None;
+        let parked: Vec<(SessionKey, SessionParams)> =
+            self.pending.iter().map(|(k, p)| (*k, *p)).collect();
+        for (key, params) in parked {
+            if !self.subscribers.contains_key(&key) || self.sessions.get(&key).is_some() {
+                self.pending.remove(&key);
+                continue;
+            }
+            match self.add_session(key, params) {
+                Ok(()) => {
+                    self.pending.remove(&key);
+                    tracing::info!(?key, "stamp: session created on retry");
+                }
+                Err(e) => {
+                    tracing::debug!(?key, error = %e, "stamp: session retry failed");
+                }
+            }
+        }
+        if !self.pending.is_empty() {
+            self.arm_retry_timer();
         }
     }
 
@@ -601,6 +683,7 @@ impl Stamp {
                         self.on_reply_recv(key, reply, t4, t4_kernel),
                     Message::TxTick { key } => self.on_tx_tick(key),
                     Message::ExportTick { key } => self.on_export_tick(key),
+                    Message::RetryPending => self.retry_pending(),
                 },
                 Some(msg) = self.cm.rx.recv() => self.process_cm_msg(msg),
                 Some(msg) = self.show.rx.recv() => {
@@ -678,6 +761,44 @@ mod tests {
         stamp.unsubscribe("ospf", &key);
         assert_eq!(stamp.sessions.len(), 0, "last unsubscribe tears down");
         assert!(stamp.probers.is_empty());
+    }
+
+    /// A session whose socket can't be created (here a local address
+    /// that is on no interface — the shape of a v6 link-local still
+    /// tentative under DAD) keeps its subscription and is parked for
+    /// retry instead of being dropped; the last unsubscribe clears the
+    /// parked entry so nothing retries a session nobody wants.
+    #[tokio::test]
+    async fn failed_create_is_parked_until_unsubscribe() {
+        let mut stamp = fresh_stamp();
+        // TEST-NET-1 (RFC 5737): never configured on a host interface,
+        // so the sender bind fails with EADDRNOTAVAIL.
+        let key = SessionKey {
+            local: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            remote: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2)),
+            ifindex: 0,
+        };
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+        assert!(stamp.sessions.get(&key).is_none(), "no socket, no session");
+        assert_eq!(stamp.pending.get(&key), Some(&SessionParams::default()));
+        assert!(stamp.subscribers.contains_key(&key), "subscription kept");
+        assert!(stamp.retry_timer.is_some(), "retry armed");
+
+        // The tick finds the address still unusable: stays parked,
+        // timer re-armed.
+        stamp.retry_pending();
+        assert!(stamp.sessions.get(&key).is_none());
+        assert!(stamp.pending.contains_key(&key));
+        assert!(stamp.retry_timer.is_some(), "re-armed while parked");
+
+        // Last unsubscribe drops the parked entry; the next tick has
+        // nothing to do and does not re-arm.
+        stamp.unsubscribe("isis", &key);
+        assert!(stamp.pending.is_empty());
+        stamp.retry_pending();
+        assert!(stamp.retry_timer.is_none());
     }
 
     /// A later Subscribe with different timing retunes the stored


### PR DESCRIPTION
## Summary

`@stamp_v6_te_metric` failed in the c=16 full run gating #2354: st1 reported "No STAMP sessions" for the whole 60 s window while st2 had its session, and the IS-IS link-delay sub-TLV assertion failed as a cascade. The daemon log had the mechanism:

```
WARN stamp/inst.rs:301: stamp: cannot create session key=SessionKey { local: fe80::…, remote: fe80::…, ifindex: 6093 } error=Cannot assign requested address (os error 99)
```

logged at the same instant st2 logged `session created`. The same warning appears once in an August log.

**Mechanism.** The v6 link-local session is keyed the moment the IS-IS neighbor reaches Up. IS-IS runs over L2, so the adjacency can form while the kernel is still running DAD on the local link-local, and binding the sender socket to a tentative address fails with `EADDRNOTAVAIL`. `Stamp::subscribe` logged the error and kept the subscription, but nothing ever retried the creation, and the IGP never re-subscribes on its own (its key is stable while the neighbor stays Up). The link stayed unmeasured for the life of the adjacency.

## Fix

Park a failed creation (key + params) and retry it on a one-second tick until the socket comes up or the last subscriber leaves. `unsubscribe` clears the parked entry; the timer task is held by the instance so despawn aborts it. Log lines: `cannot create session, will retry` on the first failure, `session created on retry` on success.

## Test

- Unit test `failed_create_is_parked_until_unsubscribe`: parks on an unbindable TEST-NET-1 local address, checks the retry tick keeps it parked and re-armed, and that the last unsubscribe clears it.
- New BDD feature `@stamp_v6_dad_retry` (own config dir, a copy of `stamp_v6_te_metric`'s): raises `dad_transmits` on st1's link and bounces it before the daemons start so the link-local stays tentative for ~8 s while IS-IS comes up. It requires the daemon log to show the failed creation first (so a fast DAD cannot let it pass without exercising the retry), then `session created on retry`, then `show stamp` with the `fe80:` remote and `Active`.
  - Previous binary: fails deterministically at the retry assertion, with the same `EADDRNOTAVAIL` warning as the full-run failure.
  - This branch: 3/3, all 23 steps executed; `stamp_v6_te_metric`, `stamp_te_metric`, `isis_ipv6` also pass.
- `cargo fmt --check`, workspace clippy (0 warnings), `cargo test --workspace --exclude bdd` (3049 passed).
- Full BDD at c=16 on this branch: 292 ran, 292 passed, 0 failed (~17 min; the 292nd is the new feature), zero leaks.

Not touched here: IS-IS still keys STAMP from a tentative link-local although the RIB tracks the tentative flag; this PR makes STAMP robust to any transient socket failure rather than special-casing DAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJPZzL9yXsyWn6L71g72pb
