### PR TITLE
vty: keep sessions alive on kernels without pidfd_open (D31)

### DIFF
--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -183,8 +183,9 @@ at the first existing session, at init (pid ≤ 1), or after
 [create]  Lazy on first RPC; no explicit OpenSession call.
 [active]  Each RPC updates Session.last_active.
 [end]     Triggered by any of:
-            - Parent bash death (pidfd, immediate); for a
-              parent-less client (D30), the client's own death
+            - Parent bash death (pidfd, immediate; /proc poll on
+              kernels < 5.3, D31); for a parent-less client (D30),
+              the client's own death
             - Idle TTL expiry (~10 min, periodic sweep)
             - Explicit Logout RPC (bash EXIT trap)
             - Daemon shutdown
@@ -194,7 +195,9 @@ Bash-death detection uses a three-tier strategy:
 
 1. **`pidfd_open(bash_pid)`** wrapped in `tokio::io::unix::AsyncFd`.
    Fires immediately when the bash process exits, including via
-   `kill -9`. (Linux 5.3+.)
+   `kill -9`. (Linux 5.3+.) On older kernels the syscall returns
+   `ENOSYS`; the session is kept and the watcher polls
+   `/proc/{bash_pid}` once a second instead (D31).
 2. **`Logout` RPC** sent from the bash EXIT trap. Covers normal
    `exit` cleanly even if pidfd notification is briefly delayed.
    The same trap first offers to commit uncommitted config changes
@@ -411,6 +414,7 @@ Each phase is intended to ship as an independent PR.
 | D28 | **PAM authenticates root for non-group callers.** Non-members who type `enable`/`configure` are prompted for the root password immediately (no passwordless probe). Client `auth_user` is ignored. |
 | D29 | **Uncommitted changes are confirmed at shell exit, from the client.** The bash `EXIT` trap asks `vtyhelper -u` (a comparison of `show running-config formal` against `show candidate-config formal`, both exec-mode and un-gated) and, when they differ, prompts `y`=commit / `n`=discard / anything else=leave pending. It runs **before** the `Logout` RPC: dropping the session first would make the commit re-resolve as a fresh View session and be refused. The check is client-side because none of the daemon's session-teardown paths owns the candidate — `ExecService` has no handle to `ConfigStore` — and because only the client has a terminal to ask on. Since the candidate is global (D11), the prompt is gated on *this shell* having entered configure mode, so a read-only session is never offered the chance to discard someone else's edits. |
 | D30 | **Parent-less clients get a session keyed on their own pid.** Guard 1 used to reject any peer whose `/proc` `PPid` was 0 or 1 as an "orphan client (no parent shell)". That refused two legitimate automation shapes: a daemon that speaks gRPC to the socket itself (systemd service, snap daemon — `PPid` 1), and anything started by `docker exec` / `nsenter -p`, whose parent sits outside the daemon's PID namespace (`PPid` 0). The resolver now keys such a peer on `(uid, peer_pid)` and points the pidfd death watcher at the client, so the session lives exactly as long as the process. Authorization is unchanged: the role still comes from the `SO_PEERCRED` uid (root → Admin per D20, others → View plus `enable`), and D26 already trusted any uid-0 connector regardless of ancestry — the orphan guard was a session-lifetime mechanism, not an authorization gate. A child the agent forks (`vtyctl`) attaches to the agent's session because its `PPid` is the agent pid. `ParentVanished` still fires when a parent pid *was* reported but has since disappeared. |
