### PR TITLE
rib: fan a link's hardware-address change out to protocol subscribers

### DIFF
--- a/bdd/docs/isis_lan_snpa_change.md
+++ b/bdd/docs/isis_lan_snpa_change.md
@@ -1,0 +1,67 @@
+# IS-IS LAN adjacency survives a change of the interface hardware address
+
+## Overview
+
+As a network operator
+I want IS-IS to follow the kernel when an interface's MAC address changes,
+so an adjacency on that circuit stays up (and the SNPA I see in
+`show isis interface detail` is the one on the wire) instead of being pinned
+at Init for the rest of the process.
+
+Why this can happen without anyone touching the address by hand: the
+kernel recomputes a bridge's MAC from its port set on every enslave or
+release, and a bond adopts its first slave's. Both are ordinary
+results of our own configuration. `ip link set ... address` is the
+operator's version of the same event and is what this feature uses.
+
+The mechanism it pins: IS-IS caches the interface MAC as the circuit
+SNPA and compares it against the IS Neighbors TLV of every LAN IIH it
+receives (ISO 10589 8.4.2.5). Once the neighbour has learnt our new
+source address, its IIHs list only that, so a stale SNPA fails the
+check on each one: the adjacency drops to Init and never recovers. The
+RIB now fans the kernel's new address out (`RibRx::LinkMac`) and IS-IS
+refreshes the SNPA in place, sends an immediate Hello and re-runs DIS
+election.
+
+## Test Topology
+
+```
+ a1 ───────────── a2
+ i2  10.0.12.0/30  i1
+ lo 10.0.0.1/32   lo 10.0.0.2/32
+```
+
+Both routers are level-2-only on a broadcast (LAN) circuit with 1 s
+Hellos and hold-time 5 s, so the fallout of the address change lands
+within seconds either way.
+
+## Notes
+
+- The address is changed with `ip link set dev i2 address` inside a1's
+  namespace; zebra-rs has no MAC configuration leaf and mirrors the
+  kernel value through netlink (`Rib::link_add` adopts it, then fans
+  `RibRx::LinkMac` out to protocol subscribers).
+- The 10 s wait after the change is twice the hold time: long enough
+  for a2's IS Neighbors TLV to have turned over to the new address and
+  for a1 to have received several IIHs carrying it. Before the fix each
+  of those IIHs failed a1's three-way check, so the decisive
+  assertions (a1's adjacency Up, a2 reaching a1's loopback) failed
+  deterministically rather than by timing.
+- `show isis interface detail` renders the SNPA in colon form
+  (`02:00:00:00:12:01`); the neighbour table renders it dotted
+  (`0200.0000.1201`).
+
+## Test Scenarios
+
+### Changing a1's interface address keeps the adjacency up and refreshes the SNPA on both sides
+
+Bring the adjacency up and confirm reachability, move a1's address,
+wait out the hold time, then assert: a1 reports the new SNPA on the
+circuit, a2's neighbour table shows it, both adjacencies are Up, and
+loopback reachability holds in both directions (a2 to a1 depends on
+a1's LSP still listing a2, i.e. on a1's adjacency not having dropped).
+
+### Teardown topology
+
+Stop both daemons, delete the namespaces, and verify the environment
+is clean.

--- a/bdd/tests/configs/isis_lan_snpa_change/a1.yaml
+++ b/bdd/tests/configs/isis_lan_snpa_change/a1.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enabled: true
+    - if-name: i2
+      circuit-type: level-2-only
+      metric: 10
+      hello:
+        interval: 1
+        multiplier: 5
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_snpa_change/a2.yaml
+++ b/bdd/tests/configs/isis_lan_snpa_change/a2.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: a2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enabled: true
+    - if-name: i1
+      circuit-type: level-2-only
+      metric: 10
+      hello:
+        interval: 1
+        multiplier: 5
+      ipv4:
+        enabled: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -390,6 +390,34 @@ async fn set_namespace_interface_mtu(
     );
 }
 
