### PR TITLE
bgp-packet: keep VPNv4/VPNv6/EVPN UPDATEs within the negotiated message size

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -17,6 +17,32 @@ use crate::{
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Rtcv6Reach, Vpnv4Reach, Vpnv6Reach};
 
+/// Octets of an MP_REACH_NLRI attribute header in its extended-length form
+/// (flags, type, 2-octet length). The paginating emitters budget for this
+/// form; when the value ends up at 255 octets or less the short header is
+/// used and one octet of the budget goes unused.
+pub(crate) const MP_REACH_HEADER_LEN: usize = 4;
+
+/// Append a complete MP_REACH_NLRI path attribute (header + `value`) to
+/// `buf`, choosing the short or extended-length header by the value size.
+pub(crate) fn put_mp_reach_attr(buf: &mut BytesMut, value: &[u8]) {
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(value);
+}
+
 #[derive(Clone, Debug, NomBE)]
 pub struct MpReachHeader {
     pub afi: Afi,
@@ -164,17 +190,23 @@ impl MpReachAttr {
         }
     }
 
-    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
+    /// Paginating twin of [`attr_emit`](Self::attr_emit) for the families
+    /// whose flush batches one attribute group per `UpdatePacket` (VPNv4,
+    /// VPNv6, EVPN). Emits as many NLRIs as fit in a packet of
+    /// `max_packet_size` octets given what `buf` already holds, leaves the
+    /// rest queued for the next call, and returns the number written. Writes
+    /// nothing and returns 0 when not even the first NLRI fits; families
+    /// without a paginating emitter also return 0.
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_packet_size: usize) -> usize {
         match self {
-            MpReachAttr::Vpnv4(attr) => {
-                attr.attr_emit_mut(buf, max_size);
-            }
-            MpReachAttr::Vpnv6(attr) => {
-                attr.attr_emit_mut(buf, max_size);
-            }
-            _ => {
-                //
-            }
+            MpReachAttr::Vpnv4(attr) => attr.attr_emit_mut(buf, max_packet_size),
+            MpReachAttr::Vpnv6(attr) => attr.attr_emit_mut(buf, max_packet_size),
+            MpReachAttr::Evpn {
+                snpa,
+                nhop,
+                updates,
+            } => evpn_attr_emit_mut(*snpa, nhop, updates, buf, max_packet_size),
+            _ => 0,
         }
     }
 }
@@ -862,8 +894,9 @@ pub(crate) fn ipv6_attr_emit(nhop: &IpAddr, updates: &[Ipv6Nlri], buf: &mut Byte
     buf.put(&value[..]);
 }
 
-pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], buf: &mut BytesMut) {
-    let mut value = BytesMut::new();
+/// Write the EVPN MP_REACH_NLRI value preamble (AFI/SAFI, next-hop, SNPA)
+/// into `value`.
+fn evpn_value_preamble(nhop: &IpAddr, value: &mut BytesMut) {
     value.put_u16(u16::from(Afi::L2vpn));
     value.put_u8(u8::from(Safi::Evpn));
     match nhop {
@@ -878,25 +911,52 @@ pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], bu
     }
     // Reserved / SNPA byte, always zero per RFC 4760 §3.
     value.put_u8(0);
+}
+
+pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    evpn_value_preamble(nhop, &mut value);
     for r in updates {
         r.nlri_emit(&mut value);
     }
+    put_mp_reach_attr(buf, &value);
+}
 