+| D31 | **Kernels without `pidfd_open` keep their sessions.** The death watcher used to treat every `pidfd_open` failure as "the parent is already dead" and dropped the session on the spot. On Linux < 5.3 (Ubuntu 16.04) the syscall returns `ENOSYS` for every live process, so each RPC created a session that was gone before the next one arrived: root still worked (Admin at creation), but non-root operators lost `enable` between RPCs and the log carried one warning per RPC. `ENOSYS` now keeps the session and falls back to polling `/proc/{bash_pid}` every second, so bash death is still noticed within about a second and a reused PID cannot inherit a stale session for long; the notice is logged once per daemon lifetime. Every other open failure (`ESRCH`, the parent really is gone) still drops the session immediately. |
 
 ## Deferred work
 

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -446,6 +446,11 @@ impl SessionTable {
         self.sessions.remove(key).is_some()
     }
 
+    /// Whether a session with `key` is currently present.
+    pub fn contains(&self, key: &SessionKey) -> bool {
+        self.sessions.contains_key(key)
+    }
+
     /// Number of active sessions.
     #[cfg(test)]
     pub fn len(&self) -> usize {
@@ -509,19 +514,63 @@ mod pidfd {
     }
 }
 
+/// Poll interval for the `/proc` fallback watcher used when the kernel has
+/// no `pidfd_open(2)` (Linux < 5.3, e.g. Ubuntu 16.04).
+#[cfg(target_os = "linux")]
+pub const PROC_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Set once the daemon has discovered that the running kernel lacks
+/// `pidfd_open(2)`, so the fallback notice is logged a single time rather
+/// than once per session.
+#[cfg(target_os = "linux")]
+static PIDFD_UNSUPPORTED_LOGGED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Per-session watcher: opens a pidfd for the parent bash and removes the
 /// session from the table the moment bash exits (even via `kill -9`).
 ///
 /// Intended to be `tokio::spawn`'d once per new session created by