+/// Set the kernel hardware address of an interface inside a namespace.
+/// zebra-rs has no MAC config leaf — it mirrors the kernel value via
+/// netlink (`Rib::link_add` adopts it, `RibRx::LinkMac` fans it out,
+/// `Isis::link_mac` refreshes the SNPA) — so this is THE way a test
+/// moves the address that IS-IS's LAN three-way check and DIS election
+/// read.
+#[given(expr = "I set mac {string} on interface {string} in namespace {string}")]
+#[when(expr = "I set mac {string} on interface {string} in namespace {string}")]
+async fn set_namespace_interface_mac(
+    world: &mut World,
+    mac: String,
+    interface: String,
+    namespace: String,
+) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(
+        &scoped,
+        "ip",
+        &["link", "set", "dev", &interface, "address", &mac],
+    )
+    .await
+    .expect("Failed to set interface MAC");
+    println!(
+        "✓ Interface {} in namespace {} address {}",
+        interface, scoped, mac
+    );
+}
+
 // Keyword-agnostic on purpose: cucumber-rs binds a step to its
 // attribute keyword, and an `And` inherits the preceding `Given`/
 // `When`/`Then` — a `when`-only utility step silently SKIPS (along

--- a/bdd/tests/features/isis_lan_snpa_change.feature
+++ b/bdd/tests/features/isis_lan_snpa_change.feature
@@ -1,0 +1,72 @@
+@isis_lan_snpa_change
+@isis
+Feature: IS-IS LAN adjacency survives a change of the interface hardware address
+  As a network operator
+  I want IS-IS to follow the kernel when an interface's MAC address changes,
+  so an adjacency on that circuit stays up (and the SNPA I see in
+  `show isis interface detail` is the one on the wire) instead of being pinned
+  at Init for the rest of the process.
+
+  Why this can happen without anyone touching the address by hand: the
+  kernel recomputes a bridge's MAC from its port set on every enslave or
+  release, and a bond adopts its first slave's. Both are ordinary
+  results of our own configuration. `ip link set ... address` is the
+  operator's version of the same event and is what this feature uses.
+
+  The mechanism it pins: IS-IS caches the interface MAC as the circuit
+  SNPA and compares it against the IS Neighbors TLV of every LAN IIH it
+  receives (ISO 10589 8.4.2.5). Once the neighbour has learnt our new
+  source address, its IIHs list only that, so a stale SNPA fails the
+  check on each one: the adjacency drops to Init and never recovers. The
+  RIB now fans the kernel's new address out (`RibRx::LinkMac`) and IS-IS
+  refreshes the SNPA in place, sends an immediate Hello and re-runs DIS
+  election.
+
+  Test Topology:
+  ```
+   a1 ───────────── a2
+   i2  10.0.12.0/30  i1
+   lo 10.0.0.1/32   lo 10.0.0.2/32
+  ```
+
+  Both routers are level-2-only on a broadcast (LAN) circuit with 1 s
+  Hellos and hold-time 5 s, so the fallout of the address change lands
+  within seconds either way.
+
+  Scenario: Changing a1's interface address keeps the adjacency up and refreshes the SNPA on both sides
+    Given a clean test environment
+    When I create namespace "a1"
+    And I create namespace "a2"
+    And I connect namespace "a1" interface "i2" to namespace "a2" interface "i1"
+    And I start zebra-rs in namespace "a1"
+    And I start zebra-rs in namespace "a2"
+    And I apply config "a1.yaml" to namespace "a1"
+    And I apply config "a2.yaml" to namespace "a2"
+    Then isis neighbor in namespace "a1" at level 2 on interface "i2" should be up
+    And isis neighbor in namespace "a2" at level 2 on interface "i1" should be up
+    And ping from "a2" to "10.0.0.1" should eventually succeed
+    # Move a1's address. The 10 s wait is twice the hold time: long
+    # enough for a2's IS Neighbors TLV to have turned over to the new
+    # address and for a1 to have received several IIHs carrying it —
+    # every one of which broke the adjacency before the fix.
+    When I set mac "02:00:00:00:12:01" on interface "i2" in namespace "a1"
+    And I wait 10 seconds
+    # a1's own view: the SNPA follows the kernel (colon form in
+    # `show isis interface detail`, dotted form in the neighbour table).
+    Then show command "show isis interface detail" in namespace "a1" should eventually contain "SNPA: 02:00:00:00:12:01"
+    And show command "show isis neighbor" in namespace "a2" should eventually contain "0200.0000.1201"
+    # The decisive assertions: a1's adjacency is Up, not pinned at Init,
+    # and the LAN still carries traffic in the direction that needs
+    # a1's LSP to list a2 (the two-way check on a2's SPF).
+    And isis neighbor in namespace "a1" at level 2 on interface "i2" should be up
+    And isis neighbor in namespace "a2" at level 2 on interface "i1" should be up
+    And ping from "a2" to "10.0.0.1" should eventually succeed
+    And ping from "a1" to "10.0.0.2" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "a1"
+    And I stop zebra-rs in namespace "a2"
+    And I delete namespace "a1"
+    And I delete namespace "a2"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1855,6 +1855,9 @@ impl Isis {
             RibRx::LinkMtu { ifindex, mtu } => {
                 self.link_mtu(ifindex, mtu);
             }
+            RibRx::LinkMac { ifindex, mac } => {
+                self.link_mac(ifindex, mac);
+            }
             RibRx::AddrAdd(addr) => {
                 // isis_info!("Isis::AddrAdd {}", addr.addr);
                 self.addr_add(addr);
@@ -4545,7 +4548,7 @@ mod commit_and_microloop_gate_tests {
     use super::bfd_wiring_tests::{test_config_tx, test_ctx, test_rib_subscriber};
     use super::*;
 
-    fn fresh_isis() -> Isis {
+    pub(super) fn fresh_isis() -> Isis {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, policy_rx) = mpsc::unbounded_channel();
         Box::leak(Box::new(policy_rx));
@@ -4808,5 +4811,95 @@ mod commit_and_microloop_gate_tests {
         assert_eq!(isis.dis_gen_timer.l1.len(), 2);
         assert_eq!(isis.dis_gen_pending_base.l1.get(&nid(3)), Some(&Some(5)));
         assert_eq!(isis.dis_gen_pending_base.l1.get(&nid(4)), Some(&None));
+    }
+}
+
+#[cfg(test)]
+mod link_mac_tests {
+    use netlink_packet_route::link::LinkFlags;
+    use tokio::sync::mpsc;
+
+    use super::commit_and_microloop_gate_tests::fresh_isis;
+    use super::*;
+    use crate::isis::link::{IsisLink, LinkConfig, LinkState, LinkTimer};
+    use crate::rib::MacAddr;
+
+    fn mac(last: u8) -> MacAddr {
+        MacAddr::from([0x02, 0, 0, 0, 0, last])
+    }
+
+    /// A socket-less link record. The RIB-driven attribute refreshers
+    /// (`link_mtu`, `link_mac`) only touch `state`, so no packet task
+    /// is needed; the parked `prx` keeps `ptx` sendable.
+    fn parked_link(ifindex: u32, mac: Option<MacAddr>) -> IsisLink {
+        let (ptx, prx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(prx));
+        let mut link = IsisLink {
+            ifindex,
+            ptx,
+            read_task: tokio::spawn(async {}),
+            flags: LinkFlags::empty(),
+            circuit_id: 0,
+            config: LinkConfig::default(),
+            state: LinkState::default(),
+            timer: LinkTimer::default(),
+        };
+        link.state.mac = mac;
+        link
+    }
+
+    fn drain(isis: &mut Isis) {
+        while isis.rx.try_recv().is_ok() {}
+    }
+
+    /// The bridge/bond case: the SNPA moves, and the instance nudges
+    /// itself — a Hello on every level so neighbours learn the new
+    /// source address at once, then a level-agnostic DIS re-election
+    /// because the address is the priority tie-breaker.
+    #[tokio::test]
+    async fn changed_address_refreshes_snpa_and_nudges_hello_then_dis() {
+        let mut isis = fresh_isis();
+        isis.links.insert(7, parked_link(7, Some(mac(1))));
+        drain(&mut isis);
+
+        isis.link_mac(7, mac(2));
+
+        assert_eq!(isis.links.get(&7).unwrap().state.mac, Some(mac(2)));
+        assert!(matches!(
+            isis.rx.try_recv(),
+            Ok(Message::Ifsm(IfsmEvent::HelloOriginate, 7, None))
+        ));
+        assert!(matches!(
+            isis.rx.try_recv(),
+            Ok(Message::Ifsm(IfsmEvent::DisSelection, 7, None))
+        ));
+        assert!(isis.rx.try_recv().is_err());
+    }
+
+    /// The RIB only fans out genuine changes, but a duplicate must
+    /// still be harmless: no Hello burst, no election churn.
+    #[tokio::test]
+    async fn same_address_is_silent() {
+        let mut isis = fresh_isis();
+        isis.links.insert(7, parked_link(7, Some(mac(1))));
+        drain(&mut isis);
+
+        isis.link_mac(7, mac(1));
+
+        assert_eq!(isis.links.get(&7).unwrap().state.mac, Some(mac(1)));
+        assert!(isis.rx.try_recv().is_err());
+    }
+
+    /// A link IS-IS never saw (not in this VRF, or deleted meanwhile)
+    /// is ignored rather than created.
+    #[tokio::test]
+    async fn unknown_link_is_ignored() {
+        let mut isis = fresh_isis();
+        drain(&mut isis);
+
+        isis.link_mac(9, mac(1));
+
+        assert!(isis.links.get(&9).is_none());
+        assert!(isis.rx.try_recv().is_err());
     }
 }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1148,6 +1148,40 @@ impl Isis {
         }
     }
 
+    /// Refresh the cached SNPA after the kernel changed the interface's
+    /// hardware address (`RibRx::LinkMac`: a bridge recomputing its
+    /// address from its port set, a bond adopting its first slave's,
+    /// an operator `ip link set ... address`). The SNPA is what the LAN
+    /// three-way check compares against a neighbour's IS Neighbors TLV
+    /// (ISO 10589 §8.4.2.5): once a neighbour has learnt the new source
+    /// address from our Hellos, every IIH it sends lists that address,
+    /// and a stale copy here fails the check on each one — the
+    /// adjacency drops to Init and stays there. It is also the DIS
+    /// election tie-breaker (§8.4.5) and the `show isis interface` SNPA.
+    ///
+    /// Beyond the in-place update, two nudges keep the flap short:
+    /// an immediate Hello on every level, so neighbours learn the new
+    /// address now rather than at the next interval, and a
+    /// level-agnostic DIS re-election, since an address change can
+    /// flip a priority tie. Both are no-ops on a circuit that runs no
+    /// Hello protocol (passive, or a level the link is not in), and
+    /// the re-election on a level with no Up neighbour.
+    pub fn link_mac(&mut self, ifindex: u32, mac: MacAddr) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        if link.state.mac == Some(mac) {
+            return;
+        }
+        link.state.mac = Some(mac);
+        let _ = self
+            .tx
+            .send(Message::Ifsm(IfsmEvent::HelloOriginate, ifindex, None));
+        let _ = self
+            .tx
+            .send(Message::Ifsm(IfsmEvent::DisSelection, ifindex, None));
+    }
+
     /// React to a kernel-side link-down event. Adjacencies on this
     /// link can't continue — packets stop flowing the moment IFF_UP
     /// drops — so tear them down immediately rather than ride out

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -111,6 +111,22 @@ pub enum RibRx {
         ifindex: u32,
         mtu: u32,
     },
+    /// The hardware address of an already-known link changed. The
+    /// kernel moves it on a live link in the ordinary course of our
+    /// own configuration — a bridge recomputes its address from its
+    /// port set on every enslave/release, a bond adopts its first
+    /// slave's — and `ip link set ... address` is always available to
+    /// the operator. IS-IS caches it as the circuit SNPA: the value
+    /// the LAN three-way check compares against a neighbour's IS
+    /// Neighbors TLV (ISO 10589 §8.4.2.5) and the DIS-election
+    /// tie-breaker (§8.4.5), so a stale copy pins adjacencies at
+    /// Init. Subscribers update the cached value in place. A
+    /// brand-new link carries its address on `LinkAdd` and never
+    /// sees this.
+    LinkMac {
+        ifindex: u32,
+        mac: MacAddr,
+    },
     AddrAdd(LinkAddr),
     AddrDel(LinkAddr),
     RouterIdUpdate(Ipv4Addr),
@@ -396,6 +412,15 @@ impl Rib {
         let vrf_id = self.ifindex_vrf_id(ifindex);
         for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkMtu { ifindex, mtu });
+        }
+    }
+
+    /// Push a hardware-address change to subscribers bound to this
+    /// link's VRF.
+    pub fn api_link_mac(&self, ifindex: u32, mac: MacAddr) {
+        let vrf_id = self.ifindex_vrf_id(ifindex);
+        for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
+            let _ = sub.rib_rx_tx.send(RibRx::LinkMac { ifindex, mac });
         }
     }
 

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -868,6 +868,12 @@ impl Rib {
         let prev_mtu: Option<u32> = self.links.get(&ifindex).map(|l| l.mtu);
         let new_mtu: u32 = fib_link.mtu;
 
+        // Hardware-address pre-state, for the same reason as `prev_mtu`:
+        // IS-IS caches it as the circuit SNPA. `None` for a brand-new
+        // link (its address rides on `api_link_add`); `Some(None)` for
+        // a known link the kernel reports no address for.
+        let prev_mac: Option<Option<MacAddr>> = self.links.get(&ifindex).map(|l| l.mac);
+
         // Capture master pre-state so an existing link crossing a VRF
         // boundary (operator `interface X vrf Y`, applied by the kernel
         // as an RTM_NEWLINK on an already-known ifindex) can be
@@ -997,6 +1003,16 @@ impl Rib {
             && prev != new_mtu
         {
             self.api_link_mtu(ifindex, new_mtu);
+        }
+
+        // Likewise for the hardware address. Compare against the value
+        // now *stored* rather than `fib_link.mac`, so the adopt-if-present
+        // rule above is honoured: an RTM_NEWLINK that omits IFLA_ADDRESS
+        // leaves the cache untouched and fires nothing.
+        if let Some(prev) = prev_mac
+            && let Some(mac) = link_mac_delta(prev, self.links.get(&ifindex).and_then(|l| l.mac))
+        {
+            self.api_link_mac(ifindex, mac);
         }
 
         // A master change that crosses a VRF boundary moves this
@@ -1913,6 +1929,57 @@ pub fn link_vrf_name<'a>(rib: &'a Rib, link: &Link) -> Option<&'a str> {
         .values()
         .find(|v| v.ifindex == master)
         .map(|v| v.name.as_str())
+}
+
+/// The hardware address to fan out after reconciling an already-known
+/// link, if any: the address now cached, when it is present and differs
+/// from what was cached before. `None` means nothing changed that a
+/// subscriber could act on — including a cache that went from an
+/// address to none, which the adopt-if-present rule in [`Rib::link_add`]
+/// never produces but which would carry nothing to announce anyway.
+pub fn link_mac_delta(prev: Option<MacAddr>, now: Option<MacAddr>) -> Option<MacAddr> {
+    match now {
+        Some(mac) if prev != Some(mac) => Some(mac),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod link_mac_delta_tests {
+    use super::*;
+
+    fn mac(last: u8) -> MacAddr {
+        MacAddr::from([0x02, 0, 0, 0, 0, last])
+    }
+
+    /// The bridge case: the address the link was created with gives
+    /// way to one recomputed from its port set.
+    #[test]
+    fn changed_address_is_announced() {
+        assert_eq!(link_mac_delta(Some(mac(1)), Some(mac(2))), Some(mac(2)));
+    }
+
+    /// Every other RTM_NEWLINK on the link (flag flips, MTU, master)
+    /// re-reports the same address; that must not fan out.
+    #[test]
+    fn unchanged_address_is_silent() {
+        assert_eq!(link_mac_delta(Some(mac(1)), Some(mac(1))), None);
+    }
+
+    /// A link known without an address that gains one (not something
+    /// the kernel does, but the honest answer is to announce it).
+    #[test]
+    fn first_address_is_announced() {
+        assert_eq!(link_mac_delta(None, Some(mac(1))), Some(mac(1)));
+    }
+
+    /// Nothing cached now means nothing to announce, whatever was
+    /// cached before.
+    #[test]
+    fn absent_address_is_silent() {
+        assert_eq!(link_mac_delta(Some(mac(1)), None), None);
+        assert_eq!(link_mac_delta(None, None), None);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow-up to #2357. That PR made `Rib::link_add()` adopt the kernel's current hardware address on an already-known link, so `show interface` follows a bridge whose MAC the kernel recomputes from its port set. The protocol modules that cache the address were still left with the first value they ever saw. This PR fans the change out, the way an MTU change already is.

## Why it matters

IS-IS keeps the interface MAC as the circuit SNPA and compares it against the IS Neighbors TLV of every LAN IIH it receives (ISO 10589 §8.4.2.5). Once a neighbour has learnt our new source address from our Hellos, its IIHs list only that, so a stale SNPA fails the check on each one: the adjacency drops to Init and never recovers. A bond taking its first slave, a bridge SVI gaining a port, or an operator `ip link set ... address` all get there. It is also the DIS-election tie-breaker (§8.4.5) and the `show isis interface detail` SNPA.

No other subscriber caches the address: BGP's Type-5 router MAC comes only from explicit config, and the L3 VNI binding reads the VRF device, whose MAC never moves.

## Change

- **RIB** — `RibRx::LinkMac { ifindex, mac }` beside `LinkMtu`, and `api_link_mac()` beside `api_link_mtu()`. `link_add()` fires it only when the cached address actually changed. The comparison reads the value back *after* the adopt-if-present reconcile, so an `RTM_NEWLINK` that omits `IFLA_ADDRESS` fires nothing. The decision is a pure `link_mac_delta()` with its own unit rows. A brand-new link still carries its address on `LinkAdd`.
- **IS-IS** — `Isis::link_mac()` refreshes `state.mac` in place, then nudges itself twice: `HelloOriginate` on every level so neighbours learn the new address now rather than at the next interval, and a level-agnostic `DisSelection` since the address can flip a priority tie. Both are no-ops on passive circuits or levels the link is not in. A duplicate address is silent; an unknown ifindex is ignored.
- Every other `RibRx` consumer already has a wildcard arm (`cargo check --tests` needed no other change).

## Tests

- Unit: `rib::link::link_mac_delta_tests` (4 rows) and `isis::inst::link_mac_tests` (refresh + Hello-then-DIS nudges, duplicate silent, unknown link ignored). The IS-IS tests build a socket-less `IsisLink` on the existing `fresh_isis()` harness.
- BDD: new `isis_lan_snpa_change` feature with a new `I set mac {string} on interface {string} in namespace {string}` step (mirrors the MTU step). Two L2 routers on a LAN circuit with 1 s Hellos; a1's address is moved on the live adjacency; after twice the hold time it asserts the new SNPA in a1's `show isis interface detail` and a2's neighbour table, both adjacencies Up, and loopback reachability both ways.

| Run | Result |
|---|---|
| `isis_lan_snpa_change` on this branch | 2 scenarios, 25/25 steps |
| same, with `Isis::link_mac` stubbed to a no-op | fails at the first assertion; diagnostics show a1's adjacency at **Init** and the creation-time SNPA |
| `cargo test --workspace --exclude bdd` | 3056 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings`, and the `--features lua` lane | clean |
| `cargo test -p bdd --lib` (feature-tag prefix guard) | 4/4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017idTru6bhpWDXDtUqWpWFn
