### PR TITLE
rib: adopt the kernel's hardware address on an existing link

### DIFF
--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -933,6 +933,19 @@ impl Rib {
             // here, as does an external `ip link set`). The fan-out to
             // protocols happens after the borrow is released, below.
             link.mtu = fib_link.mtu;
+            // Hardware address: adopt-if-present, same rule as parent /
+            // vlan_id above. It DOES change on a live link, and our own
+            // config is what moves it: the kernel recomputes a bridge's
+            // address from its port set whenever that set changes
+            // (`br_stp_recalculate_bridge_id`), so `interface <x> bridge
+            // <br>` and `vxlan <v> bridge <br>` both retarget it — as does
+            // an external `ip link set <dev> address`. Without this the
+            // cache keeps the address the link happened to have when it
+            // first appeared, which `show interface` then reports for the
+            // rest of the run.
+            if fib_link.mac.is_some() {
+                link.mac = fib_link.mac;
+            }
         } else {
             let link = Link::from(fib_link);
             let _ = sysctl_mpls_enable(&link.name);


### PR DESCRIPTION
A three-line change in `Rib::link_add()`: adopt `fib_link.mac` on an already-known ifindex, the
same adopt-if-present rule `parent` and `vlan_id` follow two lines above. 
The existing-link branch updates several attributes from fib_link, but does not refresh mac.

Our own configuration moves it: the kernel recomputes a bridge's address from its port set
(`br_stp_recalculate_bridge_id`), so `interface <x> bridge <br>` and `vxlan <v> bridge <br>`
retarget it. We cache the address the bridge is created with, the ports are then enslaved,
and `show interface <bridge>` reports that stale value for the rest of the run.
When the bridge is also used as the SVI, the stale value is the tenant-facing gateway MAC.

## Steps to reproduce

```
configure
set bridge br10
set vxlan vxlan10 vni 10
set vxlan vxlan10 local-address 10.0.0.3
set vxlan vxlan10 bridge br10
set interface eth5 bridge br10
commit
```

- Expected: `show interface br10` agrees with `ip -o link show br10`.
- Actual: it keeps the address the bridge was created with, for the life of the process.

## Cause / fix

The existing-link branch reconciles `master`, `vni`, `parent`, `vlan_id` and `mtu` against the
incoming `RTM_NEWLINK` but not `mac`, so the address carried by the resulting notification is dropped.

```rust
if fib_link.mac.is_some() {
    link.mac = fib_link.mac;
}
```

Adopt-if-present, not an unconditional assignment: a partial `RTM_NEWLINK` omitting the
attribute means "unchanged", not "gone". No other field is touched.

## Tests

The same commit built with and without the patch on a two-VTEP EVPN/VXLAN lab, comparing
`ip -o link show` against `show interface` across five stages — startup, then detaching and
re-attaching the VXLAN and an access port. Unpatched reports one mismatched link at every stage
on both nodes, including the node never reconfigured after startup; patched reports none.
Everything else collected per stage — BGP, RIB, EVPN routes, kernel FIB, bridge FDB, overlay
reachability — is identical.

`cargo fmt`, both clippy lanes, the vty exit-hook test and `packaging playset` pass on this
change.