### PR TITLE
bgp: pack withdrawals per peer into full-size UPDATEs, reconciled against the Adj-RIB-Out

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -556,6 +556,13 @@ bgp_evpn_capability:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_evpn_capability"
 
+# Wire-level bulk withdrawal packing + Adj-RIB-Out coherence for IPv4, IPv6,
+# VPNv4/v6 and EVPN.
+.PHONY: bgp_withdraw_packing
+bgp_withdraw_packing:
+	mkdir -p allure-results
+	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_withdraw_packing"
+
 bgp_vrf_evpn_type5:
 	mkdir -p allure-results
 	$(CUCUMBER) -- --concurrency=1 --tags "@bgp_vrf_evpn_type5"

--- a/bdd/docs/bgp_withdraw_packing.md
+++ b/bdd/docs/bgp_withdraw_packing.md
@@ -1,0 +1,22 @@
+# Bulk withdrawals are packed per peer and stay coherent with the Adj-RIB-Out
+
+## Overview
+
+Two scripted iBGP clients connect to a zebra-rs route reflector. The source
+announces 1000 routes per family and withdraws them in a burst; the observer
+parses the reflector's raw TCP stream and checks that the withdrawals arrive
+packed into a bounded number of UPDATEs within the negotiated message size,
+with no stale announcement overtaking a withdrawal. It then sends
+announce+withdraw and withdraw+announce back to back and checks the observer
+settles absent / present respectively — a queued withdrawal must neither
+overtake the announcement it races nor outlive a re-advertise. IPv4, IPv6,
+VPNv4, VPNv6 and EVPN are covered at both message limits.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup a reflector and two scripted clients | |
+| Pack withdrawals without extended messages | |
+| Pack withdrawals with extended messages after reconnect | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_withdraw_packing/z1.yaml
+++ b/bdd/tests/configs/bgp_withdraw_packing/z1.yaml
@@ -1,0 +1,45 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.0.2.1
+    timer:
+      adv-interval:
+        ibgp: 0
+    neighbor:
+    - remote-address: 192.0.2.2
+      remote-as: 65001
+      enabled: true
+      transport:
+        passive-mode: true
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+      - name: vpnv4
+        enabled: true
+      - name: vpnv6
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.0.2.3
+      remote-as: 65001
+      enabled: true
+      transport:
+        passive-mode: true
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+      - name: vpnv4
+        enabled: true
+      - name: vpnv6
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -641,6 +641,39 @@ async fn start_zebra_rs_sharded_peer_task(world: &mut World, namespace: String, 
     );
 }
 
