### PR TITLE
vty: give parent-less clients a session keyed on their own pid (D30)

### DIFF
--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -227,9 +227,16 @@ sudo ip netns exec vrf-red vtyctl show 'show ip route'
 ```
 
 The remaining guards still apply to root peers: cross-PID-namespace
-clients and orphaned clients (parent reparented to init, or the
-parent process disappeared between the credential snapshot and the
-`/proc` lookup) are rejected regardless of uid.
+clients, and clients whose parent process disappeared between the
+credential snapshot and the `/proc` lookup, are rejected regardless
+of uid.
+
+A client with no visible parent at all — a systemd service or snap
+daemon that connects to the socket itself, or a process started by
+`docker exec` / `nsenter -p` whose parent lives outside the daemon's
+PID namespace — is not rejected. It gets a session of its own, keyed
+on its pid and torn down when the process exits, with the role its
+uid implies (root is Admin immediately).
 
 Non-root peers must connect from a same-uid shell — a setuid
 escalation to a non-root effective uid is still refused.

--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -118,11 +118,14 @@ fn resolve_session_key(peer_uid: u32, peer_pid: u32)
         .map_err(|_| Status::internal("cannot read /proc"))?;
     let ppid = stat.ppid as u32;
 
-    // Guard 1: orphan client (parent died, reparented to init).
+    // Guard 1: no visible parent (D30). PPid 1 = parented by init
+    // (systemd service, snap daemon, an agent speaking gRPC itself, or a
+    // client whose shell already died); PPid 0 = the parent lives outside
+    // our PID namespace (`docker exec`, `nsenter -p`). There is no shell
+    // to own the session, so key it on the client itself: the session
+    // then lives exactly as long as that process.
     if ppid <= 1 {
-        return Err(Status::unauthenticated(
-            "orphan client (no parent shell)"
-        ));
+        return Ok((peer_uid, peer_pid));
     }
 
     // Guard 2: parent uid must match peer uid (PID-reuse race), except
@@ -149,6 +152,13 @@ Why this design:
 - The same key `(uid, bash_pid)` is derived for every `vtyhelper`
   invocation spawned from the same vty bash, automatically grouping
   all RPCs from one shell into one session.
+- A client with **no visible parent** (`PPid` 0 or 1) is keyed on its
+  own pid instead (D30). This is the shape of a systemd service or snap
+  daemon that speaks gRPC to the socket itself, and of any process
+  started by `docker exec` / `nsenter -p`, whose parent sits outside
+  the daemon's PID namespace. Because a child that such an agent forks
+  (say, `vtyctl`) carries the agent's pid as its `PPid`, it lands in the
+  agent's session through the ordinary parent-keyed lookup.
 
 When the immediate-parent key has no session, the resolver walks a
 bounded number of parent hops (`MAX_ANCESTOR_WALK`) looking for an
@@ -173,7 +183,8 @@ at the first existing session, at init (pid ≤ 1), or after
 [create]  Lazy on first RPC; no explicit OpenSession call.
 [active]  Each RPC updates Session.last_active.
 [end]     Triggered by any of:
-            - Parent bash death (pidfd, immediate)
+            - Parent bash death (pidfd, immediate); for a
+              parent-less client (D30), the client's own death
             - Idle TTL expiry (~10 min, periodic sweep)
             - Explicit Logout RPC (bash EXIT trap)
             - Daemon shutdown
@@ -293,6 +304,12 @@ and `vtyctl` rarely has a long-lived parent shell, **interactive
 `enable` is effectively a `vty` shell-only feature**. Scripted
 admin work uses `sudo vtyctl …`.
 
+A long-lived agent that connects to the socket directly (a systemd
+service, a snap daemon) holds one session for its whole lifetime,
+keyed on its own pid (D30). Running as root it is Admin from the first
+RPC; as a non-root uid it starts at View and must `enable` like any
+other session.
+
 ## Pipeline / parent-process conventions
 
 vty's `vty.sh` invokes `vtyhelper` via `$(vtyhelper ...)` so the
@@ -373,7 +390,7 @@ Each phase is intended to ship as an independent PR.
 | D5 | The initial Session struct is minimal; enable-related fields are added later. |
 | D6 | PAM is invoked via a separate setuid (or capability-restricted) helper named `vtypam`, installed at `/usr/sbin/vtypam` for distribution. |
 | D7 | The initial Enable RPC uses a single password field. Bidirectional PAM conversation (for OTP, password change) is deferred. |
-| D8 | Session key derivation assumes the direct vty-bash-to-vtyhelper parent relationship; the daemon verifies via `/proc` (orphan check + parent uid match) but does not inspect the parent's command name. |
+| D8 | Session key derivation assumes the direct vty-bash-to-vtyhelper parent relationship; the daemon verifies via `/proc` (parent uid match) but does not inspect the parent's command name. Parent-less clients are keyed on themselves (D30). |
 | D9 | vtyctl receives no special-casing. Stateful RPCs (configure, enable, monitor) naturally fail across vtyctl invocations because the session is not continuous. |
 | D10 | Script-driven admin operations use `sudo vtyctl …` (root), not interactive enable. |
 | D11 | Configure-mode locking is not part of the initial implementation. Concurrent edits are tolerated; conflict-resolution policy is left to commit semantics. |
@@ -389,10 +406,11 @@ Each phase is intended to ship as an independent PR.
 | D22 | **Initial admin gates: Apply and Clear RPCs.** `SessionTable::require_admin` checks `enabled`, enforces sliding TTL + hard cap (with auto-downgrade on expiry), and slides the idle deadline on each authorized call. |
 | D23 | **Configure-mode admin gate** on `DoExec`. For `ExecType::Exec` only (completion paths remain free): admin is required when `mode != "exec"` (catches a client that sets `mode=configure` directly) and when `mode == "exec" && first_word == "configure"` (UX courtesy — block at entry so the prompt doesn't flip uselessly). Configure-mode mutex/lock is deliberately NOT included; multiple admins can enter configure simultaneously (D11 still deferred). |
 | D24 | **Auto-elevate on `configure`**. When a non-admin user types `configure`, root (uid 0) and group members send a passwordless `Enable` RPC; non-members are prompted for **Root password:** immediately (no configure probe). |
-| D26 | **Root peers bypass the parent-uid check.** `resolve_session_key` skips Guard 2 when `peer_uid == 0`. Rationale: the strict match rejected the common `sudo <cmd>` pattern, where the outer `sudo` process retains the invoking user's ruid while the client itself runs as uid 0. Risk surface: any uid-0 connector is trusted regardless of ancestry, but `SO_PEERCRED`'s effective-uid attestation already implies that — a process running as root can already do anything on the host. The remaining guards (D12 cross-PID-namespace, OrphanClient, ParentVanished) still fire for root peers. Non-root peers are unaffected — the parent-uid match is still enforced, so a setuid escalation to a non-zero uid is still refused. |
+| D26 | **Root peers bypass the parent-uid check.** `resolve_session_key` skips Guard 2 when `peer_uid == 0`. Rationale: the strict match rejected the common `sudo <cmd>` pattern, where the outer `sudo` process retains the invoking user's ruid while the client itself runs as uid 0. Risk surface: any uid-0 connector is trusted regardless of ancestry, but `SO_PEERCRED`'s effective-uid attestation already implies that — a process running as root can already do anything on the host. The remaining guards (D12 cross-PID-namespace, ParentVanished) still fire for root peers. Non-root peers are unaffected — the parent-uid match is still enforced, so a setuid escalation to a non-zero uid is still refused. |
 | D27 | **`zebra-rs` Linux group for passwordless enable.** Package postinstall creates the group. Supplementary membership is checked on `enable` via `getgrouplist`; members are promoted without PAM. Group name overridable with `ZEBRA_VTY_CONFIG_GROUP`. Missing group → PAM-only fallback. |
 | D28 | **PAM authenticates root for non-group callers.** Non-members who type `enable`/`configure` are prompted for the root password immediately (no passwordless probe). Client `auth_user` is ignored. |
 | D29 | **Uncommitted changes are confirmed at shell exit, from the client.** The bash `EXIT` trap asks `vtyhelper -u` (a comparison of `show running-config formal` against `show candidate-config formal`, both exec-mode and un-gated) and, when they differ, prompts `y`=commit / `n`=discard / anything else=leave pending. It runs **before** the `Logout` RPC: dropping the session first would make the commit re-resolve as a fresh View session and be refused. The check is client-side because none of the daemon's session-teardown paths owns the candidate — `ExecService` has no handle to `ConfigStore` — and because only the client has a terminal to ask on. Since the candidate is global (D11), the prompt is gated on *this shell* having entered configure mode, so a read-only session is never offered the chance to discard someone else's edits. |
+| D30 | **Parent-less clients get a session keyed on their own pid.** Guard 1 used to reject any peer whose `/proc` `PPid` was 0 or 1 as an "orphan client (no parent shell)". That refused two legitimate automation shapes: a daemon that speaks gRPC to the socket itself (systemd service, snap daemon — `PPid` 1), and anything started by `docker exec` / `nsenter -p`, whose parent sits outside the daemon's PID namespace (`PPid` 0). The resolver now keys such a peer on `(uid, peer_pid)` and points the pidfd death watcher at the client, so the session lives exactly as long as the process. Authorization is unchanged: the role still comes from the `SO_PEERCRED` uid (root → Admin per D20, others → View plus `enable`), and D26 already trusted any uid-0 connector regardless of ancestry — the orphan guard was a session-lifetime mechanism, not an authorization gate. A child the agent forks (`vtyctl`) attaches to the agent's session because its `PPid` is the agent pid. `ParentVanished` still fires when a parent pid *was* reported but has since disappeared. |
 
 ## Deferred work
 

--- a/tools/fpm-tap/README.md
+++ b/tools/fpm-tap/README.md
@@ -113,13 +113,13 @@ Two things that cost time to work out, both worth knowing before writing
 any rig of your own:
 
 * Configuration goes in as a **startup config file** (`zebra-rs -c`), not
-  through `vtyctl`. zebra-rs ties a VTY session to the caller's parent
-  shell and rejects any client whose ppid is `<= 1`
-  (`SessionError::OrphanClient`) — which is every `docker exec`, and
-  `bash -c "vtyctl ..."` does not help because bash execs a lone command
-  and inherits the same orphaned parent. Using a config file is also
-  closer to the real deployment, where a container renders its config and
-  starts the daemon on it.
+  through `vtyctl`. That is closer to the real deployment, where a
+  container renders its config and starts the daemon on it. (Older
+  zebra-rs also rejected any client whose ppid was `<= 1` as an orphan —
+  which is every `docker exec` — so `vtyctl` from outside the container
+  was not an option; since D30 in the VTY session design a parent-less
+  client gets a session keyed on its own pid, so `docker exec … vtyctl`
+  now works too.)
 * The tee is enabled with `set system fpm enabled true` in that config.
   Address and port default to `127.0.0.1:2620`, where fpmsyncd listens in
   SONiC's bgp container; `system fpm address` / `system fpm port` override

--- a/tools/fpm-tap/rig/live-tee.sh
+++ b/tools/fpm-tap/rig/live-tee.sh
@@ -91,12 +91,10 @@ sleep 2
 
 # Configuration goes in as a startup config file rather than through
 # vtyctl. That is both simpler and closer to the real deployment: a SONiC
-# container renders its config and starts the daemon on it. It also
-# sidesteps the VTY session model, which ties a session to the caller's
-# parent shell and rejects any client whose ppid is <= 1
-# (SessionError::OrphanClient) — which is every `docker exec`, including
-# `bash -c "vtyctl ..."`, because bash execs a lone command and so
-# inherits the same orphaned parent.
+# container renders its config and starts the daemon on it. (It also used
+# to be the only option: older zebra-rs rejected any client whose ppid was
+# <= 1 as an orphan — which is every `docker exec`. Since D30 in the VTY
+# session design a parent-less client is keyed on its own pid instead.)
 echo "live-tee: writing startup config"
 cat > "$SOCKDIR/routes.conf" <<'EOF'
 set system fpm enabled true

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -672,10 +672,9 @@ impl VtyPeerInterceptor {
 ///
 /// Enforces the same `ZEBRA_VTY_ALLOW_UIDS` allow-list from
 /// SO_PEERCRED as [`VtyPeerInterceptor`], but does NOT resolve a vty
-/// session: machine peers are typically daemons whose parent is init,
-/// which the session model rejects as orphan clients, and these RPCs
-/// carry no role-gated operations — they are read/serve surfaces at
-/// the same trust level as the session-less `Show` phase. TCP peers
+/// session: these RPCs carry no role-gated operations — they are
+/// read/serve surfaces at the same trust level as the session-less
+/// `Show` phase — so there is nothing a session would gate. TCP peers
 /// pass through untouched, matching the vty interceptor's posture.
 #[derive(Clone)]
 struct MachinePeerInterceptor {
@@ -759,12 +758,6 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
                         "client not visible in daemon's PID namespace",
                     ));
                 }
-                Err(SessionError::OrphanClient) => {
-                    tracing::warn!(uid, gid, pid, "vty rpc denied: orphan client");
-                    return Err(tonic::Status::unauthenticated(
-                        "orphan client (no parent shell)",
-                    ));
-                }
                 Err(SessionError::ParentVanished) => {
                     tracing::warn!(uid, gid, pid, "vty rpc denied: parent shell vanished");
                     return Err(tonic::Status::unauthenticated("parent shell vanished"));
@@ -813,9 +806,9 @@ pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     };
     // Machine-facing APIs: running-config subscription
     // (zebra.config.v1) and the external show provider
-    // (zebra.show.v1). Both use the session-less machine interceptor
-    // so daemonized peers (init-parented) are not rejected as orphan
-    // clients.
+    // (zebra.show.v1). Both use the session-less machine interceptor:
+    // they carry no role-gated operations, so there is no session to
+    // resolve.
     let config_service = ConfigSubscribeService { tx: cli.tx.clone() };
     let show_provider = ShowProviderBridge { tx: cli.tx.clone() };
     let machine_interceptor = MachinePeerInterceptor::from_env();

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -3,9 +3,11 @@
 //! See `book/src/ch-06-01-session-design.md` for the full design.
 //!
 //! Provides an in-memory [`SessionTable`] keyed by
-//! `(peer_uid, parent_pid)`. Both components are derived from kernel-backed
-//! sources (`SO_PEERCRED` plus `/proc/{pid}/status`) and never from
-//! client-supplied data. Per-RPC integration lives in `serve.rs`.
+//! `(peer_uid, parent_pid)` — or `(peer_uid, peer_pid)` when the client has
+//! no visible parent (init-parented daemons, `docker exec`-shaped peers).
+//! Both components are derived from kernel-backed sources (`SO_PEERCRED`
+//! plus `/proc/{pid}/status`) and never from client-supplied data. Per-RPC
+//! integration lives in `serve.rs`.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -37,7 +39,12 @@ pub const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60);
 #[cfg(target_os = "linux")]
 const MAX_ANCESTOR_WALK: usize = 8;
 
-/// Composite session identifier: `(peer_uid, parent_pid)`.
+/// Composite session identifier: `(peer_uid, lifetime_pid)`.
+///
+/// `lifetime_pid` is the parent shell for an ordinary client and the
+/// client's own pid when it has no visible parent (see
+/// [`SessionTable::resolve`]). Either way it is the process whose death
+/// ends the session.
 pub type SessionKey = (u32, u32);
 
 /// VTY authorization role. See decision D18.
@@ -69,6 +76,8 @@ pub struct SessionContext {
 /// Session record.
 #[derive(Debug, Clone)]
 pub struct Session {
+    /// Process the session's lifetime is bound to: the parent shell, or
+    /// the client itself when it has no visible parent. Mirrors `key.1`.
     pub bash_pid: u32,
     /// Resolved via `getpwuid_r` at session creation. Retained for
     /// future audit logging; not used by the enable/PAM path today.
@@ -146,9 +155,6 @@ pub enum SessionError {
     CrossPidNamespace,
     /// `/proc/{peer_pid}/status` could not be read.
     ProcReadFailure,
-    /// Parent pid is 0 or 1 — the client has been reparented to init,
-    /// indicating its shell already died.
-    OrphanClient,
     /// Parent process disappeared between the SO_PEERCRED snapshot and the
     /// `/proc` lookup.
     ParentVanished,
@@ -211,12 +217,20 @@ impl SessionTable {
     /// for the peer's parent pid, verify the parent uid matches, then create
     /// the session.
     ///
+    /// No visible parent (D30): when `/proc` reports PPid 0 or 1 there is
+    /// no shell to key the session on — the peer is init-parented (a
+    /// systemd service, a snap daemon, an agent speaking gRPC itself) or
+    /// its parent sits outside our PID namespace (`docker exec`,
+    /// `nsenter -p`). The session is then keyed on the client's own pid and
+    /// lives exactly as long as that process; the caller's death watcher
+    /// follows `key.1` either way.
+    ///
     /// Root short-circuit (D26): when `peer_uid == 0`, the parent-uid check
     /// is skipped. This lets `sudo <cmd>` invocations work (the outer `sudo`
     /// process retains the invoking user's ruid, which would otherwise fail
     /// the match) without weakening the check for non-root peers. The
-    /// `ParentVanished` guard still runs so an orphaned uid-0 client is
-    /// rejected.
+    /// `ParentVanished` guard still runs when a parent pid was reported but
+    /// has since disappeared.
     ///
     /// Returns `(key, is_new)` so callers can choose log verbosity.
     pub fn resolve<P: ProcStatusReader>(
@@ -234,9 +248,24 @@ impl SessionTable {
             .read_ppid(peer_pid)
             .map_err(|_| SessionError::ProcReadFailure)?;
 
-        // Guard 1: orphan client (parent died, reparented to init).
+        // Guard 1 (D30): no visible parent. PPid 1 = parented by init
+        // (daemon-shaped peer, or a client whose shell already died); PPid 0
+        // = the parent lives outside our PID namespace (`docker exec`,
+        // `nsenter -p`). Neither has a shell to own the session, so key it
+        // on the client itself. Authorization is unaffected: the role still
+        // derives from the SO_PEERCRED uid, and there is no parent whose
+        // uid could be matched. A child the peer forks later (an agent
+        // running `vtyctl`) carries this pid as its PPid and therefore
+        // attaches to this same session through the fast path below.
         if ppid <= 1 {
-            return Err(SessionError::OrphanClient);
+            let key = (peer_uid, peer_pid as u32);
+            if let Some(mut entry) = self.sessions.get_mut(&key) {
+                entry.last_active = Instant::now();
+                return Ok((key, false));
+            }
+            let session = Self::new_session(reader, peer_uid, key.1);
+            self.sessions.insert(key, session);
+            return Ok((key, true));
         }
         let ppid_u32 = ppid as u32;
         let key = (peer_uid, ppid_u32);
@@ -290,15 +319,21 @@ impl SessionTable {
             return Err(SessionError::ParentUidMismatch);
         }
 
+        let session = Self::new_session(reader, peer_uid, ppid_u32);
+        self.sessions.insert(key, session);
+        Ok((key, true))
+    }
+
+    /// Build a fresh session whose lifetime is bound to `lifetime_pid`.
+    /// Permanent admin: root only (D20); everyone else starts at `View`.
+    fn new_session<P: ProcStatusReader>(reader: &P, peer_uid: u32, lifetime_pid: u32) -> Session {
         let username = reader.resolve_username(peer_uid);
-        let mut session = Session::new(ppid_u32, username);
-        // Permanent admin: root only (D20).
+        let mut session = Session::new(lifetime_pid, username);
         if peer_uid == 0 {
             session.role = Role::Admin;
             session.enabled = true;
         }
-        self.sessions.insert(key, session);
-        Ok((key, true))
+        session
     }
 
     /// Promote a session to Admin after a successful `enable`.
@@ -795,17 +830,64 @@ mod tests {
     }
 
     #[test]
-    fn orphan_client_is_rejected() {
+    fn init_parented_client_gets_self_keyed_session() {
+        // D30: a daemon-shaped peer (systemd service, snap daemon, an agent
+        // that speaks gRPC itself) is parented by init. There is no shell to
+        // key the session on, so it is keyed on the client's own pid.
         let table = SessionTable::new();
         let reader = StubReader::default();
-        // Reparented to init (ppid=1).
         reader.set_ppid(1234, 1);
-        let err = table.resolve(&reader, 1000, 1234).unwrap_err();
-        assert_eq!(err, SessionError::OrphanClient);
-        // ppid=0 should also be rejected (defensive).
+        let (key, is_new) = table.resolve(&reader, 0, 1234).unwrap();
+        assert_eq!(key, (0, 1234));
+        assert!(is_new);
+        let sess = table.get(&key).unwrap();
+        assert_eq!(sess.bash_pid, 1234);
+        // Root is still implicit Admin (D20).
+        assert_eq!(sess.role, Role::Admin);
+        assert!(sess.enabled);
+        assert!(table.require_admin(&key).is_ok());
+        // A second RPC from the same process hits the fast path.
+        let (again, is_new) = table.resolve(&reader, 0, 1234).unwrap();
+        assert_eq!(again, key);
+        assert!(!is_new);
+        assert_eq!(table.len(), 1);
+    }
+
+    #[test]
+    fn invisible_parent_client_gets_self_keyed_session() {
+        // D30: `docker exec` / `nsenter -p` leave the parent outside our PID
+        // namespace, so /proc reports PPid 0. Same treatment as PPid 1, and
+        // a non-root peer starts at View like any other non-root session —
+        // there is no parent whose uid could be matched, and the role comes
+        // from SO_PEERCRED alone.
+        let table = SessionTable::new();
+        let reader = StubReader::default();
         reader.set_ppid(1235, 0);
-        let err = table.resolve(&reader, 1000, 1235).unwrap_err();
-        assert_eq!(err, SessionError::OrphanClient);
+        let (key, is_new) = table.resolve(&reader, 1000, 1235).unwrap();
+        assert_eq!(key, (1000, 1235));
+        assert!(is_new);
+        let sess = table.get(&key).unwrap();
+        assert_eq!(sess.bash_pid, 1235);
+        assert_eq!(sess.role, Role::View);
+        assert!(!sess.enabled);
+        assert_eq!(table.require_admin(&key).unwrap_err(), AuthzError::NotAdmin);
+    }
+
+    #[test]
+    fn child_of_self_keyed_client_shares_its_session() {
+        // An init-parented agent that later forks `vtyctl`: the child's PPid
+        // is the agent pid, which is exactly the agent's own session key, so
+        // the child attaches to the agent's session instead of opening a
+        // second one.
+        let table = SessionTable::new();
+        let reader = StubReader::default();
+        reader.set_ppid(1234, 1);
+        let (agent_key, _) = table.resolve(&reader, 0, 1234).unwrap();
+        reader.set_ppid(5678, 1234);
+        let (child_key, is_new) = table.resolve(&reader, 0, 5678).unwrap();
+        assert_eq!(child_key, agent_key);
+        assert!(!is_new);
+        assert_eq!(table.len(), 1);
     }
 
     #[test]
@@ -849,7 +931,7 @@ mod tests {
     #[test]
     fn root_peer_still_rejects_vanished_parent() {
         // The D26 bypass only skips the uid match; the ParentVanished
-        // guard still fires so an orphaned uid-0 client is refused.
+        // guard still fires for a uid-0 client whose reported parent is gone.
         let table = SessionTable::new();
         let reader = StubReader::default();
         reader.set_ppid(1234, 1000);


### PR DESCRIPTION
## Problem

Configuring zebra-rs over the vty socket from an automation client was refused with

```
WARN zebra-rs/src/config/serve.rs:763: vty rpc denied: orphan client uid=0 gid=0 pid=13187
```

The session resolver rejected any peer whose `/proc/<pid>/status` PPid was 0 or 1 as an "orphan client (no parent shell)". Two legitimate shapes hit that:

- a daemon that speaks gRPC to the socket itself (systemd service, snap daemon) — its parent is init, PPid 1
- anything started by `docker exec` / `lxc exec` / `nsenter -p` — the parent lives outside the daemon's PID namespace, PPid 0 (`tools/fpm-tap` had documented this one as "use a startup config instead")

The guard was a session-lifetime mechanism, not an authorization gate: the role derives from the SO_PEERCRED uid, and D26 already trusts any uid-0 connector regardless of ancestry.

## Change

When there is no visible parent, key the session on `(uid, peer_pid)` and point the pidfd death watcher at the client, so the session lives exactly as long as that process. Root is Admin from the first RPC; non-root starts at View and must `enable` like any other session. A child the agent forks (`vtyctl`) carries the agent pid as its PPid and attaches to the agent's session through the ordinary parent-keyed lookup.

- `SessionError::OrphanClient` removed; `ParentVanished` still fires when a parent pid was reported but has since disappeared.
- Session creation factored into `SessionTable::new_session`.
- Design chapter ch-06-01: decision **D30**, guard snippet, lifecycle and vtyctl notes; ch-06-00 access chapter; `tools/fpm-tap` README and `live-tee.sh` comments no longer describe `docker exec` as unusable.

## Tests

- 3 new unit tests: PPid 1 root → Admin with fast path on the second RPC; PPid 0 non-root → View; forked child shares the agent's session. Session suite 35/35.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` all green.
- **Live before/after** on a real daemon (throwaway netns, filesystem socket, `system tracing config vty`):
  - PPid 1 client: `systemd-run --wait --pipe -- vtyctl --vty-socket unix:/run/… apply -c "set system hostname x"`
  - PPid 0 client: daemon under `unshare --pid --fork --mount-proc`, client via `nsenter -t <pid> -p -- vtyctl …`
  - installed (pre-fix) binary: both denied with the exact error above
  - this branch: both `applied`, `show running-config` shows the hostname, trace log shows `vty rpc (new session) pid=N bash_pid=N` followed by `vty session removed` when the client exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUQavxm92J5J2wn1kh8Yib