-    let len = value.len();
-    let extended = len > 255;
-    let flags = if extended {
-        AttrFlags::new().with_optional(true).with_extended(true)
-    } else {
-        AttrFlags::new().with_optional(true)
-    };
-    buf.put_u8(flags.into());
-    buf.put_u8(AttrType::MpReachNlri.into());
-    if extended {
-        buf.put_u16(len as u16);
-    } else {
-        buf.put_u8(len as u8);
+/// Paginating twin of [`evpn_attr_emit`]: emit the EVPN MP_REACH_NLRI
+/// attribute with as many leading routes from `updates` as fit in a packet
+/// of `max_packet_size` octets given what `buf` already holds, remove the
+/// emitted routes from `updates` (order preserved) and return their count.
+/// Writes nothing and returns 0 when even the first route does not fit.
+pub(crate) fn evpn_attr_emit_mut(
+    _snpa: u8,
+    nhop: &IpAddr,
+    updates: &mut Vec<EvpnRoute>,
+    buf: &mut BytesMut,
+    max_packet_size: usize,
+) -> usize {
+    let budget = max_packet_size.saturating_sub(buf.len() + MP_REACH_HEADER_LEN);
+    let mut value = BytesMut::new();
+    evpn_value_preamble(nhop, &mut value);
+
+    // EVPN NLRIs vary in size by route type and address family, so
+    // measure each one by encoding it rather than estimating.
+    let mut emitted = 0;
+    let mut nlri = BytesMut::new();
+    for r in updates.iter() {
+        nlri.clear();
+        r.nlri_emit(&mut nlri);
+        if value.len() + nlri.len() > budget {
+            break;
+        }
+        value.put(&nlri[..]);
+        emitted += 1;
     }
-    buf.put(&value[..]);
+    if emitted == 0 {
+        return 0;
+    }
+    updates.drain(..emitted);
+    put_mp_reach_attr(buf, &value);
+    emitted
 }
 
 /// Serialize an `MpReachAttr::Mup { afi, snpa, nhop, updates }` as a

--- a/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
@@ -11,6 +11,7 @@ use nom_derive::*;
 
 use crate::{Afi, AttrType, Label, ParseNlri, RouteDistinguisher, Safi, nlri_psize};
 
+use super::mp_reach::{MP_REACH_HEADER_LEN, put_mp_reach_attr};
 use super::{AttrEmitter, AttrFlags, Ipv4Nlri};
 
 #[derive(Debug, Clone)]
@@ -190,85 +191,69 @@ impl AttrEmitter for Vpnv4Reach {
 }
 
 impl Vpnv4Reach {
-    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
-        let flags = self.attr_flags();
-        let attr_type = self.attr_type();
-        let emit_header = |buf: &mut BytesMut, len: usize, extended: bool| {
-            if extended {
-                buf.put_u8(flags.with_extended(true).into());
-                buf.put_u8(attr_type.into());
-                buf.put_u16(len as u16);
-            } else {
-                buf.put_u8(flags.into());
-                buf.put_u8(attr_type.into());
-                buf.put_u8(len as u8);
-            }
-        };
-
-        if let Some(len) = self.len() {
-            // Length is known.
-            let extended = len > 255;
-            emit_header(buf, len, extended);
-            self.emit_mut(buf, max_size);
-        } else {
-            // Buffer the attribute to determine its length.
-            let mut attr_buf = BytesMut::new();
-            self.emit_mut(&mut attr_buf, max_size);
-            let len = attr_buf.len();
-            let extended = len > 255;
-            emit_header(buf, len, extended);
-            buf.put(&attr_buf[..]);
+    /// Emit the MP_REACH_NLRI attribute into `buf` with as many NLRIs from
+    /// `updates` as fit in a packet of `max_packet_size` octets, and return
+    /// how many were emitted. `buf` already holds the BGP header, the two
+    /// length fields and the ordinary path attributes, so the budget for
+    /// this attribute is what remains of `max_packet_size` after those
+    /// octets and the attribute's own header.
+    ///
+    /// NLRIs that did not fit stay in `updates` for the next call. When not
+    /// even the first one fits, nothing is written and 0 is returned so the
+    /// caller can refuse to send an empty MP_REACH.
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_packet_size: usize) -> usize {
+        let budget = max_packet_size.saturating_sub(buf.len() + MP_REACH_HEADER_LEN);
+        let mut value = BytesMut::new();
+        let emitted = self.emit_value(&mut value, budget);
+        if emitted == 0 {
+            return 0;
         }
+        put_mp_reach_attr(buf, &value);
+        emitted
     }
 
-    fn emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
+    /// Write the attribute value (AFI/SAFI, next-hop, SNPA, NLRIs) into
+    /// `value`, stopping before the NLRI that would push it past `budget`
+    /// octets. Returns the number of NLRIs written.
+    fn emit_value(&mut self, value: &mut BytesMut, budget: usize) -> usize {
         // AFI/SAFI.
-        buf.put_u16(u16::from(Afi::Ip));
-        buf.put_u8(u8::from(Safi::MplsVpn));
-        // Nexthop
+        value.put_u16(u16::from(Afi::Ip));
+        value.put_u8(u8::from(Safi::MplsVpn));
         // Nexthop: length + zero RD + address. Adapts to v4 (len 12)
         // or v6 (len 24, RFC 8950 / RFC 9252).
-        emit_vpnv4_nexthop(buf, &self.nhop.nhop);
+        emit_vpnv4_nexthop(value, &self.nhop.nhop);
         // SNPA
-        buf.put_u8(0);
+        value.put_u8(0);
 
-        // Prefix.
+        let mut emitted = 0;
         while let Some(update) = self.updates.pop() {
-            // Need to check remaining buffer size.
-            let mut nlri_len: usize = 0;
-            if update.nlri.id != 0 {
-                nlri_len += 4;
-            }
-            // Plen.
-            nlri_len += 1;
-            // Label.
-            nlri_len += 4;
-            // RD.
-            nlri_len += 8;
-            // Prefix.
-            nlri_len += nlri_psize(update.nlri.prefix.prefix_len());
-
-            if nlri_len + buf.len() > max_size {
+            // Exact wire size of this NLRI: optional 4-octet path-id,
+            // 1-octet length, 3-octet label, 8-octet RD, prefix octets.
+            let path_id_len = if update.nlri.id != 0 { 4 } else { 0 };
+            let nlri_len = path_id_len + 1 + 3 + 8 + nlri_psize(update.nlri.prefix.prefix_len());
+            if value.len() + nlri_len > budget {
                 self.updates.push(update);
-                return;
+                break;
             }
 
             // AddPath
             if update.nlri.id != 0 {
-                buf.put_u32(update.nlri.id);
+                value.put_u32(update.nlri.id);
             }
             // Plen
             let plen = update.nlri.prefix.prefix_len() + 88;
-            buf.put_u8(plen);
+            value.put_u8(plen);
             // Label
-            buf.put(&update.label.to_bytes()[..]);
+            value.put(&update.label.to_bytes()[..]);
             // RD
-            buf.put_u16(update.rd.typ as u16);
-            buf.put(&update.rd.val[..]);
+            value.put_u16(update.rd.typ as u16);
+            value.put(&update.rd.val[..]);
             // Prefix
             let plen = nlri_psize(update.nlri.prefix.prefix_len());
-            buf.put(&update.nlri.prefix.addr().octets()[0..plen]);
+            value.put(&update.nlri.prefix.addr().octets()[0..plen]);
+            emitted += 1;
         }
+        emitted
     }
 }
 

--- a/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
@@ -11,6 +11,7 @@ use nom_derive::*;
 
 use crate::{Afi, AttrType, Label, ParseNlri, RouteDistinguisher, Safi, nlri_psize};
 
+use super::mp_reach::{MP_REACH_HEADER_LEN, put_mp_reach_attr};
 use super::{AttrEmitter, AttrFlags, Ipv6Nlri};
 
 #[derive(Debug, Clone)]
@@ -168,88 +169,67 @@ impl AttrEmitter for Vpnv6Reach {
 }
 
 impl Vpnv6Reach {
-    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
-        let flags = self.attr_flags();
-        let attr_type = self.attr_type();
-        let emit_header = |buf: &mut BytesMut, len: usize, extended: bool| {
-            if extended {
-                buf.put_u8(flags.with_extended(true).into());
-                buf.put_u8(attr_type.into());
-                buf.put_u16(len as u16);
-            } else {
-                buf.put_u8(flags.into());
-                buf.put_u8(attr_type.into());
-                buf.put_u8(len as u8);
-            }
-        };
-
-        if let Some(len) = self.len() {
-            // Length is known.
-            let extended = len > 255;
-            emit_header(buf, len, extended);
-            self.emit_mut(buf, max_size);
-        } else {
-            // Buffer the attribute to determine its length.
-            let mut attr_buf = BytesMut::new();
-            self.emit_mut(&mut attr_buf, max_size);
-            let len = attr_buf.len();
-            let extended = len > 255;
-            emit_header(buf, len, extended);
-            buf.put(&attr_buf[..]);
+    /// Emit the MP_REACH_NLRI attribute into `buf` with as many NLRIs from
+    /// `updates` as fit in a packet of `max_packet_size` octets, and return
+    /// how many were emitted. See [`Vpnv4Reach::attr_emit_mut`] for the
+    /// budget rule; this is its VPNv6 twin.
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_packet_size: usize) -> usize {
+        let budget = max_packet_size.saturating_sub(buf.len() + MP_REACH_HEADER_LEN);
+        let mut value = BytesMut::new();
+        let emitted = self.emit_value(&mut value, budget);
+        if emitted == 0 {
+            return 0;
         }
+        put_mp_reach_attr(buf, &value);
+        emitted
     }
 
-    fn emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
+    /// Write the attribute value (AFI/SAFI, next-hop, SNPA, NLRIs) into
+    /// `value`, stopping before the NLRI that would push it past `budget`
+    /// octets. Returns the number of NLRIs written.
+    fn emit_value(&mut self, value: &mut BytesMut, budget: usize) -> usize {
         // AFI/SAFI.
-        buf.put_u16(u16::from(Afi::Ip6));
-        buf.put_u8(u8::from(Safi::MplsVpn));
+        value.put_u16(u16::from(Afi::Ip6));
+        value.put_u8(u8::from(Safi::MplsVpn));
         // Nexthop
-        buf.put_u8(24); // Nexthop length.  RD(8)+IPv6 Nexthop(16);
+        value.put_u8(24); // Nexthop length.  RD(8)+IPv6 Nexthop(16);
         // Nexthop RD.
         let rd = [0u8; 8];
-        buf.put(&rd[..]);
+        value.put(&rd[..]);
         // Nexthop.
-        buf.put(&self.nhop.nhop.octets()[..]);
+        value.put(&self.nhop.nhop.octets()[..]);
         // SNPA
-        buf.put_u8(0);
+        value.put_u8(0);
 
-        // Prefix.
+        let mut emitted = 0;
         while let Some(update) = self.updates.pop() {
-            // Need to check remaining buffer size.
-            let mut nlri_len: usize = 0;
-            if update.nlri.id != 0 {
-                nlri_len += 4;
-            }
-            // Plen.
-            nlri_len += 1;
-            // Label.
-            nlri_len += 4;
-            // RD.
-            nlri_len += 8;
-            // Prefix.
-            nlri_len += nlri_psize(update.nlri.prefix.prefix_len());
-
-            if nlri_len + buf.len() > max_size {
+            // Exact wire size of this NLRI: optional 4-octet path-id,
+            // 1-octet length, 3-octet label, 8-octet RD, prefix octets.
+            let path_id_len = if update.nlri.id != 0 { 4 } else { 0 };
+            let nlri_len = path_id_len + 1 + 3 + 8 + nlri_psize(update.nlri.prefix.prefix_len());
+            if value.len() + nlri_len > budget {
                 self.updates.push(update);
-                return;
+                break;
             }
 
             // AddPath
             if update.nlri.id != 0 {
-                buf.put_u32(update.nlri.id);
+                value.put_u32(update.nlri.id);
             }
             // Plen
             let plen = update.nlri.prefix.prefix_len() + 88;
-            buf.put_u8(plen);
+            value.put_u8(plen);
             // Label
-            buf.put(&update.label.to_bytes()[..]);
+            value.put(&update.label.to_bytes()[..]);
             // RD
-            buf.put_u16(update.rd.typ as u16);
-            buf.put(&update.rd.val[..]);
+            value.put_u16(update.rd.typ as u16);
+            value.put(&update.rd.val[..]);
             // Prefix
             let plen = nlri_psize(update.nlri.prefix.prefix_len());
-            buf.put(&update.nlri.prefix.addr().octets()[0..plen]);
+            value.put(&update.nlri.prefix.addr().octets()[0..plen]);
+            emitted += 1;
         }
+        emitted
     }
 }
 

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -976,11 +976,12 @@ mod mp_reach_pagination_tests {
 
     /// A reflected route's ordinary attributes: AS_PATH plus a community.
     fn attrs(nexthop: BgpNexthop) -> BgpAttr {
-        let mut attr = BgpAttr::default();
-        attr.aspath = Some(As4Path::from_str("65001 65002 65003").unwrap());
-        attr.com = Some(Community::from_str("65001:100").unwrap());
-        attr.nexthop = Some(nexthop);
-        attr
+        BgpAttr {
+            aspath: Some(As4Path::from_str("65001 65002 65003").unwrap()),
+            com: Some(Community::from_str("65001:100").unwrap()),
+            nexthop: Some(nexthop),
+            ..Default::default()
+        }
     }
 
     fn vpnv4_nlri(i: u32) -> Vpnv4Nlri {

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -269,28 +269,22 @@ impl UpdatePacket {
         Some(buf)
     }
 
-    /// Emit the BGP UPDATE that carries an `MP_REACH_NLRI` for EVPN
+    /// Emit one BGP UPDATE carrying an `MP_REACH_NLRI` for EVPN
     /// (AFI=25 / SAFI=70). Mirrors `pop_vpnv4`'s framing — empty IPv4
-    /// withdraw, attributes, MP_REACH — but uses the un-paginated
-    /// `evpn_attr_emit` helper from `mp_reach`. All NLRIs in the
-    /// `MpReachAttr::Evpn::updates` vector are emitted in a single
-    /// packet; pagination across multiple UPDATEs (e.g. when a
-    /// large RD's MAC table doesn't fit) is a follow-up.
+    /// withdraw, attributes, MP_REACH — and its pagination: as many
+    /// routes as fit within `max_packet_size` go into this packet and
+    /// the rest stay in `MpReachAttr::Evpn::updates` for the next call,
+    /// so callers loop until `None`.
     ///
-    /// Returns `None` when the packet has no EVPN payload to emit
-    /// (caller can stop iterating). Distinct from `pop_vpnv4` in
-    /// that it's idempotently single-shot — callers that want to
-    /// emit multiple UPDATEs should batch into separate
-    /// `UpdatePacket` instances.
+    /// Returns `None` when no EVPN payload is left, or when not even the
+    /// first route fits beside the path attributes (an empty MP_REACH is
+    /// never emitted).
     pub fn pop_evpn(&mut self) -> Option<BytesMut> {
-        let (snpa, nhop, updates) = match &self.mp_update {
-            Some(MpReachAttr::Evpn {
-                snpa,
-                nhop,
-                updates,
-            }) if !updates.is_empty() => (*snpa, *nhop, updates.clone()),
+        match &self.mp_update {
+            Some(MpReachAttr::Evpn { updates, .. }) if !updates.is_empty() => {}
             _ => return None,
-        };
+        }
+        let mp_update = self.mp_update.as_mut().unwrap();
 
         let mut buf = FixedBuf::new(self.max_packet_size);
         let header: BytesMut = self.header.clone().into();
@@ -306,19 +300,18 @@ impl UpdatePacket {
             bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
 
-        super::attrs::mp_reach::evpn_attr_emit(snpa, &nhop, &updates, buf.get_mut());
+        // MP reach: as many routes as fit next to what the packet already
+        // holds; the rest stay queued for the next call.
+        let emitted = mp_update.attr_emit_mut(buf.get_mut(), self.max_packet_size);
+        if emitted == 0 {
+            return None;
+        }
 
         let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
         let _ = buf.put_u16_at(attr_len_pos, attr_len);
 
         let length: u16 = buf.len() as u16;
         let _ = buf.put_u16_at(16, length);
-
-        // Drain so a second call returns None — matches VPNv4's
-        // "consume once" semantics from the flush_vpnv4 callers.
-        if let Some(MpReachAttr::Evpn { updates, .. }) = self.mp_update.as_mut() {
-            updates.clear();
-        }
 
         Some(buf.get())
     }
@@ -417,9 +410,14 @@ impl UpdatePacket {
             bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
 
-        // MP reach (dispatches to Vpnv6Reach::attr_emit_mut, which
-        // paginates the NLRI list across calls).
-        mp_update.attr_emit_mut(buf.get_mut(), self.max_packet_size);
+        // MP reach: as many NLRIs as fit next to what the packet already
+        // holds; the rest stay queued for the next call. Not even one
+        // fitting means the fixed preamble alone exceeds the budget —
+        // refuse to emit an empty MP_REACH, as `pop_ipv4_mp_reach` does.
+        let emitted = mp_update.attr_emit_mut(buf.get_mut(), self.max_packet_size);
+        if emitted == 0 {
+            return None;
+        }
 
         let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
         let _ = buf.put_u16_at(attr_len_pos, attr_len);
@@ -453,8 +451,14 @@ impl UpdatePacket {
             bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
 
-        // MP reach.
-        mp_update.attr_emit_mut(buf.get_mut(), self.max_packet_size);
+        // MP reach: as many NLRIs as fit next to what the packet already
+        // holds; the rest stay queued for the next call. Not even one
+        // fitting means the fixed preamble alone exceeds the budget —
+        // refuse to emit an empty MP_REACH, as `pop_ipv4_mp_reach` does.
+        let emitted = mp_update.attr_emit_mut(buf.get_mut(), self.max_packet_size);
+        if emitted == 0 {
+            return None;
+        }
 
         // Fill in attr length.
         let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
@@ -946,5 +950,278 @@ mod tests {
                 .pop_ipv4_mp_reach(Ipv4MpReachNextHop::LinkLocal(ll))
                 .is_none()
         );
+    }
+}
+
+/// Pagination of the MP_REACH families whose flush batches one attribute
+/// group per `UpdatePacket` (VPNv4, VPNv6, EVPN): every emitted packet must
+/// stay within `max_packet_size`, and every queued NLRI must come out
+/// exactly once.
+#[cfg(test)]
+mod mp_reach_pagination_tests {
+    use super::*;
+    use crate::{
+        As4Path, BgpNexthop, Community, EvpnMulticast, EvpnRoute, Ipv6Nlri, Label,
+        RouteDistinguisher, Vpnv4Nexthop, Vpnv4Nlri, Vpnv4Reach, Vpnv6Nexthop, Vpnv6Nlri,
+        Vpnv6Reach,
+    };
+    use ipnet::{Ipv4Net, Ipv6Net};
+    use std::collections::BTreeSet;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    fn rd() -> RouteDistinguisher {
+        RouteDistinguisher::from_str("65001:1").unwrap()
+    }
+
+    /// A reflected route's ordinary attributes: AS_PATH plus a community.
+    fn attrs(nexthop: BgpNexthop) -> BgpAttr {
+        let mut attr = BgpAttr::default();
+        attr.aspath = Some(As4Path::from_str("65001 65002 65003").unwrap());
+        attr.com = Some(Community::from_str("65001:100").unwrap());
+        attr.nexthop = Some(nexthop);
+        attr
+    }
+
+    fn vpnv4_nlri(i: u32) -> Vpnv4Nlri {
+        Vpnv4Nlri {
+            label: Label::new(100, 0, true),
+            rd: rd(),
+            nlri: Ipv4Nlri {
+                id: 0,
+                prefix: Ipv4Net::new(Ipv4Addr::from(0x0A00_0000u32 + (i << 8)), 24).unwrap(),
+            },
+        }
+    }
+
+    /// One VPNv4 attribute group of `n` /24s, as `Peer::flush_vpnv4` builds it.
+    fn vpnv4_group(n: u32, max: usize) -> UpdatePacket {
+        let nhop = Vpnv4Nexthop {
+            rd: rd(),
+            nhop: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+        };
+        let mut update = UpdatePacket::with_max_packet_size(max);
+        update.bgp_attr = Some(attrs(BgpNexthop::Vpnv4(nhop.clone())));
+        update.mp_update = Some(MpReachAttr::Vpnv4(Vpnv4Reach {
+            snpa: 0,
+            nhop,
+            updates: (0..n).map(vpnv4_nlri).collect(),
+        }));
+        update
+    }
+
+    fn vpnv6_nlri(i: u32) -> Vpnv6Nlri {
+        let addr =
+            Ipv6Addr::from(0x2001_0DB8_0000_0000_0000_0000_0000_0000u128 | ((i as u128) << 64));
+        Vpnv6Nlri {
+            label: Label::new(100, 0, true),
+            rd: rd(),
+            nlri: Ipv6Nlri {
+                id: 0,
+                prefix: Ipv6Net::new(addr, 64).unwrap(),
+            },
+        }
+    }
+
+    /// One VPNv6 attribute group of `n` /64s, as `Peer::flush_vpnv6` builds it.
+    fn vpnv6_group(n: u32, max: usize) -> UpdatePacket {
+        let nhop = Vpnv6Nexthop {
+            rd: rd(),
+            nhop: "2001:db8::1".parse().unwrap(),
+        };
+        let mut update = UpdatePacket::with_max_packet_size(max);
+        update.bgp_attr = Some(attrs(BgpNexthop::Vpnv6(nhop.clone())));
+        update.mp_update = Some(MpReachAttr::Vpnv6(Vpnv6Reach {
+            snpa: 0,
+            nhop,
+            updates: (0..n).map(vpnv6_nlri).collect(),
+        }));
+        update
+    }
+
+    /// Type-3 Inclusive Multicast route from originator `10.0.0.0 + i`.
+    fn evpn_route(i: u32) -> EvpnRoute {
+        EvpnRoute::Multicast(EvpnMulticast {
+            id: 0,
+            rd: rd(),
+            ether_tag: 0,
+            addr: IpAddr::V4(Ipv4Addr::from(0x0A00_0000u32 + i)),
+        })
+    }
+
+    /// One EVPN attribute group of `n` routes, as `Peer::flush_evpn` builds it.
+    fn evpn_group(n: u32, max: usize) -> UpdatePacket {
+        let nhop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+        let mut update = UpdatePacket::with_max_packet_size(max);
+        update.bgp_attr = Some(attrs(BgpNexthop::Evpn(nhop)));
+        update.mp_update = Some(MpReachAttr::Evpn {
+            snpa: 0,
+            nhop,
+            updates: (0..n).map(evpn_route).collect(),
+        });
+        update
+    }
+
+    /// Pop packets until the emitter runs dry, checking that each one fits
+    /// `max`, declares its true length, and parses back; returns the parsed
+    /// packets in emission order.
+    fn drain(
+        update: &mut UpdatePacket,
+        pop: fn(&mut UpdatePacket) -> Option<BytesMut>,
+        max: usize,
+    ) -> Vec<UpdatePacket> {
+        let mut parsed = vec![];
+        while let Some(bytes) = pop(update) {
+            assert!(
+                bytes.len() <= max,
+                "packet of {} octets exceeds the {} octet budget",
+                bytes.len(),
+                max
+            );
+            let declared = u16::from_be_bytes([bytes[16], bytes[17]]) as usize;
+            assert_eq!(declared, bytes.len(), "header Length matches the body");
+            let (_, packet) = UpdatePacket::parse_packet(&bytes, true, None)
+                .expect("an emitted packet must parse back");
+            parsed.push(packet);
+        }
+        parsed
+    }
+
+    fn vpnv4_prefixes(packets: &[UpdatePacket]) -> Vec<Ipv4Net> {
+        packets
+            .iter()
+            .flat_map(|p| -> Vec<Ipv4Net> {
+                match &p.mp_update {
+                    Some(MpReachAttr::Vpnv4(r)) => {
+                        r.updates.iter().map(|u| u.nlri.prefix).collect()
+                    }
+                    other => panic!("expected a VPNv4 MP_REACH, got {:?}", other),
+                }
+            })
+            .collect()
+    }
+
+    fn vpnv6_prefixes(packets: &[UpdatePacket]) -> Vec<Ipv6Net> {
+        packets
+            .iter()
+            .flat_map(|p| -> Vec<Ipv6Net> {
+                match &p.mp_update {
+                    Some(MpReachAttr::Vpnv6(r)) => {
+                        r.updates.iter().map(|u| u.nlri.prefix).collect()
+                    }
+                    other => panic!("expected a VPNv6 MP_REACH, got {:?}", other),
+                }
+            })
+            .collect()
+    }
+
+    fn evpn_routes(packets: &[UpdatePacket]) -> Vec<EvpnRoute> {
+        packets
+            .iter()
+            .flat_map(|p| -> Vec<EvpnRoute> {
+                match &p.mp_update {
+                    Some(MpReachAttr::Evpn { updates, .. }) => updates.clone(),
+                    other => panic!("expected an EVPN MP_REACH, got {:?}", other),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn vpnv4_group_shares_one_packet() {
+        let mut update = vpnv4_group(3, BGP_PACKET_LEN);
+        let packets = drain(&mut update, UpdatePacket::pop_vpnv4, BGP_PACKET_LEN);
+        assert_eq!(
+            packets.len(),
+            1,
+            "three same-attribute NLRIs ride one UPDATE"
+        );
+        assert_eq!(vpnv4_prefixes(&packets).len(), 3);
+    }
+
+    /// A full-table sized group used to spill past 4096 octets by the
+    /// header, path attributes and MP_REACH header, because the budget was
+    /// checked against the attribute value alone.
+    #[test]
+    fn vpnv4_group_paginates_within_4096() {
+        let mut update = vpnv4_group(1000, BGP_PACKET_LEN);
+        let packets = drain(&mut update, UpdatePacket::pop_vpnv4, BGP_PACKET_LEN);
+        assert!(
+            packets.len() > 1,
+            "1000 VPNv4 NLRIs need more than one packet"
+        );
+        let got: BTreeSet<Ipv4Net> = vpnv4_prefixes(&packets).into_iter().collect();
+        let want: BTreeSet<Ipv4Net> = (0..1000).map(|i| vpnv4_nlri(i).nlri.prefix).collect();
+        assert_eq!(got.len(), 1000, "no NLRI is emitted twice");
+        assert_eq!(got, want, "every NLRI is emitted");
+    }
+
+    /// With RFC 8654 extended messages the same overrun would have wrapped
+    /// the 2-octet Length field; the budget must hold at 65535 as well.
+    #[test]
+    fn vpnv4_group_paginates_within_extended_max() {
+        let mut update = vpnv4_group(5000, BGP_EXTENDED_PACKET_LEN);
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_vpnv4,
+            BGP_EXTENDED_PACKET_LEN,
+        );
+        assert!(
+            packets.len() > 1,
+            "5000 VPNv4 NLRIs exceed one extended message"
+        );
+        assert_eq!(vpnv4_prefixes(&packets).len(), 5000);
+    }
+
+    /// A budget too small for even one NLRI beside the attributes yields
+    /// `None` instead of an empty MP_REACH, so the flush loop terminates.
+    #[test]
+    fn vpnv4_returns_none_when_first_nlri_does_not_fit() {
+        let mut update = vpnv4_group(1, 40);
+        assert!(update.pop_vpnv4().is_none());
+    }
+
+    #[test]
+    fn vpnv6_group_paginates_within_4096() {
+        let mut update = vpnv6_group(1000, BGP_PACKET_LEN);
+        let packets = drain(&mut update, UpdatePacket::pop_vpnv6, BGP_PACKET_LEN);
+        assert!(
+            packets.len() > 1,
+            "1000 VPNv6 NLRIs need more than one packet"
+        );
+        let got: BTreeSet<Ipv6Net> = vpnv6_prefixes(&packets).into_iter().collect();
+        let want: BTreeSet<Ipv6Net> = (0..1000).map(|i| vpnv6_nlri(i).nlri.prefix).collect();
+        assert_eq!(got.len(), 1000, "no NLRI is emitted twice");
+        assert_eq!(got, want, "every NLRI is emitted");
+    }
+
+    #[test]
+    fn vpnv6_returns_none_when_first_nlri_does_not_fit() {
+        let mut update = vpnv6_group(1, 40);
+        assert!(update.pop_vpnv6().is_none());
+    }
+
+    /// EVPN used to emit a whole attribute group in one packet regardless
+    /// of size; it now paginates like VPNv4 and keeps the route order.
+    #[test]
+    fn evpn_group_paginates_within_4096_in_order() {
+        let mut update = evpn_group(1000, BGP_PACKET_LEN);
+        let packets = drain(&mut update, UpdatePacket::pop_evpn, BGP_PACKET_LEN);
+        assert!(
+            packets.len() > 1,
+            "1000 EVPN routes need more than one packet"
+        );
+        let want: Vec<EvpnRoute> = (0..1000).map(evpn_route).collect();
+        assert_eq!(evpn_routes(&packets), want, "every route once, in order");
+        assert!(
+            update.pop_evpn().is_none(),
+            "nothing left after the last packet"
+        );
+    }
+
+    #[test]
+    fn evpn_returns_none_when_first_route_does_not_fit() {
+        let mut update = evpn_group(1, 40);
+        assert!(update.pop_evpn().is_none());
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14038,10 +14038,9 @@ impl Peer {
         }
     }
 
-    /// Drain `cache_evpn` and emit one BGP UPDATE per attribute
-    /// group via `pop_evpn`. Pagination across multiple UPDATEs is a
-    /// follow-up; the encoder currently emits all NLRIs from a
-    /// single attr group in one packet.
+    /// Drain `cache_evpn` and emit the BGP UPDATEs for each attribute
+    /// group via `pop_evpn`, which paginates a group that does not fit
+    /// one packet across as many as it needs.
     pub fn flush_evpn(&mut self) {
         let packet_tx = self.packet_tx.clone();
         let max_size = self.max_packet_size();
@@ -14066,10 +14065,10 @@ impl Peer {
             });
             update.bgp_attr = Some((*attr).clone());
 
-            if let Some(bytes) = update.pop_evpn()
-                && let Some(ref tx) = packet_tx
-            {
-                let _ = tx.send(bytes);
+            while let Some(bytes) = update.pop_evpn() {
+                if let Some(ref tx) = packet_tx {
+                    let _ = tx.send(bytes);
+                }
             }
         }
         self.cache_evpn_rev.clear();


### PR DESCRIPTION
## Summary

The VPNv4 and VPNv6 MP_REACH emitters checked the per-NLRI budget against a scratch buffer holding only the attribute value, so the BGP header, the two length fields, the ordinary path attributes and the MP_REACH header were never counted. A route reflector dumping a VPN table therefore emitted UPDATEs of 4096 plus header plus attributes octets (4109 and 4133 measured). A peer without RFC 8654 extended messages answers that with a Bad Message Length NOTIFICATION and drops the session; with extended messages negotiated the same overrun wrapped the 2-octet Length field. Introduced with e724837c.

EVPN did not paginate at all: `pop_evpn` wrote a whole attribute group into one packet regardless of size.

## Changes

- `Vpnv4Reach` / `Vpnv6Reach::attr_emit_mut` budget the space actually left in the packet (`max_packet_size` minus what the packet already holds minus the MP_REACH header), using exact NLRI sizes (the label is 3 octets; the old count used 4).
- EVPN gets the same pagination via `evpn_attr_emit_mut`, measuring each route by encoding it since EVPN NLRI sizes vary by route type and address family. Route order is preserved.
- `pop_vpnv4` / `pop_vpnv6` / `pop_evpn` return `None` instead of emitting an empty MP_REACH when not even the first NLRI fits, mirroring `pop_ipv4_mp_reach`; `flush_evpn` now loops until `pop_evpn` runs dry.
- New shared helper `put_mp_reach_attr` + `MP_REACH_HEADER_LEN` in `mp_reach.rs` replace three copies of the short/extended header logic.
- Second commit: the pagination test helper builds `BgpAttr` with a struct literal so workspace clippy (`field_reassign_with_default`) stays clean.

VPNv4/VPNv6/EVPN withdraws are sent one route per UPDATE, so they need no pagination.

## Tests

- New unit tests in `crates/bgp-packet/src/update.rs`: same-attribute packing, a 1000-route VPNv4 group at 4096 and a 5000-route group at 65535, VPNv6 pagination, ordered EVPN pagination, and the first-NLRI-does-not-fit case for all three families. Every emitted packet is checked to fit the budget, declare its true length, and parse back; every queued NLRI comes out exactly once.
- `cargo test -p bgp-packet`: 521 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt --all --check`: clean.
- BDD on the installed branch binary: `bgp_vpnv4_rr_transit_label`, `bgp_vrf_vpnv6_export`, `l3vpn_bgp_v4`, `bgp_evpn_srv6_rr`, `bgp_evpn_local_mac` — 5 features, 27 scenarios, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C226yfQ3dJMQrHPpzDhP2N