-/// [`SessionTable::resolve`]. If pidfd open fails (bash already dead, or the
-/// kernel is < 5.3), the session is removed immediately and the task exits.
+/// [`SessionTable::resolve`]. If the kernel has no `pidfd_open` (`ENOSYS`,
+/// Linux < 5.3) the session is kept and its lifetime is tracked by
+/// [`watch_bash_death_by_polling`] instead (D31). Any other open failure
+/// means the process is already gone, and the session is removed
+/// immediately.
 #[cfg(target_os = "linux")]
 pub async fn watch_bash_death(table: Arc<SessionTable>, key: SessionKey, bash_pid: u32) {
+    watch_bash_death_with(table, key, bash_pid, pidfd::open, PROC_POLL_INTERVAL).await;
+}
+
+/// [`watch_bash_death`] with the pidfd opener and the fallback poll
+/// interval injectable, so tests can drive the `ENOSYS` path on kernels
+/// that do have `pidfd_open`.
+#[cfg(target_os = "linux")]
+async fn watch_bash_death_with<F>(
+    table: Arc<SessionTable>,
+    key: SessionKey,
+    bash_pid: u32,
+    open: F,
+    poll_interval: Duration,
+) where
+    F: FnOnce(i32) -> std::io::Result<std::os::fd::OwnedFd>,
+{
     use tokio::io::Interest;
     use tokio::io::unix::AsyncFd;
 
-    let fd = match pidfd::open(bash_pid as i32) {
+    let fd = match open(bash_pid as i32) {
         Ok(fd) => fd,
+        Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => {
+            // D31: the kernel predates pidfd_open (Linux 5.3). The shell is
+            // alive — we just cannot get a pidfd for it — so keep the
+            // session and watch `/proc` instead of refusing service.
+            if !PIDFD_UNSUPPORTED_LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                tracing::info!(
+                    poll_secs = poll_interval.as_secs_f64(),
+                    "kernel lacks pidfd_open (Linux 5.3+); vty session lifetimes tracked by polling /proc",
+                );
+            }
+            watch_bash_death_by_polling(table, key, bash_pid, poll_interval).await;
+            return;
+        }
         Err(e) => {
             tracing::warn!(
                 uid = key.0,
@@ -564,6 +613,46 @@ pub async fn watch_bash_death(table: Arc<SessionTable>, key: SessionKey, bash_pi
         Err(e) => {
             tracing::warn!(uid = key.0, bash_pid, error = %e, "pidfd readable() failed");
         }
+    }
+}
+
+/// Fallback watcher for kernels without `pidfd_open` (D31): checks
+/// `/proc/{bash_pid}` every `interval` and removes the session once it is
+/// gone. Also exits once the session has been removed by someone else
+/// (GC, `Logout`), so watchers don't pile up behind long-lived shells.
+#[cfg(target_os = "linux")]
+pub async fn watch_bash_death_by_polling(
+    table: Arc<SessionTable>,
+    key: SessionKey,
+    bash_pid: u32,
+    interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // The first tick completes immediately; skip it so the first check
+    // happens one interval from now.
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        if !table.contains(&key) {
+            tracing::debug!(
+                uid = key.0,
+                bash_pid,
+                "session already gone; /proc poll watcher exits",
+            );
+            return;
+        }
+        if ProcfsReader.process_exists(bash_pid as i32) {
+            continue;
+        }
+        if table.remove(&key) && super::tracing::vty() {
+            tracing::info!(
+                uid = key.0,
+                bash_pid,
+                "vty session removed (bash exited, /proc poll)",
+            );
+        }
+        return;
     }
 }
 
@@ -1458,6 +1547,129 @@ mod tests {
         table.insert_for_test(key, Instant::now());
 
         super::watch_bash_death(table.clone(), key, 0).await;
+
+        assert!(table.get(&key).is_none());
+    }
+
+    /// Spawn a `/bin/sleep` child to stand in for a vty bash; the caller
+    /// kills it to simulate the shell dying.
+    fn spawn_fake_bash() -> std::process::Child {
+        std::process::Command::new("/bin/sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn /bin/sleep")
+    }
+
+    fn reap(mut child: std::process::Child) {
+        child.kill().expect("kill child");
+        let _ = child.wait();
+    }
+
+    #[tokio::test]
+    async fn polling_watcher_removes_session_when_bash_dies() {
+        let child = spawn_fake_bash();
+        let bash_pid = child.id();
+        let key = (1000u32, bash_pid);
+        let table = SessionTable::new();
+        table.insert_for_test(key, Instant::now());
+
+        let watcher = tokio::spawn(super::watch_bash_death_by_polling(
+            table.clone(),
+            key,
+            bash_pid,
+            Duration::from_millis(20),
+        ));
+
+        // A few polls while bash is alive must leave the session alone.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            table.get(&key).is_some(),
+            "session dropped while bash was alive"
+        );
+
+        reap(child);
+        tokio::time::timeout(Duration::from_secs(5), watcher)
+            .await
+            .expect("watcher timed out")
+            .expect("watcher panicked");
+        assert!(table.get(&key).is_none(), "session was not removed");
+    }
+
+    #[tokio::test]
+    async fn polling_watcher_exits_when_session_removed_elsewhere() {
+        let child = spawn_fake_bash();
+        let bash_pid = child.id();
+        let key = (1000u32, bash_pid);
+        let table = SessionTable::new();
+        table.insert_for_test(key, Instant::now());
+
+        let watcher = tokio::spawn(super::watch_bash_death_by_polling(
+            table.clone(),
+            key,
+            bash_pid,
+            Duration::from_millis(20),
+        ));
+
+        // Logout / GC removes the session while bash is still alive; the
+        // watcher must notice and stop rather than poll until bash dies.
+        assert!(table.remove(&key));
+        tokio::time::timeout(Duration::from_secs(5), watcher)
+            .await
+            .expect("watcher kept polling a removed session")
+            .expect("watcher panicked");
+
+        reap(child);
+    }
+
+    #[tokio::test]
+    async fn enosys_keeps_session_and_falls_back_to_polling() {
+        // Kernels before 5.3 have no pidfd_open (Ubuntu 16.04). The watcher
+        // must keep the session (D31) instead of treating the failure as a
+        // dead parent, and still notice when bash actually dies.
+        let child = spawn_fake_bash();
+        let bash_pid = child.id();
+        let key = (1000u32, bash_pid);
+        let table = SessionTable::new();
+        table.insert_for_test(key, Instant::now());
+
+        let enosys = |_pid: i32| -> std::io::Result<std::os::fd::OwnedFd> {
+            Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+        };
+        let watcher = tokio::spawn(super::watch_bash_death_with(
+            table.clone(),
+            key,
+            bash_pid,
+            enosys,
+            Duration::from_millis(20),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            table.get(&key).is_some(),
+            "ENOSYS must not drop a live session"
+        );
+
+        reap(child);
+        tokio::time::timeout(Duration::from_secs(5), watcher)
+            .await
+            .expect("watcher timed out")
+            .expect("watcher panicked");
+        assert!(table.get(&key).is_none(), "session was not removed");
+    }
+
+    #[tokio::test]
+    async fn non_enosys_open_failure_still_drops_session() {
+        // Every other pidfd_open failure (ESRCH: parent already dead) keeps
+        // the immediate-drop behaviour.
+        let key = (1000u32, 4242u32);
+        let table = SessionTable::new();
+        table.insert_for_test(key, Instant::now());
+
+        let esrch = |_pid: i32| -> std::io::Result<std::os::fd::OwnedFd> {
+            Err(std::io::Error::from_raw_os_error(libc::ESRCH))
+        };
+        super::watch_bash_death_with(table.clone(), key, 4242, esrch, Duration::from_millis(20))
+            .await;
 
         assert!(table.get(&key).is_none());
     }


### PR DESCRIPTION
## Problem

On Linux < 5.3 (Ubuntu 16.04 ships 4.4) `pidfd_open(2)` returns `ENOSYS` for every live process. The vty session death watcher treated any open failure as "parent already dead" and removed the session immediately, so every RPC created a fresh session and logged:

```
WARN zebra-rs/src/config/session.rs:526: pidfd_open failed; dropping session immediately uid=0 bash_pid=25895 error=Function not implemented (os error 38)
```

Root still worked (Admin at creation, D20), but non-root operators lost `enable` between RPCs, stream abort-on-death and the EXIT-trap commit offer had no session to anchor to, and the log carried one warning per RPC.

## Fix (D31)

- `ENOSYS` now keeps the session and falls back to `watch_bash_death_by_polling`, which stats `/proc/<bash_pid>` once a second and removes the session when the shell dies. It also exits early when Logout or the GC sweep already removed the session, so watchers don't pile up behind long-lived shells.
- The "kernel lacks pidfd_open" notice is logged once per daemon lifetime at INFO, not once per RPC at WARN.
- Every other `pidfd_open` failure (`ESRCH`, the parent really is gone) still drops the session immediately, so behaviour on kernels ≥ 5.3 is unchanged.
- `watch_bash_death_with(opener, poll_interval)` is the injectable seam that lets tests drive the `ENOSYS` path on modern kernels.

## Verification

- 4 new unit tests: polling watcher removes the session on bash death, exits when the session was removed elsewhere, injected `ENOSYS` keeps a live session and still notices death, injected `ESRCH` still drops immediately. `config::session` is at 39 tests.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` all green locally.
- Live before/after against real daemons run under `systemd-run -p SystemCallFilter=~pidfd_open -p SystemCallErrorNumber=ENOSYS`, which reproduces the 16.04 condition exactly. Old binary: a new session plus a WARN for each of the 3 RPCs. New binary: one `new session`, one INFO notice, the apply and show RPCs reuse the session, and `vty session removed (bash exited, /proc poll)` lands about a second after the client shell exits.

## Docs

Book ch-06-01: lifecycle tier 1 now describes the `/proc` polling fallback; new decision row D31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUQavxm92J5J2wn1kh8Yib