+#[when(expr = "I start zebra-rs in namespace {string} with peer task")]
+async fn start_zebra_rs_peer_task(world: &mut World, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let log_file = format!("logs/{}.log", scoped);
+    world.mark_log_start(&scoped);
+    let pid_file = world.pid_file(&namespace);
+
+    let _child = netns::spawn_in_netns_env(
+        &scoped,
+        // A2 ⑥ gate-on: ZEBRA_BGP_PEER_TASK runs the v4-unicast egress in
+        // per-peer tasks (the GoBGP model, no update-groups). Un-sharded, so
+        // this exercises the per-peer egress axis alone — used by the withdraw
+        // packing feature to confirm IPv4 withdrawals pack in the PET.
+        &[("ZEBRA_BGP_PEER_TASK", "1")],
+        "zebra-rs",
+        &[
+            "--daemon",
+            "--log-output=file",
+            &format!("--log-file={}", log_file),
+            &format!("--pid-file={}", pid_file),
+        ],
+    )
+    .await
+    .expect("Failed to start zebra-rs");
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    println!(
+        "✓ zebra-rs started in namespace {} with peer task (pid file {})",
+        scoped, pid_file
+    );
+}
+
 #[when(expr = "I start zebra-rs in namespace {string} with egress group task")]
 async fn start_zebra_rs_egress_group_task(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/bgp_withdraw_packing.feature
+++ b/bdd/tests/features/bgp_withdraw_packing.feature
@@ -33,6 +33,28 @@ Feature: Bulk withdrawals are packed per peer and stay coherent with the Adj-RIB
     When I wait 6 seconds for BGP to operate
     When I execute "timeout 300 python3 tests/scripts/bgp_withdraw_packing.py 65535" in namespace "h1"
 
+  # The IPv4-unicast egress is diverted off the update-group path at gate-on:
+  # ZEBRA_BGP_PEER_TASK routes it to the per-peer egress task, and
+  # ZEBRA_BGP_EGRESS_GROUP_TASK to the per-update-group task. Both engines pack
+  # their own IPv4 withdrawals; the other families stay on the shared queue.
+  # Restart the reflector under each gate and re-run the wire check so the
+  # packing bound and Adj-RIB-Out coherence hold in every egress model.
+  Scenario: Pack withdrawals with the per-peer egress task
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z1" with peer task
+    And I apply config "z1.yaml" to namespace "z1"
+    And I wait 6 seconds for BGP to operate
+    And I execute "timeout 300 python3 tests/scripts/bgp_withdraw_packing.py 4096" in namespace "h1"
+
+  Scenario: Pack withdrawals with the per-update-group egress task
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z1" with egress group task
+    And I apply config "z1.yaml" to namespace "z1"
+    And I wait 6 seconds for BGP to operate
+    And I execute "timeout 300 python3 tests/scripts/bgp_withdraw_packing.py 4096" in namespace "h1"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/bdd/tests/features/bgp_withdraw_packing.feature
+++ b/bdd/tests/features/bgp_withdraw_packing.feature
@@ -1,0 +1,41 @@
+@serial
+@bgp_withdraw_packing
+Feature: Bulk withdrawals are packed per peer and stay coherent with the Adj-RIB-Out
+  Two scripted iBGP clients connect to a zebra-rs route reflector. The source
+  announces 1000 routes per family and withdraws them in a burst; the observer
+  parses the reflector's raw TCP stream and checks that the withdrawals arrive
+  packed into a bounded number of UPDATEs within the negotiated message size,
+  with no stale announcement overtaking a withdrawal. It then sends
+  announce+withdraw and withdraw+announce back to back and checks the observer
+  settles absent / present respectively — a queued withdrawal must neither
+  overtake the announcement it races nor outlive a re-advertise. IPv4, IPv6,
+  VPNv4, VPNv6 and EVPN are covered at both message limits.
+
+  Scenario: Setup a reflector and two scripted clients
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "h1"
+    And I connect namespace "z1" interface "eth0" to namespace "h1" interface "eth0"
+    And I execute "ip addr add 192.0.2.1/24 dev eth0" in namespace "z1"
+    And I execute "ip -6 addr add 2001:db8::1/64 dev eth0 nodad" in namespace "z1"
+    And I execute "ip addr add 192.0.2.2/24 dev eth0" in namespace "h1"
+    And I execute "ip addr add 192.0.2.3/24 dev eth0" in namespace "h1"
+    And I execute "ip -6 addr add 2001:db8::2/64 dev eth0 nodad" in namespace "h1"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+
+  Scenario: Pack withdrawals without extended messages
+    Given the test topology exists
+    When I execute "timeout 300 python3 tests/scripts/bgp_withdraw_packing.py 4096" in namespace "h1"
+
+  Scenario: Pack withdrawals with extended messages after reconnect
+    Given the test topology exists
+    When I wait 6 seconds for BGP to operate
+    When I execute "timeout 300 python3 tests/scripts/bgp_withdraw_packing.py 65535" in namespace "h1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete namespace "h1"
+    Then the test environment should be clean

--- a/bdd/tests/scripts/bgp_withdraw_packing.py
+++ b/bdd/tests/scripts/bgp_withdraw_packing.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Wire-level check of bulk-withdraw packing and Adj-RIB-Out coherence.
+
+Two scripted iBGP clients of one zebra-rs route reflector, both living in the
+feature's h1 namespace on different addresses. The *source* feeds routes and
+withdrawals in bursts; the *observer* parses the reflector's raw TCP stream
+and checks:
+
+  1. Packing — a burst of 1000 withdrawals per family arrives in a bounded
+     number of UPDATEs, each within the negotiated message size.
+  2. Coherence — announce+withdraw and withdraw+announce sent back to back
+     leave the observer in the right final state (absent / present), i.e. a
+     queued withdrawal never overtakes or outlives the announcement it races.
+
+Run as `bgp_withdraw_packing.py <4096|65535>`; the second form negotiates
+RFC 8654 extended messages. All sockets are scoped to this process.
+"""
+import ipaddress
+import json
+import math
+import select
+import socket
+import struct
+import sys
+import time
+
+FAMILIES = ((1, 1), (2, 1), (1, 128), (2, 128), (25, 70))
+COUNT = 1000
+# Routes per input UPDATE. The reflector drains its withdraw queue on a
+# next-tick marker that lands behind the ingest already queued, so every
+# drain covers at least one whole input UPDATE.
+BATCH = 40
+
+
+def frame(kind, body=b""):
+    return b"\xff" * 16 + struct.pack("!HB", len(body) + 19, kind) + body
+
+
+def attribute(kind, value, flags=0x80):
+    if len(value) > 255:
+        return struct.pack("!BBH", flags | 0x10, kind, len(value)) + value
+    return bytes((flags, kind, len(value))) + value
+
+
+def open_message(address, maximum):
+    caps = b"".join(bytes((1, 4)) + struct.pack("!HBB", afi, 0, safi)
+                    for afi, safi in FAMILIES)
+    caps += bytes((65, 4)) + struct.pack("!I", 65001)
+    if maximum > 4096:
+        caps += bytes((6, 0))
+    options = bytes((2, len(caps))) + caps
+    return frame(1, struct.pack("!BHH4sB", 4, 65001, 90,
+                               socket.inet_aton(address), len(options)) + options)
+
+
+def nlri(family, i):
+    v4 = ipaddress.IPv4Address(0x0a640000 + i).packed
+    v6 = ipaddress.IPv6Address(int(ipaddress.IPv6Address("2001:db8:100::")) + i).packed
+    rd = struct.pack("!HHI", 0, 65001, i % 3 + 1)
+    if family == (1, 1):
+        return b"\x20" + v4
+    if family == (2, 1):
+        return b"\x80" + v6
+    if family[1] == 128:
+        prefix = v4 if family[0] == 1 else v6
+        return bytes((88 + len(prefix) * 8,)) + b"\x00\x06\x41" + rd + prefix
+    # EVPN Type-5, alternating IPv4/IPv6 to exercise variable wire lengths.
+    prefix = v4 if i % 2 == 0 else v6
+    value = rd + bytes(10) + bytes(4) + bytes((len(prefix) * 8,))
+    value += prefix + bytes(len(prefix)) + b"\x00\x06\x41"
+    return bytes((5, len(value))) + value
+
+
+def route_key(family, raw):
+    # Withdrawals reconstruct labels (and EVPN gateways) rather than retaining
+    # the announcement's forwarding fields. Compare route identity, not labels.
+    if family[1] == 128:
+        return raw[:1] + raw[4:]
+    if family == (25, 70):
+        return raw[:29 if raw[1] == 34 else 41]
+    return raw
+
+
+def entries(family, data):
+    result = []
+    while data:
+        size = 2 + data[1] if family == (25, 70) else 1 + (data[0] + 7) // 8
+        assert size <= len(data), "truncated NLRI"
+        result.append(route_key(family, data[:size]))
+        data = data[size:]
+    return result
+
+
+def update(family, routes, withdraw):
+    data = b"".join(routes)
+    if withdraw:
+        attrs = b"" if family == (1, 1) else attribute(15, struct.pack("!HB", *family) + data)
+        withdrawn = data if family == (1, 1) else b""
+        tail = b""
+    else:
+        attrs = attribute(1, b"\x00", 0x40) + attribute(2, b"", 0x40)
+        attrs += attribute(5, struct.pack("!I", 100), 0x40)
+        withdrawn = b""
+        tail = data if family == (1, 1) else b""
+        if family == (1, 1):
+            attrs += attribute(3, socket.inet_aton("192.0.2.2"), 0x40)
+        else:
+            nh = ipaddress.ip_address("2001:db8::2" if family[0] == 2 else "192.0.2.2").packed
+            if family[1] == 128:
+                nh = bytes(8) + nh
+            attrs += attribute(14, struct.pack("!HB", *family) + bytes((len(nh),)) + nh + b"\x00" + data)
+    return frame(2, struct.pack("!H", len(withdrawn)) + withdrawn
+                 + struct.pack("!H", len(attrs)) + attrs + tail)
+
+
+def burst(family, routes, withdraw):
+    """`routes` as a run of BATCH-route UPDATEs, concatenated for one send."""
+    return b"".join(update(family, routes[i:i + BATCH], withdraw)
+                    for i in range(0, len(routes), BATCH))
+
+
+def parse_update(body):
+    withdrawn_len = struct.unpack("!H", body[:2])[0]
+    changes = []
+    if withdrawn_len:
+        changes.append(((1, 1), True, entries((1, 1), body[2:2 + withdrawn_len])))
+    pos = 2 + withdrawn_len
+    attrs_len = struct.unpack("!H", body[pos:pos + 2])[0]
+    pos += 2
+    end = pos + attrs_len
+    assert end <= len(body)
+    while pos < end:
+        flags, kind = body[pos:pos + 2]
+        width = 2 if flags & 0x10 else 1
+        length = int.from_bytes(body[pos + 2:pos + 2 + width], "big")
+        start = pos + 2 + width
+        value = body[start:start + length]
+        assert start + length <= end
+        pos = start + length
+        if kind in (14, 15):
+            family = struct.unpack("!HB", value[:3])
+            skip = 5 + value[3] if kind == 14 else 3
+            changes.append((family, kind == 15, entries(family, value[skip:])))
+    if end < len(body):
+        changes.append(((1, 1), False, entries((1, 1), body[end:])))
+    return changes
+
+
+class Client:
+    def __init__(self, address, maximum):
+        self.sock = socket.socket()
+        self.sock.settimeout(10)
+        self.sock.bind((address, 0))
+        self.sock.connect(("192.0.2.1", 179))
+        self.sock.sendall(open_message(address, maximum))
+        self.buffer = b""
+        self.established = False
+        self.maximum = maximum
+
+    def receive(self):
+        data = self.sock.recv(262144)
+        assert data, "session closed unexpectedly"
+        self.buffer += data
+        changes = []
+        while len(self.buffer) >= 19:
+            assert self.buffer[:16] == b"\xff" * 16
+            length, kind = struct.unpack("!HB", self.buffer[16:19])
+            assert 19 <= length <= self.maximum, f"invalid message length {length}"
+            if len(self.buffer) < length:
+                break
+            body, self.buffer = self.buffer[19:length], self.buffer[length:]
+            assert kind != 3, f"BGP NOTIFICATION: {body.hex()}"
+            if kind == 1:
+                # Verify extended negotiation rather than merely assuming it.
+                if self.maximum > 4096:
+                    assert b"\x06\x00" in body[10:], "DUT did not advertise extended messages"
+                self.sock.sendall(frame(4))
+            elif kind == 4:
+                self.established = True
+            elif kind == 2:
+                changes.extend(parse_update(body))
+        return changes
+
+
+class Observer:
+    """Tracks, per family, the set of routes the reflector currently
+    advertises to the observer client, applying UPDATEs in wire order."""
+
+    def __init__(self):
+        self.present = {family: set() for family in FAMILIES}
+        # Per-family log of (withdrawn?, nlri_count) since the last reset.
+        self.log = {family: [] for family in FAMILIES}
+
+    def apply(self, family, withdrawn, keys):
+        if family not in self.present:
+            return
+        if withdrawn:
+            self.present[family].difference_update(keys)
+        else:
+            self.present[family].update(keys)
+        self.log[family].append((withdrawn, len(keys)))
+
+    def reset_log(self, family):
+        self.log[family] = []
+
+
+def run(maximum):
+    source = Client("192.0.2.2", maximum)
+    observer = Client("192.0.2.3", maximum)
+    clients = (source, observer)
+    state = Observer()
+    last_keepalive = time.monotonic()
+
+    def pump(deadline, what):
+        nonlocal last_keepalive
+        assert time.monotonic() < deadline, f"timed out waiting for {what}"
+        if time.monotonic() - last_keepalive > 15:
+            for c in clients:
+                c.sock.sendall(frame(4))
+            last_keepalive = time.monotonic()
+        readable, _, _ = select.select([c.sock for c in clients], [], [], 0.2)
+        seen = False
+        for c in clients:
+            if c.sock in readable:
+                for family, withdrawn, keys in c.receive():
+                    if c is observer:
+                        state.apply(family, withdrawn, keys)
+                        seen = True
+        return seen
+
+    def wait_until(predicate, what, seconds=30):
+        deadline = time.monotonic() + seconds
+        while not predicate():
+            pump(deadline, what)
+
+    def settle(seconds=2.0, limit=60):
+        """Pump until the observer has been quiet for `seconds`."""
+        deadline = time.monotonic() + limit
+        quiet_since = time.monotonic()
+        while time.monotonic() - quiet_since < seconds:
+            if pump(deadline, "quiescence"):
+                quiet_since = time.monotonic()
+
+    try:
+        wait_until(lambda: all(c.established for c in clients), "sessions")
+        results = []
+        for family in FAMILIES:
+            routes = [nlri(family, i) for i in range(COUNT)]
+            expected = {route_key(family, r) for r in routes}
+            present = state.present[family]
+
+            # ── 1. Packing: announce, wait for every route, withdraw in a burst.
+            source.sock.sendall(burst(family, routes, False))
+            wait_until(lambda: present == expected, f"{family} announcements")
+            assert present <= expected, "unexpected reflected route"
+            state.reset_log(family)
+            source.sock.sendall(burst(family, routes, True))
+            wait_until(lambda: not present, f"{family} withdrawals")
+            log = state.log[family]
+            assert all(withdrawn for withdrawn, _ in log), \
+                f"{family}: a stale announcement overtook a withdrawal: {log}"
+            assert all(n > 0 for _, n in log), "unexpected EoR during withdrawals"
+            sizes = [n for _, n in log]
+            assert sum(sizes) == COUNT
+            # Bound: each drain covers at least one whole input UPDATE, so at
+            # most COUNT/BATCH drains, each spilling at most one packet's worth
+            # of NLRI to the next packet; a second COUNT/BATCH of slack covers
+            # a drain replayed behind an in-flight announce job.
+            wire = [len(route_key(family, r)) + (3 if family[1] == 128 else 0) for r in routes]
+            overhead = 23 if family == (1, 1) else 30
+            per_packet = maximum - overhead - max(wire)
+            bound = 2 * math.ceil(COUNT / BATCH) + math.ceil(sum(wire) / per_packet)
+            assert len(sizes) <= bound, \
+                f"{family}: {COUNT} withdrawals took {len(sizes)} UPDATEs, bound {bound}"
+            assert max(sizes) > 1, f"{family}: all withdrawals were singleton UPDATEs"
+            results.append(dict(family=family, withdrawn=COUNT, messages=len(sizes),
+                                largest_nlri_count=max(sizes), bound=bound))
+            print(f"PASS {family}: {COUNT} withdrawals in {len(sizes)} UPDATEs "
+                  f"(bound {bound}), largest {max(sizes)} NLRIs", flush=True)
+
+            # ── 2. Coherence: announce+withdraw back to back ⇒ absent.
+            state.reset_log(family)
+            source.sock.sendall(burst(family, routes, False) + burst(family, routes, True))
+            settle()
+            assert not present, \
+                f"{family}: {len(present)} routes survived announce+withdraw"
+            print(f"PASS {family}: announce+withdraw burst settles absent "
+                  f"({len(state.log[family])} UPDATEs seen)", flush=True)
+
+            # ── 3. Coherence: withdraw+announce back to back ⇒ present.
+            source.sock.sendall(burst(family, routes, False))
+            wait_until(lambda: present == expected, f"{family} re-announcements")
+            state.reset_log(family)
+            source.sock.sendall(burst(family, routes, True) + burst(family, routes, False))
+            settle()
+            assert present == expected, \
+                f"{family}: {len(expected - present)} routes lost across withdraw+announce"
+            print(f"PASS {family}: withdraw+announce burst settles present "
+                  f"({len(state.log[family])} UPDATEs seen)", flush=True)
+
+            # ── 4. Clean up for the next family.
+            source.sock.sendall(burst(family, routes, True))
+            wait_until(lambda: not present, f"{family} final withdrawals")
+
+        # A final KEEPALIVE exchange verifies the parser/session survived all
+        # of it. The sockets remain open until every assertion completes.
+        for c in clients:
+            c.sock.sendall(frame(4))
+        settle(1.0)
+        assert not any(state.present.values()), "late route change after completion"
+        print(json.dumps(results), flush=True)
+        # The harness discards stdout; leave the numbers where a human can
+        # read them after the run.
+        with open(f"/tmp/bgp_withdraw_packing-{maximum}.json", "w") as f:
+            f.write(json.dumps(results, indent=2) + "\n")
+    finally:
+        for c in clients:
+            c.sock.close()
+
+
+if __name__ == "__main__":
+    maximum = int(sys.argv[1])
+    assert maximum in (4096, 65535)
+    run(maximum)

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -46,8 +46,11 @@ pub(crate) fn put_mp_unreach_attr(buf: &mut BytesMut, value: &[u8]) {
 
 /// Write one MP_UNREACH_NLRI attribute carrying as many of `withdraws` as
 /// fit in a packet of `max_packet_size` octets given what `buf` already
-/// holds. The NLRIs written are drained from the front of `withdraws`;
-/// the rest stay for the next call. Returns the number written, or 0 —
+/// holds. The NLRIs written are taken from the *end* of `withdraws` — the
+/// order among withdrawals is immaterial, and truncating the tail keeps
+/// each call proportional to what it emitted instead of shifting the
+/// whole remainder down (a 400k-route burst paid for that quadratically).
+/// The rest stay for the next call. Returns the number written, or 0 —
 /// writing nothing — when not even the first NLRI fits, so the caller can
 /// refuse to emit an empty MP_UNREACH (which would read as end-of-RIB).
 ///
@@ -69,7 +72,7 @@ fn unreach_emit_mut<T>(
 
     let mut emitted = 0;
     let mut nlri = BytesMut::new();
-    for w in withdraws.iter() {
+    for w in withdraws.iter().rev() {
         nlri.clear();
         emit(w, &mut nlri);
         if value.len() + nlri.len() > budget {
@@ -81,7 +84,7 @@ fn unreach_emit_mut<T>(
     if emitted == 0 {
         return 0;
     }
-    withdraws.drain(..emitted);
+    withdraws.truncate(withdraws.len() - emitted);
     put_mp_unreach_attr(buf, &value);
     emitted
 }

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -225,25 +225,23 @@ impl MpUnreachAttr {
 }
 
 impl MpUnreachAttr {
-    /// Whether this attribute withdraws nothing: an end-of-RIB variant, or
-    /// a list variant whose list has been drained. `attr_emit_mut` never
-    /// writes such an attribute (an empty MP_UNREACH on the wire *is* an
-    /// end-of-RIB marker), so callers use this to stop paginating.
-    pub fn is_empty(&self) -> bool {
+    /// How many withdrawals this attribute still queues: zero for an
+    /// end-of-RIB variant or a list variant whose list has been drained.
+    pub fn len(&self) -> usize {
         match self {
-            MpUnreachAttr::Ipv4Nlri(w) => w.is_empty(),
-            MpUnreachAttr::Ipv6Nlri(w) => w.is_empty(),
-            MpUnreachAttr::Vpnv4(w) => w.is_empty(),
-            MpUnreachAttr::Vpnv6(w) => w.is_empty(),
-            MpUnreachAttr::Evpn(w) => w.is_empty(),
-            MpUnreachAttr::Rtcv4(w) => w.is_empty(),
-            MpUnreachAttr::Rtcv6(w) => w.is_empty(),
-            MpUnreachAttr::Mup { withdraws, .. } => withdraws.is_empty(),
-            MpUnreachAttr::Flowspec { withdraws, .. } => withdraws.is_empty(),
-            MpUnreachAttr::Labelv4(w) => w.is_empty(),
-            MpUnreachAttr::Labelv6(w) => w.is_empty(),
-            MpUnreachAttr::SrPolicy { withdraws, .. } => withdraws.is_empty(),
-            MpUnreachAttr::LinkState { withdraws } => withdraws.is_empty(),
+            MpUnreachAttr::Ipv4Nlri(w) => w.len(),
+            MpUnreachAttr::Ipv6Nlri(w) => w.len(),
+            MpUnreachAttr::Vpnv4(w) => w.len(),
+            MpUnreachAttr::Vpnv6(w) => w.len(),
+            MpUnreachAttr::Evpn(w) => w.len(),
+            MpUnreachAttr::Rtcv4(w) => w.len(),
+            MpUnreachAttr::Rtcv6(w) => w.len(),
+            MpUnreachAttr::Mup { withdraws, .. } => withdraws.len(),
+            MpUnreachAttr::Flowspec { withdraws, .. } => withdraws.len(),
+            MpUnreachAttr::Labelv4(w) => w.len(),
+            MpUnreachAttr::Labelv6(w) => w.len(),
+            MpUnreachAttr::SrPolicy { withdraws, .. } => withdraws.len(),
+            MpUnreachAttr::LinkState { withdraws } => withdraws.len(),
             MpUnreachAttr::Ipv4Eor
             | MpUnreachAttr::Ipv6Eor
             | MpUnreachAttr::Vpnv4Eor
@@ -252,8 +250,16 @@ impl MpUnreachAttr {
             | MpUnreachAttr::Rtcv4Eor
             | MpUnreachAttr::Rtcv6Eor
             | MpUnreachAttr::Labelv4Eor
-            | MpUnreachAttr::Labelv6Eor => true,
+            | MpUnreachAttr::Labelv6Eor => 0,
         }
+    }
+
+    /// Whether this attribute withdraws nothing: an end-of-RIB variant, or
+    /// a list variant whose list has been drained. `attr_emit_mut` never
+    /// writes such an attribute (an empty MP_UNREACH on the wire *is* an
+    /// end-of-RIB marker), so callers use this to stop paginating.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Paginating twin of [`attr_emit`](Self::attr_emit): emit as many of

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -18,6 +18,74 @@ pub struct MpUnreachHeader {
     pub safi: Safi,
 }
 
+/// Octets of an MP_UNREACH_NLRI attribute header in its extended-length
+/// form (flags, type, 2-octet length). The paginating emitter budgets for
+/// this form; a value of 255 octets or less takes the short header and one
+/// octet of the budget goes unused. Twin of `MP_REACH_HEADER_LEN`.
+pub(crate) const MP_UNREACH_HEADER_LEN: usize = 4;
+
+/// Append a complete MP_UNREACH_NLRI path attribute (header + `value`) to
+/// `buf`, choosing the short or extended-length header by the value size.
+pub(crate) fn put_mp_unreach_attr(buf: &mut BytesMut, value: &[u8]) {
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(value);
+}
+
+/// Write one MP_UNREACH_NLRI attribute carrying as many of `withdraws` as
+/// fit in a packet of `max_packet_size` octets given what `buf` already
+/// holds. The NLRIs written are drained from the front of `withdraws`;
+/// the rest stay for the next call. Returns the number written, or 0 —
+/// writing nothing — when not even the first NLRI fits, so the caller can
+/// refuse to emit an empty MP_UNREACH (which would read as end-of-RIB).
+///
+/// Each NLRI is measured by encoding it into a scratch buffer rather than
+/// by a per-family size formula, so one routine serves every family
+/// (EVPN and Flowspec NLRIs vary in length by route type).
+fn unreach_emit_mut<T>(
+    afi: Afi,
+    safi: Safi,
+    withdraws: &mut Vec<T>,
+    emit: impl Fn(&T, &mut BytesMut),
+    buf: &mut BytesMut,
+    max_packet_size: usize,
+) -> usize {
+    let budget = max_packet_size.saturating_sub(buf.len() + MP_UNREACH_HEADER_LEN);
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(afi));
+    value.put_u8(u8::from(safi));
+
+    let mut emitted = 0;
+    let mut nlri = BytesMut::new();
+    for w in withdraws.iter() {
+        nlri.clear();
+        emit(w, &mut nlri);
+        if value.len() + nlri.len() > budget {
+            break;
+        }
+        value.put(&nlri[..]);
+        emitted += 1;
+    }
+    if emitted == 0 {
+        return 0;
+    }
+    withdraws.drain(..emitted);
+    put_mp_unreach_attr(buf, &value);
+    emitted
+}
+
 #[derive(Clone)]
 pub enum MpUnreachAttr {
     /// IPv4 unicast withdrawals carried in MP_UNREACH (RFC 4760 §4,
@@ -149,6 +217,122 @@ impl MpUnreachAttr {
             _ => {
                 //
             }
+        }
+    }
+}
+
+impl MpUnreachAttr {
+    /// Whether this attribute withdraws nothing: an end-of-RIB variant, or
+    /// a list variant whose list has been drained. `attr_emit_mut` never
+    /// writes such an attribute (an empty MP_UNREACH on the wire *is* an
+    /// end-of-RIB marker), so callers use this to stop paginating.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            MpUnreachAttr::Ipv4Nlri(w) => w.is_empty(),
+            MpUnreachAttr::Ipv6Nlri(w) => w.is_empty(),
+            MpUnreachAttr::Vpnv4(w) => w.is_empty(),
+            MpUnreachAttr::Vpnv6(w) => w.is_empty(),
+            MpUnreachAttr::Evpn(w) => w.is_empty(),
+            MpUnreachAttr::Rtcv4(w) => w.is_empty(),
+            MpUnreachAttr::Rtcv6(w) => w.is_empty(),
+            MpUnreachAttr::Mup { withdraws, .. } => withdraws.is_empty(),
+            MpUnreachAttr::Flowspec { withdraws, .. } => withdraws.is_empty(),
+            MpUnreachAttr::Labelv4(w) => w.is_empty(),
+            MpUnreachAttr::Labelv6(w) => w.is_empty(),
+            MpUnreachAttr::SrPolicy { withdraws, .. } => withdraws.is_empty(),
+            MpUnreachAttr::LinkState { withdraws } => withdraws.is_empty(),
+            MpUnreachAttr::Ipv4Eor
+            | MpUnreachAttr::Ipv6Eor
+            | MpUnreachAttr::Vpnv4Eor
+            | MpUnreachAttr::Vpnv6Eor
+            | MpUnreachAttr::EvpnEor
+            | MpUnreachAttr::Rtcv4Eor
+            | MpUnreachAttr::Rtcv6Eor
+            | MpUnreachAttr::Labelv4Eor
+            | MpUnreachAttr::Labelv6Eor => true,
+        }
+    }
+
+    /// Paginating twin of [`attr_emit`](Self::attr_emit): emit as many of
+    /// the queued withdrawals as fit in a packet of `max_packet_size`
+    /// octets given what `buf` already holds, drain those from the list,
+    /// and return the number written. Writes nothing and returns 0 when
+    /// not even the first NLRI fits, and for the end-of-RIB variants
+    /// (which have nothing to paginate — emit those with `attr_emit`).
+    /// Route-Target withdrawals (`Rtcv4` / `Rtcv6`) have no emitter and
+    /// also return 0.
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_packet_size: usize) -> usize {
+        let max = max_packet_size;
+        match self {
+            MpUnreachAttr::Ipv4Nlri(w) => {
+                unreach_emit_mut(Afi::Ip, Safi::Unicast, w, Ipv4Nlri::nlri_emit, buf, max)
+            }
+            MpUnreachAttr::Ipv6Nlri(w) => {
+                unreach_emit_mut(Afi::Ip6, Safi::Unicast, w, Ipv6Nlri::nlri_emit, buf, max)
+            }
+            MpUnreachAttr::Vpnv4(w) => {
+                unreach_emit_mut(Afi::Ip, Safi::MplsVpn, w, Vpnv4Nlri::nlri_emit, buf, max)
+            }
+            MpUnreachAttr::Vpnv6(w) => {
+                unreach_emit_mut(Afi::Ip6, Safi::MplsVpn, w, Vpnv6Nlri::nlri_emit, buf, max)
+            }
+            MpUnreachAttr::Evpn(w) => {
+                unreach_emit_mut(Afi::L2vpn, Safi::Evpn, w, EvpnRoute::nlri_emit, buf, max)
+            }
+            MpUnreachAttr::Mup { afi, withdraws } => {
+                unreach_emit_mut(*afi, Safi::Mup, withdraws, MupRoute::nlri_emit, buf, max)
+            }
+            MpUnreachAttr::Flowspec { afi, withdraws } => unreach_emit_mut(
+                *afi,
+                Safi::Flowspec,
+                withdraws,
+                FlowspecNlri::nlri_emit,
+                buf,
+                max,
+            ),
+            MpUnreachAttr::Labelv4(w) => unreach_emit_mut(
+                Afi::Ip,
+                Safi::MplsLabel,
+                w,
+                Labelv4Nlri::nlri_emit,
+                buf,
+                max,
+            ),
+            MpUnreachAttr::Labelv6(w) => unreach_emit_mut(
+                Afi::Ip6,
+                Safi::MplsLabel,
+                w,
+                Labelv6Nlri::nlri_emit,
+                buf,
+                max,
+            ),
+            MpUnreachAttr::SrPolicy { afi, withdraws } => unreach_emit_mut(
+                *afi,
+                Safi::SrTePolicy,
+                withdraws,
+                |r, b| r.nlri_emit(b, false),
+                buf,
+                max,
+            ),
+            MpUnreachAttr::LinkState { withdraws } => unreach_emit_mut(
+                Afi::LinkState,
+                Safi::LinkState,
+                withdraws,
+                |w, b| crate::bgpls_nlri_emit(b, w),
+                buf,
+                max,
+            ),
+            MpUnreachAttr::Rtcv4(_)
+            | MpUnreachAttr::Rtcv6(_)
+            | MpUnreachAttr::Ipv4Eor
+            | MpUnreachAttr::Ipv6Eor
+            | MpUnreachAttr::Vpnv4Eor
+            | MpUnreachAttr::Vpnv6Eor
+            | MpUnreachAttr::EvpnEor
+            | MpUnreachAttr::Rtcv4Eor
+            | MpUnreachAttr::Rtcv6Eor
+            | MpUnreachAttr::Labelv4Eor
+            | MpUnreachAttr::Labelv6Eor => 0,
         }
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
@@ -21,6 +21,24 @@ pub struct Vpnv4Nlri {
     pub nlri: Ipv4Nlri,
 }
 
+impl Vpnv4Nlri {
+    /// Encode this NLRI as it appears in an MP_REACH / MP_UNREACH NLRI
+    /// list (RFC 4364 §4.3.4 / RFC 8277): the optional 4-octet path-id,
+    /// the 1-octet length in bits (label + RD + prefix), the 3-octet
+    /// label, the 8-octet RD, then the significant prefix octets.
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.nlri.id != 0 {
+            buf.put_u32(self.nlri.id);
+        }
+        buf.put_u8(self.nlri.prefix.prefix_len() + 88);
+        buf.put(&self.label.to_bytes()[..]);
+        buf.put_u16(self.rd.typ as u16);
+        buf.put(&self.rd.val[..]);
+        let plen = nlri_psize(self.nlri.prefix.prefix_len());
+        buf.put(&self.nlri.prefix.addr().octets()[0..plen]);
+    }
+}
+
 // Identity excludes the MPLS `label`: a VPNv4 route is identified by its
 // (RD, prefix, path-id), and the label is a forwarding property attached
 // to it (and may not be known at every comparison site — e.g. an
@@ -280,21 +298,7 @@ impl AttrEmitter for Vpnv4Unreach {
         buf.put_u8(u8::from(Safi::MplsVpn));
         // Prefix.
         for withdraw in self.withdraw.iter() {
-            // AddPath
-            if withdraw.nlri.id != 0 {
-                buf.put_u32(withdraw.nlri.id);
-            }
-            // Plen
-            let plen = withdraw.nlri.prefix.prefix_len() + 88;
-            buf.put_u8(plen);
-            // Label
-            buf.put(&withdraw.label.to_bytes()[..]);
-            // RD
-            buf.put_u16(withdraw.rd.typ as u16);
-            buf.put(&withdraw.rd.val[..]);
-            // Prefix
-            let plen = nlri_psize(withdraw.nlri.prefix.prefix_len());
-            buf.put(&withdraw.nlri.prefix.addr().octets()[0..plen]);
+            withdraw.nlri_emit(buf);
         }
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
@@ -21,6 +21,22 @@ pub struct Vpnv6Nlri {
     pub nlri: Ipv6Nlri,
 }
 
+impl Vpnv6Nlri {
+    /// Encode this NLRI as it appears in an MP_REACH / MP_UNREACH NLRI
+    /// list — the v6 twin of [`super::nlri_vpnv4::Vpnv4Nlri::nlri_emit`].
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.nlri.id != 0 {
+            buf.put_u32(self.nlri.id);
+        }
+        buf.put_u8(self.nlri.prefix.prefix_len() + 88);
+        buf.put(&self.label.to_bytes()[..]);
+        buf.put_u16(self.rd.typ as u16);
+        buf.put(&self.rd.val[..]);
+        let plen = nlri_psize(self.nlri.prefix.prefix_len());
+        buf.put(&self.nlri.prefix.addr().octets()[0..plen]);
+    }
+}
+
 // Identity excludes the MPLS `label` — see [`super::nlri_vpnv4::Vpnv4Nlri`].
 // A VPNv6 route is identified by (RD, prefix, path-id); the label is a
 // forwarding property, and the advertise-cache removal path
@@ -256,21 +272,7 @@ impl AttrEmitter for Vpnv6Unreach {
         buf.put_u8(u8::from(Safi::MplsVpn));
         // Prefix.
         for withdraw in self.withdraw.iter() {
-            // AddPath
-            if withdraw.nlri.id != 0 {
-                buf.put_u32(withdraw.nlri.id);
-            }
-            // Plen
-            let plen = withdraw.nlri.prefix.prefix_len() + 88;
-            buf.put_u8(plen);
-            // Label
-            buf.put(&withdraw.label.to_bytes()[..]);
-            // RD
-            buf.put_u16(withdraw.rd.typ as u16);
-            buf.put(&withdraw.rd.val[..]);
-            // Prefix
-            let plen = nlri_psize(withdraw.nlri.prefix.prefix_len());
-            buf.put(&withdraw.nlri.prefix.addr().octets()[0..plen]);
+            withdraw.nlri_emit(buf);
         }
     }
 }

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -1613,7 +1613,10 @@ mod withdraw_pagination_tests {
                 other => panic!("expected an EVPN MP_UNREACH, got {:?}", other),
             })
             .collect();
-        assert_eq!(seen, routes, "every route once, in queue order");
+        // Packets take routes from the end of the queue, so the wire order
+        // is the reverse of the queue order — every route exactly once.
+        let expected: Vec<EvpnRoute> = routes.into_iter().rev().collect();
+        assert_eq!(seen, expected, "every route once");
         // Every packet but the last is full: the next route would not fit.
         for p in &packets[..packets.len() - 1] {
             let body = p.header.length as usize;

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -472,6 +472,86 @@ impl UpdatePacket {
     }
 }
 
+impl UpdatePacket {
+    /// Emit one withdraw-only UPDATE carrying as many of the queued IPv4
+    /// unicast withdrawals (the legacy Withdrawn Routes field, RFC 4271
+    /// §4.3) as fit in `max_packet_size`; the rest stay queued for the
+    /// next call. `None` once the queue is empty. Path attributes and
+    /// reachable NLRI on `self` are not emitted — a withdraw-only UPDATE
+    /// carries neither — so a caller building one puts nothing else on it.
+    pub fn pop_ipv4_withdraw(&mut self) -> Option<BytesMut> {
+        if self.ipv4_withdraw.is_empty() {
+            return None;
+        }
+        let mut buf = BytesMut::with_capacity(self.max_packet_size);
+        let header: BytesMut = self.header.clone().into();
+        buf.put(&header[..]);
+
+        let withdraw_len_pos = buf.len();
+        buf.put_u16(0u16); // Placeholder.
+        // The 2-octet (zero) Total Path Attribute Length still follows the
+        // withdrawn routes, so keep room for it.
+        let budget = self.max_packet_size.saturating_sub(2);
+        let mut emitted = 0;
+        while let Some(ip) = self.ipv4_withdraw.pop() {
+            let path_id_len = if ip.id != 0 { 4 } else { 0 };
+            let nlri_len = path_id_len + 1 + nlri_psize(ip.prefix.prefix_len());
+            if buf.len() + nlri_len > budget {
+                self.ipv4_withdraw.push(ip);
+                break;
+            }
+            ip.nlri_emit(&mut buf);
+            emitted += 1;
+        }
+        // Not even one fits: only reachable with a budget under the 19-octet
+        // header plus one NLRI, which no negotiated size allows. Refuse
+        // rather than emit an empty UPDATE (that is the IPv4 end-of-RIB).
+        if emitted == 0 {
+            return None;
+        }
+        let withdraw_len = (buf.len() - withdraw_len_pos - 2) as u16;
+        buf[withdraw_len_pos..withdraw_len_pos + 2].copy_from_slice(&withdraw_len.to_be_bytes());
+        buf.put_u16(0u16); // No path attributes.
+
+        const LENGTH_POS: std::ops::Range<usize> = 16..18;
+        let length = buf.len() as u16;
+        buf[LENGTH_POS].copy_from_slice(&length.to_be_bytes());
+        Some(buf)
+    }
+
+    /// Emit one withdraw-only UPDATE carrying as many of the queued
+    /// MP_UNREACH_NLRI withdrawals as fit in `max_packet_size`; the rest
+    /// stay queued for the next call. `None` once nothing is queued —
+    /// including for the end-of-RIB variants, which have nothing to
+    /// paginate and go out through [`try_emit`](Self::try_emit). Path
+    /// attributes on `self` are not emitted: a withdraw-only UPDATE carries
+    /// only the MP_UNREACH_NLRI attribute (RFC 4760 §4).
+    pub fn pop_mp_withdraw(&mut self) -> Option<BytesMut> {
+        let mp_withdraw = self.mp_withdraw.as_mut()?;
+        if mp_withdraw.is_empty() {
+            return None;
+        }
+        let mut buf = BytesMut::with_capacity(self.max_packet_size);
+        let header: BytesMut = self.header.clone().into();
+        buf.put(&header[..]);
+        buf.put_u16(0u16); // No legacy IPv4 withdraw.
+
+        let attr_len_pos = buf.len();
+        buf.put_u16(0u16); // Placeholder.
+        let emitted = mp_withdraw.attr_emit_mut(&mut buf, self.max_packet_size);
+        if emitted == 0 {
+            return None;
+        }
+        let attr_len = (buf.len() - attr_len_pos - 2) as u16;
+        buf[attr_len_pos..attr_len_pos + 2].copy_from_slice(&attr_len.to_be_bytes());
+
+        const LENGTH_POS: std::ops::Range<usize> = 16..18;
+        let length = buf.len() as u16;
+        buf[LENGTH_POS].copy_from_slice(&length.to_be_bytes());
+        Some(buf)
+    }
+}
+
 /// Why an [`UpdatePacket`] could not be serialised.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum UpdateEmitError {
@@ -1224,5 +1304,363 @@ mod mp_reach_pagination_tests {
     fn evpn_returns_none_when_first_route_does_not_fit() {
         let mut update = evpn_group(1, 40);
         assert!(update.pop_evpn().is_none());
+    }
+}
+
+#[cfg(test)]
+mod withdraw_pagination_tests {
+    use super::*;
+    use crate::{
+        AfiSafi, As4Path, Direct, EvpnIpPrefix, EvpnMac, EvpnMulticast, EvpnRoute, Ipv6Nlri, Label,
+        RouteDistinguisher, Vpnv4Nlri, Vpnv6Nlri,
+    };
+    use ipnet::{Ipv4Net, Ipv6Net};
+    use std::collections::BTreeSet;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    fn rd() -> RouteDistinguisher {
+        RouteDistinguisher::from_str("65001:1").unwrap()
+    }
+
+    fn v4(i: u32, id: u32) -> Ipv4Nlri {
+        Ipv4Nlri {
+            id,
+            prefix: Ipv4Net::new(Ipv4Addr::from(0x0A00_0000u32 + i), 32).unwrap(),
+        }
+    }
+
+    fn vpnv4(i: u32) -> Vpnv4Nlri {
+        Vpnv4Nlri {
+            label: Label::default(),
+            rd: rd(),
+            nlri: Ipv4Nlri {
+                id: 0,
+                prefix: Ipv4Net::new(Ipv4Addr::from(0x0A00_0000u32 + (i << 8)), 24).unwrap(),
+            },
+        }
+    }
+
+    fn vpnv6(i: u32) -> Vpnv6Nlri {
+        Vpnv6Nlri {
+            label: Label::default(),
+            rd: rd(),
+            nlri: Ipv6Nlri {
+                id: 0,
+                prefix: Ipv6Net::new(
+                    Ipv6Addr::from(0x2001_0db8_0000_0000_0000_0000_0000_0000u128 + (i as u128)),
+                    128,
+                )
+                .unwrap(),
+            },
+        }
+    }
+
+    /// EVPN routes of three types so the NLRI wire sizes vary.
+    fn evpn(i: u32) -> EvpnRoute {
+        match i % 3 {
+            0 => EvpnRoute::Multicast(EvpnMulticast {
+                id: 0,
+                rd: rd(),
+                ether_tag: 0,
+                addr: IpAddr::V4(Ipv4Addr::from(0x0A00_0000u32 + i)),
+            }),
+            1 => EvpnRoute::Mac(EvpnMac {
+                id: 0,
+                rd: rd(),
+                esi: [0; 10],
+                ether_tag: 0,
+                mac: [0, 0x11, 0x22, (i >> 16) as u8, (i >> 8) as u8, i as u8],
+                vni: 100,
+            }),
+            _ => EvpnRoute::Prefix(EvpnIpPrefix {
+                id: 0,
+                rd: rd(),
+                esi: [0; 10],
+                ether_tag: 0,
+                prefix: ipnet::IpNet::V6(
+                    Ipv6Net::new(
+                        Ipv6Addr::from(0x2001_0db8_0000_0000_0000_0000_0000_0000u128 + i as u128),
+                        128,
+                    )
+                    .unwrap(),
+                ),
+                gw: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                label: 0,
+            }),
+        }
+    }
+
+    /// Pop packets until the emitter runs dry, checking that each one fits
+    /// `max`, declares its true length, and parses back as a withdraw-only
+    /// UPDATE; returns the parsed packets in emission order.
+    fn drain(
+        update: &mut UpdatePacket,
+        pop: fn(&mut UpdatePacket) -> Option<BytesMut>,
+        max: usize,
+        opt: Option<ParseOption>,
+    ) -> Vec<UpdatePacket> {
+        let mut parsed = vec![];
+        while let Some(bytes) = pop(update) {
+            assert!(
+                bytes.len() <= max,
+                "packet of {} octets exceeds the {} octet budget",
+                bytes.len(),
+                max
+            );
+            let declared = u16::from_be_bytes([bytes[16], bytes[17]]) as usize;
+            assert_eq!(declared, bytes.len(), "header Length matches the body");
+            let (rest, packet) = UpdatePacket::parse_packet(&bytes, true, opt.clone())
+                .expect("an emitted packet must parse back");
+            assert!(rest.is_empty(), "no trailing octets");
+            assert!(packet.ipv4_update.is_empty(), "withdraw-only: no NLRI");
+            assert!(packet.mp_update.is_none(), "withdraw-only: no MP_REACH");
+            parsed.push(packet);
+        }
+        parsed
+    }
+
+    fn add_path_opt(afi: Afi, safi: Safi) -> ParseOption {
+        let mut opt = ParseOption::default();
+        opt.add_path.insert(
+            AfiSafi { afi, safi },
+            Direct {
+                recv: true,
+                send: true,
+            },
+        );
+        opt
+    }
+
+    /// 3000 host routes are 15000 octets of withdrawn NLRI: four 4096-octet
+    /// UPDATEs, each full to within one NLRI, every route exactly once.
+    #[test]
+    fn ipv4_withdraw_fills_each_packet_to_the_budget() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.ipv4_withdraw = (0..3000).map(|i| v4(i, 0)).collect();
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_ipv4_withdraw,
+            BGP_PACKET_LEN,
+            None,
+        );
+        // 19 header + 2 + 2 leaves 4073 octets for 5-octet NLRIs: 814 per
+        // packet, so 3000 need four.
+        assert_eq!(packets.len(), 4);
+        for p in &packets[..3] {
+            assert_eq!(p.ipv4_withdraw.len(), 814);
+        }
+        let seen: BTreeSet<Ipv4Net> = packets
+            .iter()
+            .flat_map(|p| p.ipv4_withdraw.iter().map(|n| n.prefix))
+            .collect();
+        assert_eq!(seen.len(), 3000);
+        assert!(packets.iter().all(|p| p.bgp_attr.is_none()));
+        assert!(update.ipv4_withdraw.is_empty(), "queue drained");
+    }
+
+    /// Add-Path ids ride along (RFC 7911 §3) and are budgeted as 4 extra
+    /// octets per NLRI.
+    #[test]
+    fn ipv4_withdraw_carries_add_path_ids() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.ipv4_withdraw = (0..1000).map(|i| v4(i, i + 1)).collect();
+        let opt = add_path_opt(Afi::Ip, Safi::Unicast);
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_ipv4_withdraw,
+            BGP_PACKET_LEN,
+            Some(opt),
+        );
+        // 4073 / 9 = 452 per packet: three packets.
+        assert_eq!(packets.len(), 3);
+        let ids: BTreeSet<u32> = packets
+            .iter()
+            .flat_map(|p| p.ipv4_withdraw.iter().map(|n| n.id))
+            .collect();
+        assert_eq!(ids, (1..=1000).collect());
+    }
+
+    /// The extended-message budget (RFC 8654) packs the same 3000 routes
+    /// into one UPDATE.
+    #[test]
+    fn ipv4_withdraw_extended_message_takes_one_packet() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_EXTENDED_PACKET_LEN);
+        update.ipv4_withdraw = (0..3000).map(|i| v4(i, 0)).collect();
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_ipv4_withdraw,
+            BGP_EXTENDED_PACKET_LEN,
+            None,
+        );
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0].ipv4_withdraw.len(), 3000);
+    }
+
+    #[test]
+    fn ipv4_withdraw_empty_queue_pops_nothing() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        assert!(update.pop_ipv4_withdraw().is_none());
+    }
+
+    fn vpnv4_withdrawn(packets: &[UpdatePacket]) -> Vec<Ipv4Net> {
+        packets
+            .iter()
+            .flat_map(|p| -> Vec<Ipv4Net> {
+                match &p.mp_withdraw {
+                    Some(MpUnreachAttr::Vpnv4(w)) => w.iter().map(|n| n.nlri.prefix).collect(),
+                    other => panic!("expected a VPNv4 MP_UNREACH, got {:?}", other),
+                }
+            })
+            .collect()
+    }
+
+    /// 2000 VPNv4 /24 withdrawals are 15 octets each: 4066 octets of value
+    /// room after the fixed preamble fits 271 per packet, so eight packets.
+    #[test]
+    fn mp_withdraw_vpnv4_fills_each_packet_to_the_budget() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.mp_withdraw = Some(MpUnreachAttr::Vpnv4((0..2000).map(vpnv4).collect()));
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_mp_withdraw,
+            BGP_PACKET_LEN,
+            None,
+        );
+        assert_eq!(packets.len(), 8);
+        let counts: Vec<usize> = packets
+            .iter()
+            .map(|p| match &p.mp_withdraw {
+                Some(MpUnreachAttr::Vpnv4(w)) => w.len(),
+                _ => 0,
+            })
+            .collect();
+        assert!(counts[..7].iter().all(|&c| c == 271), "{counts:?}");
+        let seen: BTreeSet<Ipv4Net> = vpnv4_withdrawn(&packets).into_iter().collect();
+        assert_eq!(seen.len(), 2000);
+        assert!(
+            update
+                .mp_withdraw
+                .as_ref()
+                .is_some_and(MpUnreachAttr::is_empty),
+            "queue drained"
+        );
+    }
+
+    /// The VPNv6 and IPv6-unicast emitters share the generic paginator;
+    /// pin one packet of each family parsing back under the right AFI/SAFI.
+    #[test]
+    fn mp_withdraw_vpnv6_and_ipv6_round_trip() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.mp_withdraw = Some(MpUnreachAttr::Vpnv6((0..500).map(vpnv6).collect()));
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_mp_withdraw,
+            BGP_PACKET_LEN,
+            None,
+        );
+        // 28 octets each: 145 per packet, four packets.
+        assert_eq!(packets.len(), 4);
+        let n: usize = packets
+            .iter()
+            .map(|p| match &p.mp_withdraw {
+                Some(MpUnreachAttr::Vpnv6(w)) => w.len(),
+                other => panic!("expected a VPNv6 MP_UNREACH, got {:?}", other),
+            })
+            .sum();
+        assert_eq!(n, 500);
+
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.mp_withdraw = Some(MpUnreachAttr::Ipv6Nlri(
+            (0..500).map(|i| vpnv6(i).nlri).collect(),
+        ));
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_mp_withdraw,
+            BGP_PACKET_LEN,
+            None,
+        );
+        // 17 octets each: 239 per packet, three packets.
+        assert_eq!(packets.len(), 3);
+        let n: usize = packets
+            .iter()
+            .map(|p| match &p.mp_withdraw {
+                Some(MpUnreachAttr::Ipv6Nlri(w)) => w.len(),
+                other => panic!("expected an IPv6 MP_UNREACH, got {:?}", other),
+            })
+            .sum();
+        assert_eq!(n, 500);
+    }
+
+    /// EVPN NLRIs vary in size by route type; each is measured by encoding
+    /// it, so mixed types still fill packets without overflowing.
+    #[test]
+    fn mp_withdraw_evpn_mixed_route_types() {
+        let routes: Vec<EvpnRoute> = (0..1500).map(evpn).collect();
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.mp_withdraw = Some(MpUnreachAttr::Evpn(routes.clone()));
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_mp_withdraw,
+            BGP_PACKET_LEN,
+            None,
+        );
+        assert!(packets.len() > 1, "1500 EVPN routes cannot fit one packet");
+        let seen: Vec<EvpnRoute> = packets
+            .iter()
+            .flat_map(|p| match &p.mp_withdraw {
+                Some(MpUnreachAttr::Evpn(w)) => w.clone(),
+                other => panic!("expected an EVPN MP_UNREACH, got {:?}", other),
+            })
+            .collect();
+        assert_eq!(seen, routes, "every route once, in queue order");
+        // Every packet but the last is full: the next route would not fit.
+        for p in &packets[..packets.len() - 1] {
+            let body = p.header.length as usize;
+            assert!(
+                body > BGP_PACKET_LEN - 64,
+                "packet {body} octets is under-filled"
+            );
+        }
+    }
+
+    /// End-of-RIB markers are not withdrawals to paginate: the pop refuses
+    /// them (an empty MP_UNREACH would *be* an EoR) and `try_emit` still
+    /// encodes the marker.
+    #[test]
+    fn mp_withdraw_eor_is_left_to_try_emit() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.mp_withdraw = Some(MpUnreachAttr::Vpnv4Eor);
+        assert!(update.pop_mp_withdraw().is_none());
+        let bytes = update.try_emit().expect("EoR encodes");
+        let (_, parsed) = UpdatePacket::parse_packet(&bytes, true, None).unwrap();
+        assert!(matches!(parsed.mp_withdraw, Some(MpUnreachAttr::Vpnv4Eor)));
+    }
+
+    /// A withdraw-only UPDATE carries no path attributes besides
+    /// MP_UNREACH_NLRI, whatever the packet builder left on `bgp_attr`.
+    #[test]
+    fn mp_withdraw_drops_path_attributes() {
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.bgp_attr = Some(BgpAttr {
+            aspath: Some(As4Path::from_str("65001 65002").unwrap()),
+            ..Default::default()
+        });
+        update.mp_withdraw = Some(MpUnreachAttr::Vpnv4((0..3).map(vpnv4).collect()));
+        let packets = drain(
+            &mut update,
+            UpdatePacket::pop_mp_withdraw,
+            BGP_PACKET_LEN,
+            None,
+        );
+        assert_eq!(packets.len(), 1);
+        assert!(
+            packets[0]
+                .bgp_attr
+                .as_ref()
+                .is_none_or(|a| a.aspath.is_none()),
+            "AS_PATH must not ride on a withdraw-only UPDATE"
+        );
+        assert_eq!(vpnv4_withdrawn(&packets).len(), 3);
     }
 }

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -521,15 +521,33 @@ impl UpdatePacket {
 
     /// Emit one withdraw-only UPDATE carrying as many of the queued
     /// MP_UNREACH_NLRI withdrawals as fit in `max_packet_size`; the rest
-    /// stay queued for the next call. `None` once nothing is queued —
+    /// stay queued for the next call. `Ok(None)` once nothing is queued —
     /// including for the end-of-RIB variants, which have nothing to
     /// paginate and go out through [`try_emit`](Self::try_emit). Path
     /// attributes on `self` are not emitted: a withdraw-only UPDATE carries
     /// only the MP_UNREACH_NLRI attribute (RFC 4760 §4).
-    pub fn pop_mp_withdraw(&mut self) -> Option<BytesMut> {
-        let mp_withdraw = self.mp_withdraw.as_mut()?;
+    ///
+    /// Errors leave the queue untouched, so a caller looping on `Ok(Some)`
+    /// must stop on `Err` and account for what is still queued rather than
+    /// spin: [`UpdateEmitError::Unpaginatable`] for the Route-Target
+    /// families, which have no per-NLRI emitter, and
+    /// [`UpdateEmitError::WithdrawExceedsPacket`] when the next NLRI does not
+    /// fit even an otherwise empty UPDATE (a Flowspec NLRI can run to 4095
+    /// octets, more than a 4096-octet message can carry).
+    pub fn pop_mp_withdraw(&mut self) -> Result<Option<BytesMut>, UpdateEmitError> {
+        let Some(mp_withdraw) = self.mp_withdraw.as_mut() else {
+            return Ok(None);
+        };
         if mp_withdraw.is_empty() {
-            return None;
+            return Ok(None);
+        }
+        if matches!(
+            mp_withdraw,
+            MpUnreachAttr::Rtcv4(_) | MpUnreachAttr::Rtcv6(_)
+        ) {
+            return Err(UpdateEmitError::Unpaginatable {
+                family: "Route-Target membership",
+            });
         }
         let mut buf = BytesMut::with_capacity(self.max_packet_size);
         let header: BytesMut = self.header.clone().into();
@@ -540,7 +558,9 @@ impl UpdatePacket {
         buf.put_u16(0u16); // Placeholder.
         let emitted = mp_withdraw.attr_emit_mut(&mut buf, self.max_packet_size);
         if emitted == 0 {
-            return None;
+            return Err(UpdateEmitError::WithdrawExceedsPacket {
+                max_packet_size: self.max_packet_size,
+            });
         }
         let attr_len = (buf.len() - attr_len_pos - 2) as u16;
         buf[attr_len_pos..attr_len_pos + 2].copy_from_slice(&attr_len.to_be_bytes());
@@ -548,7 +568,7 @@ impl UpdatePacket {
         const LENGTH_POS: std::ops::Range<usize> = 16..18;
         let length = buf.len() as u16;
         buf[LENGTH_POS].copy_from_slice(&length.to_be_bytes());
-        Some(buf)
+        Ok(Some(buf))
     }
 }
 
@@ -567,6 +587,22 @@ pub enum UpdateEmitError {
         field: &'static str,
         /// The octet count that could not be encoded.
         len: usize,
+    },
+    /// [`UpdatePacket::pop_mp_withdraw`]: the next queued MP_UNREACH NLRI does
+    /// not fit even an otherwise empty UPDATE of the session's size, so no
+    /// packet can carry it. The queue is left as it was.
+    #[error("queued MP_UNREACH withdrawal does not fit an empty {max_packet_size}-octet UPDATE")]
+    WithdrawExceedsPacket {
+        /// The session's negotiated message size.
+        max_packet_size: usize,
+    },
+    /// [`UpdatePacket::pop_mp_withdraw`]: the family has no per-NLRI emitter
+    /// to paginate with; its withdrawals go out through
+    /// [`UpdatePacket::try_emit`]. The queue is left as it was.
+    #[error("MP_UNREACH withdrawals of {family} cannot be paginated")]
+    Unpaginatable {
+        /// The address family, for the log line.
+        family: &'static str,
     },
 }
 
@@ -772,6 +808,7 @@ mod tests {
                 assert_eq!(field, "message length");
                 assert!(len > u16::MAX as usize, "reported the real octet count");
             }
+            Err(other) => panic!("expected TooLong, got {other}"),
             Ok(buf) => panic!(
                 "oversized UPDATE must not encode (got {} octets)",
                 buf.len()
@@ -1391,6 +1428,12 @@ mod withdraw_pagination_tests {
         }
     }
 
+    /// `pop_mp_withdraw` for the `drain` helper: every family these tests
+    /// queue paginates, so an error is a test failure.
+    fn pop_mp(update: &mut UpdatePacket) -> Option<BytesMut> {
+        update.pop_mp_withdraw().expect("family paginates")
+    }
+
     /// Pop packets until the emitter runs dry, checking that each one fits
     /// `max`, declares its true length, and parses back as a withdraw-only
     /// UPDATE; returns the parsed packets in emission order.
@@ -1521,12 +1564,7 @@ mod withdraw_pagination_tests {
     fn mp_withdraw_vpnv4_fills_each_packet_to_the_budget() {
         let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
         update.mp_withdraw = Some(MpUnreachAttr::Vpnv4((0..2000).map(vpnv4).collect()));
-        let packets = drain(
-            &mut update,
-            UpdatePacket::pop_mp_withdraw,
-            BGP_PACKET_LEN,
-            None,
-        );
+        let packets = drain(&mut update, pop_mp, BGP_PACKET_LEN, None);
         assert_eq!(packets.len(), 8);
         let counts: Vec<usize> = packets
             .iter()
@@ -1553,12 +1591,7 @@ mod withdraw_pagination_tests {
     fn mp_withdraw_vpnv6_and_ipv6_round_trip() {
         let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
         update.mp_withdraw = Some(MpUnreachAttr::Vpnv6((0..500).map(vpnv6).collect()));
-        let packets = drain(
-            &mut update,
-            UpdatePacket::pop_mp_withdraw,
-            BGP_PACKET_LEN,
-            None,
-        );
+        let packets = drain(&mut update, pop_mp, BGP_PACKET_LEN, None);
         // 28 octets each: 145 per packet, four packets.
         assert_eq!(packets.len(), 4);
         let n: usize = packets
@@ -1574,12 +1607,7 @@ mod withdraw_pagination_tests {
         update.mp_withdraw = Some(MpUnreachAttr::Ipv6Nlri(
             (0..500).map(|i| vpnv6(i).nlri).collect(),
         ));
-        let packets = drain(
-            &mut update,
-            UpdatePacket::pop_mp_withdraw,
-            BGP_PACKET_LEN,
-            None,
-        );
+        let packets = drain(&mut update, pop_mp, BGP_PACKET_LEN, None);
         // 17 octets each: 239 per packet, three packets.
         assert_eq!(packets.len(), 3);
         let n: usize = packets
@@ -1599,12 +1627,7 @@ mod withdraw_pagination_tests {
         let routes: Vec<EvpnRoute> = (0..1500).map(evpn).collect();
         let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
         update.mp_withdraw = Some(MpUnreachAttr::Evpn(routes.clone()));
-        let packets = drain(
-            &mut update,
-            UpdatePacket::pop_mp_withdraw,
-            BGP_PACKET_LEN,
-            None,
-        );
+        let packets = drain(&mut update, pop_mp, BGP_PACKET_LEN, None);
         assert!(packets.len() > 1, "1500 EVPN routes cannot fit one packet");
         let seen: Vec<EvpnRoute> = packets
             .iter()
@@ -1634,7 +1657,12 @@ mod withdraw_pagination_tests {
     fn mp_withdraw_eor_is_left_to_try_emit() {
         let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
         update.mp_withdraw = Some(MpUnreachAttr::Vpnv4Eor);
-        assert!(update.pop_mp_withdraw().is_none());
+        assert!(
+            update
+                .pop_mp_withdraw()
+                .expect("EoR is not an error")
+                .is_none()
+        );
         let bytes = update.try_emit().expect("EoR encodes");
         let (_, parsed) = UpdatePacket::parse_packet(&bytes, true, None).unwrap();
         assert!(matches!(parsed.mp_withdraw, Some(MpUnreachAttr::Vpnv4Eor)));
@@ -1650,12 +1678,7 @@ mod withdraw_pagination_tests {
             ..Default::default()
         });
         update.mp_withdraw = Some(MpUnreachAttr::Vpnv4((0..3).map(vpnv4).collect()));
-        let packets = drain(
-            &mut update,
-            UpdatePacket::pop_mp_withdraw,
-            BGP_PACKET_LEN,
-            None,
-        );
+        let packets = drain(&mut update, pop_mp, BGP_PACKET_LEN, None);
         assert_eq!(packets.len(), 1);
         assert!(
             packets[0]
@@ -1665,5 +1688,43 @@ mod withdraw_pagination_tests {
             "AS_PATH must not ride on a withdraw-only UPDATE"
         );
         assert_eq!(vpnv4_withdrawn(&packets).len(), 3);
+    }
+
+    /// An NLRI that cannot fit an otherwise empty UPDATE of the session's
+    /// size is reported, not silently dropped, and the queue is left intact
+    /// for the caller to account for. A 30-octet budget cannot carry the
+    /// 27-octet preamble plus a 15-octet VPNv4 NLRI.
+    #[test]
+    fn mp_withdraw_reports_an_nlri_that_cannot_fit_the_packet() {
+        let mut update = UpdatePacket::with_max_packet_size(30);
+        update.mp_withdraw = Some(MpUnreachAttr::Vpnv4((0..3).map(vpnv4).collect()));
+        match update.pop_mp_withdraw() {
+            Err(UpdateEmitError::WithdrawExceedsPacket { max_packet_size }) => {
+                assert_eq!(max_packet_size, 30);
+            }
+            other => panic!("expected WithdrawExceedsPacket, got {other:?}"),
+        }
+        assert_eq!(
+            update.mp_withdraw.as_ref().map(MpUnreachAttr::len),
+            Some(3),
+            "the queue is left as it was"
+        );
+    }
+
+    /// Route-Target membership has no per-NLRI emitter: the pop refuses
+    /// rather than returning `None` with the withdrawals still queued.
+    #[test]
+    fn mp_withdraw_reports_route_target_as_unpaginatable() {
+        use crate::{ExtCommunityValue, Rtcv4};
+        let mut update = UpdatePacket::with_max_packet_size(BGP_PACKET_LEN);
+        update.mp_withdraw = Some(MpUnreachAttr::Rtcv4(vec![Rtcv4::new(
+            65001,
+            ExtCommunityValue::default(),
+        )]));
+        assert!(matches!(
+            update.pop_mp_withdraw(),
+            Err(UpdateEmitError::Unpaginatable { .. })
+        ));
+        assert_eq!(update.mp_withdraw.as_ref().map(MpUnreachAttr::len), Some(1));
     }
 }

--- a/crates/bgp-packet/tests/withdraw_pagination_scaling.rs
+++ b/crates/bgp-packet/tests/withdraw_pagination_scaling.rs
@@ -1,0 +1,44 @@
+//! Manual scaling harness for MP withdrawal pagination: prints how long
+//! `pop_mp_withdraw` takes to drain 100k / 200k / 400k queued VPNv6
+//! withdrawals. The timings are diagnostic (no machine-dependent
+//! assertion); the point is that they grow linearly — the emitter takes
+//! NLRIs from the end of the queue, and an earlier version that drained
+//! the front paid quadratically (43 / 130 / 447 ms in a debug build).
+//! Run with `cargo test -p bgp-packet --test withdraw_pagination_scaling -- --ignored --nocapture`.
+
+use bgp_packet::{Ipv6Nlri, MpUnreachAttr, UpdatePacket, Vpnv6Nlri};
+use ipnet::Ipv6Net;
+use std::net::Ipv6Addr;
+use std::time::Instant;
+
+#[test]
+#[ignore = "manual scaling harness; run with --ignored --nocapture"]
+fn withdraw_pagination_scaling() {
+    for count in [100_000, 200_000, 400_000] {
+        let mut update = UpdatePacket::with_max_packet_size(4096);
+        update.mp_withdraw = Some(MpUnreachAttr::Vpnv6(
+            (0..count)
+                .map(|i| Vpnv6Nlri {
+                    label: Default::default(),
+                    rd: Default::default(),
+                    nlri: Ipv6Nlri {
+                        id: 0,
+                        prefix: Ipv6Net::new(Ipv6Addr::from(i as u128), 128).unwrap(),
+                    },
+                })
+                .collect(),
+        ));
+        // Exclude route construction; measure only pagination and encoding.
+        let start = Instant::now();
+        let mut packets = 0;
+        while let Some(bytes) = update.pop_mp_withdraw() {
+            assert!(bytes.len() <= 4096);
+            packets += 1;
+        }
+        let elapsed = start.elapsed();
+        assert!(update.mp_withdraw.as_ref().unwrap().is_empty());
+        // A VPNv6 /128 consumes 28 octets; 145 fit after the preamble.
+        assert_eq!(packets, (count + 144) / 145);
+        println!("{count} routes, {packets} packets: {elapsed:?}");
+    }
+}

--- a/crates/bgp-packet/tests/withdraw_pagination_scaling.rs
+++ b/crates/bgp-packet/tests/withdraw_pagination_scaling.rs
@@ -31,7 +31,7 @@ fn withdraw_pagination_scaling() {
         // Exclude route construction; measure only pagination and encoding.
         let start = Instant::now();
         let mut packets = 0;
-        while let Some(bytes) = update.pop_mp_withdraw() {
+        while let Some(bytes) = update.pop_mp_withdraw().expect("VPNv6 paginates") {
             assert!(bytes.len() <= 4096);
             packets += 1;
         }

--- a/docs/design/bgp-code-review-findings.md
+++ b/docs/design/bgp-code-review-findings.md
@@ -383,7 +383,8 @@ value.) Fix: apply a sane default (e.g. 120 s, clamped) or add a real config lea
   and clone only when a bound policy will rewrite.
 - Unbatched per-prefix withdraw packets (`route.rs:5505`) — ~100× the packet count
   on a full-table withdraw sweep; batch withdrawn NLRIs per peer like the announce
-  path.
+  path. — FIXED 2026-09-06 (`Peer::pending_withdraw` + next-tick flush, see
+  `bgp-withdraw-packing.md`; 1000 IPv4 withdrawals → 2 UPDATEs at 4096 octets).
 - Legacy whole-table session-up dump inline on the main loop by default
   (`route.rs:13655`); the bounded-chunk cursor exists behind an unset env var.
 - `sync_ctx` rebuilt per-route in dumps (`route.rs:13058`); `mem::replace` wins in

--- a/docs/design/bgp-rib-sharding-plan.md
+++ b/docs/design/bgp-rib-sharding-plan.md
@@ -701,6 +701,10 @@ Invariants this preserves:
   skipping it if `adj_out` shows a newer announce re-acquired the prefix.
   Announce-before-withdraw ordering holds even though the two originated
   from different shard messages at different times.
+  *2026-09-06: the park moved from the group to the peer — withdraws now
+  queue in `Peer::pending_withdraw` for packing, the in-flight gate holds
+  the unicast drain, and `flush_done_ipv4` drains it with the same
+  `adj_out` check; see `bgp-withdraw-packing.md`.*
 - **Per-prefix order preserved.** Each prefix lives on exactly one shard,
   so its add→withdraw sequence traverses that shard's queue in order and
   reaches main in order; the deferred-withdraw machinery preserves it on

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -174,6 +174,20 @@ drain and exit (`GroupEgressTask::drain_and_exit`: close the channel,
 detach the handle) instead of aborting it with that delta unread; the run
 loop flushes once more on channel close for members still present.
 
+That settlement is asynchronous, and the reassignment attaches the peer
+to its new group at once, so the two engines' sends to the peer's writer
+were unordered: the old group's late withdraw of P could follow the new
+group's re-announcement of P (review finding). The handoff orders them.
+`detach` puts a oneshot in the `RemoveMember` it sends and returns the
+receiver; the old engine fires it after its flush. A reassigning caller
+(`reassign_all_update_groups`) passes the receiver to `attach`, which puts
+it in the `AddMember`, and the new engine's run loop awaits it before
+handling that delta — so it sends the member nothing until the old group
+has settled it. A dropped sender (the old task torn down) releases the
+wait. It cannot deadlock: the `RemoveMember` is enqueued before the
+`AddMember` that waits on it, so the earliest outstanding wait always has
+its release ahead of any wait in the releasing engine.
+
 ### What still sends immediately
 
 MUP, Flowspec, SR Policy, RTC and BGP-LS withdrawals keep their

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -41,6 +41,12 @@ rule for keeping the wire in step with the Adj-RIB-Out.
   #2370 established for MP_REACH.
 - End-of-RIB variants are refused by the pop (an empty MP_UNREACH *is* an
   EoR on the wire) and keep going through `try_emit`.
+- `pop_mp_withdraw` returns `Result<Option<_>, UpdateEmitError>`: a
+  family with no per-NLRI emitter (Route-Target membership) or an NLRI
+  that cannot fit even an empty UPDATE of the session's size (a Flowspec
+  NLRI can run to 4095 octets) is an error with the queue left intact, so
+  the drain logs how many withdrawals it is dropping instead of losing
+  them silently — a `while let Some` loop would simply have ended.
 
 ### Queue and drain (`zebra-rs/src/bgp/pending_withdraw.rs`)
 
@@ -127,6 +133,16 @@ momentarily empties packs partially, because the main task fans the burst
 across several executor turns, so the engine would wake mid-burst and emit
 a fraction each time. An idle single withdrawal still flushes one timer
 tick later, the same latency the main-task queue already accepts.
+
+The bias has a failure mode of its own: the timer branch is only polled
+when the channel is momentarily empty, so a producer that keeps it
+non-empty (a full-table re-advertise outpacing the engine) would hold
+every queued withdrawal until the stream ended, with the pending set
+growing to table size. Two bounds close that (review finding): each wake
+drains at most `DRAIN_BATCH` (1024) deltas, and after every drain
+`settle_flush` checks the deadline itself and flushes if it has passed. A
+queued withdrawal therefore waits at most one `WITHDRAW_FLUSH_DELAY` plus
+one batch, whether or not the channel ever goes idle.
 
 Advertises stay immediate (the engine records the Adj-RIB-Out row and sends
 during `handle`); withdrawals queue and flush at the end of the batch. The

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -109,6 +109,34 @@ twin never recorded one, so only dump-recorded rows existed and
 AddPath path. Any new withdraw site must remove its Adj-RIB-Out row
 before queueing.
 
+### Gate-on egress engines (`peer_egress.rs`, `group_egress.rs`)
+
+The per-peer (`ZEBRA_BGP_PEER_TASK`) and per-update-group
+(`ZEBRA_BGP_EGRESS_GROUP_TASK`) egress engines own the v4-unicast
+Adj-RIB-Out at gate-on, so the reduce fans IPv4 advertise/withdraw deltas
+to them and bypasses the main-task queue above. They pack their own
+IPv4 withdrawals. Each engine runs in a task driven by its delta channel:
+it handles a delta, drains everything else already queued (`try_recv`),
+and — when a withdrawal is now pending — arms a `WITHDRAW_FLUSH_DELAY`
+(1 ms) timer, the mirror of the main-task queue's `FlushWithdraw` marker.
+The select loop is `biased` toward the channel, so a burst still arriving
+(a peer-down `route_clean`, an RR sweep) keeps draining and only flushes
+once it settles — packing into as few `pop_ipv4_withdraw` UPDATEs as the
+message size allows. The delay matters: flushing the instant the channel
+momentarily empties packs partially, because the main task fans the burst
+across several executor turns, so the engine would wake mid-burst and emit
+a fraction each time. An idle single withdrawal still flushes one timer
+tick later, the same latency the main-task queue already accepts.
+
+Advertises stay immediate (the engine records the Adj-RIB-Out row and sends
+during `handle`); withdrawals queue and flush at the end of the batch. The
+reconcile rule carries over verbatim — a queued NLRI back in the engine's
+`adj_out` (re-advertised within the batch) is dropped at flush via the
+shared `pending_withdraw::adj_out_has`, so a withdraw never overtakes or
+outlives the announcement it races. The group engine keys its queue by the
+path's source peer so a mixed-source burst still honours split-horizon:
+each source's withdrawals fan to the members that are not that source.
+
 ### What still sends immediately
 
 MUP, Flowspec, SR Policy, RTC and BGP-LS withdrawals keep their
@@ -129,9 +157,20 @@ rustybgp switches to MP_UNREACH there.
   VPN withdraw; a down peer discards. `update_group` test: the in-flight
   gate holds a unicast withdraw (a VPN one on the same peer still goes) and
   `flush_done_ipv4` releases it.
+- `peer_egress` / `group_egress` unit tests: each engine packs a
+  1000-withdrawal batch into at most two UPDATEs (was one per route) and
+  drops a withdraw re-advertised within the batch; the group engine fans a
+  mixed-source batch per source so a member never loses a withdrawal it
+  should receive nor gets one it sourced. A paused-clock test drives the
+  `run` loop's deferred flush end to end — a burst delivered across many
+  channel wakes still coalesces into one UPDATE after the timer, and
+  nothing goes out before it.
 - BDD `@bgp_withdraw_packing` (`bdd/tests/scripts/bgp_withdraw_packing.py`):
   two scripted iBGP clients of a zebra-rs RR; the observer parses the raw
   TCP stream. Per family (IPv4, IPv6, VPNv4, VPNv6, EVPN) and per message
   size (4096 / 65535): 1000 withdrawals arrive within a computed UPDATE
   bound with no stale announcement overtaking one; announce+withdraw and
-  withdraw+announce sent back to back settle absent / present.
+  withdraw+announce sent back to back settle absent / present. The reflector
+  is then restarted under `ZEBRA_BGP_PEER_TASK` and `ZEBRA_BGP_EGRESS_GROUP_TASK`
+  and the check re-run, so the IPv4 packing and coherence hold in both
+  gate-on egress models, not only the default queue.

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -162,6 +162,18 @@ matching rows, minus the queue's own source, and dropped for everyone
 else. (Found in review: the first cut dropped it for all members, and the
 peer whose own path had just become best kept the stale route.)
 
+Deferral also opened a window at membership changes (review finding):
+before packing, a withdrawal was fanned the moment it arrived, so a member
+removed a moment later — an egress-policy change reassigns a live peer to
+another group without resetting the session — had already received it.
+Queued, it would have been fanned to the membership at flush time, after
+the member left, and the new group starts from the Loc-RIB, which no
+longer has the prefix. So `RemoveMember` flushes the queue before the
+member is removed, and when the group empties `detach` lets the task
+drain and exit (`GroupEgressTask::drain_and_exit`: close the channel,
+detach the handle) instead of aborting it with that delta unread; the run
+loop flushes once more on channel close for members still present.
+
 ### What still sends immediately
 
 MUP, Flowspec, SR Policy, RTC and BGP-LS withdrawals keep their

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -83,8 +83,11 @@ withdraw goes out. Two rules close it:
    dropped. So those two families stay queued while any job carrying the
    peer's announcements is out: `flush_ipv4/6` counts the job up on each
    member (`Peer::flush_jobs_v4/v6`), the `FlushDone` message carries the
-   member list, and `flush_done_ipv4/6` counts it off and drains the
-   released members after every job byte is on the writer — replacing the
+   member list as `(ident, Peer::instance)` — the instance is a creation
+   nonce, because a peer removed and re-created at the same address gets
+   its `PeerMap` slot back and an old job's late completion must not count
+   itself off the replacement — and `flush_done_ipv4/6` counts it off and
+   drains the released members after every job byte is on the writer — replacing the
    per-group `deferred_withdraw_*` parking that served the same race
    (sharding plan A.2). The count lives on the peer, not the group, and
    `flush_done` settles it whether or not the group still exists:

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -1,0 +1,120 @@
+# BGP withdraw packing: per-peer pending withdrawals
+
+Status: implemented (branch `bgp-withdraw-pack`, 2026-09-06).
+
+## Problem
+
+Every BGP withdraw left the router as its own one-NLRI UPDATE. The
+announce side has batched for a long time — the per-peer VPNv4 / VPNv6 /
+EVPN caches and the per-update-group IPv4 / IPv6 caches group NLRIs by
+attribute and paginate to the negotiated message size — but the withdraw
+side went straight from best-path to `Peer::send_update`. A peer going
+down, a route-reflector sweep, a soft-out that now denies a table: each
+produced thousands of 27-octet UPDATEs where a handful of 4096-octet ones
+would do (`docs/design/bgp-code-review-findings.md`, "~100× the packet
+count on a full-table withdraw sweep").
+
+## Model
+
+rustybgp's `PendingTx` (`daemon/src/peer_tx.rs`): per peer, a `reach` map
+and an `unreach` map keyed on route identity. `reach()` removes the key
+from `unreach` and vice versa, so a key is in at most one of the two; the
+drain sends the withdrawals first as one logical Unreach message that the
+codec splits to the wire size, then the reaches grouped by attribute.
+
+zebra-rs already had the reach half. This change adds the unreach half
+and, because zebra-rs's announce caches are not all per-peer, an explicit
+rule for keeping the wire in step with the Adj-RIB-Out.
+
+## Implementation
+
+### Codec (`crates/bgp-packet`)
+
+- `UpdatePacket::pop_ipv4_withdraw` — one withdraw-only UPDATE per call
+  from the legacy Withdrawn Routes field, as many NLRIs as fit
+  `max_packet_size`, the rest left queued.
+- `UpdatePacket::pop_mp_withdraw` — the MP_UNREACH_NLRI form, backed by
+  `MpUnreachAttr::attr_emit_mut`: one generic paginator for every list
+  family that measures each NLRI by encoding it (EVPN / Flowspec vary by
+  route type) and budgets the whole packet (header + withdrawn-length +
+  attribute-length + 4-octet attribute header + AFI/SAFI), the rule PR
+  #2370 established for MP_REACH.
+- End-of-RIB variants are refused by the pop (an empty MP_UNREACH *is* an
+  EoR on the wire) and keep going through `try_emit`.
+
+### Queue and drain (`zebra-rs/src/bgp/pending_withdraw.rs`)
+
+`Peer::pending_withdraw` holds one set per family — IPv4 / IPv6 unicast,
+VPNv4 / VPNv6, EVPN, IPv4 / IPv6 labeled-unicast — keyed on route
+identity, so a route withdrawn twice before the flush is sent once. Every
+withdraw site (`route_withdraw_ipv4/6/vpnv6/evpn`, the labeled-unicast
+branches of `route_advertise_labeled`) now queues instead of sending.
+
+Queueing arms one `Message::FlushWithdraw(ident)` per peer, a ~1 ms
+next-tick marker (`Timer::once_ms(1)`, the `adv-interval 0` shape). The
+marker lands on the instance channel *behind* the ingest already queued,
+so under a burst the drain runs after the whole backlog has been processed
+and packs everything it produced; when the router is idle a withdraw costs
+one extra tick. The drain builds one `UpdatePacket` per family and loops
+`pop_*` until dry.
+
+### Keeping the wire in step with the Adj-RIB-Out
+
+Queueing opens a window in which a route can be re-advertised before its
+withdraw goes out. Two rules close it:
+
+1. **The Adj-RIB-Out is the authority at drain time.** Every advertise
+   site records the route in `peer.adj_out` as it queues or sends, and
+   every withdraw site removes it before queueing. At drain, a queued NLRI
+   whose `(prefix, path-id)` is back in the Adj-RIB-Out has been superseded
+   by a newer announcement — pending in a cache or already sent — and is
+   dropped. `id == 0` (non-AddPath) matches any row for the prefix; a real
+   path-id must match exactly. The per-peer caches also cancel directly:
+   `send_vpnv4/6` and `send_evpn` remove the queued withdraw of the route
+   they queue (rustybgp's `reach()`), and the announce-side eviction on
+   withdraw (`cache_remove_*`) was already there. The Adj-RIB-Out check is
+   what makes the invariant hold for IPv4 / IPv6 unicast, whose
+   announcements ride a cache shared by the whole update-group.
+2. **An in-flight update-group flush gates the drain.** The IPv4 / IPv6
+   unicast flush job encodes and enqueues its announcements on a
+   blocking-pool thread. A withdraw enqueued from the main task while that
+   job runs could reach the writer *before* the job's announcement of the
+   same prefix and leave the peer holding a route the Adj-RIB-Out has
+   dropped. So those two families stay queued while the peer's group has
+   `flush_inflight_*` set, and `flush_done_ipv4/6` drains them after every
+   job byte is on the writer — replacing the per-group
+   `deferred_withdraw_*` parking that served the same race (sharding plan
+   A.2). `flush_done` walks every peer rather than the group's members: a
+   peer can change groups while parked, and the drain re-checks its
+   *current* group.
+
+`route_clean` (session leaves Established) drops the queue and the marker
+with the advertise caches; the flush is gated on Established so a marker
+that outlives its session cannot push anything onto a new one.
+
+### What still sends immediately
+
+MUP, Flowspec, SR Policy, RTC and BGP-LS withdrawals keep their
+one-per-UPDATE sends; the codec paginates them already, so moving them
+onto the queue is a per-site change when it matters. IPv4 withdrawals
+under an RFC 8950 (extended next-hop) session still use the legacy field;
+rustybgp switches to MP_UNREACH there.
+
+## Verification
+
+- `crates/bgp-packet` unit tests: pagination fills each packet to the
+  budget for IPv4 (legacy and Add-Path), VPNv4, VPNv6, IPv6 and mixed-type
+  EVPN; extended-message budget; EoR refusal; no path attributes on a
+  withdraw-only UPDATE.
+- `pending_withdraw` unit tests: one marker per burst; 3000 IPv4
+  withdrawals in four UPDATEs; Adj-RIB-Out reconciliation for non-AddPath
+  and AddPath ids and per-RD for VPN / EVPN; re-advertise cancels a queued
+  VPN withdraw; a down peer discards. `update_group` test: the in-flight
+  gate holds a unicast withdraw (a VPN one on the same peer still goes) and
+  `flush_done_ipv4` releases it.
+- BDD `@bgp_withdraw_packing` (`bdd/tests/scripts/bgp_withdraw_packing.py`):
+  two scripted iBGP clients of a zebra-rs RR; the observer parses the raw
+  TCP stream. Per family (IPv4, IPv6, VPNv4, VPNv6, EVPN) and per message
+  size (4096 / 65535): 1000 withdrawals arrive within a computed UPDATE
+  bound with no stale announcement overtaking one; announce+withdraw and
+  withdraw+announce sent back to back settle absent / present.

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -80,13 +80,17 @@ withdraw goes out. Two rules close it:
    blocking-pool thread. A withdraw enqueued from the main task while that
    job runs could reach the writer *before* the job's announcement of the
    same prefix and leave the peer holding a route the Adj-RIB-Out has
-   dropped. So those two families stay queued while the peer's group has
-   `flush_inflight_*` set, and `flush_done_ipv4/6` drains them after every
-   job byte is on the writer — replacing the per-group
-   `deferred_withdraw_*` parking that served the same race (sharding plan
-   A.2). `flush_done` walks every peer rather than the group's members: a
-   peer can change groups while parked, and the drain re-checks its
-   *current* group.
+   dropped. So those two families stay queued while any job carrying the
+   peer's announcements is out: `flush_ipv4/6` counts the job up on each
+   member (`Peer::flush_jobs_v4/v6`), the `FlushDone` message carries the
+   member list, and `flush_done_ipv4/6` counts it off and drains the
+   released members after every job byte is on the writer — replacing the
+   per-group `deferred_withdraw_*` parking that served the same race
+   (sharding plan A.2). The count lives on the peer, not the group, and
+   `flush_done` settles it whether or not the group still exists:
+   configuration can detach a group's last member (deleting the group) or
+   move a peer to another group while the job is out, and neither may
+   strand a parked withdrawal or release it early.
 
 `route_clean` (session leaves Established) drops the queue and the marker
 with the advertise caches; the flush is gated on Established so a marker

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -130,12 +130,21 @@ tick later, the same latency the main-task queue already accepts.
 
 Advertises stay immediate (the engine records the Adj-RIB-Out row and sends
 during `handle`); withdrawals queue and flush at the end of the batch. The
-reconcile rule carries over verbatim — a queued NLRI back in the engine's
-`adj_out` (re-advertised within the batch) is dropped at flush via the
-shared `pending_withdraw::adj_out_has`, so a withdraw never overtakes or
-outlives the announcement it races. The group engine keys its queue by the
-path's source peer so a mixed-source burst still honours split-horizon:
-each source's withdrawals fan to the members that are not that source.
+reconcile rule carries over — a queued NLRI back in the engine's `adj_out`
+(re-advertised within the batch) is dropped at flush, so a withdraw never
+overtakes or outlives the announcement it races. For the per-peer engine
+that is the shared `pending_withdraw::adj_out_has` check verbatim. The
+group engine keys its queue by the path's source peer so a mixed-source
+burst still honours split-horizon: each source's withdrawals fan to the
+members that are not that source. Its Adj-RIB-Out is shared by the whole
+group with split-horizon applied at fan time, which changes what "row back
+in `adj_out`" means: the member that *sourced* the superseding row was
+excluded from that row's fan and still holds the copy the queued withdraw
+is for (it was a non-source of the original announcement). So a superseded
+withdraw is not simply dropped — it is sent to exactly the sources of the
+matching rows, minus the queue's own source, and dropped for everyone
+else. (Found in review: the first cut dropped it for all members, and the
+peer whose own path had just become best kept the stale route.)
 
 ### What still sends immediately
 

--- a/docs/design/bgp-withdraw-packing.md
+++ b/docs/design/bgp-withdraw-packing.md
@@ -92,6 +92,16 @@ withdraw goes out. Two rules close it:
 with the advertise caches; the flush is gated on Established so a marker
 that outlives its session cannot push anything onto a new one.
 
+Rule 1 makes the Adj-RIB-Out load-bearing in a way it was not before: a
+withdraw site that forgets to remove its row now silently cancels its own
+withdraw instead of merely leaving a phantom row for soft-out. The first
+full-suite run caught exactly one such site — the VPNv6 AddPath withdraw
+(`route_withdraw_vpnv6_addpath`) never removed the row, and its advertise
+twin never recorded one, so only dump-recorded rows existed and
+`bgp_shard_addpath_vpnv6` kept a withdrawn path. Both now mirror the VPNv4
+AddPath path. Any new withdraw site must remove its Adj-RIB-Out row
+before queueing.
+
 ### What still sends immediately
 
 MUP, Flowspec, SR Policy, RTC and BGP-LS withdrawals keep their

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -209,6 +209,13 @@ default = []
 # Compile the embedded Lua scripting engine (src/script).
 lua = ["dep:mlua"]
 
+[dev-dependencies]
+# `test-util` (paused clock: `start_paused`, `tokio::time::advance`) is a
+# test-only feature — it drives the deferred withdraw-flush timers in the
+# egress-engine coalescing tests deterministically. Dev-dependency features
+# do not reach a normal `cargo build`, so the release binary is unaffected.
+tokio = { workspace = true, features = ["test-util"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { git = "https://github.com/zebra-rs/rtnetlink", rev = "2d7b1830e9bd9a049a757f0a79ccd16216450bf2" }
 #rtnetlink = { path = "../../rtnetlink" }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -196,13 +196,17 @@ fn reassign_all_update_groups(bgp: &mut Bgp) {
         .map(|(_, peer)| peer.ident)
         .collect();
     for ident in idents {
-        super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, ident);
+        // The handoff orders the two groups' egress tasks on the peer's
+        // writer: the new group sends nothing until the old one has
+        // settled what it owed the peer.
+        let handoff = super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, ident);
         super::update_group::attach(
             &mut bgp.update_groups,
             &mut bgp.peers,
             ident,
             router_id,
             bgp.as_sets_withdraw,
+            handoff,
         );
     }
 }

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -121,16 +121,16 @@ pub enum GroupEgressDeltaV4 {
 }
 
 /// Handle main keeps on each [`UpdateGroup`](super::update_group::UpdateGroup)
-/// for its egress task. Dropping it — when the group empties in `detach`, or
-/// when the whole map is torn down — aborts the task (abort-on-drop) and
-/// closes the channel.
+/// for its egress task. Dropping it — when the whole map is torn down —
+/// aborts the task (abort-on-drop) and closes the channel. When the group
+/// empties in `detach`, [`drain_and_exit`](Self::drain_and_exit) is used
+/// instead so the engine settles the withdrawals its departing members are
+/// owed before it goes.
 #[derive(Debug)]
 pub struct GroupEgressTask {
     /// `attach` / `detach` (and, later, the reduce) push deltas here.
     delta_tx: UnboundedSender<GroupEgressDeltaV4>,
-    // Held only for its abort-on-drop teardown; the task is driven entirely by
-    // the channel, so the handle is never read after spawn.
-    #[allow(dead_code)]
+    /// Abort-on-drop handle; the task is driven entirely by the channel.
     task: Task<()>,
 }
 
@@ -171,6 +171,20 @@ impl GroupEgressTask {
     /// gone (the group is tearing down), which is harmless here.
     pub fn send(&self, delta: GroupEgressDeltaV4) {
         let _ = self.delta_tx.send(delta);
+    }
+
+    /// Tear the task down gracefully: close the delta channel and let the
+    /// engine drain what is already queued — the `RemoveMember` deltas
+    /// `detach` just sent, whose handling settles the withdrawals the
+    /// departing members are owed — and then exit on its own. Used when the
+    /// group empties. A plain drop would abort the engine with those deltas
+    /// unread and its queued withdrawals unsent; before packing deferred
+    /// them, a withdrawal was fanned the moment it arrived, so a member
+    /// removed a moment later had already received it.
+    pub fn drain_and_exit(self) {
+        let GroupEgressTask { delta_tx, task } = self;
+        drop(delta_tx);
+        task.detach();
     }
 
     /// Request the group's adj-out over a oneshot (for `show advertised-routes`
@@ -237,14 +251,18 @@ impl Engine {
     /// flush; each wake drains at most `DRAIN_BATCH` deltas and then
     /// [`settle_flush`](Self::settle_flush) checks the deadline itself, so a
     /// sustained stream cannot starve the flush. Exits when the channel
-    /// closes (the group emptied); any queued withdrawal is dropped with it.
+    /// closes (the group emptied, see `GroupEgressTask::drain_and_exit`),
+    /// flushing whatever is still queued to the members still present.
     async fn run(&mut self, mut rx: mpsc::UnboundedReceiver<GroupEgressDeltaV4>) {
         let mut flush_at: Option<Instant> = None;
         loop {
             tokio::select! {
                 biased;
                 maybe = rx.recv() => {
-                    let Some(delta) = maybe else { break };
+                    let Some(delta) = maybe else {
+                        self.flush_withdraws();
+                        break;
+                    };
                     self.handle(delta);
                     for _ in 1..DRAIN_BATCH {
                         let Ok(delta) = rx.try_recv() else { break };
@@ -292,6 +310,13 @@ impl Engine {
                 self.members.insert(ident, *ctx);
             }
             GroupEgressDeltaV4::RemoveMember { ident } => {
+                // Settle the queue while the member can still be fanned to:
+                // a withdrawal queued before this delta is owed to it (it
+                // held the route), and once it is gone nothing else will
+                // send it — the group it moves to starts from the Loc-RIB,
+                // which no longer has the prefix. Before packing deferred
+                // withdrawals this was implicit (fanned on arrival).
+                self.flush_withdraws();
                 self.members.remove(&ident);
             }
             GroupEgressDeltaV4::Advertise { prefix, rib } => self.advertise(prefix, rib),
@@ -895,6 +920,99 @@ mod tests {
         let frames: Vec<BytesMut> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert_eq!(frames.len(), 1, "both withdrawals in one UPDATE");
         assert!(engine.pending_withdraw.is_empty());
+    }
+
+    /// A withdrawal queued before a member leaves is owed to that member:
+    /// `RemoveMember` flushes the queue while it can still be fanned to.
+    /// (Review finding: flushing against the membership at flush time let a
+    /// peer reassigned by an egress-policy change keep the route; before
+    /// packing deferred withdrawals it received them on arrival.)
+    #[test]
+    fn remove_member_settles_the_withdrawals_it_is_owed() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        let p: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(99, "192.0.2.9"),
+        });
+        let _ = rx1.try_recv();
+        let _ = rx2.try_recv();
+
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p,
+            id: 0,
+            source_ident: 99,
+        });
+        assert!(rx2.try_recv().is_err(), "queued, not yet flushed");
+        engine.handle(GroupEgressDeltaV4::RemoveMember { ident: 2 });
+
+        let to_2: Vec<BytesMut> = std::iter::from_fn(|| rx2.try_recv().ok()).collect();
+        assert_eq!(to_2.len(), 1, "the departing member gets the withdraw");
+        assert!(is_withdraw(&to_2[0]));
+        let to_1: Vec<BytesMut> = std::iter::from_fn(|| rx1.try_recv().ok()).collect();
+        assert_eq!(
+            to_1.len(),
+            1,
+            "the staying member gets it in the same flush"
+        );
+        assert!(is_withdraw(&to_1[0]));
+        assert!(engine.pending_withdraw.is_empty());
+        assert!(!engine.members.contains_key(&2));
+    }
+
+    /// The group emptied: `detach` sends `RemoveMember` for the last member
+    /// and then closes the channel (`drain_and_exit`). The run loop must
+    /// process the removal — settling the withdrawal the member is owed —
+    /// and exit on its own, rather than be aborted with the delta unread.
+    #[tokio::test(start_paused = true)]
+    async fn closing_the_channel_drains_owed_withdrawals_before_exit() {
+        let (pkt_tx, mut pkt_rx) = mpsc::unbounded_channel();
+        let mut member_ctx = SyncCtx::for_test();
+        member_ctx.packet_tx = Some(pkt_tx);
+        let (delta_tx, delta_rx) = mpsc::unbounded_channel();
+        let mut engine = Engine::default();
+        let task = tokio::spawn(async move { engine.run(delta_rx).await });
+
+        let p: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        delta_tx
+            .send(GroupEgressDeltaV4::AddMember {
+                ident: 1,
+                ctx: Box::new(member_ctx),
+                add_path: false,
+            })
+            .unwrap();
+        delta_tx
+            .send(GroupEgressDeltaV4::Advertise {
+                prefix: p,
+                rib: rib(99, "192.0.2.9"),
+            })
+            .unwrap();
+        tokio::task::yield_now().await;
+        let _ = std::iter::from_fn(|| pkt_rx.try_recv().ok()).count();
+
+        // Withdraw, then the member leaves and the group empties: the
+        // channel closes with both deltas queued behind the flush delay.
+        delta_tx
+            .send(GroupEgressDeltaV4::Withdraw {
+                prefix: p,
+                id: 0,
+                source_ident: 99,
+            })
+            .unwrap();
+        delta_tx
+            .send(GroupEgressDeltaV4::RemoveMember { ident: 1 })
+            .unwrap();
+        drop(delta_tx);
+
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("the engine exits once the channel closes")
+            .expect("the engine task does not panic");
+        let frames: Vec<BytesMut> = std::iter::from_fn(|| pkt_rx.try_recv().ok()).collect();
+        assert_eq!(frames.len(), 1, "the departing member gets the withdraw");
+        assert!(is_withdraw(&frames[0]));
     }
 
     #[tokio::test(start_paused = true)]

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -214,7 +214,9 @@ struct Engine {
     /// [`flush_withdraws`](Self::flush_withdraws) and fanned to the members
     /// that are not that source. Grouping by source keeps a mixed-source
     /// burst correct — a member that sourced one withdrawn path still
-    /// receives the withdrawals it did not source.
+    /// receives the withdrawals it did not source. A withdrawal superseded
+    /// by a re-advertise within the batch is still owed to the member that
+    /// sourced the superseding path (see `flush_withdraws`).
     pending_withdraw: BTreeMap<usize, HashSet<Ipv4Nlri>>,
 }
 
@@ -382,10 +384,20 @@ impl Engine {
     /// Drain the batch's queued IPv4 withdrawals. Each source peer's set is
     /// packed into as few UPDATEs as the negotiated message size allows and
     /// fanned to every member except that source (split-horizon — the source
-    /// never received the advertisement). A queued NLRI whose `(prefix, id)`
-    /// is back in `adj_out` was re-advertised within the batch (`fan` already
-    /// put the announcement on the wire), so it is dropped: sending it would
-    /// tear down a route the members now hold.
+    /// never received the advertisement).
+    ///
+    /// A queued NLRI whose `(prefix, id)` is back in `adj_out` was
+    /// re-advertised within the batch: `fan` already put the announcement on
+    /// the wire, so the withdraw must not follow it to the members that hold
+    /// the replacement. But this Adj-RIB-Out is shared by the whole group with
+    /// split-horizon applied at fan time, so "row present" does not mean
+    /// *every* member holds the replacement: the member that **sourced** the
+    /// superseding row was excluded from its fan and still holds the copy the
+    /// queued withdraw is for (it received the original announcement, being a
+    /// non-source of that one). Such a withdraw is sent to exactly those
+    /// members — the sources of the matching rows, minus this queue's own
+    /// source — and dropped for everyone else. (The per-peer engines need no
+    /// such split: their Adj-RIB-Out is one member's.)
     fn flush_withdraws(&mut self) {
         if self.pending_withdraw.is_empty() {
             return;
@@ -398,17 +410,49 @@ impl Engine {
             .unwrap_or(4096);
         let pending = std::mem::take(&mut self.pending_withdraw);
         for (source_ident, queued) in pending {
-            let withdraws: Vec<Ipv4Nlri> = queued
-                .into_iter()
-                .filter(|n| !super::pending_withdraw::adj_out_has(&self.adj_out, &n.prefix, n.id))
-                .collect();
-            if withdraws.is_empty() {
-                continue;
+            // Not superseded: fan to every member but the source.
+            let mut fanned: Vec<Ipv4Nlri> = Vec::new();
+            // Superseded: owed only to the members that sourced the
+            // superseding row(s), keyed by that member.
+            let mut owed: BTreeMap<usize, HashSet<Ipv4Nlri>> = BTreeMap::new();
+            for nlri in queued {
+                let superseders: Vec<usize> = self
+                    .adj_out
+                    .0
+                    .get(&nlri.prefix)
+                    .map(|rows| {
+                        rows.iter()
+                            .filter(|r| nlri.id == 0 || r.local_id == nlri.id)
+                            .map(|r| r.ident)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if superseders.is_empty() {
+                    fanned.push(nlri);
+                    continue;
+                }
+                for ident in superseders {
+                    if ident != source_ident && self.members.contains_key(&ident) {
+                        owed.entry(ident).or_default().insert(nlri.clone());
+                    }
+                }
             }
-            let mut update = UpdatePacket::with_max_packet_size(max);
-            update.ipv4_withdraw = withdraws;
-            while let Some(bytes) = update.pop_ipv4_withdraw() {
-                self.fan(&[bytes], source_ident);
+            if !fanned.is_empty() {
+                let mut update = UpdatePacket::with_max_packet_size(max);
+                update.ipv4_withdraw = fanned;
+                while let Some(bytes) = update.pop_ipv4_withdraw() {
+                    self.fan(&[bytes], source_ident);
+                }
+            }
+            for (ident, withdraws) in owed {
+                let Some(ctx) = self.members.get(&ident) else {
+                    continue;
+                };
+                let mut update = UpdatePacket::with_max_packet_size(ctx.max_packet_size());
+                update.ipv4_withdraw = withdraws.into_iter().collect();
+                while let Some(bytes) = update.pop_ipv4_withdraw() {
+                    ctx.send_packet(bytes);
+                }
             }
         }
     }
@@ -651,6 +695,92 @@ mod tests {
             !carries(&to_2, p2_nlri),
             "member 2 does not receive its own sourced p2"
         );
+    }
+
+    /// Whether an UPDATE frame carries withdrawn routes (non-zero Withdrawn
+    /// Routes Length at octets 19..21).
+    fn is_withdraw(frame: &BytesMut) -> bool {
+        u16::from_be_bytes([frame[19], frame[20]]) > 0
+    }
+
+    /// P is advertised from an external source, so both members hold it.
+    /// Then, in one batch, the selection empties (Withdraw P) and member 2
+    /// announces P itself (Advertise P sourced by member 2). Member 1 gets
+    /// the new announcement — an implicit replace, its queued withdraw is
+    /// dropped. Member 2 is split-horizoned out of that announcement and
+    /// still holds the stale copy, so the withdraw must reach it. (Review
+    /// finding: the group Adj-RIB-Out is shared, so "row back in adj_out"
+    /// alone dropped the withdraw for member 2 as well.)
+    #[test]
+    fn superseded_withdraw_still_reaches_the_member_that_sourced_the_replacement() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        let p: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(99, "192.0.2.9"),
+        });
+        assert!(rx1.try_recv().is_ok(), "member 1 holds P");
+        assert!(rx2.try_recv().is_ok(), "member 2 holds P");
+
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p,
+            id: 0,
+            source_ident: 99,
+        });
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(2, "192.0.2.2"),
+        });
+        engine.flush_withdraws();
+
+        let to_1: Vec<BytesMut> = std::iter::from_fn(|| rx1.try_recv().ok()).collect();
+        let to_2: Vec<BytesMut> = std::iter::from_fn(|| rx2.try_recv().ok()).collect();
+        assert_eq!(to_1.len(), 1, "member 1 gets exactly the replacement");
+        assert!(!is_withdraw(&to_1[0]), "member 1's frame is an announce");
+        assert_eq!(to_2.len(), 1, "member 2 gets exactly one frame");
+        assert!(is_withdraw(&to_2[0]), "member 2's frame is the withdraw");
+        let p_nlri = [24u8, 10, 10, 10];
+        assert!(
+            to_2[0].windows(4).any(|w| w == p_nlri),
+            "member 2's withdraw carries P"
+        );
+    }
+
+    /// The pure re-advertise case: P withdrawn and re-advertised from the
+    /// same external source within one batch. Every member got the
+    /// replacement, so nobody is owed the withdraw and none goes out.
+    #[test]
+    fn withdraw_re_advertised_from_the_same_source_is_dropped_for_everyone() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        let p: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(99, "192.0.2.9"),
+        });
+        let _ = rx1.try_recv();
+        let _ = rx2.try_recv();
+
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p,
+            id: 0,
+            source_ident: 99,
+        });
+        // A different next-hop so the re-advertise is not deduped away.
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(99, "192.0.2.8"),
+        });
+        engine.flush_withdraws();
+
+        for (who, rx) in [("member 1", &mut rx1), ("member 2", &mut rx2)] {
+            let frames: Vec<BytesMut> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+            assert_eq!(frames.len(), 1, "{who} gets exactly the replacement");
+            assert!(!is_withdraw(&frames[0]), "{who} gets no withdraw");
+        }
     }
 
     #[tokio::test(start_paused = true)]

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -26,6 +26,7 @@ use bgp_packet::{Ipv4Nlri, UpdatePacket};
 use bytes::BytesMut;
 use ipnet::Ipv4Net;
 use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::sync::oneshot;
 use tokio::time::{Duration, Instant, sleep_until};
 
 /// How long a queued withdrawal waits for the rest of its burst before the
@@ -74,25 +75,31 @@ pub enum GroupEgressDeltaV4 {
         ident: usize,
         ctx: Box<SyncCtx>,
         add_path: bool,
+        /// Handoff from the group the member is leaving (`detach` → `attach`
+        /// on a reassignment): resolves once that group's engine has settled
+        /// — put on the wire — everything it owed the member. The engine
+        /// must not send this member anything before it resolves, or a
+        /// withdraw the old group still owes could follow this group's
+        /// re-announcement of the same prefix and tear it down. `None` when
+        /// the member comes from no group (session up). `run` awaits it
+        /// before handling the delta.
+        after: Option<oneshot::Receiver<()>>,
     },
     RemoveMember {
         ident: usize,
+        /// Fired after the engine has flushed its queue with the member
+        /// still present — the other half of `AddMember::after`.
+        handoff: Option<oneshot::Sender<()>>,
     },
     /// The new best path for `prefix`. The split-horizon source is the path's
     /// own origin (`rib.ident`), derived in the engine — no separate field.
-    Advertise {
-        prefix: Ipv4Net,
-        rib: BgpRib,
-    },
+    Advertise { prefix: Ipv4Net, rib: BgpRib },
     /// A route the session-up sync (`route_sync_ipv4`) already sent to a NEW
     /// member directly — record it in the group `adj_out` *without* re-sending,
     /// so the group's later withdraws reach that member (a late peer that is
     /// the first of a new group would otherwise be invisible to the group).
     /// Mirrors the PET's DumpV4 ③ `RecordAdjOut`.
-    RecordAdjOut {
-        prefix: Ipv4Net,
-        rib: BgpRib,
-    },
+    RecordAdjOut { prefix: Ipv4Net, rib: BgpRib },
     /// `prefix` is gone; `source_ident` is the withdrawing peer (excluded from
     /// the fan — it never received the advertisement under split-horizon).
     Withdraw {
@@ -263,10 +270,10 @@ impl Engine {
                         self.flush_withdraws();
                         break;
                     };
-                    self.handle(delta);
+                    self.admit(delta).await;
                     for _ in 1..DRAIN_BATCH {
                         let Ok(delta) = rx.try_recv() else { break };
-                        self.handle(delta);
+                        self.admit(delta).await;
                     }
                     self.settle_flush(&mut flush_at);
                 }
@@ -276,6 +283,38 @@ impl Engine {
                 }
             }
         }
+    }
+
+    /// Handle a delta from the channel, honouring a joining member's
+    /// handoff first: the group it is leaving must have put everything it
+    /// owed the member on the wire before this engine sends it anything,
+    /// or an old-group withdraw of P could land after this group's
+    /// re-announcement of P and tear it down. The wait is bounded by the
+    /// old engine reaching its `RemoveMember` (already queued when the
+    /// handoff was created); a dropped sender (that engine torn down)
+    /// releases the wait too. Ordering cannot deadlock: `detach` enqueues
+    /// the `RemoveMember` before `attach` enqueues the `AddMember` that
+    /// waits on it, so the earliest-enqueued outstanding wait always has
+    /// its releasing delta ahead of any wait in the releasing engine.
+    async fn admit(&mut self, delta: GroupEgressDeltaV4) {
+        let delta = match delta {
+            GroupEgressDeltaV4::AddMember {
+                ident,
+                ctx,
+                add_path,
+                after: Some(after),
+            } => {
+                let _ = after.await;
+                GroupEgressDeltaV4::AddMember {
+                    ident,
+                    ctx,
+                    add_path,
+                    after: None,
+                }
+            }
+            other => other,
+        };
+        self.handle(delta);
     }
 
     /// After a channel drain: arm the deferred flush when a withdrawal first
@@ -299,25 +338,33 @@ impl Engine {
         }
     }
 
+    /// Handle one delta from the run loop. An `AddMember` carrying a
+    /// handoff has already had it awaited by [`admit`](Self::admit); a
+    /// caller reaching `handle` directly (tests) gets no barrier.
     fn handle(&mut self, delta: GroupEgressDeltaV4) {
         match delta {
             GroupEgressDeltaV4::AddMember {
                 ident,
                 ctx,
                 add_path,
+                after: _,
             } => {
                 self.add_path = add_path;
                 self.members.insert(ident, *ctx);
             }
-            GroupEgressDeltaV4::RemoveMember { ident } => {
+            GroupEgressDeltaV4::RemoveMember { ident, handoff } => {
                 // Settle the queue while the member can still be fanned to:
                 // a withdrawal queued before this delta is owed to it (it
                 // held the route), and once it is gone nothing else will
                 // send it — the group it moves to starts from the Loc-RIB,
                 // which no longer has the prefix. Before packing deferred
-                // withdrawals this was implicit (fanned on arrival).
+                // withdrawals this was implicit (fanned on arrival). Then
+                // release the group the member is moving to.
                 self.flush_withdraws();
                 self.members.remove(&ident);
+                if let Some(handoff) = handoff {
+                    let _ = handoff.send(());
+                }
             }
             GroupEgressDeltaV4::Advertise { prefix, rib } => self.advertise(prefix, rib),
             GroupEgressDeltaV4::RecordAdjOut { prefix, rib } => self.record_adj_out(prefix, rib),
@@ -562,6 +609,7 @@ mod tests {
             ident,
             ctx: Box::new(ctx),
             add_path: false,
+            after: None,
         });
         rx
     }
@@ -631,7 +679,10 @@ mod tests {
     fn removed_member_is_dropped_from_the_fan() {
         let mut engine = Engine::default();
         let mut rx1 = member(&mut engine, 1);
-        engine.handle(GroupEgressDeltaV4::RemoveMember { ident: 1 });
+        engine.handle(GroupEgressDeltaV4::RemoveMember {
+            ident: 1,
+            handoff: None,
+        });
         advertise(&mut engine, "10.10.10.0/24", 99);
         assert!(rx1.try_recv().is_err(), "removed member receives nothing");
     }
@@ -946,7 +997,10 @@ mod tests {
             source_ident: 99,
         });
         assert!(rx2.try_recv().is_err(), "queued, not yet flushed");
-        engine.handle(GroupEgressDeltaV4::RemoveMember { ident: 2 });
+        engine.handle(GroupEgressDeltaV4::RemoveMember {
+            ident: 2,
+            handoff: None,
+        });
 
         let to_2: Vec<BytesMut> = std::iter::from_fn(|| rx2.try_recv().ok()).collect();
         assert_eq!(to_2.len(), 1, "the departing member gets the withdraw");
@@ -981,6 +1035,7 @@ mod tests {
                 ident: 1,
                 ctx: Box::new(member_ctx),
                 add_path: false,
+                after: None,
             })
             .unwrap();
         delta_tx
@@ -1002,7 +1057,10 @@ mod tests {
             })
             .unwrap();
         delta_tx
-            .send(GroupEgressDeltaV4::RemoveMember { ident: 1 })
+            .send(GroupEgressDeltaV4::RemoveMember {
+                ident: 1,
+                handoff: None,
+            })
             .unwrap();
         drop(delta_tx);
 
@@ -1013,6 +1071,148 @@ mod tests {
         let frames: Vec<BytesMut> = std::iter::from_fn(|| pkt_rx.try_recv().ok()).collect();
         assert_eq!(frames.len(), 1, "the departing member gets the withdraw");
         assert!(is_withdraw(&frames[0]));
+    }
+
+    /// The reviewer's two-engine ordering: the old group still owes the
+    /// member a withdraw of P (queued, deferred) when the member is
+    /// reassigned and the new group announces P. Without a barrier the new
+    /// group's announce could reach the writer first and the old group's
+    /// late withdraw would tear P down. With the handoff, the new engine
+    /// sends the member nothing until the old engine has settled it, so the
+    /// member sees the withdraw and then the announcement.
+    #[tokio::test(start_paused = true)]
+    async fn replacement_group_waits_for_the_old_group_to_settle_the_member() {
+        let (pkt_tx, mut pkt_rx) = mpsc::unbounded_channel();
+        let ctx_for_old = {
+            let mut c = SyncCtx::for_test();
+            c.packet_tx = Some(pkt_tx.clone());
+            c
+        };
+        let ctx_for_new = {
+            let mut c = SyncCtx::for_test();
+            c.packet_tx = Some(pkt_tx);
+            c
+        };
+        let (old_tx, old_rx) = mpsc::unbounded_channel();
+        let (new_tx, new_rx) = mpsc::unbounded_channel();
+        let mut old_engine = Engine::default();
+        let mut new_engine = Engine::default();
+        let old_task = tokio::spawn(async move { old_engine.run(old_rx).await });
+        let new_task = tokio::spawn(async move { new_engine.run(new_rx).await });
+        let p: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+
+        // 1. The old group advertised P to the member and now queues its
+        //    withdrawal (deferred behind the flush delay).
+        old_tx
+            .send(GroupEgressDeltaV4::AddMember {
+                ident: 1,
+                ctx: Box::new(ctx_for_old),
+                add_path: false,
+                after: None,
+            })
+            .unwrap();
+        old_tx
+            .send(GroupEgressDeltaV4::Advertise {
+                prefix: p,
+                rib: rib(99, "192.0.2.9"),
+            })
+            .unwrap();
+        tokio::task::yield_now().await;
+        assert_eq!(
+            std::iter::from_fn(|| pkt_rx.try_recv().ok()).count(),
+            1,
+            "the member holds P from the old group"
+        );
+        old_tx
+            .send(GroupEgressDeltaV4::Withdraw {
+                prefix: p,
+                id: 0,
+                source_ident: 99,
+            })
+            .unwrap();
+
+        // 2. Reassignment: the member joins the new group carrying the
+        //    handoff, and the new group announces P — before the old group
+        //    has handled the removal.
+        let (handoff_tx, handoff_rx) = oneshot::channel();
+        new_tx
+            .send(GroupEgressDeltaV4::AddMember {
+                ident: 1,
+                ctx: Box::new(ctx_for_new),
+                add_path: false,
+                after: Some(handoff_rx),
+            })
+            .unwrap();
+        new_tx
+            .send(GroupEgressDeltaV4::Advertise {
+                prefix: p,
+                rib: rib(99, "192.0.2.8"),
+            })
+            .unwrap();
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            pkt_rx.try_recv().is_err(),
+            "the new group sends nothing before the old group settles the member"
+        );
+
+        // 3. The old group handles the removal: flushes the withdraw, fires
+        //    the handoff; the new group then delivers its announcement.
+        old_tx
+            .send(GroupEgressDeltaV4::RemoveMember {
+                ident: 1,
+                handoff: Some(handoff_tx),
+            })
+            .unwrap();
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        let frames: Vec<BytesMut> = std::iter::from_fn(|| pkt_rx.try_recv().ok()).collect();
+        assert_eq!(frames.len(), 2, "withdraw then announce, nothing else");
+        assert!(
+            is_withdraw(&frames[0]),
+            "the old group's withdraw goes first"
+        );
+        assert!(
+            !is_withdraw(&frames[1]),
+            "the new group's announce follows it"
+        );
+        old_task.abort();
+        new_task.abort();
+    }
+
+    /// A joining member whose old engine is already gone (sender dropped)
+    /// must not wait forever: the barrier releases on a closed handoff.
+    #[tokio::test(start_paused = true)]
+    async fn a_dropped_handoff_releases_the_joining_member() {
+        let (pkt_tx, mut pkt_rx) = mpsc::unbounded_channel();
+        let mut ctx = SyncCtx::for_test();
+        ctx.packet_tx = Some(pkt_tx);
+        let (delta_tx, delta_rx) = mpsc::unbounded_channel();
+        let mut engine = Engine::default();
+        let task = tokio::spawn(async move { engine.run(delta_rx).await });
+        let (handoff_tx, handoff_rx) = oneshot::channel::<()>();
+        drop(handoff_tx);
+        delta_tx
+            .send(GroupEgressDeltaV4::AddMember {
+                ident: 1,
+                ctx: Box::new(ctx),
+                add_path: false,
+                after: Some(handoff_rx),
+            })
+            .unwrap();
+        delta_tx
+            .send(GroupEgressDeltaV4::Advertise {
+                prefix: "10.10.10.0/24".parse().unwrap(),
+                rib: rib(99, "192.0.2.9"),
+            })
+            .unwrap();
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        assert!(pkt_rx.try_recv().is_ok(), "the announce goes out");
+        task.abort();
     }
 
     #[tokio::test(start_paused = true)]
@@ -1032,6 +1232,7 @@ mod tests {
             ident: 1,
             ctx: Box::new(member_ctx),
             add_path: false,
+            after: None,
         });
         let task = tokio::spawn(async move { engine.run(delta_rx).await });
 

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -36,6 +36,13 @@ use tokio::time::{Duration, Instant, sleep_until};
 /// race would otherwise produce.
 const WITHDRAW_FLUSH_DELAY: Duration = Duration::from_millis(1);
 
+/// Most deltas one channel wake handles before the engine checks its flush
+/// deadline again — the group twin of the PET's bound. The run loop is
+/// biased toward the channel, so with no bound a producer that keeps the
+/// channel non-empty would keep the timer branch from ever being polled and
+/// hold every queued withdrawal until the stream ended.
+const DRAIN_BATCH: usize = 1024;
+
 use crate::context::task::Task;
 
 use super::adj_rib::{AdjRibTable, Out};
@@ -227,8 +234,10 @@ impl Engine {
     /// the burst settles (a `WITHDRAW_FLUSH_DELAY` timer armed when the first
     /// withdrawal queues, re-used for the whole burst). `biased` prefers
     /// draining new deltas over flushing so a burst accumulates into one
-    /// flush. Exits when the channel closes (the group emptied); any queued
-    /// withdrawal is dropped with it.
+    /// flush; each wake drains at most `DRAIN_BATCH` deltas and then
+    /// [`settle_flush`](Self::settle_flush) checks the deadline itself, so a
+    /// sustained stream cannot starve the flush. Exits when the channel
+    /// closes (the group emptied); any queued withdrawal is dropped with it.
     async fn run(&mut self, mut rx: mpsc::UnboundedReceiver<GroupEgressDeltaV4>) {
         let mut flush_at: Option<Instant> = None;
         loop {
@@ -237,18 +246,38 @@ impl Engine {
                 maybe = rx.recv() => {
                     let Some(delta) = maybe else { break };
                     self.handle(delta);
-                    while let Ok(delta) = rx.try_recv() {
+                    for _ in 1..DRAIN_BATCH {
+                        let Ok(delta) = rx.try_recv() else { break };
                         self.handle(delta);
                     }
-                    if !self.pending_withdraw.is_empty() && flush_at.is_none() {
-                        flush_at = Some(Instant::now() + WITHDRAW_FLUSH_DELAY);
-                    }
+                    self.settle_flush(&mut flush_at);
                 }
                 _ = async { sleep_until(flush_at.unwrap()).await }, if flush_at.is_some() => {
                     self.flush_withdraws();
                     flush_at = None;
                 }
             }
+        }
+    }
+
+    /// After a channel drain: arm the deferred flush when a withdrawal first
+    /// queues, and flush now if an armed deadline has already passed — the
+    /// group twin of the PET's `settle_flush`. The select is biased toward
+    /// the channel, so under a sustained delta stream the timer branch may
+    /// never be polled; checking the deadline here, after every bounded
+    /// drain, caps a queued withdrawal's wait at one `WITHDRAW_FLUSH_DELAY`
+    /// plus one batch instead of the end of the stream.
+    fn settle_flush(&mut self, flush_at: &mut Option<Instant>) {
+        match *flush_at {
+            Some(at) if Instant::now() >= at => {
+                self.flush_withdraws();
+                *flush_at = None;
+            }
+            Some(_) => {}
+            None if !self.pending_withdraw.is_empty() => {
+                *flush_at = Some(Instant::now() + WITHDRAW_FLUSH_DELAY);
+            }
+            None => {}
         }
     }
 
@@ -781,6 +810,91 @@ mod tests {
             assert_eq!(frames.len(), 1, "{who} gets exactly the replacement");
             assert!(!is_withdraw(&frames[0]), "{who} gets no withdraw");
         }
+    }
+
+    /// The reviewer's exact shape: the original announcement came from
+    /// member A, so only member B held it; B then announces P itself. B is
+    /// split-horizoned out of its own path and must still receive the
+    /// withdraw of A's copy; A receives B's path as a plain announce.
+    #[test]
+    fn superseded_withdraw_reaches_the_new_source_when_the_old_source_was_a_member() {
+        let mut engine = Engine::default();
+        let mut rx_a = member(&mut engine, 1);
+        let mut rx_b = member(&mut engine, 2);
+        let p: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(1, "192.0.2.1"),
+        });
+        assert!(rx_a.try_recv().is_err(), "A sourced P, does not get it");
+        assert!(rx_b.try_recv().is_ok(), "B holds A's P");
+
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p,
+            id: 0,
+            source_ident: 1,
+        });
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p,
+            rib: rib(2, "192.0.2.2"),
+        });
+        engine.flush_withdraws();
+
+        let to_a: Vec<BytesMut> = std::iter::from_fn(|| rx_a.try_recv().ok()).collect();
+        let to_b: Vec<BytesMut> = std::iter::from_fn(|| rx_b.try_recv().ok()).collect();
+        assert_eq!(to_a.len(), 1, "A gets exactly B's path");
+        assert!(!is_withdraw(&to_a[0]), "A's frame is an announce");
+        assert_eq!(to_b.len(), 1, "B gets exactly one frame");
+        assert!(is_withdraw(&to_b[0]), "B's frame withdraws A's stale copy");
+    }
+
+    /// The deadline is serviced by the drain itself, not only by the timer
+    /// branch — the group twin of the PET test: a withdrawal queued and then
+    /// left behind by a stream of further deltas flushes once its deadline
+    /// has passed, at the end of the next drain, without the channel ever
+    /// going idle.
+    #[tokio::test(start_paused = true)]
+    async fn drain_flushes_an_expired_deadline_without_the_timer_branch() {
+        let mut engine = Engine::default();
+        let mut rx = member(&mut engine, 1);
+        let p1: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        let p2: Ipv4Net = "10.10.11.0/24".parse().unwrap();
+        for p in [p1, p2] {
+            engine.handle(GroupEgressDeltaV4::Advertise {
+                prefix: p,
+                rib: rib(99, "192.0.2.9"),
+            });
+        }
+        let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+
+        let mut flush_at: Option<Instant> = None;
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p1,
+            id: 0,
+            source_ident: 99,
+        });
+        engine.settle_flush(&mut flush_at);
+        let armed = flush_at.expect("first queued withdrawal arms the deadline");
+        assert!(
+            rx.try_recv().is_err(),
+            "nothing flushes before the deadline"
+        );
+
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p2,
+            id: 0,
+            source_ident: 99,
+        });
+        engine.settle_flush(&mut flush_at);
+        assert_eq!(flush_at, Some(armed), "the deadline is not pushed out");
+        assert!(rx.try_recv().is_err());
+
+        tokio::time::advance(WITHDRAW_FLUSH_DELAY).await;
+        engine.settle_flush(&mut flush_at);
+        assert!(flush_at.is_none(), "flushed and disarmed");
+        let frames: Vec<BytesMut> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert_eq!(frames.len(), 1, "both withdrawals in one UPDATE");
+        assert!(engine.pending_withdraw.is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -19,13 +19,22 @@
 //! gate-on egress is unchanged; the engine is exercised by the unit tests.
 //! Default off; gate-off is byte-identical.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
 use bgp_packet::{Ipv4Nlri, UpdatePacket};
 use bytes::BytesMut;
 use ipnet::Ipv4Net;
 use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::time::{Duration, Instant, sleep_until};
+
+/// How long a queued withdrawal waits for the rest of its burst before the
+/// engine flushes — the group twin of the PET's delay and of the main-task
+/// queue's 1 ms `FlushWithdraw` marker. Lets a peer-down / RR-sweep burst
+/// accumulate on the delta channel so it packs into as few UPDATEs as the
+/// message size allows, rather than the partial flushes the main-task/engine
+/// race would otherwise produce.
+const WITHDRAW_FLUSH_DELAY: Duration = Duration::from_millis(1);
 
 use crate::context::task::Task;
 
@@ -123,7 +132,7 @@ impl GroupEgressTask {
     /// member set from `AddMember` deltas. Exits when `delta_tx` is dropped
     /// (the group emptied).
     pub fn spawn(id: UpdateGroupId) -> Self {
-        let (delta_tx, mut delta_rx) = mpsc::unbounded_channel::<GroupEgressDeltaV4>();
+        let (delta_tx, delta_rx) = mpsc::unbounded_channel::<GroupEgressDeltaV4>();
         // `spawn` is a plain constructor with no `BgpTracing` in reach, so
         // both this and the "exited" line below ride the process-global
         // `sharding` gate (see `bgp::tracing::TRACE_SHARDING`). Read once
@@ -139,9 +148,7 @@ impl GroupEgressTask {
         }
         let task = Task::spawn(async move {
             let mut engine = Engine::default();
-            while let Some(delta) = delta_rx.recv().await {
-                engine.handle(delta);
-            }
+            engine.run(delta_rx).await;
             if trace {
                 tracing::info!(
                     proto = "bgp",
@@ -200,9 +207,49 @@ struct Engine {
     add_path: bool,
     adj_out: AdjRibTable<Out>,
     attr_store: BgpAttrStore,
+    /// IPv4 withdrawals accumulated during the current channel-drain batch,
+    /// keyed by the path's source peer (the split-horizon target excluded
+    /// from that withdrawal's fan). Each source's set is packed into as few
+    /// UPDATEs as the message size allows at
+    /// [`flush_withdraws`](Self::flush_withdraws) and fanned to the members
+    /// that are not that source. Grouping by source keeps a mixed-source
+    /// burst correct — a member that sourced one withdrawn path still
+    /// receives the withdrawals it did not source.
+    pending_withdraw: BTreeMap<usize, HashSet<Ipv4Nlri>>,
 }
 
 impl Engine {
+    /// Drive the engine off its delta channel, coalescing withdrawal bursts —
+    /// the group twin of the PET's `run`. Advertises fan immediately in
+    /// [`handle`](Self::handle); withdrawals queue per source and flush once
+    /// the burst settles (a `WITHDRAW_FLUSH_DELAY` timer armed when the first
+    /// withdrawal queues, re-used for the whole burst). `biased` prefers
+    /// draining new deltas over flushing so a burst accumulates into one
+    /// flush. Exits when the channel closes (the group emptied); any queued
+    /// withdrawal is dropped with it.
+    async fn run(&mut self, mut rx: mpsc::UnboundedReceiver<GroupEgressDeltaV4>) {
+        let mut flush_at: Option<Instant> = None;
+        loop {
+            tokio::select! {
+                biased;
+                maybe = rx.recv() => {
+                    let Some(delta) = maybe else { break };
+                    self.handle(delta);
+                    while let Ok(delta) = rx.try_recv() {
+                        self.handle(delta);
+                    }
+                    if !self.pending_withdraw.is_empty() && flush_at.is_none() {
+                        flush_at = Some(Instant::now() + WITHDRAW_FLUSH_DELAY);
+                    }
+                }
+                _ = async { sleep_until(flush_at.unwrap()).await }, if flush_at.is_some() => {
+                    self.flush_withdraws();
+                    flush_at = None;
+                }
+            }
+        }
+    }
+
     fn handle(&mut self, delta: GroupEgressDeltaV4) {
         match delta {
             GroupEgressDeltaV4::AddMember {
@@ -321,20 +368,47 @@ impl Engine {
             self.adj_out.remove(prefix, id).is_some()
         };
         if removed {
-            let max = self
-                .members
-                .values()
-                .next()
-                .map(|c| c.max_packet_size())
-                .unwrap_or(4096);
+            // Queue rather than fan: the batch's withdrawals pack together in
+            // `flush_withdraws`. Removing the `adj_out` row here (not at flush)
+            // keeps the reconcile authoritative — a re-advertise later in the
+            // same batch re-adds the row and cancels this withdrawal.
+            self.pending_withdraw
+                .entry(source_ident)
+                .or_default()
+                .insert(Ipv4Nlri { id, prefix });
+        }
+    }
+
+    /// Drain the batch's queued IPv4 withdrawals. Each source peer's set is
+    /// packed into as few UPDATEs as the negotiated message size allows and
+    /// fanned to every member except that source (split-horizon — the source
+    /// never received the advertisement). A queued NLRI whose `(prefix, id)`
+    /// is back in `adj_out` was re-advertised within the batch (`fan` already
+    /// put the announcement on the wire), so it is dropped: sending it would
+    /// tear down a route the members now hold.
+    fn flush_withdraws(&mut self) {
+        if self.pending_withdraw.is_empty() {
+            return;
+        }
+        let max = self
+            .members
+            .values()
+            .next()
+            .map(|c| c.max_packet_size())
+            .unwrap_or(4096);
+        let pending = std::mem::take(&mut self.pending_withdraw);
+        for (source_ident, queued) in pending {
+            let withdraws: Vec<Ipv4Nlri> = queued
+                .into_iter()
+                .filter(|n| !super::pending_withdraw::adj_out_has(&self.adj_out, &n.prefix, n.id))
+                .collect();
+            if withdraws.is_empty() {
+                continue;
+            }
             let mut update = UpdatePacket::with_max_packet_size(max);
-            update.ipv4_withdraw.push(Ipv4Nlri { id, prefix });
-            // One withdrawn prefix cannot overflow a length field, but encode
-            // through the checked path anyway so no emit site can put a frame on
-            // the wire whose header contradicts its body.
-            match update.try_emit() {
-                Ok(bytes) => self.fan(&[bytes], source_ident),
-                Err(e) => tracing::warn!("dropping IPv4 withdraw for {}: {}", prefix, e),
+            update.ipv4_withdraw = withdraws;
+            while let Some(bytes) = update.pop_ipv4_withdraw() {
+                self.fan(&[bytes], source_ident);
             }
         }
     }
@@ -472,14 +546,174 @@ mod tests {
         advertise(&mut engine, "10.10.10.0/24", 99);
         let _ = rx1.try_recv();
         let _ = rx2.try_recv();
-        // Withdraw of an advertised prefix reaches the non-source members.
+        // Withdraw of an advertised prefix reaches the non-source members
+        // once the batch flushes.
         engine.handle(GroupEgressDeltaV4::Withdraw {
             prefix: "10.10.10.0/24".parse().unwrap(),
             id: 0,
             source_ident: 99,
         });
+        engine.flush_withdraws();
         assert!(rx1.try_recv().is_ok(), "member 1 receives the withdraw");
         assert!(rx2.try_recv().is_ok(), "member 2 receives the withdraw");
+    }
+
+    #[test]
+    fn withdraws_pack_into_few_updates() {
+        // A burst of withdrawals from an external source fans to the member
+        // packed into far fewer UPDATEs than one per route: 1000 /24
+        // withdrawals fit the default 4096-octet message in a single UPDATE.
+        let mut engine = Engine::default();
+        let mut rx = member(&mut engine, 1);
+        let prefixes: Vec<Ipv4Net> = (0..1000)
+            .map(|i| format!("10.{}.{}.0/24", i / 256, i % 256).parse().unwrap())
+            .collect();
+        for p in &prefixes {
+            engine.handle(GroupEgressDeltaV4::Advertise {
+                prefix: *p,
+                rib: rib(99, "192.0.2.1"),
+            });
+        }
+        let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+
+        for p in &prefixes {
+            engine.handle(GroupEgressDeltaV4::Withdraw {
+                prefix: *p,
+                id: 0,
+                source_ident: 99,
+            });
+        }
+        engine.flush_withdraws();
+        let updates: usize = std::iter::from_fn(|| rx.try_recv().ok()).count();
+        assert!(updates >= 1, "the batch is flushed");
+        assert!(
+            updates <= 2,
+            "1000 /24 withdrawals pack into at most two UPDATEs (got {updates})"
+        );
+    }
+
+    #[test]
+    fn mixed_source_withdraws_fan_per_source() {
+        // Two member-sourced prefixes withdrawn in one batch: split-horizon
+        // is per withdrawal, so grouping by source must hold. Member 1 sees
+        // only the prefix it did NOT source, and member 2 the same — a
+        // single packed UPDATE cannot suppress a withdrawal a member should
+        // receive just because another member sourced a different one.
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        let p1: Ipv4Net = "10.11.0.0/24".parse().unwrap(); // sourced by member 1
+        let p2: Ipv4Net = "10.22.0.0/24".parse().unwrap(); // sourced by member 2
+
+        // Advertise each: split-horizon fans p1 to member 2, p2 to member 1,
+        // and both are recorded in the group adj_out.
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p1,
+            rib: rib(1, "192.0.2.1"),
+        });
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: p2,
+            rib: rib(2, "192.0.2.2"),
+        });
+        let _ = std::iter::from_fn(|| rx1.try_recv().ok()).count();
+        let _ = std::iter::from_fn(|| rx2.try_recv().ok()).count();
+
+        // Withdraw both in one batch, then flush.
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p1,
+            id: 0,
+            source_ident: 1,
+        });
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: p2,
+            id: 0,
+            source_ident: 2,
+        });
+        engine.flush_withdraws();
+
+        // A /24 withdraw NLRI is `plen(24)` then the three significant
+        // octets. Member 1 must see p2's withdraw but not p1's (it sourced
+        // p1); member 2 the reverse.
+        let p1_nlri = [24u8, 10, 11, 0];
+        let p2_nlri = [24u8, 10, 22, 0];
+        let to_1: Vec<_> = std::iter::from_fn(|| rx1.try_recv().ok()).collect();
+        let to_2: Vec<_> = std::iter::from_fn(|| rx2.try_recv().ok()).collect();
+        let carries = |frames: &[bytes::BytesMut], nlri: [u8; 4]| {
+            frames.iter().any(|f| f.windows(4).any(|w| w == nlri))
+        };
+        assert!(carries(&to_1, p2_nlri), "member 1 receives p2's withdraw");
+        assert!(
+            !carries(&to_1, p1_nlri),
+            "member 1 does not receive its own sourced p1"
+        );
+        assert!(carries(&to_2, p1_nlri), "member 2 receives p1's withdraw");
+        assert!(
+            !carries(&to_2, p2_nlri),
+            "member 2 does not receive its own sourced p2"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_coalesces_a_withdraw_burst_into_few_updates() {
+        // The group twin of the PET coalescing test: a burst arriving across
+        // several channel wakes packs into one UPDATE after the deferred
+        // flush, not one flush per wake. Paused time makes the delay
+        // deterministic.
+        let (pkt_tx, mut pkt_rx) = mpsc::unbounded_channel();
+        let mut member_ctx = SyncCtx::for_test();
+        member_ctx.packet_tx = Some(pkt_tx);
+        let (delta_tx, delta_rx) = mpsc::unbounded_channel();
+        let mut engine = Engine::default();
+        // The engine must hold the member before the run loop starts driving,
+        // so seed it directly, then hand the receiver to `run`.
+        engine.handle(GroupEgressDeltaV4::AddMember {
+            ident: 1,
+            ctx: Box::new(member_ctx),
+            add_path: false,
+        });
+        let task = tokio::spawn(async move { engine.run(delta_rx).await });
+
+        let prefixes: Vec<Ipv4Net> = (0..200)
+            .map(|i| format!("10.{}.{}.0/24", i / 256, i % 256).parse().unwrap())
+            .collect();
+        // Advertise from an external source (99) so member 1 receives and the
+        // group adj_out records each row; drain those advertise frames.
+        for p in &prefixes {
+            delta_tx
+                .send(GroupEgressDeltaV4::Advertise {
+                    prefix: *p,
+                    rib: rib(99, "192.0.2.1"),
+                })
+                .unwrap();
+        }
+        tokio::task::yield_now().await;
+        let _ = std::iter::from_fn(|| pkt_rx.try_recv().ok()).count();
+
+        for p in &prefixes {
+            delta_tx
+                .send(GroupEgressDeltaV4::Withdraw {
+                    prefix: *p,
+                    id: 0,
+                    source_ident: 99,
+                })
+                .unwrap();
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            pkt_rx.try_recv().is_err(),
+            "withdrawals wait for the flush delay"
+        );
+
+        tokio::time::advance(WITHDRAW_FLUSH_DELAY * 2).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        let updates: usize = std::iter::from_fn(|| pkt_rx.try_recv().ok()).count();
+        assert!(updates >= 1, "the burst is flushed after the delay");
+        assert!(
+            updates <= 2,
+            "the deferred burst packs into at most two UPDATEs (got {updates})"
+        );
+        task.abort();
     }
 
     #[test]
@@ -501,6 +735,7 @@ mod tests {
         // exercises the local-id used by Add-Path Adj-RIB-Out and withdraw.
         path1.ident = 0;
         engine.advertise(prefix, path1);
+        engine.flush_withdraws();
 
         let packet = rx.try_recv().expect("filtered Add-Path row is withdrawn");
         assert_eq!(engine.adj_out.0[&prefix].len(), 1);
@@ -560,6 +795,7 @@ mod tests {
             id: 0,
             source_ident: 99,
         });
+        engine.flush_withdraws();
         assert!(
             rx1.try_recv().is_ok(),
             "the withdraw reaches the sync-recorded member"

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -108,6 +108,12 @@ pub enum Message {
         super::update_group::UpdateGroupId,
         super::update_group::UpdateGroupCounters,
     ),
+    /// Next-tick flush marker for a peer's queued withdrawals (see
+    /// [`super::pending_withdraw`]): drain them into as few UPDATEs as the
+    /// session's message size allows. Armed once per peer while anything
+    /// is queued; lands behind the ingest already on this channel, so a
+    /// burst of withdrawals shares one drain.
+    FlushWithdraw(usize),
     /// BGP Link-State (RFC 9552) objects produced by the local IS-IS task
     /// and pushed over the IS-IS→BGP channel. `add` are originated into the
     /// `bgp_ls` Loc-RIB; `withdraw` are removed. The IS-IS producer diffs
@@ -2623,6 +2629,13 @@ impl Bgp {
                     &self.tx,
                     &group_id,
                     deltas,
+                );
+            }
+            Message::FlushWithdraw(ident) => {
+                super::pending_withdraw::flush_pending_withdraws(
+                    ident,
+                    &self.update_groups,
+                    &mut self.peers,
                 );
             }
             Message::BgpLs { add, withdraw } => {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -100,13 +100,19 @@ pub enum Message {
     /// the group's in-flight latch, replay withdraws parked during
     /// the flight, and re-run the flush if the debounce timer fired
     /// while the job was out.
+    /// The third field is the job's member idents: each had
+    /// `Peer::flush_jobs_v4/v6` counted up when the job was spawned and is
+    /// counted back down here, releasing its parked unicast withdrawals —
+    /// even if the group itself is gone by now.
     FlushDoneIpv4(
         super::update_group::UpdateGroupId,
         super::update_group::UpdateGroupCounters,
+        Vec<usize>,
     ),
     FlushDoneIpv6(
         super::update_group::UpdateGroupId,
         super::update_group::UpdateGroupCounters,
+        Vec<usize>,
     ),
     /// Next-tick flush marker for a peer's queued withdrawals (see
     /// [`super::pending_withdraw`]): drain them into as few UPDATEs as the
@@ -2612,31 +2618,29 @@ impl Bgp {
                     &group_id,
                 );
             }
-            Message::FlushDoneIpv4(group_id, deltas) => {
+            Message::FlushDoneIpv4(group_id, deltas, members) => {
                 super::update_group::flush_done_ipv4(
                     &mut self.update_groups,
                     &mut self.peers,
                     &self.tx,
                     &group_id,
                     deltas,
+                    &members,
                     &self.interface_addrs,
                 );
             }
-            Message::FlushDoneIpv6(group_id, deltas) => {
+            Message::FlushDoneIpv6(group_id, deltas, members) => {
                 super::update_group::flush_done_ipv6(
                     &mut self.update_groups,
                     &mut self.peers,
                     &self.tx,
                     &group_id,
                     deltas,
+                    &members,
                 );
             }
             Message::FlushWithdraw(ident) => {
-                super::pending_withdraw::flush_pending_withdraws(
-                    ident,
-                    &self.update_groups,
-                    &mut self.peers,
-                );
+                super::pending_withdraw::flush_pending_withdraws(ident, &mut self.peers);
             }
             Message::BgpLs { add, withdraw } => {
                 // Locally-produced BGP-LS (IS-IS producer, RFC 9552). Store

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -100,19 +100,21 @@ pub enum Message {
     /// the group's in-flight latch, replay withdraws parked during
     /// the flight, and re-run the flush if the debounce timer fired
     /// while the job was out.
-    /// The third field is the job's member idents: each had
-    /// `Peer::flush_jobs_v4/v6` counted up when the job was spawned and is
-    /// counted back down here, releasing its parked unicast withdrawals —
-    /// even if the group itself is gone by now.
+    /// The third field is the job's members as `(ident, Peer::instance)`:
+    /// each had `Peer::flush_jobs_v4/v6` counted up when the job was
+    /// spawned and is counted back down here, releasing its parked unicast
+    /// withdrawals — even if the group itself is gone by now. The instance
+    /// nonce keeps a late completion from settling a *replacement* peer
+    /// that reused the slot.
     FlushDoneIpv4(
         super::update_group::UpdateGroupId,
         super::update_group::UpdateGroupCounters,
-        Vec<usize>,
+        Vec<super::update_group::JobMember>,
     ),
     FlushDoneIpv6(
         super::update_group::UpdateGroupId,
         super::update_group::UpdateGroupCounters,
-        Vec<usize>,
+        Vec<super::update_group::JobMember>,
     ),
     /// Next-tick flush marker for a peer's queued withdrawals (see
     /// [`super::pending_withdraw`]): drain them into as few UPDATEs as the

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -19,6 +19,7 @@ pub mod peer;
 pub mod peer_egress;
 pub mod peer_key;
 pub mod peer_map;
+pub mod pending_withdraw;
 pub mod show;
 pub mod show_update_group;
 pub mod update_group;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2270,6 +2270,7 @@ pub fn fsm(
                 id,
                 *bgp_ref.router_id,
                 bgp_ref.as_sets_withdraw,
+                None,
             );
         }
         peer_map.debug_verify_membership();

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1248,6 +1248,17 @@ pub struct Peer {
     /// The next-tick `Message::FlushWithdraw` marker, `Some` while one is
     /// armed; consumed by the flush, cancelled by `route_clean`.
     pub withdraw_timer: Option<Timer>,
+    /// Update-group flush jobs currently on the blocking pool that carry
+    /// this peer's IPv4-unicast announcements (`flush_ipv4` counts one
+    /// up per member when it spawns a job, `flush_done_ipv4` counts it
+    /// back down). While non-zero the peer's queued IPv4 withdrawals stay
+    /// queued: a withdraw enqueued now could reach the writer before the
+    /// job's announcement of the same prefix. Kept on the peer, not the
+    /// group, so it survives the group being deleted or the peer moving
+    /// to another group while the job is out.
+    pub flush_jobs_v4: u32,
+    /// IPv6-unicast twin of `flush_jobs_v4`.
+    pub flush_jobs_v6: u32,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
     // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
     // this peer. Needed because TCP_AO_DEL_KEY requires the exact
@@ -1409,6 +1420,8 @@ impl Peer {
             cache_evpn_timer: None,
             pending_withdraw: super::pending_withdraw::PendingWithdraw::default(),
             withdraw_timer: None,
+            flush_jobs_v4: 0,
+            flush_jobs_v6: 0,
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
             adv_interval: timer::AdvInterval::default(),

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1240,6 +1240,14 @@ pub struct Peer {
     pub cache_evpn_rev: HashMap<EvpnCacheKey, (Arc<BgpAttr>, EvpnRoute)>,
     pub cache_vpnv4_timer: Option<Timer>,
     pub cache_evpn_timer: Option<Timer>,
+    /// Withdrawals queued for the next flush, per family — the withdraw
+    /// twin of the advertise caches above. See [`super::pending_withdraw`]
+    /// for the drain and the Adj-RIB-Out reconciliation that keeps a
+    /// queued withdraw from racing a later re-advertise.
+    pub pending_withdraw: super::pending_withdraw::PendingWithdraw,
+    /// The next-tick `Message::FlushWithdraw` marker, `Some` while one is
+    /// armed; consumed by the flush, cancelled by `route_clean`.
+    pub withdraw_timer: Option<Timer>,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
     // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
     // this peer. Needed because TCP_AO_DEL_KEY requires the exact
@@ -1399,6 +1407,8 @@ impl Peer {
             cache_evpn_rev: HashMap::default(),
             cache_vpnv4_timer: None,
             cache_evpn_timer: None,
+            pending_withdraw: super::pending_withdraw::PendingWithdraw::default(),
+            withdraw_timer: None,
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
             adv_interval: timer::AdvInterval::default(),
@@ -5233,6 +5243,12 @@ mod adv_timer_phantom_tests {
         let mut peer = idle_peer();
         peer.cache_vpnv4_timer = Some(timer::start_adv_timer_vpnv4(&peer));
         peer.cache_vpnv6_timer = Some(timer::start_adv_timer_vpnv6(&peer));
+        // A withdraw queued for the dead session, with its flush marker.
+        peer.queue_withdraw_v4(Ipv4Nlri {
+            id: 0,
+            prefix: "10.9.0.0/24".parse().unwrap(),
+        });
+        assert!(peer.withdraw_timer.is_some());
         peers.insert("10.0.0.2".parse().unwrap(), peer);
         let ident = peers.get(&"10.0.0.2".parse().unwrap()).unwrap().ident;
 
@@ -5275,6 +5291,14 @@ mod adv_timer_phantom_tests {
         assert!(
             peer.cache_vpnv6_timer.is_none(),
             "route_clean must cancel the VPNv6 advertise timer"
+        );
+        assert!(
+            peer.pending_withdraw.v4.is_empty(),
+            "route_clean must drop the queued withdrawals"
+        );
+        assert!(
+            peer.withdraw_timer.is_none(),
+            "route_clean must cancel the withdraw flush marker"
         );
     }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1020,6 +1020,9 @@ impl PeerStat {
 /// gateway IP) that the NLRI also carries.
 pub type EvpnCacheKey = (RouteDistinguisher, EvpnPrefix, u32);
 
+/// Source of [`Peer::instance`] nonces.
+static NEXT_PEER_INSTANCE: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Debug)]
 pub struct Peer {
     pub ident: usize,
@@ -1259,6 +1262,15 @@ pub struct Peer {
     pub flush_jobs_v4: u32,
     /// IPv6-unicast twin of `flush_jobs_v4`.
     pub flush_jobs_v6: u32,
+    /// Creation nonce: distinct for every `Peer` value ever constructed,
+    /// unlike `ident`, which is a `PeerMap` slot that a peer removed and
+    /// re-added at the same address gets back. A flush job's completion
+    /// carries `(ident, instance)` for each member and settles
+    /// `flush_jobs_*` only on the `Peer` value it was spawned against —
+    /// an old session's late completion must not count a job off the
+    /// replacement peer and release its parked withdrawals under a job
+    /// of its own.
+    pub instance: u64,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
     // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
     // this peer. Needed because TCP_AO_DEL_KEY requires the exact
@@ -1422,6 +1434,7 @@ impl Peer {
             withdraw_timer: None,
             flush_jobs_v4: 0,
             flush_jobs_v6: 0,
+            instance: NEXT_PEER_INSTANCE.fetch_add(1, Ordering::Relaxed),
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
             adv_interval: timer::AdvInterval::default(),

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -16,11 +16,21 @@
 //! Gate-off (the default) is untouched — the egress stays on the main task
 //! via update-groups.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use bgp_packet::{Ipv4Nlri, UpdatePacket};
 use ipnet::Ipv4Net;
 use tokio::sync::mpsc::{self, UnboundedSender};
+use tokio::time::{Duration, Instant, sleep_until};
+
+/// How long a queued withdrawal waits for the rest of its burst before the
+/// engine flushes. Mirrors the main-task queue's `FlushWithdraw` marker
+/// (`pending_withdraw::start_withdraw_flush_timer`, also 1 ms): the delay
+/// lets a peer-down / RR-sweep burst accumulate on the delta channel so it
+/// packs into as few UPDATEs as the message size allows, instead of the
+/// partial flushes the main-task/engine race would otherwise produce.
+const WITHDRAW_FLUSH_DELAY: Duration = Duration::from_millis(1);
 
 use crate::context::task::Task;
 
@@ -152,17 +162,16 @@ impl PeerEgressTask {
     /// be refreshed by a `Refresh` delta on policy / connection change.
     /// Exits when `delta_tx` is dropped at teardown.
     pub fn spawn(ctx: SyncCtx, add_path: bool) -> Self {
-        let (delta_tx, mut delta_rx) = mpsc::unbounded_channel::<EgressDeltaV4>();
+        let (delta_tx, delta_rx) = mpsc::unbounded_channel::<EgressDeltaV4>();
         let task = Task::spawn(async move {
             let mut engine = Engine {
                 ctx,
                 add_path,
                 adj_out: AdjRibTable::new(),
                 attr_store: BgpAttrStore::new(),
+                pending_withdraw: HashSet::new(),
             };
-            while let Some(delta) = delta_rx.recv().await {
-                engine.handle(delta);
-            }
+            engine.run(delta_rx).await;
         });
         PeerEgressTask { delta_tx, task }
     }
@@ -177,9 +186,48 @@ struct Engine {
     add_path: bool,
     adj_out: AdjRibTable<Out>,
     attr_store: BgpAttrStore,
+    /// IPv4 withdrawals accumulated during the current channel-drain batch,
+    /// packed into as few UPDATEs as the message size allows at
+    /// [`flush_withdraws`](Self::flush_withdraws). Keyed on wire identity
+    /// (`Ipv4Nlri` = `{id, prefix}`) so a route withdrawn twice in one batch
+    /// is sent once.
+    pending_withdraw: HashSet<Ipv4Nlri>,
 }
 
 impl Engine {
+    /// Drive the engine off its delta channel, coalescing withdrawal bursts.
+    /// Advertises act immediately in [`handle`](Self::handle); withdrawals
+    /// queue and flush once the burst settles — a `WITHDRAW_FLUSH_DELAY`
+    /// timer armed when the first withdrawal queues and re-used for the whole
+    /// burst, the mirror of the main-task queue's `FlushWithdraw` marker.
+    /// `biased` prefers draining new deltas over flushing, so a burst still
+    /// arriving on the channel accumulates into one flush instead of the
+    /// partial flushes the main-task/engine race would otherwise produce.
+    /// Exits when the channel closes at teardown; the session is gone, so any
+    /// still-queued withdrawal is dropped (a new session re-syncs).
+    async fn run(&mut self, mut rx: mpsc::UnboundedReceiver<EgressDeltaV4>) {
+        let mut flush_at: Option<Instant> = None;
+        loop {
+            tokio::select! {
+                biased;
+                maybe = rx.recv() => {
+                    let Some(delta) = maybe else { break };
+                    self.handle(delta);
+                    while let Ok(delta) = rx.try_recv() {
+                        self.handle(delta);
+                    }
+                    if !self.pending_withdraw.is_empty() && flush_at.is_none() {
+                        flush_at = Some(Instant::now() + WITHDRAW_FLUSH_DELAY);
+                    }
+                }
+                _ = async { sleep_until(flush_at.unwrap()).await }, if flush_at.is_some() => {
+                    self.flush_withdraws();
+                    flush_at = None;
+                }
+            }
+        }
+    }
+
     fn handle(&mut self, delta: EgressDeltaV4) {
         match delta {
             EgressDeltaV4::Advertise { prefix, rib } => self.advertise(prefix, rib),
@@ -254,9 +302,35 @@ impl Engine {
     /// `id` (0 for non-AddPath). Per-path AddPath withdraw is a follow-on.
     fn withdraw(&mut self, prefix: Ipv4Net, id: u32) {
         if self.adj_out.0.remove(&prefix).is_some() {
-            let mut update = UpdatePacket::with_max_packet_size(self.ctx.max_packet_size());
-            update.ipv4_withdraw.push(Ipv4Nlri { id, prefix });
-            self.ctx.send_update(update);
+            // Queue rather than emit: the batch's withdrawals pack together
+            // in `flush_withdraws`. Removing the `adj_out` row here (not at
+            // flush) keeps the reconcile authoritative — a re-advertise later
+            // in the same batch re-adds the row and cancels this withdrawal.
+            self.pending_withdraw.insert(Ipv4Nlri { id, prefix });
+        }
+    }
+
+    /// Drain the batch's queued IPv4 withdrawals onto the wire, packed into
+    /// as few UPDATEs as the negotiated message size allows. A queued NLRI
+    /// whose `(prefix, id)` is back in `adj_out` was re-advertised within the
+    /// batch (`send_ipv4_direct` already put the announcement on the wire), so
+    /// it is dropped — sending it would tear down a route the peer now holds.
+    fn flush_withdraws(&mut self) {
+        if self.pending_withdraw.is_empty() {
+            return;
+        }
+        let queued = std::mem::take(&mut self.pending_withdraw);
+        let withdraws: Vec<Ipv4Nlri> = queued
+            .into_iter()
+            .filter(|n| !super::pending_withdraw::adj_out_has(&self.adj_out, &n.prefix, n.id))
+            .collect();
+        if withdraws.is_empty() {
+            return;
+        }
+        let mut update = UpdatePacket::with_max_packet_size(self.ctx.max_packet_size());
+        update.ipv4_withdraw = withdraws;
+        while let Some(bytes) = update.pop_ipv4_withdraw() {
+            self.ctx.send_packet(bytes);
         }
     }
 }
@@ -313,6 +387,7 @@ mod tests {
             add_path: false,
             adj_out: AdjRibTable::new(),
             attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
         };
         let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
 
@@ -341,6 +416,7 @@ mod tests {
             add_path: false,
             adj_out: AdjRibTable::new(),
             attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
         };
         let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
 
@@ -350,8 +426,10 @@ mod tests {
 
         // The best is now from peer 0 (== the ctx's own ident) →
         // `route_update_ipv4` returns None (split-horizon), so the prior
-        // advertisement is withdrawn (gate-off's `Withdraw` outcome).
+        // advertisement is withdrawn (gate-off's `Withdraw` outcome). The
+        // withdrawal queues; the batch flush puts it on the wire.
         engine.advertise(prefix, rib(0, "192.0.2.2"));
+        engine.flush_withdraws();
         assert!(
             rx.try_recv().is_ok(),
             "split-horizon withdraws the prior advertisement"
@@ -368,20 +446,23 @@ mod tests {
             add_path: false,
             adj_out: AdjRibTable::new(),
             attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
         };
         let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
 
         // Withdraw of a never-advertised prefix → nothing on the wire.
         engine.withdraw(prefix, 0);
+        engine.flush_withdraws();
         assert!(
             rx.try_recv().is_err(),
             "withdraw of an unadvertised prefix sends nothing"
         );
 
-        // Advertise, then withdraw → the withdraw is sent.
+        // Advertise, then withdraw → the withdraw is sent at flush.
         engine.advertise(prefix, rib(5, "192.0.2.1"));
         let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
         engine.withdraw(prefix, 0);
+        engine.flush_withdraws();
         assert!(
             rx.try_recv().is_ok(),
             "withdraw of an advertised prefix sends an UPDATE"
@@ -398,6 +479,7 @@ mod tests {
             add_path: false,
             adj_out: AdjRibTable::new(),
             attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
         };
         let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
 
@@ -416,9 +498,78 @@ mod tests {
         // A later withdraw with wire id 0 must still reach the peer — it
         // matches by prefix, not the local_id (the gate-on bug 1f caught).
         engine.withdraw(prefix, 0);
+        engine.flush_withdraws();
         assert!(
             rx.try_recv().is_ok(),
             "a dump-learned prefix can be withdrawn"
+        );
+    }
+
+    #[test]
+    fn engine_packs_a_batch_of_withdraws_into_few_updates() {
+        // A burst of withdrawals — a peer-down `route_clean` fanned to the
+        // PET — must pack into far fewer UPDATEs than one per route. 1000
+        // /24 withdrawals fit the default 4096-octet message in a single
+        // UPDATE; the old immediate path emitted 1000.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut ctx = SyncCtx::for_test();
+        ctx.packet_tx = Some(tx);
+        let mut engine = Engine {
+            ctx,
+            add_path: false,
+            adj_out: AdjRibTable::new(),
+            attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
+        };
+        let prefixes: Vec<Ipv4Net> = (0..1000)
+            .map(|i| format!("10.{}.{}.0/24", i / 256, i % 256).parse().unwrap())
+            .collect();
+        for p in &prefixes {
+            engine.advertise(*p, rib(5, "192.0.2.1"));
+        }
+        let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+
+        // Queue every withdrawal, then flush the whole batch once.
+        for p in &prefixes {
+            engine.withdraw(*p, 0);
+        }
+        engine.flush_withdraws();
+        let updates: usize = std::iter::from_fn(|| rx.try_recv().ok()).count();
+        assert!(updates >= 1, "the batch is flushed");
+        assert!(
+            updates <= 2,
+            "1000 /24 withdrawals pack into at most two UPDATEs (got {updates})"
+        );
+    }
+
+    #[test]
+    fn engine_reconcile_drops_a_withdraw_readvertised_in_the_batch() {
+        // A withdraw queued behind a re-advertise of the same prefix in one
+        // batch must be dropped: the Adj-RIB-Out holds the prefix again, so
+        // sending the withdraw would tear down the route the peer now holds.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut ctx = SyncCtx::for_test();
+        ctx.packet_tx = Some(tx);
+        let mut engine = Engine {
+            ctx,
+            add_path: false,
+            adj_out: AdjRibTable::new(),
+            attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
+        };
+        let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        engine.advertise(prefix, rib(5, "192.0.2.1"));
+        let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+
+        // Within one batch: withdraw, then re-advertise a DIFFERENT attr (a
+        // new next-hop, so the advertise is not deduped and re-sends).
+        engine.withdraw(prefix, 0);
+        engine.advertise(prefix, rib(5, "192.0.2.2"));
+        let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+        engine.flush_withdraws();
+        assert!(
+            rx.try_recv().is_err(),
+            "the re-advertised prefix's queued withdraw is dropped"
         );
     }
 
@@ -432,6 +583,7 @@ mod tests {
             add_path: false,
             adj_out: AdjRibTable::new(),
             attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
         };
 
         // Refresh to a new snapshot whose writer is a different channel.
@@ -463,6 +615,7 @@ mod tests {
             add_path: false,
             adj_out: AdjRibTable::new(),
             attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
         };
         let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
         engine.advertise(prefix, rib(5, "192.0.2.1"));
@@ -473,6 +626,69 @@ mod tests {
         let entries = reply_rx.try_recv().expect("DumpAdjOut replied");
         assert_eq!(entries.len(), 1, "the advertised prefix is in the dump");
         assert_eq!(entries[0].0, prefix);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_coalesces_a_withdraw_burst_into_few_updates() {
+        // The run loop defers its flush by WITHDRAW_FLUSH_DELAY, so a burst
+        // that arrives across several channel wakes (the main-task/engine
+        // race) still packs into one UPDATE instead of one flush per wake.
+        // Drive the real channel under paused time to make the delay
+        // deterministic.
+        let (pkt_tx, mut pkt_rx) = mpsc::unbounded_channel();
+        let mut ctx = SyncCtx::for_test();
+        ctx.packet_tx = Some(pkt_tx);
+        let (delta_tx, delta_rx) = mpsc::unbounded_channel();
+        let mut engine = Engine {
+            ctx,
+            add_path: false,
+            adj_out: AdjRibTable::new(),
+            attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
+        };
+        let task = tokio::spawn(async move { engine.run(delta_rx).await });
+
+        let prefixes: Vec<Ipv4Net> = (0..200)
+            .map(|i| format!("10.{}.{}.0/24", i / 256, i % 256).parse().unwrap())
+            .collect();
+        // Advertise the set so each withdrawal has a row to remove, then
+        // drain the advertise frames — only withdraw UPDATEs are counted.
+        for p in &prefixes {
+            delta_tx
+                .send(EgressDeltaV4::Advertise {
+                    prefix: *p,
+                    rib: rib(5, "192.0.2.1"),
+                })
+                .unwrap();
+        }
+        tokio::task::yield_now().await;
+        let _ = std::iter::from_fn(|| pkt_rx.try_recv().ok()).count();
+
+        // Withdraw the set one delta at a time, yielding between sends so the
+        // engine wakes repeatedly — the deferred flush must still coalesce.
+        for p in &prefixes {
+            delta_tx
+                .send(EgressDeltaV4::Withdraw { prefix: *p, id: 0 })
+                .unwrap();
+            tokio::task::yield_now().await;
+        }
+        // Nothing on the wire yet: the flush deadline has not passed.
+        assert!(
+            pkt_rx.try_recv().is_err(),
+            "withdrawals wait for the flush delay"
+        );
+
+        // Pass the deadline; the whole burst flushes once.
+        tokio::time::advance(WITHDRAW_FLUSH_DELAY * 2).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        let updates: usize = std::iter::from_fn(|| pkt_rx.try_recv().ok()).count();
+        assert!(updates >= 1, "the burst is flushed after the delay");
+        assert!(
+            updates <= 2,
+            "the deferred burst packs into at most two UPDATEs (got {updates})"
+        );
+        task.abort();
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -32,6 +32,13 @@ use tokio::time::{Duration, Instant, sleep_until};
 /// partial flushes the main-task/engine race would otherwise produce.
 const WITHDRAW_FLUSH_DELAY: Duration = Duration::from_millis(1);
 
+/// Most deltas one channel wake handles before the engine checks its flush
+/// deadline again. The run loop is biased toward the channel, so with no
+/// bound a producer that keeps the channel non-empty (a full-table
+/// re-advertise outpacing the engine) would keep the timer branch from ever
+/// being polled and hold every queued withdrawal until the stream ended.
+const DRAIN_BATCH: usize = 1024;
+
 use crate::context::task::Task;
 
 use super::adj_rib::{AdjRibTable, Out};
@@ -203,8 +210,11 @@ impl Engine {
     /// `biased` prefers draining new deltas over flushing, so a burst still
     /// arriving on the channel accumulates into one flush instead of the
     /// partial flushes the main-task/engine race would otherwise produce.
-    /// Exits when the channel closes at teardown; the session is gone, so any
-    /// still-queued withdrawal is dropped (a new session re-syncs).
+    /// Each wake drains at most `DRAIN_BATCH` deltas and then
+    /// [`settle_flush`](Self::settle_flush) checks the deadline itself, so a
+    /// sustained stream cannot starve the flush. Exits when the channel closes
+    /// at teardown; the session is gone, so any still-queued withdrawal is
+    /// dropped (a new session re-syncs).
     async fn run(&mut self, mut rx: mpsc::UnboundedReceiver<EgressDeltaV4>) {
         let mut flush_at: Option<Instant> = None;
         loop {
@@ -213,18 +223,37 @@ impl Engine {
                 maybe = rx.recv() => {
                     let Some(delta) = maybe else { break };
                     self.handle(delta);
-                    while let Ok(delta) = rx.try_recv() {
+                    for _ in 1..DRAIN_BATCH {
+                        let Ok(delta) = rx.try_recv() else { break };
                         self.handle(delta);
                     }
-                    if !self.pending_withdraw.is_empty() && flush_at.is_none() {
-                        flush_at = Some(Instant::now() + WITHDRAW_FLUSH_DELAY);
-                    }
+                    self.settle_flush(&mut flush_at);
                 }
                 _ = async { sleep_until(flush_at.unwrap()).await }, if flush_at.is_some() => {
                     self.flush_withdraws();
                     flush_at = None;
                 }
             }
+        }
+    }
+
+    /// After a channel drain: arm the deferred flush when a withdrawal first
+    /// queues, and flush now if an armed deadline has already passed. The
+    /// select is biased toward the channel, so under a sustained delta stream
+    /// the timer branch may never be polled; checking the deadline here, after
+    /// every bounded drain, caps a queued withdrawal's wait at one
+    /// `WITHDRAW_FLUSH_DELAY` plus one batch instead of the end of the stream.
+    fn settle_flush(&mut self, flush_at: &mut Option<Instant>) {
+        match *flush_at {
+            Some(at) if Instant::now() >= at => {
+                self.flush_withdraws();
+                *flush_at = None;
+            }
+            Some(_) => {}
+            None if !self.pending_withdraw.is_empty() => {
+                *flush_at = Some(Instant::now() + WITHDRAW_FLUSH_DELAY);
+            }
+            None => {}
         }
     }
 
@@ -626,6 +655,54 @@ mod tests {
         let entries = reply_rx.try_recv().expect("DumpAdjOut replied");
         assert_eq!(entries.len(), 1, "the advertised prefix is in the dump");
         assert_eq!(entries[0].0, prefix);
+    }
+
+    /// The deadline is serviced by the drain itself, not only by the timer
+    /// branch: a withdrawal queued and then left behind by a stream of
+    /// further deltas flushes once its deadline has passed, at the end of
+    /// the next drain, without the channel ever going idle.
+    #[tokio::test(start_paused = true)]
+    async fn drain_flushes_an_expired_deadline_without_the_timer_branch() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut ctx = SyncCtx::for_test();
+        ctx.packet_tx = Some(tx);
+        let mut engine = Engine {
+            ctx,
+            add_path: false,
+            adj_out: AdjRibTable::new(),
+            attr_store: BgpAttrStore::new(),
+            pending_withdraw: HashSet::new(),
+        };
+        let p1: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        let p2: Ipv4Net = "10.10.11.0/24".parse().unwrap();
+        engine.advertise(p1, rib(5, "192.0.2.1"));
+        engine.advertise(p2, rib(5, "192.0.2.1"));
+        let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+
+        // First drain queues a withdrawal: the deadline is armed, nothing sent.
+        let mut flush_at: Option<Instant> = None;
+        engine.withdraw(p1, 0);
+        engine.settle_flush(&mut flush_at);
+        let armed = flush_at.expect("first queued withdrawal arms the deadline");
+        assert!(
+            rx.try_recv().is_err(),
+            "nothing flushes before the deadline"
+        );
+
+        // A later drain before the deadline: still armed at the same instant.
+        engine.withdraw(p2, 0);
+        engine.settle_flush(&mut flush_at);
+        assert_eq!(flush_at, Some(armed), "the deadline is not pushed out");
+        assert!(rx.try_recv().is_err());
+
+        // The deadline passes while the channel stays busy (no timer branch
+        // is polled here): the next drain flushes both, packed.
+        tokio::time::advance(WITHDRAW_FLUSH_DELAY).await;
+        engine.settle_flush(&mut flush_at);
+        assert!(flush_at.is_none(), "flushed and disarmed");
+        let frames: Vec<bytes::BytesMut> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert_eq!(frames.len(), 1, "both withdrawals in one UPDATE");
+        assert!(engine.pending_withdraw.is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/zebra-rs/src/bgp/pending_withdraw.rs
+++ b/zebra-rs/src/bgp/pending_withdraw.rs
@@ -226,8 +226,10 @@ fn drain_peer(peer: &mut Peer) {
 /// Whether the Adj-RIB-Out still (or again) holds `(prefix, id)`. `id == 0`
 /// is the non-AddPath wire id and matches any row for the prefix — a
 /// non-AddPath advertisement is stored under the Loc-RIB `local_id`, never
-/// 0 — while a real path-id must match exactly.
-fn adj_out_has<P: Ord>(table: &AdjRibTable<Out, P>, prefix: &P, id: u32) -> bool {
+/// 0 — while a real path-id must match exactly. Shared with the gate-on
+/// egress engines ([`super::peer_egress`], [`super::group_egress`]), which
+/// pack their own IPv4 withdrawals and apply the same reconcile at flush.
+pub(super) fn adj_out_has<P: Ord>(table: &AdjRibTable<Out, P>, prefix: &P, id: u32) -> bool {
     table
         .0
         .get(prefix)

--- a/zebra-rs/src/bgp/pending_withdraw.rs
+++ b/zebra-rs/src/bgp/pending_withdraw.rs
@@ -237,12 +237,26 @@ pub(super) fn adj_out_has<P: Ord>(table: &AdjRibTable<Out, P>, prefix: &P, id: u
 }
 
 /// Emit `attr`'s withdrawals as as many UPDATEs as the session's message
-/// size needs.
+/// size needs. A queue the codec cannot paginate — a family with no
+/// per-NLRI emitter, or an NLRI larger than an empty UPDATE of the session's
+/// size — is logged with the number of withdrawals it still held and
+/// dropped, rather than lost silently or spun on.
 fn send_mp_withdraws(peer: &Peer, attr: MpUnreachAttr) {
     let mut update = peer.update_packet();
     update.mp_withdraw = Some(attr);
-    while let Some(bytes) = update.pop_mp_withdraw() {
-        peer.send_packet(bytes);
+    loop {
+        match update.pop_mp_withdraw() {
+            Ok(Some(bytes)) => peer.send_packet(bytes),
+            Ok(None) => break,
+            Err(e) => {
+                let left = update.mp_withdraw.as_ref().map_or(0, MpUnreachAttr::len);
+                tracing::warn!(
+                    peer = %peer.address,
+                    "dropping {left} queued withdrawals that cannot be sent: {e}"
+                );
+                break;
+            }
+        }
     }
 }
 
@@ -728,6 +742,20 @@ mod tests {
             }
             other => panic!("expected a VPNv6 MP_UNREACH, got {other:?}"),
         }
+    }
+
+    /// A queue the codec refuses to paginate (Route-Target membership has
+    /// no per-NLRI emitter) is dropped with a log line: nothing goes on the
+    /// wire and the send loop terminates instead of spinning on the error.
+    #[tokio::test]
+    async fn send_mp_withdraws_drops_an_unpaginatable_queue_and_returns() {
+        use bgp_packet::{ExtCommunityValue, Rtcv4};
+        let (peer, mut prx, _rx) = established_peer();
+        send_mp_withdraws(
+            &peer,
+            MpUnreachAttr::Rtcv4(vec![Rtcv4::new(65001, ExtCommunityValue::default())]),
+        );
+        assert!(sent(&mut prx).is_empty(), "nothing is sent");
     }
 
     /// A flush on a peer that left Established discards the queue instead

--- a/zebra-rs/src/bgp/pending_withdraw.rs
+++ b/zebra-rs/src/bgp/pending_withdraw.rs
@@ -171,12 +171,22 @@ pub fn flush_pending_withdraws(ident: usize, peers: &mut PeerMap) {
 /// After an update-group flush job for `afi` unicast completed — its
 /// `members` already counted off their `flush_jobs_*` — drain the unicast
 /// withdrawals those members parked behind it. A member another job is
-/// still carrying stays parked until that one completes too.
-pub fn drain_after_flush(afi: Afi, members: &[usize], peers: &mut PeerMap) {
-    for &ident in members {
+/// still carrying stays parked until that one completes too, and a slot
+/// whose `Peer` value changed since the job was spawned (the peer was
+/// removed and re-created at the same address) is not the job's member
+/// at all and is left alone.
+pub fn drain_after_flush(
+    afi: Afi,
+    members: &[super::update_group::JobMember],
+    peers: &mut PeerMap,
+) {
+    for &(ident, instance) in members {
         let Some(peer) = peers.get_mut_by_idx(ident) else {
             continue;
         };
+        if peer.instance != instance {
+            continue;
+        }
         let (queued, gated) = match afi {
             Afi::Ip => (!peer.pending_withdraw.v4.is_empty(), peer.flush_jobs_v4 > 0),
             _ => (!peer.pending_withdraw.v6.is_empty(), peer.flush_jobs_v6 > 0),

--- a/zebra-rs/src/bgp/pending_withdraw.rs
+++ b/zebra-rs/src/bgp/pending_withdraw.rs
@@ -36,10 +36,14 @@
 //!    that job runs could land on the writer *before* the job's
 //!    announcement of the same prefix, leaving the peer with a route the
 //!    Adj-RIB-Out has already dropped. So those two families stay queued
-//!    while the peer's group has a job in flight, and
-//!    [`flush_done`](super::update_group::flush_done_ipv4) drains them
-//!    once every job byte is on the writer channel. (This replaces the
-//!    per-group `deferred_withdraw_*` parking that served the same race.)
+//!    while any job carrying this peer's announcements is out
+//!    (`Peer::flush_jobs_v4` / `v6`, counted up when the job is spawned),
+//!    and [`flush_done`](super::update_group::flush_done_ipv4) counts the
+//!    job off and drains them once every job byte is on the writer
+//!    channel. The count lives on the peer rather than the group so it
+//!    survives the group being deleted or the peer moving to another
+//!    group while the job is out. (This replaces the per-group
+//!    `deferred_withdraw_*` parking that served the same race.)
 //!
 //! A session leaving Established clears the queue and cancels the marker
 //! (`route_clean`); the flush itself is gated on Established so a marker
@@ -47,9 +51,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use bgp_packet::{
-    Afi, AfiSafi, EvpnRoute, Ipv4Nlri, Ipv6Nlri, MpUnreachAttr, Safi, Vpnv4Nlri, Vpnv6Nlri,
-};
+use bgp_packet::{Afi, EvpnRoute, Ipv4Nlri, Ipv6Nlri, MpUnreachAttr, Vpnv4Nlri, Vpnv6Nlri};
 
 use crate::context::Timer;
 
@@ -57,7 +59,6 @@ use super::Message;
 use super::adj_rib::{AdjRibTable, Out};
 use super::peer::{EvpnCacheKey, Peer};
 use super::peer_map::PeerMap;
-use super::update_group::UpdateGroupMap;
 
 /// The withdrawals queued for one peer, per family. Each family is a set
 /// keyed on route identity — for the VPN families that identity is
@@ -157,28 +158,30 @@ impl Peer {
 
 /// `Message::FlushWithdraw(ident)`: drain the peer's queued withdrawals
 /// onto the wire, family by family. Unicast IPv4 / IPv6 stay queued while
-/// the peer's update-group has a flush job in flight (see the module doc);
-/// `flush_done_*` drains them afterwards.
-pub fn flush_pending_withdraws(ident: usize, update_groups: &UpdateGroupMap, peers: &mut PeerMap) {
+/// a flush job carrying the peer's announcements is in flight (see the
+/// module doc); `flush_done_*` drains them afterwards.
+pub fn flush_pending_withdraws(ident: usize, peers: &mut PeerMap) {
     let Some(peer) = peers.get_mut_by_idx(ident) else {
         return;
     };
     peer.withdraw_timer = None;
-    drain_peer(peer, update_groups);
+    drain_peer(peer);
 }
 
-/// After an update-group flush job for `afi` unicast completed: drain the
-/// unicast withdrawals every peer parked behind that job. Walks every peer
-/// rather than the group's members — a peer can change groups while its
-/// withdrawals are parked — and re-checks each peer's *current* group,
-/// so a peer whose new group is itself mid-flight stays parked.
-pub fn drain_after_flush(afi: Afi, update_groups: &UpdateGroupMap, peers: &mut PeerMap) {
-    for (_, peer) in peers.iter_mut_all() {
-        let queued = match afi {
-            Afi::Ip => !peer.pending_withdraw.v4.is_empty(),
-            _ => !peer.pending_withdraw.v6.is_empty(),
+/// After an update-group flush job for `afi` unicast completed — its
+/// `members` already counted off their `flush_jobs_*` — drain the unicast
+/// withdrawals those members parked behind it. A member another job is
+/// still carrying stays parked until that one completes too.
+pub fn drain_after_flush(afi: Afi, members: &[usize], peers: &mut PeerMap) {
+    for &ident in members {
+        let Some(peer) = peers.get_mut_by_idx(ident) else {
+            continue;
         };
-        if !queued || group_flush_inflight(peer, update_groups, afi) {
+        let (queued, gated) = match afi {
+            Afi::Ip => (!peer.pending_withdraw.v4.is_empty(), peer.flush_jobs_v4 > 0),
+            _ => (!peer.pending_withdraw.v6.is_empty(), peer.flush_jobs_v6 > 0),
+        };
+        if !queued || gated {
             continue;
         }
         if !peer.state.is_established() {
@@ -192,15 +195,15 @@ pub fn drain_after_flush(afi: Afi, update_groups: &UpdateGroupMap, peers: &mut P
     }
 }
 
-fn drain_peer(peer: &mut Peer, update_groups: &UpdateGroupMap) {
+fn drain_peer(peer: &mut Peer) {
     if !peer.state.is_established() {
         peer.clear_pending_withdraws();
         return;
     }
-    if !group_flush_inflight(peer, update_groups, Afi::Ip) {
+    if peer.flush_jobs_v4 == 0 {
         drain_v4(peer);
     }
-    if !group_flush_inflight(peer, update_groups, Afi::Ip6) {
+    if peer.flush_jobs_v6 == 0 {
         drain_v6(peer);
     }
     drain_v4vpn(peer);
@@ -208,22 +211,6 @@ fn drain_peer(peer: &mut Peer, update_groups: &UpdateGroupMap) {
     drain_evpn(peer);
     drain_v4lu(peer);
     drain_v6lu(peer);
-}
-
-/// Whether the peer's `afi`-unicast update-group has a flush job on the
-/// blocking pool right now.
-fn group_flush_inflight(peer: &Peer, update_groups: &UpdateGroupMap, afi: Afi) -> bool {
-    let afi_safi = AfiSafi::new(afi, Safi::Unicast);
-    let Some(gid) = peer.update_group_id.get(&afi_safi) else {
-        return false;
-    };
-    update_groups
-        .get(&afi_safi)
-        .and_then(|af| af.group_by_id(gid))
-        .is_some_and(|group| match afi {
-            Afi::Ip => group.flush_inflight_ipv4,
-            _ => group.flush_inflight_ipv6,
-        })
 }
 
 /// Whether the Adj-RIB-Out still (or again) holds `(prefix, id)`. `id == 0`
@@ -380,9 +367,10 @@ fn drain_v6lu(peer: &mut Peer) {
 mod tests {
     use super::super::peer::State;
     use super::super::route::{BgpRib, BgpRibType};
-    use super::super::update_group::empty_map;
     use super::*;
-    use bgp_packet::{BgpAttr, EvpnMulticast, EvpnPrefix, Label, RouteDistinguisher, UpdatePacket};
+    use bgp_packet::{
+        AfiSafi, BgpAttr, EvpnMulticast, EvpnPrefix, Label, RouteDistinguisher, Safi, UpdatePacket,
+    };
     use bytes::BytesMut;
     use ipnet::Ipv4Net;
     use std::net::{IpAddr, Ipv4Addr};
@@ -505,7 +493,7 @@ mod tests {
         for i in 0..3000 {
             peer.queue_withdraw_v4(v4(i, 0));
         }
-        flush_pending_withdraws(1, &empty_map(), &mut PeerMap::new());
+        flush_pending_withdraws(1, &mut PeerMap::new());
         // No such peer in that map — nothing sent, queue intact.
         assert_eq!(queued(&peer.pending_withdraw), 3000);
 
@@ -513,7 +501,7 @@ mod tests {
         let address = peer.address;
         peers.insert(address, peer);
         let ident = peers.get(&address).unwrap().ident;
-        flush_pending_withdraws(ident, &empty_map(), &mut peers);
+        flush_pending_withdraws(ident, &mut peers);
         let packets = sent(&mut prx);
         assert_eq!(packets.len(), 4);
         let n: usize = packets.iter().map(|p| p.ipv4_withdraw.len()).sum();
@@ -535,7 +523,7 @@ mod tests {
         peer.queue_withdraw_v4(v4(1, 0));
         peer.adj_out.v4.add(v4(1, 0).prefix, rib(7));
         peer.queue_withdraw_v4(v4(2, 0));
-        drain_peer(&mut peer, &empty_map());
+        drain_peer(&mut peer);
         let packets = sent(&mut prx);
         assert_eq!(packets.len(), 1);
         let got: Vec<Ipv4Net> = packets[0].ipv4_withdraw.iter().map(|n| n.prefix).collect();
@@ -549,7 +537,7 @@ mod tests {
         peer.adj_out.v4.add(v4(3, 0).prefix, rib(4));
         peer.queue_withdraw_v4(v4(4, 5));
         peer.adj_out.v4.add(v4(4, 0).prefix, rib(5));
-        drain_peer(&mut peer, &empty_map());
+        drain_peer(&mut peer);
         let packets = sent_opt(&mut prx, Some(add_path_v4()));
         assert_eq!(packets.len(), 1);
         let got: Vec<(Ipv4Net, u32)> = packets[0]
@@ -602,7 +590,7 @@ mod tests {
         let (_, prefix0) = EvpnPrefix::from_route(&mcast(0));
         peer.adj_out.add_evpn(rd, prefix0, rib(2));
 
-        drain_peer(&mut peer, &empty_map());
+        drain_peer(&mut peer);
         let packets = sent(&mut prx);
         assert_eq!(packets.len(), 2, "one VPNv4 UPDATE and one EVPN UPDATE");
         let vpn: Vec<Ipv4Net> = packets
@@ -703,7 +691,7 @@ mod tests {
         assert_eq!(rows, vec![2], "path 1's row is gone, path 2 stays");
         assert_eq!(peer.pending_withdraw.v6vpn.len(), 1);
 
-        drain_peer(peer, &empty_map());
+        drain_peer(peer);
         let packets = sent_opt(
             &mut prx,
             Some({
@@ -737,7 +725,7 @@ mod tests {
         let (mut peer, mut prx, _rx) = established_peer();
         peer.queue_withdraw_v4(v4(1, 0));
         peer.state = State::Idle;
-        drain_peer(&mut peer, &empty_map());
+        drain_peer(&mut peer);
         assert!(sent(&mut prx).is_empty());
         assert_eq!(queued(&peer.pending_withdraw), 0);
         assert!(peer.withdraw_timer.is_none());

--- a/zebra-rs/src/bgp/pending_withdraw.rs
+++ b/zebra-rs/src/bgp/pending_withdraw.rs
@@ -647,6 +647,89 @@ mod tests {
         assert_eq!(peer.cache_vpnv4_rev.len(), 1);
     }
 
+    /// The VPNv6 AddPath withdraw must drop the path's Adj-RIB-Out row
+    /// before queueing, or the drain's reconciliation would read the row
+    /// as a re-advertise and cancel the withdraw. Found by
+    /// `bgp_shard_addpath_vpnv6`: the session-up dump recorded the rows,
+    /// the AddPath withdraw never removed them, and the peer kept the
+    /// withdrawn path.
+    #[tokio::test]
+    async fn vpnv6_addpath_withdraw_drops_adj_rib_out_row_so_it_is_sent() {
+        use super::super::route::route_withdraw_vpnv6_addpath;
+        use bgp_packet::{AfiSafi, Direct};
+        use ipnet::Ipv6Net;
+
+        let (mut peer, mut prx, _rx) = established_peer();
+        // VPNv6 negotiated both ways with AddPath-send, so the membership
+        // index puts the peer in the AddPath fan-out set.
+        let mp = bgp_packet::CapMultiProtocol::new(&Afi::Ip6, &Safi::MplsVpn);
+        if let Some(sr) = peer.cap_map.get_mut(&mp) {
+            sr.send = true;
+            sr.recv = true;
+        }
+        peer.opt.add_path.insert(
+            AfiSafi::new(Afi::Ip6, Safi::MplsVpn),
+            Direct {
+                recv: true,
+                send: true,
+            },
+        );
+        let rd = RouteDistinguisher::from_str("65001:100").unwrap();
+        let prefix: Ipv6Net = "2001:db8:9::/64".parse().unwrap();
+        // Two paths advertised (as the session-up dump records them).
+        peer.adj_out
+            .v6vpn
+            .entry(rd)
+            .or_default()
+            .add(prefix, rib(1));
+        peer.adj_out
+            .v6vpn
+            .entry(rd)
+            .or_default()
+            .add(prefix, rib(2));
+        let mut peers = PeerMap::new();
+        let address = peer.address;
+        peers.insert(address, peer);
+        let ident = peers.get(&address).unwrap().ident;
+        peers.membership_enroll(ident);
+
+        route_withdraw_vpnv6_addpath(rd, prefix, &rib(1), &mut peers);
+
+        let peer = peers.get_mut_by_idx(ident).unwrap();
+        let rows: Vec<u32> = peer.adj_out.v6vpn[&rd].0[&prefix]
+            .iter()
+            .map(|r| r.local_id)
+            .collect();
+        assert_eq!(rows, vec![2], "path 1's row is gone, path 2 stays");
+        assert_eq!(peer.pending_withdraw.v6vpn.len(), 1);
+
+        drain_peer(peer, &empty_map());
+        let packets = sent_opt(
+            &mut prx,
+            Some({
+                let mut opt = bgp_packet::ParseOption::default();
+                opt.add_path.insert(
+                    AfiSafi::new(Afi::Ip6, Safi::MplsVpn),
+                    Direct {
+                        recv: true,
+                        send: true,
+                    },
+                );
+                opt
+            }),
+        );
+        assert_eq!(packets.len(), 1, "the withdraw of path 1 goes out");
+        match &packets[0].mp_withdraw {
+            Some(MpUnreachAttr::Vpnv6(w)) => {
+                assert_eq!(w.len(), 1);
+                assert_eq!(w[0].rd, rd);
+                assert_eq!(w[0].nlri.prefix, prefix);
+                assert_eq!(w[0].nlri.id, 1);
+            }
+            other => panic!("expected a VPNv6 MP_UNREACH, got {other:?}"),
+        }
+    }
+
     /// A flush on a peer that left Established discards the queue instead
     /// of pushing stale withdrawals onto whatever session comes next.
     #[tokio::test]

--- a/zebra-rs/src/bgp/pending_withdraw.rs
+++ b/zebra-rs/src/bgp/pending_withdraw.rs
@@ -1,0 +1,662 @@
+//! Per-peer pending withdrawals: the withdraw half of the outbound
+//! batching that the advertise caches (`cache_vpnv4`, the update-group
+//! `cache_ipv4`, …) provide for announcements.
+//!
+//! Modelled on rustybgp's `PendingTx`: instead of putting every withdrawn
+//! NLRI on the wire as its own one-route UPDATE the moment best-path
+//! removes it, a withdraw is queued on the peer and a next-tick flush
+//! ([`Message::FlushWithdraw`], armed once per peer while anything is
+//! queued) drains the queue into as few UPDATEs as the negotiated message
+//! size allows. Because the flush marker lands on the BGP instance channel
+//! *behind* whatever ingest is already queued, a burst — a peer going down,
+//! a route-reflector sweep, a soft-out — is drained in one go, so packing
+//! scales with the backlog and stays at one extra tick of latency when the
+//! router is idle.
+//!
+//! # Keeping the wire in step with the Adj-RIB-Out
+//!
+//! Queueing a withdraw opens a window in which the same route can be
+//! re-advertised before the withdraw goes out. Two rules close it:
+//!
+//! 1. **The Adj-RIB-Out is the authority at drain time.** Every advertise
+//!    site records the route in `peer.adj_out` as it queues or sends the
+//!    announcement, and every withdraw site removes it before queueing the
+//!    withdraw. So when the queue drains, a queued NLRI whose `(prefix,
+//!    path-id)` is back in the Adj-RIB-Out has been superseded by a newer
+//!    announcement — pending in a cache or already sent — and is dropped:
+//!    sending it would tear down a route the Adj-RIB-Out says the peer
+//!    holds. (The announce-side caches already evict a queued announce on
+//!    withdraw, and [`Peer::send_vpnv4`] & co. drop a queued withdraw on
+//!    re-advertise, mirroring rustybgp's `reach()` / `unreach()`; the
+//!    Adj-RIB-Out check is what makes this hold for the families whose
+//!    announcements ride a shared update-group cache.)
+//! 2. **An in-flight update-group flush gates the drain.** The IPv4 /
+//!    IPv6 unicast flush job encodes and enqueues its announcements on a
+//!    blocking-pool thread; a withdraw enqueued from the main task while
+//!    that job runs could land on the writer *before* the job's
+//!    announcement of the same prefix, leaving the peer with a route the
+//!    Adj-RIB-Out has already dropped. So those two families stay queued
+//!    while the peer's group has a job in flight, and
+//!    [`flush_done`](super::update_group::flush_done_ipv4) drains them
+//!    once every job byte is on the writer channel. (This replaces the
+//!    per-group `deferred_withdraw_*` parking that served the same race.)
+//!
+//! A session leaving Established clears the queue and cancels the marker
+//! (`route_clean`); the flush itself is gated on Established so a marker
+//! that outlives its session cannot push anything onto a new one.
+
+use std::collections::{HashMap, HashSet};
+
+use bgp_packet::{
+    Afi, AfiSafi, EvpnRoute, Ipv4Nlri, Ipv6Nlri, MpUnreachAttr, Safi, Vpnv4Nlri, Vpnv6Nlri,
+};
+
+use crate::context::Timer;
+
+use super::Message;
+use super::adj_rib::{AdjRibTable, Out};
+use super::peer::{EvpnCacheKey, Peer};
+use super::peer_map::PeerMap;
+use super::update_group::UpdateGroupMap;
+
+/// The withdrawals queued for one peer, per family. Each family is a set
+/// keyed on route identity — for the VPN families that identity is
+/// label-blind (`Vpnv4Nlri`'s `Eq`), and an EVPN route is keyed by
+/// `(RD, prefix, path-id)` because the withdraw is rebuilt from the RIB key
+/// and never sees the queued NLRI's label or gateway — so a route withdrawn
+/// twice before the flush is sent once.
+#[derive(Debug, Default)]
+pub struct PendingWithdraw {
+    pub v4: HashSet<Ipv4Nlri>,
+    pub v6: HashSet<Ipv6Nlri>,
+    pub v4vpn: HashSet<Vpnv4Nlri>,
+    pub v6vpn: HashSet<Vpnv6Nlri>,
+    pub evpn: HashMap<EvpnCacheKey, EvpnRoute>,
+    pub v4lu: HashSet<Ipv4Nlri>,
+    pub v6lu: HashSet<Ipv6Nlri>,
+}
+
+impl PendingWithdraw {
+    pub fn clear(&mut self) {
+        self.v4.clear();
+        self.v6.clear();
+        self.v4vpn.clear();
+        self.v6vpn.clear();
+        self.evpn.clear();
+        self.v4lu.clear();
+        self.v6lu.clear();
+    }
+}
+
+/// Arm the next-tick flush marker: one `Message::FlushWithdraw` on the
+/// instance channel after ~1 ms. Mirrors `start_adv_timer!` with
+/// adv-interval 0 — the 1 ms is the executor's turnover, not a debounce.
+fn start_withdraw_flush_timer(peer: &Peer) -> Timer {
+    let ident = peer.ident;
+    let tx = peer.tx.clone();
+    Timer::once_ms(1, move || {
+        let tx = tx.clone();
+        async move {
+            let _ = tx.send(Message::FlushWithdraw(ident)).await;
+        }
+    })
+}
+
+impl Peer {
+    /// Arm the flush marker unless one is already pending. The marker is
+    /// cleared when it is serviced, so a burst of queued withdraws shares
+    /// one flush.
+    fn arm_withdraw_flush(&mut self) {
+        if self.withdraw_timer.is_none() {
+            self.withdraw_timer = Some(start_withdraw_flush_timer(self));
+        }
+    }
+
+    pub fn queue_withdraw_v4(&mut self, nlri: Ipv4Nlri) {
+        self.pending_withdraw.v4.insert(nlri);
+        self.arm_withdraw_flush();
+    }
+
+    pub fn queue_withdraw_v6(&mut self, nlri: Ipv6Nlri) {
+        self.pending_withdraw.v6.insert(nlri);
+        self.arm_withdraw_flush();
+    }
+
+    pub fn queue_withdraw_v4vpn(&mut self, nlri: Vpnv4Nlri) {
+        self.pending_withdraw.v4vpn.insert(nlri);
+        self.arm_withdraw_flush();
+    }
+
+    pub fn queue_withdraw_v6vpn(&mut self, nlri: Vpnv6Nlri) {
+        self.pending_withdraw.v6vpn.insert(nlri);
+        self.arm_withdraw_flush();
+    }
+
+    pub fn queue_withdraw_evpn(&mut self, key: EvpnCacheKey, route: EvpnRoute) {
+        self.pending_withdraw.evpn.insert(key, route);
+        self.arm_withdraw_flush();
+    }
+
+    pub fn queue_withdraw_v4lu(&mut self, nlri: Ipv4Nlri) {
+        self.pending_withdraw.v4lu.insert(nlri);
+        self.arm_withdraw_flush();
+    }
+
+    pub fn queue_withdraw_v6lu(&mut self, nlri: Ipv6Nlri) {
+        self.pending_withdraw.v6lu.insert(nlri);
+        self.arm_withdraw_flush();
+    }
+
+    /// Drop every queued withdrawal and the flush marker — the session is
+    /// gone, and a new one re-syncs from scratch.
+    pub fn clear_pending_withdraws(&mut self) {
+        self.pending_withdraw.clear();
+        self.withdraw_timer = None;
+    }
+}
+
+/// `Message::FlushWithdraw(ident)`: drain the peer's queued withdrawals
+/// onto the wire, family by family. Unicast IPv4 / IPv6 stay queued while
+/// the peer's update-group has a flush job in flight (see the module doc);
+/// `flush_done_*` drains them afterwards.
+pub fn flush_pending_withdraws(ident: usize, update_groups: &UpdateGroupMap, peers: &mut PeerMap) {
+    let Some(peer) = peers.get_mut_by_idx(ident) else {
+        return;
+    };
+    peer.withdraw_timer = None;
+    drain_peer(peer, update_groups);
+}
+
+/// After an update-group flush job for `afi` unicast completed: drain the
+/// unicast withdrawals every peer parked behind that job. Walks every peer
+/// rather than the group's members — a peer can change groups while its
+/// withdrawals are parked — and re-checks each peer's *current* group,
+/// so a peer whose new group is itself mid-flight stays parked.
+pub fn drain_after_flush(afi: Afi, update_groups: &UpdateGroupMap, peers: &mut PeerMap) {
+    for (_, peer) in peers.iter_mut_all() {
+        let queued = match afi {
+            Afi::Ip => !peer.pending_withdraw.v4.is_empty(),
+            _ => !peer.pending_withdraw.v6.is_empty(),
+        };
+        if !queued || group_flush_inflight(peer, update_groups, afi) {
+            continue;
+        }
+        if !peer.state.is_established() {
+            peer.clear_pending_withdraws();
+            continue;
+        }
+        match afi {
+            Afi::Ip => drain_v4(peer),
+            _ => drain_v6(peer),
+        }
+    }
+}
+
+fn drain_peer(peer: &mut Peer, update_groups: &UpdateGroupMap) {
+    if !peer.state.is_established() {
+        peer.clear_pending_withdraws();
+        return;
+    }
+    if !group_flush_inflight(peer, update_groups, Afi::Ip) {
+        drain_v4(peer);
+    }
+    if !group_flush_inflight(peer, update_groups, Afi::Ip6) {
+        drain_v6(peer);
+    }
+    drain_v4vpn(peer);
+    drain_v6vpn(peer);
+    drain_evpn(peer);
+    drain_v4lu(peer);
+    drain_v6lu(peer);
+}
+
+/// Whether the peer's `afi`-unicast update-group has a flush job on the
+/// blocking pool right now.
+fn group_flush_inflight(peer: &Peer, update_groups: &UpdateGroupMap, afi: Afi) -> bool {
+    let afi_safi = AfiSafi::new(afi, Safi::Unicast);
+    let Some(gid) = peer.update_group_id.get(&afi_safi) else {
+        return false;
+    };
+    update_groups
+        .get(&afi_safi)
+        .and_then(|af| af.group_by_id(gid))
+        .is_some_and(|group| match afi {
+            Afi::Ip => group.flush_inflight_ipv4,
+            _ => group.flush_inflight_ipv6,
+        })
+}
+
+/// Whether the Adj-RIB-Out still (or again) holds `(prefix, id)`. `id == 0`
+/// is the non-AddPath wire id and matches any row for the prefix — a
+/// non-AddPath advertisement is stored under the Loc-RIB `local_id`, never
+/// 0 — while a real path-id must match exactly.
+fn adj_out_has<P: Ord>(table: &AdjRibTable<Out, P>, prefix: &P, id: u32) -> bool {
+    table
+        .0
+        .get(prefix)
+        .is_some_and(|rows| id == 0 || rows.iter().any(|r| r.local_id == id))
+}
+
+/// Emit `attr`'s withdrawals as as many UPDATEs as the session's message
+/// size needs.
+fn send_mp_withdraws(peer: &Peer, attr: MpUnreachAttr) {
+    let mut update = peer.update_packet();
+    update.mp_withdraw = Some(attr);
+    while let Some(bytes) = update.pop_mp_withdraw() {
+        peer.send_packet(bytes);
+    }
+}
+
+fn drain_v4(peer: &mut Peer) {
+    if peer.pending_withdraw.v4.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.v4);
+    let withdraws: Vec<Ipv4Nlri> = queued
+        .into_iter()
+        .filter(|n| !adj_out_has(&peer.adj_out.v4, &n.prefix, n.id))
+        .collect();
+    if withdraws.is_empty() {
+        return;
+    }
+    let mut update = peer.update_packet();
+    update.ipv4_withdraw = withdraws;
+    while let Some(bytes) = update.pop_ipv4_withdraw() {
+        peer.send_packet(bytes);
+    }
+}
+
+fn drain_v6(peer: &mut Peer) {
+    if peer.pending_withdraw.v6.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.v6);
+    let withdraws: Vec<Ipv6Nlri> = queued
+        .into_iter()
+        .filter(|n| !adj_out_has(&peer.adj_out.v6, &n.prefix, n.id))
+        .collect();
+    if !withdraws.is_empty() {
+        send_mp_withdraws(peer, MpUnreachAttr::Ipv6Nlri(withdraws));
+    }
+}
+
+fn drain_v4vpn(peer: &mut Peer) {
+    if peer.pending_withdraw.v4vpn.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.v4vpn);
+    let withdraws: Vec<Vpnv4Nlri> = queued
+        .into_iter()
+        .filter(|n| {
+            !peer
+                .adj_out
+                .v4vpn
+                .get(&n.rd)
+                .is_some_and(|t| adj_out_has(t, &n.nlri.prefix, n.nlri.id))
+        })
+        .collect();
+    if !withdraws.is_empty() {
+        send_mp_withdraws(peer, MpUnreachAttr::Vpnv4(withdraws));
+    }
+}
+
+fn drain_v6vpn(peer: &mut Peer) {
+    if peer.pending_withdraw.v6vpn.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.v6vpn);
+    let withdraws: Vec<Vpnv6Nlri> = queued
+        .into_iter()
+        .filter(|n| {
+            !peer
+                .adj_out
+                .v6vpn
+                .get(&n.rd)
+                .is_some_and(|t| adj_out_has(t, &n.nlri.prefix, n.nlri.id))
+        })
+        .collect();
+    if !withdraws.is_empty() {
+        send_mp_withdraws(peer, MpUnreachAttr::Vpnv6(withdraws));
+    }
+}
+
+fn drain_evpn(peer: &mut Peer) {
+    if peer.pending_withdraw.evpn.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.evpn);
+    let withdraws: Vec<EvpnRoute> = queued
+        .into_iter()
+        .filter(|((rd, prefix, id), _)| {
+            !peer.adj_out.evpn.get(rd).is_some_and(|t| {
+                t.0.get(prefix)
+                    .is_some_and(|rows| *id == 0 || rows.iter().any(|r| r.local_id == *id))
+            })
+        })
+        .map(|(_, route)| route)
+        .collect();
+    if !withdraws.is_empty() {
+        send_mp_withdraws(peer, MpUnreachAttr::Evpn(withdraws));
+    }
+}
+
+fn drain_v4lu(peer: &mut Peer) {
+    if peer.pending_withdraw.v4lu.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.v4lu);
+    let withdraws: Vec<bgp_packet::Labelv4Nlri> = queued
+        .into_iter()
+        .filter(|n| !adj_out_has(&peer.adj_out.v4lu, &n.prefix, n.id))
+        .map(|nlri| bgp_packet::Labelv4Nlri {
+            label: bgp_packet::Label::default(),
+            nlri,
+        })
+        .collect();
+    if !withdraws.is_empty() {
+        send_mp_withdraws(peer, MpUnreachAttr::Labelv4(withdraws));
+    }
+}
+
+fn drain_v6lu(peer: &mut Peer) {
+    if peer.pending_withdraw.v6lu.is_empty() {
+        return;
+    }
+    let queued = std::mem::take(&mut peer.pending_withdraw.v6lu);
+    let withdraws: Vec<bgp_packet::Labelv6Nlri> = queued
+        .into_iter()
+        .filter(|n| !adj_out_has(&peer.adj_out.v6lu, &n.prefix, n.id))
+        .map(|nlri| bgp_packet::Labelv6Nlri {
+            label: bgp_packet::Label::default(),
+            nlri,
+        })
+        .collect();
+    if !withdraws.is_empty() {
+        send_mp_withdraws(peer, MpUnreachAttr::Labelv6(withdraws));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::peer::State;
+    use super::super::route::{BgpRib, BgpRibType};
+    use super::super::update_group::empty_map;
+    use super::*;
+    use bgp_packet::{BgpAttr, EvpnMulticast, EvpnPrefix, Label, RouteDistinguisher, UpdatePacket};
+    use bytes::BytesMut;
+    use ipnet::Ipv4Net;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    /// An Established peer whose writer channel is `rx`.
+    fn established_peer() -> (
+        Peer,
+        mpsc::UnboundedReceiver<BytesMut>,
+        mpsc::Receiver<Message>,
+    ) {
+        let (tx, rx) = mpsc::channel::<Message>(64);
+        let mut peer = Peer::new(
+            1,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65001,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = State::Established;
+        let (ptx, prx) = mpsc::unbounded_channel::<BytesMut>();
+        peer.packet_tx = Some(ptx);
+        (peer, prx, rx)
+    }
+
+    fn rib(local_id: u32) -> BgpRib {
+        let mut rib = BgpRib::new_arc(
+            2,
+            "10.0.0.9".parse().unwrap(),
+            BgpRibType::IBGP,
+            0,
+            100,
+            Arc::new(BgpAttr::default()),
+            None,
+            None,
+            false,
+        );
+        rib.local_id = local_id;
+        rib
+    }
+
+    fn queued(p: &PendingWithdraw) -> usize {
+        p.v4.len()
+            + p.v6.len()
+            + p.v4vpn.len()
+            + p.v6vpn.len()
+            + p.evpn.len()
+            + p.v4lu.len()
+            + p.v6lu.len()
+    }
+
+    fn v4(i: u32, id: u32) -> Ipv4Nlri {
+        Ipv4Nlri {
+            id,
+            prefix: Ipv4Net::new(Ipv4Addr::from(0x0A00_0000u32 + i), 32).unwrap(),
+        }
+    }
+
+    /// Drain the writer channel into parsed UPDATEs.
+    fn sent(rx: &mut mpsc::UnboundedReceiver<BytesMut>) -> Vec<UpdatePacket> {
+        sent_opt(rx, None)
+    }
+
+    fn sent_opt(
+        rx: &mut mpsc::UnboundedReceiver<BytesMut>,
+        opt: Option<bgp_packet::ParseOption>,
+    ) -> Vec<UpdatePacket> {
+        let mut out = vec![];
+        while let Ok(bytes) = rx.try_recv() {
+            let (_, p) = UpdatePacket::parse_packet(&bytes, true, opt.clone()).expect("parses");
+            out.push(p);
+        }
+        out
+    }
+
+    /// Parse options for a session with Add-Path negotiated on IPv4 unicast.
+    fn add_path_v4() -> bgp_packet::ParseOption {
+        let mut opt = bgp_packet::ParseOption::default();
+        opt.add_path.insert(
+            AfiSafi::new(Afi::Ip, Safi::Unicast),
+            bgp_packet::Direct {
+                recv: true,
+                send: true,
+            },
+        );
+        opt
+    }
+
+    /// Queueing arms one flush marker per peer; a burst shares it, and it
+    /// lands on the instance channel as `FlushWithdraw(ident)`.
+    #[tokio::test]
+    async fn queue_arms_one_flush_marker() {
+        let (mut peer, _prx, mut rx) = established_peer();
+        peer.queue_withdraw_v4(v4(1, 0));
+        peer.queue_withdraw_v4(v4(2, 0));
+        peer.queue_withdraw_v4vpn(Vpnv4Nlri {
+            label: Label::default(),
+            rd: RouteDistinguisher::default(),
+            nlri: v4(3, 0),
+        });
+        assert_eq!(queued(&peer.pending_withdraw), 3);
+        assert!(peer.withdraw_timer.is_some());
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+            .await
+            .expect("marker within the timeout")
+            .expect("channel open");
+        assert!(matches!(msg, Message::FlushWithdraw(1)));
+        assert!(rx.try_recv().is_err(), "one marker for the burst");
+    }
+
+    /// 3000 queued IPv4 withdrawals go out as four 4096-octet UPDATEs.
+    #[tokio::test]
+    async fn drain_packs_ipv4_withdrawals() {
+        let (mut peer, mut prx, _rx) = established_peer();
+        for i in 0..3000 {
+            peer.queue_withdraw_v4(v4(i, 0));
+        }
+        flush_pending_withdraws(1, &empty_map(), &mut PeerMap::new());
+        // No such peer in that map — nothing sent, queue intact.
+        assert_eq!(queued(&peer.pending_withdraw), 3000);
+
+        let mut peers = PeerMap::new();
+        let address = peer.address;
+        peers.insert(address, peer);
+        let ident = peers.get(&address).unwrap().ident;
+        flush_pending_withdraws(ident, &empty_map(), &mut peers);
+        let packets = sent(&mut prx);
+        assert_eq!(packets.len(), 4);
+        let n: usize = packets.iter().map(|p| p.ipv4_withdraw.len()).sum();
+        assert_eq!(n, 3000);
+        let peer = peers.get_by_idx(ident).unwrap();
+        assert_eq!(queued(&peer.pending_withdraw), 0);
+        assert!(peer.withdraw_timer.is_none(), "marker consumed");
+    }
+
+    /// A queued withdraw whose route is back in the Adj-RIB-Out was
+    /// superseded by a re-advertise and must not go out; one whose
+    /// path-id differs from the re-advertised path still does.
+    #[tokio::test]
+    async fn drain_drops_withdrawals_the_adj_rib_out_has_re_acquired() {
+        // Non-AddPath session: id 0 on the wire, rows stored under the
+        // Loc-RIB local_id. 10.0.0.1 was re-advertised — dropped;
+        // 10.0.0.2 was not — goes.
+        let (mut peer, mut prx, _rx) = established_peer();
+        peer.queue_withdraw_v4(v4(1, 0));
+        peer.adj_out.v4.add(v4(1, 0).prefix, rib(7));
+        peer.queue_withdraw_v4(v4(2, 0));
+        drain_peer(&mut peer, &empty_map());
+        let packets = sent(&mut prx);
+        assert_eq!(packets.len(), 1);
+        let got: Vec<Ipv4Net> = packets[0].ipv4_withdraw.iter().map(|n| n.prefix).collect();
+        assert_eq!(got, vec![v4(2, 0).prefix]);
+
+        // AddPath session: path 3 of 10.0.0.3 withdrawn while path 4 was
+        // re-advertised — 3 still goes; path 5 of 10.0.0.4 withdrawn then
+        // re-advertised — dropped.
+        let (mut peer, mut prx, _rx) = established_peer();
+        peer.queue_withdraw_v4(v4(3, 3));
+        peer.adj_out.v4.add(v4(3, 0).prefix, rib(4));
+        peer.queue_withdraw_v4(v4(4, 5));
+        peer.adj_out.v4.add(v4(4, 0).prefix, rib(5));
+        drain_peer(&mut peer, &empty_map());
+        let packets = sent_opt(&mut prx, Some(add_path_v4()));
+        assert_eq!(packets.len(), 1);
+        let got: Vec<(Ipv4Net, u32)> = packets[0]
+            .ipv4_withdraw
+            .iter()
+            .map(|n| (n.prefix, n.id))
+            .collect();
+        assert_eq!(got, vec![(v4(3, 0).prefix, 3)]);
+    }
+
+    /// VPN and EVPN withdrawals reconcile against their per-RD tables and
+    /// paginate through MP_UNREACH.
+    #[tokio::test]
+    async fn drain_reconciles_vpn_and_evpn_per_rd() {
+        let (mut peer, mut prx, _rx) = established_peer();
+        let rd = RouteDistinguisher::from_str("65001:1").unwrap();
+        let other = RouteDistinguisher::from_str("65001:2").unwrap();
+        for i in 0..3 {
+            peer.queue_withdraw_v4vpn(Vpnv4Nlri {
+                label: Label::default(),
+                rd,
+                nlri: v4(i, 0),
+            });
+        }
+        // Same prefix re-advertised under `rd` — dropped; under `other` —
+        // a different route, the withdraw still goes.
+        peer.adj_out
+            .v4vpn
+            .entry(rd)
+            .or_default()
+            .add(v4(0, 0).prefix, rib(9));
+        peer.adj_out
+            .v4vpn
+            .entry(other)
+            .or_default()
+            .add(v4(1, 0).prefix, rib(9));
+
+        let mcast = |i: u32| {
+            EvpnRoute::Multicast(EvpnMulticast {
+                id: 0,
+                rd,
+                ether_tag: 0,
+                addr: IpAddr::V4(Ipv4Addr::from(0x0A00_0000u32 + i)),
+            })
+        };
+        for i in 0..2 {
+            let (rd, prefix) = EvpnPrefix::from_route(&mcast(i));
+            peer.queue_withdraw_evpn((rd, prefix, 0), mcast(i));
+        }
+        let (_, prefix0) = EvpnPrefix::from_route(&mcast(0));
+        peer.adj_out.add_evpn(rd, prefix0, rib(2));
+
+        drain_peer(&mut peer, &empty_map());
+        let packets = sent(&mut prx);
+        assert_eq!(packets.len(), 2, "one VPNv4 UPDATE and one EVPN UPDATE");
+        let vpn: Vec<Ipv4Net> = packets
+            .iter()
+            .filter_map(|p| match &p.mp_withdraw {
+                Some(MpUnreachAttr::Vpnv4(w)) => Some(w.iter().map(|n| n.nlri.prefix)),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(vpn.len(), 2);
+        assert!(!vpn.contains(&v4(0, 0).prefix));
+        let evpn: Vec<EvpnRoute> = packets
+            .iter()
+            .filter_map(|p| match &p.mp_withdraw {
+                Some(MpUnreachAttr::Evpn(w)) => Some(w.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        assert_eq!(evpn, vec![mcast(1)]);
+    }
+
+    /// A re-advertise through the VPN advertise cache drops the queued
+    /// withdraw for the same route (rustybgp's `reach()` cancelling
+    /// `unreach`), so the peer sees one implicit replace, never a withdraw
+    /// racing the announcement.
+    #[tokio::test]
+    async fn re_advertise_cancels_queued_vpn_withdraw() {
+        let (mut peer, _prx, _rx) = established_peer();
+        let rd = RouteDistinguisher::from_str("65001:1").unwrap();
+        let nlri = Vpnv4Nlri {
+            label: Label::default(),
+            rd,
+            nlri: v4(1, 0),
+        };
+        peer.queue_withdraw_v4vpn(nlri.clone());
+        let mut labelled = nlri.clone();
+        labelled.label = Label::new(300, 0, true);
+        peer.send_vpnv4(labelled, Arc::new(BgpAttr::default()), false);
+        assert!(peer.pending_withdraw.v4vpn.is_empty());
+        assert_eq!(peer.cache_vpnv4_rev.len(), 1);
+    }
+
+    /// A flush on a peer that left Established discards the queue instead
+    /// of pushing stale withdrawals onto whatever session comes next.
+    #[tokio::test]
+    async fn drain_on_a_down_peer_discards() {
+        let (mut peer, mut prx, _rx) = established_peer();
+        peer.queue_withdraw_v4(v4(1, 0));
+        peer.state = State::Idle;
+        drain_peer(&mut peer, &empty_map());
+        assert!(sent(&mut prx).is_empty());
+        assert_eq!(queued(&peer.pending_withdraw), 0);
+        assert!(peer.withdraw_timer.is_none());
+    }
+}

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6411,8 +6411,17 @@ mod evpn_nexthop_wiring_tests {
 /// an empty selection at the peer triggers `route_evpn_export_selected`
 /// which sends `Message::MacDel` / `MdbDel` and the kernel FDB row goes
 /// away.
-fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
-    peer.queue_withdraw_evpn(evpn_cache_key(&route), route);
+fn route_withdraw_evpn(
+    peer: &mut Peer,
+    rd: &RouteDistinguisher,
+    prefix: &EvpnPrefix,
+    id: u32,
+    route: EvpnRoute,
+) {
+    // Keyed on the RIB identity the caller withdrew by — the same key the
+    // Adj-RIB-Out and `cache_evpn_rev` use — so the drain's Adj-RIB-Out
+    // check and a re-advertise's cancel both find it.
+    peer.queue_withdraw_evpn((*rd, prefix.clone(), id), route);
 }
 
 /// Fan out a withdraw to every peer with `(L2vpn, Evpn)` Established.
@@ -6439,7 +6448,7 @@ fn evpn_withdraw_one(peer: &mut Peer, rd: &RouteDistinguisher, prefix: &EvpnPref
     // reality — without this a follow-up policy change would think the
     // route is still advertised and emit a redundant withdraw.
     peer.adj_out.remove_evpn(*rd, prefix, id);
-    route_withdraw_evpn(peer, route);
+    route_withdraw_evpn(peer, rd, prefix, id, route);
 }
 
 pub fn route_withdraw_evpn_to_peers(
@@ -6730,8 +6739,8 @@ pub fn route_advertise_evpn_to_peers(
 /// Queue a per-peer IPv4-unicast (`rd = None`) or VPNv4 withdraw. The
 /// NLRI joins the peer's pending withdrawals and the next-tick flush
 /// packs it with whatever else is queued — one UPDATE per full message
-/// rather than one per route. The caller has already dropped the route
-/// from the peer's Adj-RIB-Out; the flush re-checks that table, so a
+/// rather than one per route. The caller drops the route from the peer's
+/// Adj-RIB-Out in the same pass; the flush re-checks that table, so a
 /// re-advertise landing before the flush cancels the withdraw, and a
 /// unicast withdraw stays queued while the peer's update-group has an
 /// announce job in flight (see [`super::pending_withdraw`]).

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5827,6 +5827,18 @@ impl BatchAfi for V6Batch {
             if !peer.rtcv6.is_empty() && !rtc_match(&peer.rtcv6, &attr.ecom) {
                 return;
             }
+            // Record the path in the VPNv6 Adj-RIB-Out under its path-id,
+            // as the VPNv4 twin and the session-up dump do. Without this
+            // row the withdraw side cannot tell a path it advertised from
+            // one it never did — and with only the dump recording rows,
+            // `route_withdraw_vpnv6_addpath` found rows it never removed.
+            let mut rib_clone = rib.clone();
+            rib_clone.attr = attr.clone();
+            peer.adj_out
+                .v6vpn
+                .entry(rd)
+                .or_default()
+                .add(prefix, rib_clone);
             let vpnv6_nlri = Vpnv6Nlri {
                 label: rib.label.unwrap_or_default(),
                 rd,
@@ -13300,10 +13312,16 @@ pub(super) fn route_advertise_to_peers_vpnv6_addpath(
     route_advertise_batch_addpath::<V6Batch>(Some(rd), prefix, rib, bgp, peers);
 }
 
-/// VPNv6 AddPath withdraw twin — emit an MP_UNREACH carrying the
-/// withdrawn path's `local_id` to every AddPath-Send member, and drop
-/// the matching entry from each peer's pending cache. The other paths
-/// for the prefix stay advertised (they carry different path-ids).
+/// VPNv6 AddPath withdraw twin — queue an MP_UNREACH carrying the
+/// withdrawn path's `local_id` to every AddPath-Send member, drop the
+/// matching entry from each peer's pending cache, and drop the path's
+/// row from the peer's VPNv6 Adj-RIB-Out. The other paths for the
+/// prefix stay advertised (they carry different path-ids).
+///
+/// The Adj-RIB-Out removal is load-bearing: the pending-withdraw drain
+/// drops a queued withdraw whose `(prefix, path-id)` is still in that
+/// table (a re-advertise supersedes it), so a row left behind here would
+/// silently cancel the withdraw and leave the peer holding the path.
 pub(super) fn route_withdraw_vpnv6_addpath(
     rd: RouteDistinguisher,
     prefix: Ipv6Net,
@@ -13317,6 +13335,9 @@ pub(super) fn route_withdraw_vpnv6_addpath(
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         peer.cache_remove_vpnv6(rd, prefix, removed.local_id);
+        if let Some(t) = peer.adj_out.v6vpn.get_mut(&rd) {
+            t.remove(prefix, removed.local_id);
+        }
         route_withdraw_vpnv6(peer, rd, prefix, removed.local_id);
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4959,7 +4959,7 @@ fn route_withdraw_from_addpath(
                 super::update_group::cache_remove_ipv4(group, prefix, removed.local_id);
             }
         }
-        withdraw_ipv4_deferrable(bgp.update_groups, peer, rd, prefix, removed.local_id);
+        route_withdraw_ipv4(peer, rd, prefix, removed.local_id);
         peer.adj_out.remove(rd, prefix, removed.local_id);
     }
 }
@@ -5599,7 +5599,7 @@ impl BatchAfi for V4Batch {
             }
         }
         if peer.adj_out.contains_key(rd, &prefix) {
-            withdraw_ipv4_deferrable(bgp.update_groups, peer, rd, prefix, 0);
+            route_withdraw_ipv4(peer, rd, prefix, 0);
             peer.adj_out.remove(rd, prefix, 0);
         }
     }
@@ -5796,7 +5796,7 @@ impl BatchAfi for V6Batch {
                 {
                     super::update_group::cache_remove_ipv6(group, prefix, 0);
                 }
-                withdraw_ipv6_deferrable(bgp.update_groups, peer, prefix, 0);
+                route_withdraw_ipv6(peer, prefix, 0);
                 peer.adj_out.v6.remove(prefix, 0);
             }
         }
@@ -6403,16 +6403,16 @@ mod evpn_nexthop_wiring_tests {
     }
 }
 
-/// Send a single EVPN withdraw to one peer. Mirrors
-/// `route_withdraw_ipv4` — no caching, straight to the wire as a
-/// one-NLRI MP_UNREACH UPDATE. The receiver removes the route from
-/// its adj-RIB-in and re-runs best-path; an empty selection at the
-/// peer triggers `route_evpn_export_selected` which sends
-/// `Message::MacDel` / `MdbDel` and the kernel FDB row goes away.
+/// Queue a single EVPN withdraw for one peer. Mirrors
+/// `route_withdraw_ipv4`: the NLRI joins the peer's pending withdrawals
+/// and the next-tick flush packs it into an MP_UNREACH UPDATE with
+/// whatever else is queued (see [`super::pending_withdraw`]). The
+/// receiver removes the route from its adj-RIB-in and re-runs best-path;
+/// an empty selection at the peer triggers `route_evpn_export_selected`
+/// which sends `Message::MacDel` / `MdbDel` and the kernel FDB row goes
+/// away.
 fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
-    let mut update = peer.update_packet();
-    update.mp_withdraw = Some(MpUnreachAttr::Evpn(vec![route]));
-    peer.send_update(update);
+    peer.queue_withdraw_evpn(evpn_cache_key(&route), route);
 }
 
 /// Fan out a withdraw to every peer with `(L2vpn, Evpn)` Established.
@@ -6519,7 +6519,7 @@ pub(super) fn evpn_path_id(route: &EvpnRoute) -> u32 {
 }
 
 /// The advertise-cache identity of `route` — see [`super::peer::EvpnCacheKey`].
-fn evpn_cache_key(route: &EvpnRoute) -> super::peer::EvpnCacheKey {
+pub(super) fn evpn_cache_key(route: &EvpnRoute) -> super::peer::EvpnCacheKey {
     let (rd, prefix) = EvpnPrefix::from_route(route);
     (rd, prefix, evpn_path_id(route))
 }
@@ -6727,66 +6727,28 @@ pub fn route_advertise_evpn_to_peers(
     }
 }
 
-// Send BGP withdrawal for a prefix
+/// Queue a per-peer IPv4-unicast (`rd = None`) or VPNv4 withdraw. The
+/// NLRI joins the peer's pending withdrawals and the next-tick flush
+/// packs it with whatever else is queued — one UPDATE per full message
+/// rather than one per route. The caller has already dropped the route
+/// from the peer's Adj-RIB-Out; the flush re-checks that table, so a
+/// re-advertise landing before the flush cancels the withdraw, and a
+/// unicast withdraw stays queued while the peer's update-group has an
+/// announce job in flight (see [`super::pending_withdraw`]).
 pub(super) fn route_withdraw_ipv4(
     peer: &mut Peer,
     rd: Option<RouteDistinguisher>,
     prefix: Ipv4Net,
     id: u32,
 ) {
-    let mut update = peer.update_packet();
-
     match rd {
-        Some(rd) => {
-            let vpnv4_nlri = Vpnv4Nlri {
-                label: Label::default(),
-                rd,
-                nlri: Ipv4Nlri { id, prefix },
-            };
-            let mp_withdraw = MpUnreachAttr::Vpnv4(vec![vpnv4_nlri]);
-            update.mp_withdraw = Some(mp_withdraw);
-        }
-        None => {
-            let nlri = Ipv4Nlri { id, prefix };
-            update.ipv4_withdraw.push(nlri);
-        }
+        Some(rd) => peer.queue_withdraw_v4vpn(Vpnv4Nlri {
+            label: Label::default(),
+            rd,
+            nlri: Ipv4Nlri { id, prefix },
+        }),
+        None => peer.queue_withdraw_v4(Ipv4Nlri { id, prefix }),
     }
-
-    peer.send_update(update);
-}
-
-/// Send — or, while the peer's update-group has a flush job in
-/// flight, defer — a per-peer IPv4 withdraw (sharding plan A.2).
-///
-/// The flush worker may still be writing the in-flight job's announce
-/// bytes onto the members' writer channels; a withdraw enqueued from
-/// the main task now could be overtaken by an in-flight announce of
-/// the same prefix, leaving the peer holding a stale route — and
-/// unlike announce/announce inversions, nothing later corrects it.
-/// Parked withdraws are replayed by `flush_done_ipv4` after every job
-/// byte is enqueued. VPN withdraws (`rd = Some`) never ride the group
-/// cache and always send immediately.
-pub(super) fn withdraw_ipv4_deferrable(
-    update_groups: &mut super::update_group::UpdateGroupMap,
-    peer: &mut Peer,
-    rd: Option<RouteDistinguisher>,
-    prefix: Ipv4Net,
-    id: u32,
-) {
-    if rd.is_none() {
-        let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
-        if let Some(gid) = peer.update_group_id.get(&afi_safi)
-            && let Some(af) = update_groups.get_mut(&afi_safi)
-            && let Some(group) = af.group_by_id_mut(gid)
-            && group.flush_inflight_ipv4
-        {
-            group
-                .deferred_withdraw_ipv4
-                .push((peer.ident, Ipv4Nlri { id, prefix }));
-            return;
-        }
-    }
-    route_withdraw_ipv4(peer, rd, prefix, id);
 }
 
 // Soft-reconfiguration outbound: walk Loc-RIB for the AFI/SAFIs the
@@ -6996,7 +6958,7 @@ fn route_soft_out_peer_table(
             }
         }
         peer.adj_out.remove(rd, prefix, 0);
-        withdraw_ipv4_deferrable(bgp.update_groups, peer, rd, prefix, 0);
+        route_withdraw_ipv4(peer, rd, prefix, 0);
     }
 }
 
@@ -11764,6 +11726,10 @@ pub fn route_clean(
     peer.cache_vpnv6.clear();
     peer.cache_vpnv6_rev.clear();
     peer.cache_vpnv6_timer = None;
+    // Withdrawals queued for the dead session go with it (every family):
+    // the new session re-syncs from the Loc-RIB, and the flush marker must
+    // not push a stale queue onto its writer.
+    peer.clear_pending_withdraws();
 
     // IPv6 unicast. Same shape as the IPv4 block above — withdraw
     // every prefix the peer gave us from the Loc-RIB (which fans out
@@ -13157,35 +13123,11 @@ pub fn route_update_ipv6(
     Some((nlri, attrs))
 }
 
-/// Per-peer IPv6 unicast withdraw — emit an MP_UNREACH(AFI=2, SAFI=1)
+/// Per-peer IPv6 unicast withdraw — queue an MP_UNREACH(AFI=2, SAFI=1)
 /// for `prefix`. The v6 counterpart of [`route_withdraw_ipv4`]'s
 /// unicast arm; v6 has no legacy withdraw field.
 pub(super) fn route_withdraw_ipv6(peer: &mut Peer, prefix: Ipv6Net, id: u32) {
-    let mut update = peer.update_packet();
-    update.mp_withdraw = Some(MpUnreachAttr::Ipv6Nlri(vec![Ipv6Nlri { id, prefix }]));
-    peer.send_update(update);
-}
-
-/// v6 twin of [`withdraw_ipv4_deferrable`] — defer the per-peer
-/// MP_UNREACH while the peer's group has a v6 flush job in flight.
-fn withdraw_ipv6_deferrable(
-    update_groups: &mut super::update_group::UpdateGroupMap,
-    peer: &mut Peer,
-    prefix: Ipv6Net,
-    id: u32,
-) {
-    let afi_safi = AfiSafi::new(Afi::Ip6, Safi::Unicast);
-    if let Some(gid) = peer.update_group_id.get(&afi_safi)
-        && let Some(af) = update_groups.get_mut(&afi_safi)
-        && let Some(group) = af.group_by_id_mut(gid)
-        && group.flush_inflight_ipv6
-    {
-        group
-            .deferred_withdraw_ipv6
-            .push((peer.ident, Ipv6Nlri { id, prefix }));
-        return;
-    }
-    route_withdraw_ipv6(peer, prefix, id);
+    peer.queue_withdraw_v6(Ipv6Nlri { id, prefix });
 }
 
 /// IPv6 unicast advertise — the v6 counterpart of
@@ -13295,24 +13237,21 @@ pub(super) fn route_advertise_to_peers_v6(
             {
                 super::update_group::cache_remove_ipv6(group, prefix, id);
             }
-            withdraw_ipv6_deferrable(bgp.update_groups, peer, prefix, id);
+            route_withdraw_ipv6(peer, prefix, id);
             peer.adj_out.v6.remove(prefix, id);
         }
     }
 }
 
-/// Per-peer VPNv6 withdraw — emit an MP_UNREACH(AFI=2, SAFI=128) for
+/// Per-peer VPNv6 withdraw — queue an MP_UNREACH(AFI=2, SAFI=128) for
 /// `(rd, prefix)`. The v6 counterpart of the VPNv4 withdraw arm of
 /// [`route_withdraw_ipv4`].
 fn route_withdraw_vpnv6(peer: &mut Peer, rd: RouteDistinguisher, prefix: Ipv6Net, id: u32) {
-    let mut update = peer.update_packet();
-    let vpnv6_nlri = Vpnv6Nlri {
+    peer.queue_withdraw_v6vpn(Vpnv6Nlri {
         label: Label::default(),
         rd,
         nlri: Ipv6Nlri { id, prefix },
-    };
-    update.mp_withdraw = Some(MpUnreachAttr::Vpnv6(vec![vpnv6_nlri]));
-    peer.send_update(update);
+    });
 }
 
 /// VPNv6 advertise — the v6 counterpart of the `rd.is_some()` branch
@@ -13614,7 +13553,8 @@ trait LabeledAfi {
         weight: u32,
     ) -> Option<PolicyDecision>;
     fn reach(nhop: IpAddr, label: Label, nlri: Self::Nlri) -> MpReachAttr;
-    fn unreach(prefix: Self::Prefix, id: u32) -> MpUnreachAttr;
+    /// Queue a withdraw of `(prefix, id)` on the peer's pending set.
+    fn queue_withdraw(peer: &mut Peer, prefix: Self::Prefix, id: u32);
 }
 
 struct LabeledV4;
@@ -13679,11 +13619,8 @@ impl LabeledAfi for LabeledV4 {
             updates: vec![Labelv4Nlri { label, nlri }],
         }
     }
-    fn unreach(prefix: Ipv4Net, id: u32) -> MpUnreachAttr {
-        MpUnreachAttr::Labelv4(vec![Labelv4Nlri {
-            label: Label::default(),
-            nlri: Ipv4Nlri { id, prefix },
-        }])
+    fn queue_withdraw(peer: &mut Peer, prefix: Ipv4Net, id: u32) {
+        peer.queue_withdraw_v4lu(Ipv4Nlri { id, prefix });
     }
 }
 
@@ -13749,11 +13686,8 @@ impl LabeledAfi for LabeledV6 {
             updates: vec![Labelv6Nlri { label, nlri }],
         }
     }
-    fn unreach(prefix: Ipv6Net, id: u32) -> MpUnreachAttr {
-        MpUnreachAttr::Labelv6(vec![Labelv6Nlri {
-            label: Label::default(),
-            nlri: Ipv6Nlri { id, prefix },
-        }])
+    fn queue_withdraw(peer: &mut Peer, prefix: Ipv6Net, id: u32) {
+        peer.queue_withdraw_v6lu(Ipv6Nlri { id, prefix });
     }
 }
 
@@ -13836,10 +13770,8 @@ fn route_advertise_labeled<A: LabeledAfi>(
             }
             None => {
                 if A::adj_out_contains(peer, &prefix) {
-                    let mut update = peer.update_packet();
-                    update.mp_withdraw = Some(A::unreach(prefix, 0));
-                    peer.send_update(update);
                     A::adj_out_remove(peer, prefix, 0);
+                    A::queue_withdraw(peer, prefix, 0);
                 }
             }
         }
@@ -13891,10 +13823,8 @@ fn route_advertise_labeled<A: LabeledAfi>(
             if newly.contains(&id) {
                 continue;
             }
-            let mut update = peer.update_packet();
-            update.mp_withdraw = Some(A::unreach(prefix, id));
-            peer.send_update(update);
             A::adj_out_remove(peer, prefix, id);
+            A::queue_withdraw(peer, prefix, id);
         }
     }
 }
@@ -13964,6 +13894,9 @@ impl Peer {
     }
 
     pub fn send_vpnv4(&mut self, nlri: Vpnv4Nlri, attr: Arc<BgpAttr>, timer: bool) {
+        // A re-advertise supersedes a queued withdraw of the same route:
+        // the peer sees one implicit replace, never a withdraw racing it.
+        self.pending_withdraw.v4vpn.remove(&nlri);
         self.cache_vpnv4
             .entry(attr.clone())
             .or_default()
@@ -14005,6 +13938,7 @@ impl Peer {
         // NLRI) also catches a re-advertise that changed only the label /
         // gateway under an unchanged attribute set.
         let key = evpn_cache_key(&route);
+        self.pending_withdraw.evpn.remove(&key);
         if let Some((old_attr, old_route)) = self
             .cache_evpn_rev
             .insert(key, (attr.clone(), route.clone()))
@@ -14104,6 +14038,7 @@ impl Peer {
     // VPNv6 advertise cache — mirror of the VPNv4 trio above.
 
     pub fn send_vpnv6(&mut self, nlri: Vpnv6Nlri, attr: Arc<BgpAttr>, timer: bool) {
+        self.pending_withdraw.v6vpn.remove(&nlri);
         self.cache_vpnv6
             .entry(attr.clone())
             .or_default()
@@ -24973,6 +24908,19 @@ mod v6_empty_selection_tests {
         route_ipv6_update(
             a, &nlri, None, None, &attr, None, &mut top, &mut peers, false,
         );
+
+        // The withdraw is queued on B and packed by the next-tick flush
+        // (`Message::FlushWithdraw`); service that flush here.
+        assert!(
+            drain(&mut rx_b).is_empty(),
+            "the withdraw rides the pending queue, not an immediate send"
+        );
+        let b = peers.get(&"2001:db8::2".parse().unwrap()).unwrap().ident;
+        assert!(
+            peers.get_by_idx(b).unwrap().withdraw_timer.is_some(),
+            "queueing the withdraw must arm the flush marker"
+        );
+        crate::bgp::pending_withdraw::flush_pending_withdraws(b, &update_groups, &mut peers);
 
         let packets = drain(&mut rx_b);
         assert!(

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -24950,7 +24950,7 @@ mod v6_empty_selection_tests {
             peers.get_by_idx(b).unwrap().withdraw_timer.is_some(),
             "queueing the withdraw must arm the flush marker"
         );
-        crate::bgp::pending_withdraw::flush_pending_withdraws(b, &update_groups, &mut peers);
+        crate::bgp::pending_withdraw::flush_pending_withdraws(b, &mut peers);
 
         let packets = drain(&mut rx_b);
         assert!(

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5419,6 +5419,7 @@ fn soft_out_v4_to_group(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
                 ident,
                 ctx: Box::new(m.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw)),
                 add_path: m.opt.is_add_path_send(Afi::Ip, Safi::Unicast),
+                after: None,
             });
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -246,15 +246,6 @@ impl SyncCtx {
         enqueue_update(&self.packet_tx, &self.egress_depth, self.ident, bytes);
     }
 
-    /// Serialise and enqueue one UPDATE, dropping it with a log if its length
-    /// fields cannot describe it. See [`Peer::send_update`].
-    pub fn send_update(&self, update: UpdatePacket) {
-        match update.try_emit() {
-            Ok(bytes) => self.send_packet(bytes),
-            Err(e) => tracing::warn!("dropping UPDATE to {}: {}", self.ident, e),
-        }
-    }
-
     /// Max on-wire UPDATE size for this session (RFC 8654 extended).
     pub fn max_packet_size(&self) -> usize {
         if self.extended_message {

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -546,13 +546,20 @@ fn enhe_negotiated_for(
 /// Takes split borrows on `update_groups` and `peers` so the caller
 /// can be the FSM (which holds a `BgpTop` separately from the
 /// `PeerMap`).
+///
+/// `after` is the handoff [`detach`] returned when this is a reassignment
+/// of a live peer (an egress-policy change re-forms the groups): the
+/// group's egress task will not send the peer anything until the group it
+/// left has settled what it owed it. `None` at session up.
 pub fn attach(
     update_groups: &mut UpdateGroupMap,
     peers: &mut PeerMap,
     peer_idx: usize,
     router_id: Ipv4Addr,
     as_sets_withdraw: bool,
+    after: Option<tokio::sync::oneshot::Receiver<()>>,
 ) {
+    let mut after = after;
     let Some(peer) = peers.get_by_idx(peer_idx) else {
         return;
     };
@@ -613,6 +620,7 @@ pub fn attach(
                 ident: peer_idx,
                 ctx: Box::new(peer.sync_ctx(router_id, as_sets_withdraw)),
                 add_path,
+                after: after.take(),
             });
         }
 
@@ -628,11 +636,20 @@ pub fn attach(
 /// a future signature gets a fresh ID rather than reusing a retired
 /// one, so log correlation across the lifetime of the daemon stays
 /// stable.
-pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx: usize) {
+///
+/// Returns the handoff for the peer's egress task (gate-on, IPv4 unicast):
+/// it resolves once that task has settled what it owed the peer. A caller
+/// re-attaching a live peer passes it to [`attach`] so the new group's task
+/// does not send the peer anything before then; other callers (session
+/// down, peer deletion) drop it.
+pub fn detach(
+    update_groups: &mut UpdateGroupMap,
+    peers: &mut PeerMap,
+    peer_idx: usize,
+) -> Option<tokio::sync::oneshot::Receiver<()>> {
+    let mut handoff_rx = None;
     let memberships: Vec<(AfiSafi, UpdateGroupId)> = {
-        let Some(peer) = peers.get_mut_by_idx(peer_idx) else {
-            return;
-        };
+        let peer = peers.get_mut_by_idx(peer_idx)?;
         let ms = peer
             .update_group_id
             .iter()
@@ -661,8 +678,11 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
                 // below rather than dropped (aborted) with that delta and
                 // its queued withdrawals unread.
                 if let Some(t) = &group.task {
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    handoff_rx = Some(rx);
                     t.send(super::group_egress::GroupEgressDeltaV4::RemoveMember {
                         ident: peer_idx,
+                        handoff: Some(tx),
                     });
                 }
                 group.members.is_empty()
@@ -675,6 +695,7 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
             }
         }
     }
+    handoff_rx
 }
 
 // ── IPv4 unicast send / cache_remove / flush ──
@@ -1904,8 +1925,8 @@ mod tests {
 
         let mut groups = empty_map();
         let rid = "1.1.1.1".parse().unwrap();
-        attach(&mut groups, &mut peers, dual_idx, rid, true);
-        attach(&mut groups, &mut peers, v4only_idx, rid, true);
+        attach(&mut groups, &mut peers, dual_idx, rid, true, None);
+        attach(&mut groups, &mut peers, v4only_idx, rid, true, None);
 
         let v4_key = AfiSafi::new(Afi::Ip, Safi::Unicast);
         let v6_key = AfiSafi::new(Afi::Ip6, Safi::Unicast);
@@ -2611,6 +2632,7 @@ mod tests {
                 ident,
                 ctx: Box::new(ctx),
                 add_path: false,
+                after: None,
             });
             task.send(GroupEgressDeltaV4::Advertise {
                 prefix,
@@ -2638,7 +2660,8 @@ mod tests {
                 source_ident: 99,
             });
         }
-        detach(&mut groups, &mut peers, ident);
+        let handoff = detach(&mut groups, &mut peers, ident)
+            .expect("a group with an egress task hands the member off");
         assert!(peers.get_by_idx(ident).unwrap().state.is_established());
         assert!(
             groups[&AfiSafi::new(Afi::Ip, Safi::Unicast)]
@@ -2646,19 +2669,43 @@ mod tests {
                 .is_none()
         );
 
-        let mut sent = Vec::new();
-        for _ in 0..20 {
-            tokio::task::yield_now().await;
-            sent.extend(recv_all(&mut prx));
-            if !sent.is_empty() {
-                break;
-            }
-        }
+        // The handoff resolves only once the old task has settled the
+        // member — by then the withdraw is on the member's writer.
+        tokio::time::timeout(std::time::Duration::from_secs(5), handoff)
+            .await
+            .expect("the old task settles the member promptly")
+            .expect("the old task fires the handoff rather than dropping it");
+        let sent = recv_all(&mut prx);
         assert_eq!(sent.len(), 1, "the detached member still gets the withdraw");
         assert!(
             u16::from_be_bytes([sent[0][19], sent[0][20]]) > 0,
             "the frame is a withdraw"
         );
+    }
+
+    /// Gate-off (no egress task) has nothing to hand off.
+    #[test]
+    fn detach_without_an_egress_task_returns_no_handoff() {
+        let (id, mut group) = test_group(0);
+        let (tx, _rx) = mpsc::channel::<Message>(64);
+        let mut peer = super::super::peer::Peer::new(
+            0,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65002,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.update_group_id
+            .insert(AfiSafi::new(Afi::Ip, Safi::Unicast), id.clone());
+        group.members.insert(0);
+        let mut groups = groups_with(group);
+        let mut peers = PeerMap::new();
+        peers.insert("10.0.0.2".parse().unwrap(), peer);
+        let ident = peers.get(&"10.0.0.2".parse().unwrap()).unwrap().ident;
+        assert!(detach(&mut groups, &mut peers, ident).is_none());
     }
 
     /// A peer removed and re-created at the same address gets its old

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -826,6 +826,11 @@ pub(super) struct FlushJob<N> {
 }
 
 impl<N: FlushNlri> FlushJob<N> {
+    /// Idents of the members this job will send to.
+    pub(super) fn member_idents(&self) -> Vec<usize> {
+        self.members.iter().map(|m| m.ident).collect()
+    }
+
     /// Encode and send every bucket; returns the counter deltas for
     /// the caller to merge into the group. Per attr-bucket we encode
     /// at most:
@@ -1067,6 +1072,14 @@ pub fn flush_ipv4(
         return;
     };
     group.flush_inflight_ipv4 = true;
+    // Count the job against each member so its queued unicast withdrawals
+    // wait for `flush_done_ipv4` (see `Peer::flush_jobs_v4`).
+    let members = job.member_idents();
+    for &ident in &members {
+        if let Some(peer) = peers.get_mut_by_idx(ident) {
+            peer.flush_jobs_v4 += 1;
+        }
+    }
     let tx = tx.clone();
     let id = id.clone();
     let _ = tokio::task::spawn_blocking(move || {
@@ -1074,14 +1087,14 @@ pub fn flush_ipv4(
         // blocking_send is correct here — this runs on a blocking-pool
         // thread, not in async context. Failure means the BGP instance
         // is shutting down; the deltas die with it.
-        let _ = tx.blocking_send(Message::FlushDoneIpv4(id, deltas));
+        let _ = tx.blocking_send(Message::FlushDoneIpv4(id, deltas, members));
     });
 }
 
-/// Worker completion for an IPv4 flush: merge the counter deltas,
-/// release the in-flight latch, drain the withdraws the members queued
-/// during the flight, and re-run the flush if the debounce timer fired
-/// while the job was out.
+/// Worker completion for an IPv4 flush: count the job off each member
+/// it carried, merge the counter deltas, release the in-flight latch,
+/// drain the withdraws the members queued during the flight, and re-run
+/// the flush if the debounce timer fired while the job was out.
 ///
 /// The drain is ordered-safe by construction: the worker sends
 /// `FlushDoneIpv4` only after [`FlushJob::run`] returned, so every
@@ -1089,25 +1102,39 @@ pub fn flush_ipv4(
 /// drained withdraw lands strictly after the announce it must
 /// override. Withdraws a newer announce has superseded are dropped by
 /// the drain's Adj-RIB-Out check (see [`super::pending_withdraw`]).
+///
+/// The per-member settlement happens whether or not the group still
+/// exists: configuration can detach a group's last member — deleting
+/// the group — while its job is out, and the parked withdrawals of a
+/// still-Established peer must be released by *this* completion, not
+/// stranded until some later withdraw arms a new marker.
 pub fn flush_done_ipv4(
     update_groups: &mut UpdateGroupMap,
     peers: &mut PeerMap,
     tx: &mpsc::Sender<Message>,
     id: &UpdateGroupId,
     deltas: UpdateGroupCounters,
+    members: &[usize],
     interface_addrs: &super::interface_addrs::InterfaceAddrs,
 ) {
+    for &ident in members {
+        if let Some(peer) = peers.get_mut_by_idx(ident) {
+            peer.flush_jobs_v4 = peer.flush_jobs_v4.saturating_sub(1);
+        }
+    }
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
-    let Some(af) = update_groups.get_mut(&afi_safi) else {
-        return;
+    let rerun = match update_groups
+        .get_mut(&afi_safi)
+        .and_then(|af| af.group_by_id_mut(id))
+    {
+        Some(group) => {
+            group.counters.merge(&deltas);
+            group.flush_inflight_ipv4 = false;
+            std::mem::take(&mut group.flush_pending_ipv4)
+        }
+        None => false,
     };
-    let Some(group) = af.group_by_id_mut(id) else {
-        return;
-    };
-    group.counters.merge(&deltas);
-    group.flush_inflight_ipv4 = false;
-    let rerun = std::mem::take(&mut group.flush_pending_ipv4);
-    super::pending_withdraw::drain_after_flush(Afi::Ip, update_groups, peers);
+    super::pending_withdraw::drain_after_flush(Afi::Ip, members, peers);
     if rerun {
         flush_ipv4(update_groups, peers, tx, id, interface_addrs);
     }
@@ -1321,11 +1348,17 @@ pub fn flush_ipv6(
         return;
     };
     group.flush_inflight_ipv6 = true;
+    let members = job.member_idents();
+    for &ident in &members {
+        if let Some(peer) = peers.get_mut_by_idx(ident) {
+            peer.flush_jobs_v6 += 1;
+        }
+    }
     let tx = tx.clone();
     let id = id.clone();
     let _ = tokio::task::spawn_blocking(move || {
         let deltas = job.run();
-        let _ = tx.blocking_send(Message::FlushDoneIpv6(id, deltas));
+        let _ = tx.blocking_send(Message::FlushDoneIpv6(id, deltas, members));
     });
 }
 
@@ -1337,18 +1370,26 @@ pub fn flush_done_ipv6(
     tx: &mpsc::Sender<Message>,
     id: &UpdateGroupId,
     deltas: UpdateGroupCounters,
+    members: &[usize],
 ) {
+    for &ident in members {
+        if let Some(peer) = peers.get_mut_by_idx(ident) {
+            peer.flush_jobs_v6 = peer.flush_jobs_v6.saturating_sub(1);
+        }
+    }
     let afi_safi = AfiSafi::new(Afi::Ip6, Safi::Unicast);
-    let Some(af) = update_groups.get_mut(&afi_safi) else {
-        return;
+    let rerun = match update_groups
+        .get_mut(&afi_safi)
+        .and_then(|af| af.group_by_id_mut(id))
+    {
+        Some(group) => {
+            group.counters.merge(&deltas);
+            group.flush_inflight_ipv6 = false;
+            std::mem::take(&mut group.flush_pending_ipv6)
+        }
+        None => false,
     };
-    let Some(group) = af.group_by_id_mut(id) else {
-        return;
-    };
-    group.counters.merge(&deltas);
-    group.flush_inflight_ipv6 = false;
-    let rerun = std::mem::take(&mut group.flush_pending_ipv6);
-    super::pending_withdraw::drain_after_flush(Afi::Ip6, update_groups, peers);
+    super::pending_withdraw::drain_after_flush(Afi::Ip6, members, peers);
     if rerun {
         flush_ipv6(update_groups, peers, tx, id);
     }
@@ -2321,7 +2362,7 @@ mod tests {
             bytes_formatted: 100,
             ..Default::default()
         };
-        flush_done_ipv4(&mut groups, &mut peers, &tx, &id, deltas, &addrs);
+        flush_done_ipv4(&mut groups, &mut peers, &tx, &id, deltas, &[], &addrs);
 
         let af = groups
             .get_mut(&AfiSafi::new(Afi::Ip, Safi::Unicast))
@@ -2333,11 +2374,12 @@ mod tests {
         assert_eq!(group.counters.bytes_formatted, 100);
     }
 
-    /// A withdraw queued while the member's group has a job in flight
-    /// stays queued — draining it now could put it on the writer ahead
-    /// of the job's announce of the same prefix — and `flush_done_ipv4`
-    /// drains it once the job is done. The sharding-plan A.2 race, now
-    /// gated on the peer's pending set instead of a per-group park.
+    /// A withdraw queued while a job carrying the member's announcements
+    /// is in flight stays queued — draining it now could put it on the
+    /// writer ahead of the job's announce of the same prefix — and
+    /// `flush_done_ipv4` drains it once the job is done. The sharding-plan
+    /// A.2 race, now gated on the peer's job count instead of a per-group
+    /// park.
     #[tokio::test]
     async fn flush_inflight_gates_queued_withdraws_until_flush_done() {
         use super::super::pending_withdraw::flush_pending_withdraws;
@@ -2368,6 +2410,8 @@ mod tests {
         let ident = peers.get(&"10.0.0.2".parse().unwrap()).unwrap().ident;
 
         let peer = peers.get_mut_by_idx(ident).unwrap();
+        // The job `flush_ipv4` spawned counts against the member.
+        peer.flush_jobs_v4 = 1;
         peer.queue_withdraw_v4(nlri("10.0.0.1/32"));
         // A VPNv4 withdraw on the same peer is not gated by the unicast job.
         peer.queue_withdraw_v4vpn(bgp_packet::Vpnv4Nlri {
@@ -2376,7 +2420,7 @@ mod tests {
             nlri: nlri("10.0.0.9/32"),
         });
 
-        flush_pending_withdraws(ident, &groups, &mut peers);
+        flush_pending_withdraws(ident, &mut peers);
         let sent = recv_all(&mut prx);
         assert_eq!(sent.len(), 1, "only the VPNv4 withdraw goes out");
         let (_, p) = UpdatePacket::parse_packet(&sent[0], true, None).unwrap();
@@ -2394,6 +2438,7 @@ mod tests {
             &tx,
             &id,
             UpdateGroupCounters::default(),
+            &[ident],
             &addrs,
         );
         let sent = recv_all(&mut prx);
@@ -2402,6 +2447,82 @@ mod tests {
         assert_eq!(p.ipv4_withdraw, vec![nlri("10.0.0.1/32")]);
         let peer = peers.get_by_idx(ident).unwrap();
         assert!(peer.pending_withdraw.v4.is_empty());
+        assert_eq!(peer.flush_jobs_v4, 0);
+    }
+
+    /// A live peer leaves its last-member group — deleting the group —
+    /// after its withdraw marker parked behind that group's in-flight job.
+    /// The job's completion must still release the parked withdrawal:
+    /// the gate lives on the peer, and `flush_done_ipv4` settles it
+    /// whether or not the group still exists. (Review finding: an earlier
+    /// version returned early on a missing group and stranded the
+    /// withdrawal indefinitely, with no marker left to fire.)
+    #[tokio::test]
+    async fn parked_withdraw_survives_group_reassignment() {
+        use super::super::pending_withdraw::flush_pending_withdraws;
+        use bgp_packet::UpdatePacket;
+
+        let (id, mut group) = test_group(0);
+        group.flush_inflight_ipv4 = true;
+        let (tx, _rx) = mpsc::channel::<Message>(64);
+        let mut peer = super::super::peer::Peer::new(
+            0,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65002,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx.clone(),
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = super::super::peer::State::Established;
+        let (ptx, mut prx) = mpsc::unbounded_channel::<bytes::BytesMut>();
+        peer.packet_tx = Some(ptx);
+        peer.update_group_id
+            .insert(AfiSafi::new(Afi::Ip, Safi::Unicast), id.clone());
+        group.members.insert(0);
+        let mut groups = groups_with(group);
+        let mut peers = PeerMap::new();
+        peers.insert("10.0.0.2".parse().unwrap(), peer);
+        let ident = peers.get(&"10.0.0.2".parse().unwrap()).unwrap().ident;
+
+        let peer = peers.get_mut_by_idx(ident).unwrap();
+        peer.flush_jobs_v4 = 1;
+        peer.queue_withdraw_v4(nlri("10.0.0.1/32"));
+
+        flush_pending_withdraws(ident, &mut peers);
+        assert!(recv_all(&mut prx).is_empty(), "gated behind the job");
+        let peer = peers.get_by_idx(ident).unwrap();
+        assert_eq!(peer.pending_withdraw.v4.len(), 1, "unicast stays queued");
+        assert!(peer.withdraw_timer.is_none(), "flush marker was consumed");
+
+        // Configuration detaches the Established peer; the group empties
+        // and is deleted while its job is still out.
+        detach(&mut groups, &mut peers, ident);
+        assert!(peers.get_by_idx(ident).unwrap().state.is_established());
+        assert!(
+            groups[&AfiSafi::new(Afi::Ip, Safi::Unicast)]
+                .group_by_id(&id)
+                .is_none()
+        );
+
+        let addrs = super::super::interface_addrs::InterfaceAddrs::default();
+        flush_done_ipv4(
+            &mut groups,
+            &mut peers,
+            &tx,
+            &id,
+            UpdateGroupCounters::default(),
+            &[ident],
+            &addrs,
+        );
+        let sent = recv_all(&mut prx);
+        assert_eq!(sent.len(), 1, "the job's completion releases the withdraw");
+        let (_, p) = UpdatePacket::parse_packet(&sent[0], true, None).unwrap();
+        assert_eq!(p.ipv4_withdraw, vec![nlri("10.0.0.1/32")]);
+        let peer = peers.get_by_idx(ident).unwrap();
+        assert!(peer.pending_withdraw.v4.is_empty());
+        assert_eq!(peer.flush_jobs_v4, 0);
     }
 
     /// End-to-end offload: flush spawns the job on the blocking pool,
@@ -2435,14 +2556,14 @@ mod tests {
             assert!(group.cache_ipv4.is_empty(), "cache drained into the job");
         }
 
-        let Some(Message::FlushDoneIpv4(done_id, deltas)) = rx.recv().await else {
+        let Some(Message::FlushDoneIpv4(done_id, deltas, _)) = rx.recv().await else {
             panic!("expected FlushDoneIpv4 from the worker");
         };
         assert_eq!(done_id, id);
         assert_eq!(deltas.messages_formatted, 1);
         assert!(deltas.bytes_formatted > 0);
 
-        flush_done_ipv4(&mut groups, &mut peers, &tx, &id, deltas, &addrs);
+        flush_done_ipv4(&mut groups, &mut peers, &tx, &id, deltas, &[], &addrs);
         let af = groups
             .get_mut(&AfiSafi::new(Afi::Ip, Safi::Unicast))
             .unwrap();

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -312,18 +312,16 @@ pub struct UpdateGroup {
     // first's on the members' writer channels. A timer that fires
     // mid-flight latches `flush_pending_*`; `flush_done_*` re-runs
     // the flush. Per-peer withdraws that would race the in-flight
-    // announces are parked in `deferred_withdraw_*` and replayed by
+    // announces stay queued on the peer (`Peer::pending_withdraw`)
+    // while `flush_inflight_*` is set and are drained by
     // `flush_done_*` after every job byte is enqueued.
     /// An IPv4 flush job is running on the blocking pool.
     pub flush_inflight_ipv4: bool,
     /// The IPv4 debounce timer fired while a job was in flight.
     pub flush_pending_ipv4: bool,
-    /// `(ident, nlri)` withdraws parked during an IPv4 flight.
-    pub deferred_withdraw_ipv4: Vec<(usize, Ipv4Nlri)>,
-    /// IPv6 twins of the three fields above.
+    /// IPv6 twins of the two fields above.
     pub flush_inflight_ipv6: bool,
     pub flush_pending_ipv6: bool,
-    pub deferred_withdraw_ipv6: Vec<(usize, Ipv6Nlri)>,
     /// Per-update-group egress task (see
     /// `docs/design/bgp-egress-group-task-migration.md`). `Some` only at
     /// gate-on (`ZEBRA_BGP_EGRESS_GROUP_TASK`); spawned when the group is
@@ -598,10 +596,8 @@ pub fn attach(
                 adv_interval,
                 flush_inflight_ipv4: false,
                 flush_pending_ipv4: false,
-                deferred_withdraw_ipv4: Vec::new(),
                 flush_inflight_ipv6: false,
                 flush_pending_ipv6: false,
-                deferred_withdraw_ipv6: Vec::new(),
                 task,
             }
         });
@@ -1083,15 +1079,16 @@ pub fn flush_ipv4(
 }
 
 /// Worker completion for an IPv4 flush: merge the counter deltas,
-/// release the in-flight latch, replay the withdraws parked during
-/// the flight, and re-run the flush if the debounce timer fired
+/// release the in-flight latch, drain the withdraws the members queued
+/// during the flight, and re-run the flush if the debounce timer fired
 /// while the job was out.
 ///
-/// The replay is ordered-safe by construction: the worker sends
+/// The drain is ordered-safe by construction: the worker sends
 /// `FlushDoneIpv4` only after [`FlushJob::run`] returned, so every
 /// announce byte is already on the members' writer channels and a
-/// replayed withdraw lands strictly after the announce it must
-/// override.
+/// drained withdraw lands strictly after the announce it must
+/// override. Withdraws a newer announce has superseded are dropped by
+/// the drain's Adj-RIB-Out check (see [`super::pending_withdraw`]).
 pub fn flush_done_ipv4(
     update_groups: &mut UpdateGroupMap,
     peers: &mut PeerMap,
@@ -1109,29 +1106,8 @@ pub fn flush_done_ipv4(
     };
     group.counters.merge(&deltas);
     group.flush_inflight_ipv4 = false;
-    let deferred = std::mem::take(&mut group.deferred_withdraw_ipv4);
     let rerun = std::mem::take(&mut group.flush_pending_ipv4);
-    let members = group.members.clone();
-    for (ident, nlri) in deferred {
-        // Skip members that left the group during the flight (a
-        // session bounce re-syncs the table from scratch) and peers
-        // whose Adj-RIB-Out re-acquired the prefix (a newer announce
-        // superseded this withdraw; it is sitting in the pending
-        // cache and the next flush carries it).
-        if !members.contains(&ident) {
-            continue;
-        }
-        let Some(peer) = peers.get_mut_by_idx(ident) else {
-            continue;
-        };
-        if !peer.state.is_established() {
-            continue;
-        }
-        if nlri.id == 0 && peer.adj_out.contains_key(None, &nlri.prefix) {
-            continue;
-        }
-        super::route::route_withdraw_ipv4(peer, None, nlri.prefix, nlri.id);
-    }
+    super::pending_withdraw::drain_after_flush(Afi::Ip, update_groups, peers);
     if rerun {
         flush_ipv4(update_groups, peers, tx, id, interface_addrs);
     }
@@ -1371,21 +1347,8 @@ pub fn flush_done_ipv6(
     };
     group.counters.merge(&deltas);
     group.flush_inflight_ipv6 = false;
-    let deferred = std::mem::take(&mut group.deferred_withdraw_ipv6);
     let rerun = std::mem::take(&mut group.flush_pending_ipv6);
-    let members = group.members.clone();
-    for (ident, nlri) in deferred {
-        if !members.contains(&ident) {
-            continue;
-        }
-        let Some(peer) = peers.get_mut_by_idx(ident) else {
-            continue;
-        };
-        if !peer.state.is_established() {
-            continue;
-        }
-        super::route::route_withdraw_ipv6(peer, nlri.prefix, nlri.id);
-    }
+    super::pending_withdraw::drain_after_flush(Afi::Ip6, update_groups, peers);
     if rerun {
         flush_ipv6(update_groups, peers, tx, id);
     }
@@ -1944,10 +1907,8 @@ mod tests {
                 adv_interval: AdvInterval::default(),
                 flush_inflight_ipv4: false,
                 flush_pending_ipv4: false,
-                deferred_withdraw_ipv4: Vec::new(),
                 flush_inflight_ipv6: false,
                 flush_pending_ipv6: false,
-                deferred_withdraw_ipv6: Vec::new(),
                 task: None,
             },
         );
@@ -2293,10 +2254,8 @@ mod tests {
             adv_interval: AdvInterval::default(),
             flush_inflight_ipv4: false,
             flush_pending_ipv4: false,
-            deferred_withdraw_ipv4: Vec::new(),
             flush_inflight_ipv6: false,
             flush_pending_ipv6: false,
-            deferred_withdraw_ipv6: Vec::new(),
             task: None,
         };
         (id, group)
@@ -2347,15 +2306,11 @@ mod tests {
 
     /// FlushDone merges the worker's deltas, releases the latch, and
     /// consumes the pending flag (empty cache ⇒ the rerun no-ops).
-    /// Deferred withdraws whose peers left the group are dropped.
     #[test]
-    fn flush_done_ipv4_releases_latch_and_drops_departed() {
+    fn flush_done_ipv4_releases_latch() {
         let (id, mut group) = test_group(0);
         group.flush_inflight_ipv4 = true;
         group.flush_pending_ipv4 = true;
-        // ident 7 is NOT a member: its parked withdraw must be dropped
-        // (a session bounce re-syncs the table from scratch).
-        group.deferred_withdraw_ipv4.push((7, nlri("10.0.0.1/32")));
         let mut groups = groups_with(group);
         let mut peers = PeerMap::new();
         let (tx, _rx) = mpsc::channel(8);
@@ -2374,9 +2329,79 @@ mod tests {
         let group = af.group_by_id_mut(&id).unwrap();
         assert!(!group.flush_inflight_ipv4);
         assert!(!group.flush_pending_ipv4);
-        assert!(group.deferred_withdraw_ipv4.is_empty());
         assert_eq!(group.counters.messages_formatted, 2);
         assert_eq!(group.counters.bytes_formatted, 100);
+    }
+
+    /// A withdraw queued while the member's group has a job in flight
+    /// stays queued — draining it now could put it on the writer ahead
+    /// of the job's announce of the same prefix — and `flush_done_ipv4`
+    /// drains it once the job is done. The sharding-plan A.2 race, now
+    /// gated on the peer's pending set instead of a per-group park.
+    #[tokio::test]
+    async fn flush_inflight_gates_queued_withdraws_until_flush_done() {
+        use super::super::pending_withdraw::flush_pending_withdraws;
+        use bgp_packet::UpdatePacket;
+
+        let (id, mut group) = test_group(0);
+        group.flush_inflight_ipv4 = true;
+        let (tx, _rx) = mpsc::channel::<Message>(64);
+        let mut peer = super::super::peer::Peer::new(
+            0,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65002,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx.clone(),
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = super::super::peer::State::Established;
+        let (ptx, mut prx) = mpsc::unbounded_channel::<bytes::BytesMut>();
+        peer.packet_tx = Some(ptx);
+        peer.update_group_id
+            .insert(AfiSafi::new(Afi::Ip, Safi::Unicast), id.clone());
+        group.members.insert(0);
+        let mut groups = groups_with(group);
+        let mut peers = PeerMap::new();
+        peers.insert("10.0.0.2".parse().unwrap(), peer);
+        let ident = peers.get(&"10.0.0.2".parse().unwrap()).unwrap().ident;
+
+        let peer = peers.get_mut_by_idx(ident).unwrap();
+        peer.queue_withdraw_v4(nlri("10.0.0.1/32"));
+        // A VPNv4 withdraw on the same peer is not gated by the unicast job.
+        peer.queue_withdraw_v4vpn(bgp_packet::Vpnv4Nlri {
+            label: bgp_packet::Label::default(),
+            rd: bgp_packet::RouteDistinguisher::default(),
+            nlri: nlri("10.0.0.9/32"),
+        });
+
+        flush_pending_withdraws(ident, &groups, &mut peers);
+        let sent = recv_all(&mut prx);
+        assert_eq!(sent.len(), 1, "only the VPNv4 withdraw goes out");
+        let (_, p) = UpdatePacket::parse_packet(&sent[0], true, None).unwrap();
+        assert!(matches!(
+            p.mp_withdraw,
+            Some(bgp_packet::MpUnreachAttr::Vpnv4(_))
+        ));
+        let peer = peers.get_by_idx(ident).unwrap();
+        assert_eq!(peer.pending_withdraw.v4.len(), 1, "unicast stays queued");
+
+        let addrs = super::super::interface_addrs::InterfaceAddrs::default();
+        flush_done_ipv4(
+            &mut groups,
+            &mut peers,
+            &tx,
+            &id,
+            UpdateGroupCounters::default(),
+            &addrs,
+        );
+        let sent = recv_all(&mut prx);
+        assert_eq!(sent.len(), 1, "flush_done drains the gated withdraw");
+        let (_, p) = UpdatePacket::parse_packet(&sent[0], true, None).unwrap();
+        assert_eq!(p.ipv4_withdraw, vec![nlri("10.0.0.1/32")]);
+        let peer = peers.get_by_idx(ident).unwrap();
+        assert!(peer.pending_withdraw.v4.is_empty());
     }
 
     /// End-to-end offload: flush spawns the job on the blocking pool,

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -825,12 +825,47 @@ pub(super) struct FlushJob<N> {
     pub enhe: bool,
 }
 
-impl<N: FlushNlri> FlushJob<N> {
-    /// Idents of the members this job will send to.
-    pub(super) fn member_idents(&self) -> Vec<usize> {
-        self.members.iter().map(|m| m.ident).collect()
-    }
+/// One member a flush job was spawned against: its `PeerMap` slot and the
+/// `Peer::instance` nonce that was in that slot at the time. The completion
+/// settles `Peer::flush_jobs_*` only where the nonce still matches, so a
+/// job whose peer was removed and re-created at the same address (same
+/// slot) cannot count itself off the replacement.
+pub type JobMember = (usize, u64);
 
+/// Stamp the job's members with the `Peer::instance` currently in each
+/// slot and count the job up on them (see [`Peer::flush_jobs_v4`]).
+fn count_job_up(job_members: &[FlushMember], peers: &mut PeerMap, afi: Afi) -> Vec<JobMember> {
+    job_members
+        .iter()
+        .filter_map(|m| {
+            let peer = peers.get_mut_by_idx(m.ident)?;
+            match afi {
+                Afi::Ip => peer.flush_jobs_v4 += 1,
+                _ => peer.flush_jobs_v6 += 1,
+            }
+            Some((m.ident, peer.instance))
+        })
+        .collect()
+}
+
+/// Count a completed job off the members it was spawned against, skipping
+/// any slot whose occupant has changed since.
+fn count_job_down(members: &[JobMember], peers: &mut PeerMap, afi: Afi) {
+    for &(ident, instance) in members {
+        let Some(peer) = peers.get_mut_by_idx(ident) else {
+            continue;
+        };
+        if peer.instance != instance {
+            continue;
+        }
+        match afi {
+            Afi::Ip => peer.flush_jobs_v4 = peer.flush_jobs_v4.saturating_sub(1),
+            _ => peer.flush_jobs_v6 = peer.flush_jobs_v6.saturating_sub(1),
+        }
+    }
+}
+
+impl<N: FlushNlri> FlushJob<N> {
     /// Encode and send every bucket; returns the counter deltas for
     /// the caller to merge into the group. Per attr-bucket we encode
     /// at most:
@@ -1074,12 +1109,7 @@ pub fn flush_ipv4(
     group.flush_inflight_ipv4 = true;
     // Count the job against each member so its queued unicast withdrawals
     // wait for `flush_done_ipv4` (see `Peer::flush_jobs_v4`).
-    let members = job.member_idents();
-    for &ident in &members {
-        if let Some(peer) = peers.get_mut_by_idx(ident) {
-            peer.flush_jobs_v4 += 1;
-        }
-    }
+    let members = count_job_up(&job.members, peers, Afi::Ip);
     let tx = tx.clone();
     let id = id.clone();
     let _ = tokio::task::spawn_blocking(move || {
@@ -1114,14 +1144,10 @@ pub fn flush_done_ipv4(
     tx: &mpsc::Sender<Message>,
     id: &UpdateGroupId,
     deltas: UpdateGroupCounters,
-    members: &[usize],
+    members: &[JobMember],
     interface_addrs: &super::interface_addrs::InterfaceAddrs,
 ) {
-    for &ident in members {
-        if let Some(peer) = peers.get_mut_by_idx(ident) {
-            peer.flush_jobs_v4 = peer.flush_jobs_v4.saturating_sub(1);
-        }
-    }
+    count_job_down(members, peers, Afi::Ip);
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
     let rerun = match update_groups
         .get_mut(&afi_safi)
@@ -1348,12 +1374,7 @@ pub fn flush_ipv6(
         return;
     };
     group.flush_inflight_ipv6 = true;
-    let members = job.member_idents();
-    for &ident in &members {
-        if let Some(peer) = peers.get_mut_by_idx(ident) {
-            peer.flush_jobs_v6 += 1;
-        }
-    }
+    let members = count_job_up(&job.members, peers, Afi::Ip6);
     let tx = tx.clone();
     let id = id.clone();
     let _ = tokio::task::spawn_blocking(move || {
@@ -1370,13 +1391,9 @@ pub fn flush_done_ipv6(
     tx: &mpsc::Sender<Message>,
     id: &UpdateGroupId,
     deltas: UpdateGroupCounters,
-    members: &[usize],
+    members: &[JobMember],
 ) {
-    for &ident in members {
-        if let Some(peer) = peers.get_mut_by_idx(ident) {
-            peer.flush_jobs_v6 = peer.flush_jobs_v6.saturating_sub(1);
-        }
-    }
+    count_job_down(members, peers, Afi::Ip6);
     let afi_safi = AfiSafi::new(Afi::Ip6, Safi::Unicast);
     let rerun = match update_groups
         .get_mut(&afi_safi)
@@ -2430,6 +2447,7 @@ mod tests {
         ));
         let peer = peers.get_by_idx(ident).unwrap();
         assert_eq!(peer.pending_withdraw.v4.len(), 1, "unicast stays queued");
+        let instance = peer.instance;
 
         let addrs = super::super::interface_addrs::InterfaceAddrs::default();
         flush_done_ipv4(
@@ -2438,7 +2456,7 @@ mod tests {
             &tx,
             &id,
             UpdateGroupCounters::default(),
-            &[ident],
+            &[(ident, instance)],
             &addrs,
         );
         let sent = recv_all(&mut prx);
@@ -2506,6 +2524,7 @@ mod tests {
                 .is_none()
         );
 
+        let instance = peers.get_by_idx(ident).unwrap().instance;
         let addrs = super::super::interface_addrs::InterfaceAddrs::default();
         flush_done_ipv4(
             &mut groups,
@@ -2513,7 +2532,7 @@ mod tests {
             &tx,
             &id,
             UpdateGroupCounters::default(),
-            &[ident],
+            &[(ident, instance)],
             &addrs,
         );
         let sent = recv_all(&mut prx);
@@ -2523,6 +2542,91 @@ mod tests {
         let peer = peers.get_by_idx(ident).unwrap();
         assert!(peer.pending_withdraw.v4.is_empty());
         assert_eq!(peer.flush_jobs_v4, 0);
+    }
+
+    /// A peer removed and re-created at the same address gets its old
+    /// `PeerMap` slot back. A job the *old* peer was a member of must not
+    /// count itself off the replacement when it completes: the
+    /// replacement may have a job of its own in flight, and releasing its
+    /// parked withdrawal early would let that job re-announce the
+    /// withdrawn route afterwards. (Review finding — the completion is
+    /// matched on `Peer::instance`, not the slot.)
+    #[tokio::test]
+    async fn stale_completion_does_not_release_replacement_peer() {
+        use super::super::pending_withdraw::flush_pending_withdraws;
+        use bgp_packet::UpdatePacket;
+
+        let addr: IpAddr = "10.0.0.2".parse().unwrap();
+        let (tx, _rx) = mpsc::channel::<Message>(64);
+        let new_peer = |tx: &mpsc::Sender<Message>| {
+            let mut peer = super::super::peer::Peer::new(
+                0,
+                65001,
+                Ipv4Addr::new(10, 0, 0, 1),
+                65002,
+                addr,
+                None,
+                tx.clone(),
+                crate::context::ProtoContext::default_table_no_rib(),
+            );
+            peer.state = super::super::peer::State::Established;
+            peer
+        };
+        let (id, _group) = test_group(0);
+        let mut groups = empty_map();
+        let mut peers = PeerMap::new();
+
+        // The old peer, with one job out.
+        peers.insert(addr, new_peer(&tx));
+        let ident = peers.get(&addr).unwrap().ident;
+        let old = peers.get_mut_by_idx(ident).unwrap();
+        old.flush_jobs_v4 = 1;
+        let old_stamp = (ident, old.instance);
+
+        // Removed and re-created: same slot, new Peer value, its own job
+        // out and a withdrawal parked behind it.
+        peers.remove(&addr);
+        peers.insert(addr, new_peer(&tx));
+        assert_eq!(peers.get(&addr).unwrap().ident, ident, "slot reused");
+        let (ptx, mut prx) = mpsc::unbounded_channel::<bytes::BytesMut>();
+        let fresh = peers.get_mut_by_idx(ident).unwrap();
+        fresh.packet_tx = Some(ptx);
+        fresh.flush_jobs_v4 = 1;
+        fresh.queue_withdraw_v4(nlri("10.0.0.1/32"));
+        let fresh_stamp = (ident, fresh.instance);
+        assert_ne!(old_stamp, fresh_stamp);
+        flush_pending_withdraws(ident, &mut peers);
+        assert!(recv_all(&mut prx).is_empty(), "parked behind its own job");
+
+        // The old peer's job completes: nothing to settle on the new peer.
+        let addrs = super::super::interface_addrs::InterfaceAddrs::default();
+        flush_done_ipv4(
+            &mut groups,
+            &mut peers,
+            &tx,
+            &id,
+            UpdateGroupCounters::default(),
+            &[old_stamp],
+            &addrs,
+        );
+        assert!(recv_all(&mut prx).is_empty(), "still parked");
+        assert_eq!(peers.get_by_idx(ident).unwrap().flush_jobs_v4, 1);
+
+        // The new peer's own job completes: released.
+        flush_done_ipv4(
+            &mut groups,
+            &mut peers,
+            &tx,
+            &id,
+            UpdateGroupCounters::default(),
+            &[fresh_stamp],
+            &addrs,
+        );
+        let sent = recv_all(&mut prx);
+        assert_eq!(sent.len(), 1);
+        let (_, p) = UpdatePacket::parse_packet(&sent[0], true, None).unwrap();
+        assert_eq!(p.ipv4_withdraw, vec![nlri("10.0.0.1/32")]);
+        assert_eq!(peers.get_by_idx(ident).unwrap().flush_jobs_v4, 0);
     }
 
     /// End-to-end offload: flush spawns the job on the blocking pool,

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -655,8 +655,11 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
             let drop_group = {
                 let group = af.groups.get_mut(&key).expect("just located");
                 group.members.remove(&peer_idx);
-                // Mirror the removal into the group's egress task (the task
-                // itself is dropped + aborted below if the group empties).
+                // Mirror the removal into the group's egress task. Handling
+                // it settles the withdrawals the member is still owed, so
+                // if the group empties the task is let drain and exit
+                // below rather than dropped (aborted) with that delta and
+                // its queued withdrawals unread.
                 if let Some(t) = &group.task {
                     t.send(super::group_egress::GroupEgressDeltaV4::RemoveMember {
                         ident: peer_idx,
@@ -664,8 +667,11 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
                 }
                 group.members.is_empty()
             };
-            if drop_group {
-                af.groups.remove(&key);
+            if drop_group
+                && let Some(mut group) = af.groups.remove(&key)
+                && let Some(task) = group.task.take()
+            {
+                task.drain_and_exit();
             }
         }
     }
@@ -2542,6 +2548,117 @@ mod tests {
         let peer = peers.get_by_idx(ident).unwrap();
         assert!(peer.pending_withdraw.v4.is_empty());
         assert_eq!(peer.flush_jobs_v4, 0);
+    }
+
+    /// Gate-on group task: an egress-policy change detaches the last live
+    /// member — the group is deleted — while the engine still holds a
+    /// withdrawal that member is owed. `detach` must let the task drain
+    /// (settling the withdrawal on `RemoveMember`) and exit, not abort it
+    /// with the delta unread. (Review finding.)
+    #[tokio::test]
+    async fn detach_of_the_last_member_drains_the_group_task_withdrawals() {
+        use super::super::group_egress::{GroupEgressDeltaV4, GroupEgressTask};
+        use super::super::route::{BgpRib, BgpRibType, SyncCtx};
+        use ipnet::Ipv4Net;
+        use std::sync::Arc;
+
+        let (id, mut group) = test_group(0);
+        group.task = Some(GroupEgressTask::spawn(id.clone()));
+        let (tx, _rx) = mpsc::channel::<Message>(64);
+        let mut peer = super::super::peer::Peer::new(
+            0,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65002,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx.clone(),
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = super::super::peer::State::Established;
+        let (ptx, mut prx) = mpsc::unbounded_channel::<bytes::BytesMut>();
+        peer.packet_tx = Some(ptx.clone());
+        peer.update_group_id
+            .insert(AfiSafi::new(Afi::Ip, Safi::Unicast), id.clone());
+        group.members.insert(0);
+        let mut groups = groups_with(group);
+        let mut peers = PeerMap::new();
+        peers.insert("10.0.0.2".parse().unwrap(), peer);
+        let ident = peers.get(&"10.0.0.2".parse().unwrap()).unwrap().ident;
+
+        // The engine holds the member and one advertised prefix.
+        let prefix: Ipv4Net = "10.10.10.0/24".parse().unwrap();
+        let rib = BgpRib::new_arc(
+            99,
+            "10.0.0.9".parse().unwrap(),
+            BgpRibType::EBGP,
+            0,
+            100,
+            Arc::new(BgpAttr {
+                nexthop: Some(BgpNexthop::Ipv4("192.0.2.9".parse().unwrap())),
+                ..Default::default()
+            }),
+            None,
+            None,
+            false,
+        );
+        {
+            let af = groups.get(&AfiSafi::new(Afi::Ip, Safi::Unicast)).unwrap();
+            let task = af.group_by_id(&id).unwrap().task.as_ref().unwrap();
+            let mut ctx = SyncCtx::for_test();
+            ctx.packet_tx = Some(ptx);
+            task.send(GroupEgressDeltaV4::AddMember {
+                ident,
+                ctx: Box::new(ctx),
+                add_path: false,
+            });
+            task.send(GroupEgressDeltaV4::Advertise {
+                prefix,
+                rib: rib.clone(),
+            });
+        }
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            recv_all(&mut prx).len(),
+            1,
+            "the advertise reached the member"
+        );
+
+        // The prefix goes away (queued behind the flush delay), then the
+        // policy change detaches the still-Established member: the group
+        // empties and is deleted.
+        {
+            let af = groups.get(&AfiSafi::new(Afi::Ip, Safi::Unicast)).unwrap();
+            let task = af.group_by_id(&id).unwrap().task.as_ref().unwrap();
+            task.send(GroupEgressDeltaV4::Withdraw {
+                prefix,
+                id: 0,
+                source_ident: 99,
+            });
+        }
+        detach(&mut groups, &mut peers, ident);
+        assert!(peers.get_by_idx(ident).unwrap().state.is_established());
+        assert!(
+            groups[&AfiSafi::new(Afi::Ip, Safi::Unicast)]
+                .group_by_id(&id)
+                .is_none()
+        );
+
+        let mut sent = Vec::new();
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+            sent.extend(recv_all(&mut prx));
+            if !sent.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(sent.len(), 1, "the detached member still gets the withdraw");
+        assert!(
+            u16::from_be_bytes([sent[0][19], sent[0][20]]) > 0,
+            "the frame is a withdraw"
+        );
     }
 
     /// A peer removed and re-created at the same address gets its old

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -2208,6 +2208,13 @@ impl BgpVrf {
                     deltas,
                 );
             }
+            Message::FlushWithdraw(ident) => {
+                super::super::pending_withdraw::flush_pending_withdraws(
+                    ident,
+                    &self.update_groups,
+                    &mut self.peers,
+                );
+            }
             Message::BgpLs { .. } => {
                 // BGP-LS (RFC 9552) is produced and stored only by the
                 // global BGP instance — per-VRF tasks never see it.

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -2189,31 +2189,29 @@ impl BgpVrf {
                     &group_id,
                 );
             }
-            Message::FlushDoneIpv4(group_id, deltas) => {
+            Message::FlushDoneIpv4(group_id, deltas, members) => {
                 super::super::update_group::flush_done_ipv4(
                     &mut self.update_groups,
                     &mut self.peers,
                     &self.tx,
                     &group_id,
                     deltas,
+                    &members,
                     &self.interface_addrs,
                 );
             }
-            Message::FlushDoneIpv6(group_id, deltas) => {
+            Message::FlushDoneIpv6(group_id, deltas, members) => {
                 super::super::update_group::flush_done_ipv6(
                     &mut self.update_groups,
                     &mut self.peers,
                     &self.tx,
                     &group_id,
                     deltas,
+                    &members,
                 );
             }
             Message::FlushWithdraw(ident) => {
-                super::super::pending_withdraw::flush_pending_withdraws(
-                    ident,
-                    &self.update_groups,
-                    &mut self.peers,
-                );
+                super::super::pending_withdraw::flush_pending_withdraws(ident, &mut self.peers);
             }
             Message::BgpLs { .. } => {
                 // BGP-LS (RFC 9552) is produced and stored only by the


### PR DESCRIPTION
## Summary

Every BGP withdraw left the router as its own one-NLRI UPDATE the moment best-path removed it, so a peer going down or a route-reflector sweep produced thousands of 27-octet messages (`docs/design/bgp-code-review-findings.md`, "~100× the packet count on a full-table withdraw sweep"). This models the withdraw side on rustybgp's `PendingTx`, with an explicit rule for keeping the wire in step with the Adj-RIB-Out across the queueing window.

- **Codec** (`crates/bgp-packet`): `UpdatePacket::pop_ipv4_withdraw` (legacy Withdrawn Routes field) and `pop_mp_withdraw` (MP_UNREACH_NLRI, backed by a generic `MpUnreachAttr::attr_emit_mut` that measures each NLRI by encoding it), budgeting the whole packet the way #2370 does for MP_REACH. End-of-RIB variants keep going through `try_emit`.
- **Queue and drain** (`zebra-rs/src/bgp/pending_withdraw.rs`): each peer keeps a per-family set of pending withdrawals (IPv4/IPv6 unicast, VPNv4/VPNv6, EVPN, IPv4/IPv6 labeled-unicast). Queueing arms one next-tick `Message::FlushWithdraw` per peer; the marker lands behind the ingest already on the instance channel, so a burst drains in one go and an idle router pays one extra tick.
- **Adj-RIB-Out coherence**: (1) the Adj-RIB-Out is the authority at drain time — every advertise site records there as it queues or sends and every withdraw site removes first, so a queued NLRI whose `(prefix, path-id)` is back in the table was superseded by a newer announcement and is dropped (`id == 0` matches any row; a real path-id must match exactly); the per-peer VPN/EVPN caches also cancel a queued withdraw directly on re-advertise (rustybgp's `reach()`). (2) An in-flight update-group flush job gates the IPv4/IPv6 unicast drain until `flush_done`, because the job is still enqueueing announcements from a blocking-pool thread — this replaces the per-group `deferred_withdraw_*` parking that served the same race.
- `route_clean` drops the queue and the marker with the advertise caches. MUP / Flowspec / SR Policy / RTC / BGP-LS withdrawals still send immediately (the codec paginates them already).
- **Found by the first full BDD run** (`bgp_shard_addpath_vpnv6`): rule (1) makes the Adj-RIB-Out load-bearing, and the VPNv6 AddPath path never maintained it — the AddPath advertise recorded no row and the AddPath withdraw removed none, so rows the session-up dump had recorded cancelled every later AddPath withdraw. Both now mirror the VPNv4 AddPath path (commit `847c3abc`), with a unit test. Every other withdraw site was swept for its matching removal.

Design doc: `docs/design/bgp-withdraw-packing.md`.

## Review fixes (commits `1eb266a9`, `7e0ec07a`)

- **Quadratic pagination cost.** The MP_UNREACH paginator drained the front of the queued `Vec` per packet, shifting the remainder every time (43 / 130 / 447 ms to drain 100k / 200k / 400k VPNv6 withdrawals in a debug build). It now takes NLRIs from the end and truncates: 21 / 43 / 85 ms. Manual harness kept as an ignored test (`cargo test -p bgp-packet --test withdraw_pagination_scaling -- --ignored --nocapture`).
- **Parked withdrawals stranded by group reassignment.** The in-flight gate lived on the update-group and `flush_done` returned early once the group was gone, so a peer whose marker had already fired and parked behind a job was never released if configuration then detached the group's last member. The gate now lives on the peer (`Peer::flush_jobs_v4/v6`, counted up per member when a job is spawned; the `FlushDone` message carries the member list and counts it off, draining the released members whether or not the group survived). This also closes the adjacent case of a peer moving to a not-in-flight group mid-job. Regression test `parked_withdraw_survives_group_reassignment` (the review probe, now permanent).
- **Slot reuse could settle the wrong peer** (commit `7e0ec07a`). `PeerMap` keeps a slot across remove and same-address re-insert, so a job completion keyed on the index alone could count an old session's job off the replacement peer and release its parked withdrawals while a job of its own was still announcing. Every `Peer` value now carries a creation nonce (`Peer::instance`); a job's members are stamped `(ident, instance)` at spawn and the completion settles only where the nonce still matches. Regression test `stale_completion_does_not_release_replacement_peer`.

## Review fixes, gate-on egress engines and codec (commits `55db1a5c`, `8bbf4161`, `f74a8b71`, `9b83ed1d`, `834042e1`)

- **IPv4 packing was bypassed at gate-on** (`55db1a5c`). Under `ZEBRA_BGP_PEER_TASK` / `ZEBRA_BGP_EGRESS_GROUP_TASK` the v4-unicast egress is diverted off the update-group path into the per-peer and per-update-group engines, whose `withdraw()` still emitted one UPDATE per route. Each engine now queues IPv4 withdrawals and drains them packed through `pop_ipv4_withdraw`; the engine task loop became a `biased` select that drains its delta channel and arms a 1 ms deferred flush (the mirror of the main-task `FlushWithdraw` marker — flushing the instant the channel empties packs only partially, because the main task fans a burst across several executor turns). Advertises stay immediate; the Adj-RIB-Out reconcile carries over. Unit tests per engine plus a paused-clock test driving the run loop; the BDD feature restarts the reflector under each gate and re-runs the wire check.
- **A superseded withdraw was dropped for the member that sourced the replacement** (`8bbf4161`, group engine only). The group engine's Adj-RIB-Out is shared by the whole update-group with split-horizon applied at fan time, so "row back in `adj_out`" does not mean every member holds the replacement: the member that sourced the superseding row was excluded from that row's fan and still holds the copy the queued withdraw is for. Sequence in one batch — Advertise(P, external) → Withdraw(P) → Advertise(P, sourced by member M) — left M holding a stale P (before packing, the withdraw went out immediately and M received it). `flush_withdraws` now sends such a withdraw to exactly the sources of the matching rows, minus the queue's own source, and drops it for everyone else. The per-peer engine and the main-task path have per-peer tables and were not affected. Regression tests `superseded_withdraw_still_reaches_the_member_that_sourced_the_replacement` (the review probe, fails on `55db1a5c`) and `withdraw_re_advertised_from_the_same_source_is_dropped_for_everyone`.

- **Sustained deltas could starve the engines' deferred flush** (`f74a8b71`). The engine run loops are `biased` toward their delta channel, so the 1 ms flush deadline was only polled when the channel went momentarily empty; a producer that kept it non-empty (a full-table re-advertise outpacing the engine) would have held every queued withdrawal until the stream ended, with the pending set growing to table size. Each wake now drains at most `DRAIN_BATCH` (1024) deltas and then `settle_flush` checks the deadline itself, so a queued withdrawal waits at most one `WITHDRAW_FLUSH_DELAY` plus one batch whether or not the channel ever idles. Paused-clock tests in both engines drive the drain past the deadline with the timer branch never polled.
- **`pop_mp_withdraw` could lose a queue silently** (`f74a8b71`). It returned `None` — ending every caller's `while let Some` loop — both for the Route-Target families, which have no per-NLRI emitter, and when the next NLRI could not fit even an empty UPDATE of the session's size (unreachable for the families queued today, but a Flowspec NLRI can run to 4095 octets). It now returns `Result<Option<_>, UpdateEmitError>` with two new variants (`Unpaginatable`, `WithdrawExceedsPacket`), leaving the queue intact; the drain logs how many withdrawals it is dropping. `MpUnreachAttr::len` added for that count.

- **Group reassignment could discard a withdrawal owed to a live member** (`9b83ed1d`, group engine only). The engine fanned its queue to the membership at flush time, so `Withdraw(P)` followed by `RemoveMember` before the deferred flush left the departing peer holding P — an egress-policy change reassigns a live peer to another group without resetting the session, and the new group starts from the Loc-RIB, which no longer has P. Before packing the withdraw was fanned on arrival, so the member had it. `RemoveMember` now flushes the queue before the member is removed, and when the group empties `detach` lets the task drain and exit (`GroupEgressTask::drain_and_exit`: close the channel, detach the handle) instead of aborting it with the delta unread; the run loop also flushes on channel close. Tests: `remove_member_settles_the_withdrawals_it_is_owed`, `closing_the_channel_drains_owed_withdrawals_before_exit`, and `detach_of_the_last_member_drains_the_group_task_withdrawals` (fails under abort-on-drop).

- **A retiring group could withdraw a route its replacement had just re-announced** (`834042e1`, group engine only). The settlement above runs asynchronously in the old group's task while reassignment attaches the peer to its new group at once, so the two engines' sends to the peer's writer were unordered: old group queues withdraw of P → peer moves → new group announces P → old group flushes → peer loses P. The handoff now orders them: `detach` puts a oneshot in the `RemoveMember` and returns the receiver, the old engine fires it after its flush, `reassign_all_update_groups` passes it to `attach`, and the new engine's run loop awaits it before handling that `AddMember` — it sends the member nothing until the old group has settled it. A dropped sender releases the wait; the enqueue order (`RemoveMember` before the `AddMember` that waits on it) rules out a deadlock. Tests: `replacement_group_waits_for_the_old_group_to_settle_the_member` (two real engine tasks in the reviewer's order; fails without the barrier with the announce going first), `a_dropped_handoff_releases_the_joining_member`, `detach_without_an_egress_task_returns_no_handoff`, and the detach test now awaits the returned handoff.

## Measured (BDD `@bgp_withdraw_packing`, 1000 withdrawals per family through a route reflector)

| family | 4096-octet UPDATEs | 65535-octet UPDATEs |
|---|---|---|
| IPv4 unicast | 2 (largest 814 NLRI) | 1 |
| IPv6 unicast | 5 | 1 |
| VPNv4 | 4 | 1 |
| VPNv6 | 7 | 1 |
| EVPN (Type-5, mixed v4/v6) | 12 | 1 |

## Test plan

- [x] `cargo test -p bgp-packet` — 532 (11 new pagination tests: the two pop errors; budget fill for IPv4 legacy / Add-Path / extended, VPNv4, VPNv6, IPv6, mixed-type EVPN; EoR refusal; no path attributes on a withdraw-only UPDATE)
- [x] `cargo test --workspace --exclude bdd` — 2177 zebra-rs (3127 workspace-wide on `834042e1`) (new: one marker per burst; 3000 IPv4 withdrawals → 4 UPDATEs; Adj-RIB-Out reconcile for non-AddPath / AddPath ids and per-RD VPN / EVPN; re-advertise cancels a queued VPN withdraw; down peer discards; in-flight gate holds a unicast withdraw while a VPN one on the same peer goes, `flush_done_ipv4` releases it; `route_clean` clears queue + marker)
- [x] `cargo clippy --workspace --exclude bdd --all-targets -- -D warnings`, `cargo fmt`
- [x] BDD `@bgp_withdraw_packing` (new): per family × message size, packing within a computed bound with no stale announcement overtaking a withdrawal; announce+withdraw ⇒ absent and withdraw+announce ⇒ present sent back to back; the reflector is then restarted under `ZEBRA_BGP_PEER_TASK` and `ZEBRA_BGP_EGRESS_GROUP_TASK` and the check re-run — 6/6 scenarios on `834042e1`
- [x] Full BDD suite at c=16: run 1 297/298 (the VPNv6 AddPath finding above); run 2 after the fix: 298/298 passed, no leaked namespaces or daemons; run 3 on the per-peer gate (`1eb266a9`): 298/298; run 4 on `7e0ec07a`: 298/298, no leaked namespaces or daemons. `55db1a5c`, `8bbf4161`, `f74a8b71`, `9b83ed1d` and `834042e1` change only the gate-on engines and the withdraw codec's error path (env-gated, default off) and were gated on the feature above plus the workspace suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMPcAWBpGsv7TMGXww4U9F

https://claude.ai/code/session_018dHVwVR2D4vsjT7fvcC1eU



