### PR TITLE
config: VyOS-derived vrrp schema, show vrrp grammar and routing

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1619,6 +1619,8 @@ impl ConfigManager {
                                 "Firewall"
                             } else if is_vpn(&paths) {
                                 "IPsec"
+                            } else if is_vrrp(&paths) {
+                                "VRRP"
                             } else if is_policy(&paths) {
                                 "Policy"
                             } else {
@@ -1813,6 +1815,14 @@ fn is_vpn(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "vpn")
 }
 
+/// `show vrrp …` — served by the external insomnia daemon, which
+/// registers the `"vrrp"` show provider (zebra.show.v1); iso-gated
+/// exec grammar. With no provider connected the not-running fallback
+/// answers.
+fn is_vrrp(paths: &[CommandPath]) -> bool {
+    paths.iter().any(|x| x.name == "vrrp")
+}
+
 /// `show pim ...`, `show igmp ...` and `show mroute` — all served by
 /// the PIM task (IGMP membership tracking and the multicast routing
 /// table live inside the PIM module).
@@ -1869,6 +1879,8 @@ fn show_proto(paths: &[CommandPath]) -> &'static str {
         "firewall"
     } else if is_vpn(paths) {
         "ipsec"
+    } else if is_vrrp(paths) {
+        "vrrp"
     } else if is_policy(paths) {
         "policy"
     } else {
@@ -7074,6 +7086,214 @@ module test-iso-gated {
         assert_eq!(
             json,
             r#"{"authentication":{"psk": [{"name":"MAIN","id": ["192.0.2.9"],"secret":"s3cret-key"}]},"esp-group": [{"name":"ESP-A","lifetime":1800,"proposal": [{"number":10,"encryption":"aes256gcm128","hash":"sha256"}]}],"ike-group": [{"name":"IKE-A","key-exchange":"ikev2","proposal": [{"number":10,"dh-group":19,"encryption":"aes256gcm128","hash":"sha256"}]}],"site-to-site":{"peer": [{"name":"192.0.2.9","authentication":{"mode":"pre-shared-secret"},"connection-type":"respond","default-esp-group":"ESP-A","ike-group":"IKE-A","local-address":"192.0.2.1","remote-address": ["192.0.2.9"],"tunnel": [{"number":1,"local":{"prefix": ["10.0.1.0/24"]},"remote":{"prefix": ["10.0.2.0/24"]}}]}]}}"#
+        );
+    }
+
+    /// The VyOS-derived `vrrp` subtree (vrrp.yang, instantiated as an
+    /// iso-gated top-level container in config.yang) is part of the
+    /// ISO-only config surface: absent on a stock start, present with
+    /// `--feature iso`.
+    #[test]
+    fn shipped_vrrp_gated_on_iso() {
+        let child = |e: &Rc<Entry>, name: &str| -> Option<Rc<Entry>> {
+            e.dir.borrow().iter().find(|c| c.name == name).cloned()
+        };
+
+        let set = child(&shipped_tree(&[]), "set").expect("set subtree");
+        assert!(
+            child(&set, "vrrp").is_none(),
+            "vrrp subtree must be absent on a stock start"
+        );
+
+        let set = child(&shipped_tree(&["iso"]), "set").expect("set subtree");
+        let vrrp = child(&set, "vrrp").expect("vrrp subtree with --feature iso");
+        // The grouping expanded: every top-level branch exists.
+        for name in ["disable", "global-parameters", "group", "sync-group"] {
+            assert!(child(&vrrp, name).is_some(), "vrrp {name} branch missing");
+        }
+    }
+
+    /// End-to-end CLI grammar for the `vrrp` subtree: representative
+    /// `set vrrp …` commands parse with iso and are rejected on a
+    /// stock start. The negatives pin the VyOS ranges and enums, the
+    /// address-typed leaves, the decimal `advertise-interval`
+    /// extension, and the absence of VyOS's `high-availability`
+    /// wrapper.
+    #[test]
+    fn vrrp_commands_parse_only_with_iso() {
+        use crate::config::parse::{State, parse};
+
+        let ok = [
+            "set vrrp disable",
+            "set vrrp global-parameters garp master-delay 10",
+            "set vrrp global-parameters garp interval 0.5",
+            "set vrrp global-parameters startup-delay 30",
+            "set vrrp global-parameters version 3",
+            "set vrrp group WAN interface eth0",
+            "set vrrp group WAN vrid 10",
+            "set vrrp group WAN priority 200",
+            "set vrrp group WAN address 192.0.2.254/24",
+            "set vrrp group WAN address 192.0.2.253/24 interface eth1",
+            "set vrrp group WAN excluded-address 2001:db8::1/64",
+            "set vrrp group WAN peer-address 192.0.2.1",
+            "set vrrp group WAN peer-address 192.0.2.2",
+            "set vrrp group WAN hello-source-address 192.0.2.1",
+            "set vrrp group WAN no-preempt",
+            "set vrrp group WAN preempt-delay 30",
+            "set vrrp group WAN rfc3768-compatibility",
+            "set vrrp group WAN v3-checksum-as-v2",
+            "set vrrp group WAN version 3",
+            "set vrrp group WAN advertise-interval 1",
+            "set vrrp group WAN advertise-interval 0.5",
+            "set vrrp group WAN authentication password s3cret",
+            "set vrrp group WAN authentication type plaintext-password",
+            "set vrrp group WAN authentication type ah",
+            "set vrrp group WAN health-check ping 192.0.2.9",
+            "set vrrp group WAN health-check script /usr/local/bin/check.sh",
+            "set vrrp group WAN health-check interval 10",
+            "set vrrp group WAN health-check failure-count 3",
+            "set vrrp group WAN health-check timeout 5",
+            "set vrrp group WAN track interface eth2",
+            "set vrrp group WAN track exclude-vrrp-interface",
+            "set vrrp group WAN transition-script master /usr/local/bin/master.sh",
+            "set vrrp group WAN description upstream gateway pair",
+            "set vrrp group WAN garp master-repeat 3",
+            "set vrrp group WAN disable",
+            "set vrrp sync-group SG member WAN",
+            "set vrrp sync-group SG health-check ping 192.0.2.9",
+            "set vrrp sync-group SG transition-script backup /usr/local/bin/backup.sh",
+        ];
+
+        let bad_with_iso = [
+            "set vrrp group WAN vrid 0",
+            "set vrrp group WAN vrid 256",
+            "set vrrp group WAN priority 0",
+            "set vrrp group WAN version 1",
+            "set vrrp group WAN authentication type md5",
+            "set vrrp group WAN preempt-delay 1001",
+            "set vrrp group WAN advertise-interval fast",
+            "set vrrp group WAN hello-source-address not-an-address",
+            "set vrrp global-parameters startup-delay 0",
+            "set vrrp global-parameters version 4",
+            // VyOS's wrapper node does not exist here.
+            "set high-availability vrrp group WAN vrid 10",
+        ];
+
+        let entry = shipped_tree(&["iso"]);
+        for cmd in ok {
+            let (code, _, _) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must parse with iso");
+        }
+        for cmd in bad_with_iso {
+            let (code, _, _) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must not parse");
+        }
+
+        let entry = shipped_tree(&[]);
+        for cmd in [
+            "set vrrp group WAN vrid 10",
+            "set vrrp global-parameters version 3",
+        ] {
+            let (code, _, _) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(
+                code,
+                ExecCode::Success,
+                "`{cmd}` must be rejected on a stock start"
+            );
+        }
+    }
+
+    /// `show vrrp …` grammar (exec.yang, iso-gated): the summary, the
+    /// two views, and their per-group filters map to the dispatch
+    /// paths the insomnia provider matches on, and every one of them
+    /// routes to the `"vrrp"` show subscriber.
+    #[test]
+    fn show_vrrp_grammar_gated_on_iso() {
+        use crate::config::parse::{State, parse};
+        use crate::config::path_from_command;
+
+        let entry = shipped_tree_mode("exec", &["iso"]);
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show vrrp", "/show/vrrp", vec![]),
+            ("show vrrp statistics", "/show/vrrp/statistics", vec![]),
+            (
+                "show vrrp statistics group WAN",
+                "/show/vrrp/statistics/group",
+                vec!["WAN"],
+            ),
+            ("show vrrp detail", "/show/vrrp/detail", vec![]),
+            (
+                "show vrrp detail group WAN",
+                "/show/vrrp/detail/group",
+                vec!["WAN"],
+            ),
+        ];
+        for (cmd, want_path, want_args) in &cases {
+            let (code, _, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, *want_path, "path for `{cmd}`");
+            let args: Vec<&str> = args.0.iter().map(String::as_str).collect();
+            assert_eq!(args, *want_args, "args for `{cmd}`");
+            assert_eq!(show_proto(&state.paths), "vrrp", "routing for `{cmd}`");
+        }
+
+        // Stock start: the whole tree is absent.
+        let entry = shipped_tree_mode("exec", &[]);
+        let (code, _, _) = parse("show vrrp", entry, None, State::new());
+        assert_ne!(code, ExecCode::Success, "gated off without --feature iso");
+    }
+
+    /// The `/vrrp` half of the marshal contract — same story as
+    /// [`ipsec_json_marshal_contract`]: the keepalived backend lives in
+    /// the insomnia daemon, this golden pins what the JSON
+    /// subscription delivers, and insomnia's backend tests pin the
+    /// parse half. Covers a keyed list whose key leaf shares the list
+    /// name (`address`), a per-entry sub-leaf, a leaf-list, a presence
+    /// leaf and a decimal.
+    #[test]
+    fn vrrp_json_marshal_contract() {
+        use crate::config::parse::{State, parse};
+
+        let entry = shipped_tree(&["iso"]);
+
+        let store = ConfigStore::new();
+        for cmd in [
+            "set vrrp global-parameters version 3",
+            "set vrrp group WAN interface eth0",
+            "set vrrp group WAN vrid 10",
+            "set vrrp group WAN priority 200",
+            "set vrrp group WAN advertise-interval 0.5",
+            "set vrrp group WAN no-preempt",
+            "set vrrp group WAN address 192.0.2.254/24",
+            "set vrrp group WAN address 192.0.2.253/24 interface eth1",
+            "set vrrp group WAN peer-address 192.0.2.1",
+            "set vrrp group WAN peer-address 192.0.2.2",
+            "set vrrp sync-group SG member WAN",
+        ] {
+            let candidate = store.candidate.borrow().clone();
+            let (code, _, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            set(path_try_trim("set", state.paths), candidate);
+        }
+
+        // Marshal the /vrrp subtree the way `subtree_json` does. Note
+        // the shape: children come out in name order (not schema
+        // order), keyed-list entries in key order, the key leaf first.
+        let node = store
+            .candidate
+            .borrow()
+            .clone()
+            .lookup(&"vrrp".to_string())
+            .expect("subtree exists");
+        let mut json = String::new();
+        node.json(&mut json);
+        eprintln!("vrrp json: {json}");
+
+        assert_eq!(
+            json,
+            r#"{"global-parameters":{"version":3},"group": [{"name":"WAN","address": [{"address":"192.0.2.253/24","interface":"eth1"},{"address":"192.0.2.254/24"}],"advertise-interval":0.5,"interface":"eth0","no-preempt":null,"peer-address": ["192.0.2.1","192.0.2.2"],"priority":200,"vrid":10}],"sync-group": [{"name":"SG","member": ["WAN"]}]}"#
         );
     }
 }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -187,6 +187,24 @@ where
     }
 }
 
+/// decimal64 value: an unsigned decimal number with an optional
+/// fraction (`1`, `0.5`, `12.345`), first word only. Range statements
+/// on decimal64 leaves are not enforced here — libyang extracts
+/// integer ranges only — so consumers validate bounds themselves.
+fn match_decimal(input: &str) -> (MatchType, usize) {
+    let s = input.split(' ').next().unwrap_or("");
+    let (int, frac) = match s.split_once('.') {
+        Some((int, frac)) => (int, Some(frac)),
+        None => (s, None),
+    };
+    let digits = |p: &str| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit());
+    if digits(int) && frac.is_none_or(digits) {
+        (MatchType::Exact, s.len())
+    } else {
+        (MatchType::None, 0usize)
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct Match {
     pub pos: usize,
@@ -288,6 +306,10 @@ fn match_builder() -> MatchMap {
         .kind(YangType::Uint64)
         .exec(|m, entry, input, node| {
             m.process(entry, match_range::<u64>(input, node), crange(entry, node));
+        })
+        .kind(YangType::Decimal64)
+        .exec(|m, entry, input, node| {
+            m.process(entry, match_decimal(input), crange(entry, node));
         })
         .kind(YangType::Ipv4Addr)
         .exec(|m, entry, input, _node| {
@@ -904,6 +926,21 @@ pub fn parse(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// decimal64 leaves accept an integer or a dotted fraction and
+    /// consume only the first word; a bare or trailing dot, a leading
+    /// sign and non-digits are rejected.
+    #[test]
+    fn match_decimal_accepts_integer_and_fraction() {
+        assert_eq!(match_decimal("1"), (MatchType::Exact, 1));
+        assert_eq!(match_decimal("0.5 rest"), (MatchType::Exact, 3));
+        assert_eq!(match_decimal("12.345"), (MatchType::Exact, 6));
+        assert_eq!(match_decimal(".5"), (MatchType::None, 0));
+        assert_eq!(match_decimal("1."), (MatchType::None, 0));
+        assert_eq!(match_decimal("-1"), (MatchType::None, 0));
+        assert_eq!(match_decimal("fast"), (MatchType::None, 0));
+        assert_eq!(match_decimal(""), (MatchType::None, 0));
+    }
 
     /// A patterned string leaf consumes the entire trimmed remainder
     /// of the line. With a fully-matching value the helper reports

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -32,6 +32,10 @@ module config {
     prefix ipsec;
   }
 
+  import vrrp {
+    prefix vrrp;
+  }
+
   import ietf-bgp {
     prefix bgp;
   }
@@ -5077,6 +5081,14 @@ module config {
         ext:help "VPN IP security (IPsec) parameters";
         uses "ipsec:vpn-ipsec";
       }
+    }
+
+    // VyOS-derived VRRP (see vrrp.yang): VyOS's `high-availability`
+    // wrapper is dropped, `vrrp` is a top-level node. ISO-only.
+    container vrrp {
+      if-feature feat:iso;
+      ext:help "Virtual Router Redundancy Protocol (VRRP)";
+      uses "vrrp:vrrp";
     }
 
     list interface {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -95,6 +95,39 @@ module exec {
     }
   }
 
+  // `show vrrp …` views, shared by the default-VRF tree and a future
+  // per-VRF `show vrrp vrf <name> …` list. Served by the external
+  // insomnia provider (zebra.show.v1 name "vrrp"): `statistics` and
+  // `detail` each take an optional group name.
+  grouping vrrp-show-views {
+    container statistics {
+      ext:help "VRRP statistics";
+      presence "VRRP statistics for all groups";
+      list group {
+        ext:help "Statistics for one VRRP group";
+        ext:presence "Statistics for one VRRP group";
+        key "name";
+        leaf name {
+          ext:help "VRRP group name";
+          type string;
+        }
+      }
+    }
+    container detail {
+      ext:help "VRRP group details";
+      presence "VRRP details for all groups";
+      list group {
+        ext:help "Details for one VRRP group";
+        ext:presence "Details for one VRRP group";
+        key "name";
+        leaf name {
+          ext:help "VRRP group name";
+          type string;
+        }
+      }
+    }
+  }
+
   container show {
     ext:help "Show command";
     presence "Show command";
@@ -374,6 +407,14 @@ module exec {
           presence "Kernel XFRM state list";
         }
       }
+    }
+    // `show vrrp …` — served by the external insomnia provider
+    // (zebra.show.v1 name "vrrp"); iso-gated like the config tree.
+    container vrrp {
+      if-feature feat:iso;
+      ext:help "VRRP information";
+      presence "VRRP group summary";
+      uses vrrp-show-views;
     }
     container evpn {
       ext:help "EVPN information";

--- a/zebra-rs/yang/vrrp.yang
+++ b/zebra-rs/yang/vrrp.yang
@@ -1,0 +1,365 @@
+module vrrp {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-vrrp";
+  prefix "vrrp";
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  description
+    "VyOS-derived VRRP configuration, ported from the VyOS 1.5
+     (circinus) interface definitions (vyos-1x
+     interface-definitions/high-availability.xml.in with its
+     include/vrrp/garp.xml.i and include/vrrp-transition-script.xml.i
+     fragments). Enforced by the out-of-process insomnia daemon, which
+     renders this tree into keepalived.conf; zebra-rs owns only the
+     schema and the config store.
+
+     This module is a grouping library in the firewall.yang /
+     ipsec.yang style: config.yang instantiates `grouping vrrp` under
+     an iso-gated top-level `container vrrp`, so every node here exists
+     only when the daemon runs with `--feature iso`.
+
+     Placement differs from VyOS on purpose: VyOS wraps VRRP in
+     `high-availability`, a node that exists only to co-locate it with
+     the IPVS load balancer (`virtual-server`). zebra-rs has no such
+     grouping, so `vrrp` is a top-level node and a VyOS line ports by
+     dropping the `high-availability` prefix; everything below `vrrp`
+     keeps VyOS's leaf names verbatim.
+
+     Three leaves are extensions borrowed from FRR's vrrpd model (they
+     map 1:1 onto keepalived keywords VyOS does not expose): a
+     per-group `version`, `v3-checksum-as-v2`, and a fractional
+     `advertise-interval`. A config that omits them is exactly VyOS's.
+
+     Current scope: `disable`, `global-parameters`, `group` and
+     `sync-group`. Deliberately deferred: VyOS `virtual-server`
+     (IPVS; would be its own top-level node), `vrrp snmp trap`, the
+     conntrack-sync failover hook, and the per-VRF `vrf` list.
+
+     Value-shape conventions follow ipsec.yang: no `pattern` statements
+     on value leaves (a patterned string leaf consumes the rest of the
+     line); `description` uses exactly that rest-of-line pattern on
+     purpose; references (`interface`, sync-group `member`) are plain
+     `type string` — not leafref — so the referent may be staged after
+     the referrer. Defaults are not declared here: the enforcement
+     daemon applies VyOS's defaults when rendering, so the JSON batch
+     carries only what the operator set.";
+
+  // ---------------------------------------------------------------
+  // Shared building blocks
+  // ---------------------------------------------------------------
+
+  // Gratuitous-ARP tuning — VyOS include/vrrp/garp.xml.i, verbatim.
+  // Used both under `global-parameters` (keepalived `vrrp_garp_*`)
+  // and per group (keepalived `garp_*`).
+  grouping garp-parameters {
+    container garp {
+      ext:help "Gratuitous ARP parameters";
+      leaf interval {
+        ext:help "Interval between gratuitous ARPs in seconds, resolution microseconds (0.000-1000, VyOS default: 0)";
+        type decimal64 {
+          fraction-digits 3;
+        }
+      }
+      leaf master-delay {
+        ext:help "Delay for second set of gratuitous ARPs after transition to master, seconds (VyOS default: 5)";
+        type uint32 {
+          range "1..1000";
+        }
+      }
+      leaf master-refresh {
+        ext:help "Minimum interval for refreshing gratuitous ARPs while master, seconds; 0 = no refresh (VyOS default: 5)";
+        type uint32 {
+          range "0..255";
+        }
+      }
+      leaf master-refresh-repeat {
+        ext:help "Number of gratuitous ARP messages to send at a time while master (VyOS default: 1)";
+        type uint32 {
+          range "1..255";
+        }
+      }
+      leaf master-repeat {
+        ext:help "Number of gratuitous ARP messages to send at a time after transition to master (VyOS default: 5)";
+        type uint32 {
+          range "1..255";
+        }
+      }
+    }
+  }
+
+  // Health check — the `health-check` node shared by `group` and
+  // `sync-group`. Exactly one of `script` / `ping` is meaningful;
+  // the enforcement daemon warns and drops the check otherwise.
+  grouping health-check {
+    container health-check {
+      ext:help "Health check script";
+      leaf failure-count {
+        ext:help "Health check failure count required for transition to fault (VyOS default: 3)";
+        type uint32 {
+          range "1..max";
+        }
+      }
+      leaf interval {
+        ext:help "Health check execution interval in seconds (VyOS default: 60)";
+        type uint32 {
+          range "1..max";
+        }
+      }
+      leaf ping {
+        ext:help "ICMP ping health check to this address";
+        type union {
+          type inet:ipv4-address;
+          type inet:ipv6-address;
+        }
+      }
+      leaf script {
+        ext:help "Health check script file";
+        type string;
+      }
+      leaf timeout {
+        ext:help "Health check script timeout in seconds";
+        type uint32;
+      }
+    }
+  }
+
+  // VRRP transition scripts — VyOS include/vrrp-transition-script.xml.i,
+  // verbatim; shared by `group` and `sync-group`.
+  grouping transition-script {
+    container transition-script {
+      ext:help "VRRP transition scripts";
+      leaf master {
+        ext:help "Script to run on VRRP state transition to master";
+        type string;
+      }
+      leaf backup {
+        ext:help "Script to run on VRRP state transition to backup";
+        type string;
+      }
+      leaf fault {
+        ext:help "Script to run on VRRP state transition to fault";
+        type string;
+      }
+      leaf stop {
+        ext:help "Script to run on VRRP state transition to stop";
+        type string;
+      }
+    }
+  }
+
+  // A virtual address entry: the address (with or without a prefix
+  // length) keyed by its own spelling, plus the optional interface it
+  // is placed on (keepalived `dev`) when that differs from the group's.
+  grouping virtual-address-entry {
+    leaf address {
+      ext:help "Virtual address (IPv4/IPv6 address or address/prefix)";
+      type string;
+    }
+    leaf interface {
+      ext:help "Interface to place this virtual address on";
+      type string;
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // global-parameters
+  // ---------------------------------------------------------------
+
+  grouping global-parameters {
+    container global-parameters {
+      ext:help "VRRP global parameters";
+      uses garp-parameters;
+      leaf startup-delay {
+        ext:help "Time VRRP startup process is delayed, seconds";
+        type uint32 {
+          range "1..600";
+        }
+      }
+      leaf version {
+        ext:help "Default VRRP version to use (keepalived: 2 for IPv4, 3 for IPv6)";
+        type enumeration {
+          enum 2;
+          enum 3;
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // group
+  // ---------------------------------------------------------------
+
+  grouping group-list {
+    list group {
+      ext:help "VRRP group";
+      key "name";
+      leaf name {
+        ext:help "VRRP group name";
+        type string;
+      }
+      leaf interface {
+        ext:help "Network interface the group runs on";
+        type string;
+      }
+      leaf vrid {
+        ext:help "Virtual router identifier";
+        type uint8 {
+          range "1..255";
+        }
+      }
+      // Extension (FRR-derived): per-group protocol version,
+      // overriding `global-parameters version`.
+      leaf version {
+        ext:help "VRRP version for this group, overriding global-parameters version";
+        type enumeration {
+          enum 2;
+          enum 3;
+        }
+      }
+      // Extension (FRR-derived): interoperate with peers that omit the
+      // IPv4 pseudoheader from the VRRPv3 checksum (keepalived
+      // `v3_checksum_as_v2`).
+      leaf v3-checksum-as-v2 {
+        ext:help "Compute the VRRPv3 IPv4 checksum without the pseudoheader";
+        type empty;
+      }
+      list address {
+        ext:help "Virtual address";
+        key "address";
+        uses virtual-address-entry;
+      }
+      list excluded-address {
+        ext:help "Virtual address not included in VRRP packets";
+        key "address";
+        uses virtual-address-entry;
+      }
+      // Extension (FRR-derived): fractional seconds. VyOS allows whole
+      // seconds 1-255 only; keepalived accepts fractions for VRRPv3
+      // (wire field is centiseconds, so 0.01-40.95 there).
+      leaf advertise-interval {
+        ext:help "Advertise interval in seconds, fractions allowed for VRRPv3 (0.01-255, VyOS default: 1)";
+        type decimal64 {
+          fraction-digits 2;
+        }
+      }
+      container authentication {
+        ext:help "VRRP authentication";
+        leaf password {
+          ext:help "VRRP password (1-8 characters)";
+          type string;
+        }
+        leaf type {
+          ext:help "Authentication type";
+          type enumeration {
+            enum plaintext-password;
+            enum ah;
+          }
+        }
+      }
+      leaf description {
+        ext:help "Description";
+        // Rest-of-line value: the pattern makes the leaf consume
+        // the remainder of the command, whitespace included
+        // (`match_regexp` in config/parse.rs).
+        type string {
+          pattern '.*';
+        }
+      }
+      leaf disable {
+        ext:help "Disable this group";
+        type empty;
+      }
+      uses garp-parameters;
+      uses health-check;
+      leaf hello-source-address {
+        ext:help "VRRP hello source address";
+        type union {
+          type inet:ipv4-address;
+          type inet:ipv6-address;
+        }
+      }
+      leaf-list peer-address {
+        ext:help "Unicast VRRP peer address";
+        type union {
+          type inet:ipv4-address;
+          type inet:ipv6-address;
+        }
+      }
+      leaf no-preempt {
+        ext:help "Disable master preemption";
+        type empty;
+      }
+      leaf preempt-delay {
+        ext:help "Preempt delay in seconds (VyOS default: 0)";
+        type uint32 {
+          range "0..1000";
+        }
+      }
+      leaf priority {
+        ext:help "Router priority (VyOS default: 100)";
+        type uint8 {
+          range "1..255";
+        }
+      }
+      leaf rfc3768-compatibility {
+        ext:help "Use VRRP virtual MAC address as per RFC3768";
+        type empty;
+      }
+      container track {
+        ext:help "Track settings";
+        leaf exclude-vrrp-interface {
+          ext:help "Ignore VRRP main interface faults";
+          type empty;
+        }
+        leaf-list interface {
+          ext:help "Interface name state check";
+          type string;
+        }
+      }
+      uses transition-script;
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // sync-group
+  // ---------------------------------------------------------------
+
+  grouping sync-group-list {
+    list sync-group {
+      ext:help "VRRP sync group";
+      key "name";
+      leaf name {
+        ext:help "VRRP sync group name";
+        type string;
+      }
+      leaf-list member {
+        ext:help "Sync group member (VRRP group name)";
+        type string;
+      }
+      uses health-check;
+      uses transition-script;
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // The whole `vrrp` tree
+  // ---------------------------------------------------------------
+
+  grouping vrrp {
+    leaf disable {
+      ext:help "Disable VRRP entirely";
+      type empty;
+    }
+    uses global-parameters;
+    uses group-list;
+    uses sync-group-list;
+  }
+}


### PR DESCRIPTION
## Summary

Schema and show-grammar half of the VRRP feature; the enforcement daemon lives in the insomnia repository (design: insomnia `design/vrrp.md`).

- **`zebra-rs/yang/vrrp.yang`** — grouping-library module in the ipsec.yang style, VyOS `high-availability vrrp` leaves verbatim with the wrapper dropped: `disable`, `global-parameters` (garp, startup-delay, version), `group` (interface, vrid, address/excluded-address lists with per-address interface, advertise-interval, authentication, description, disable, garp, health-check, hello-source-address, peer-address, no-preempt, preempt-delay, priority, rfc3768-compatibility, track, transition-script) and `sync-group`. Three extensions keepalived supports but VyOS does not expose: per-group `version`, `v3-checksum-as-v2`, fractional `advertise-interval`.
- **`config.yang`** — iso-gated top-level `container vrrp`.
- **`exec.yang`** — `show vrrp`, `show vrrp statistics [group NAME]`, `show vrrp detail [group NAME]` via a reusable grouping (a per-VRF form can reuse it later).
- **`config/manager.rs`** — `is_vrrp` routing to the external `vrrp` show provider and the not-running fallback.
- **`config/parse.rs`** — a `decimal64` matcher (the parser had none); libyang's range extraction is integer-only, so the decimal leaves carry no `range` and the renderer enforces bounds.
- Tests: schema presence gated on iso, a `set vrrp …` grammar battery, show dispatch paths, and the JSON marshal shape insomnia's serde model is written against.

Verified with insomnia's `vrrp_pair` BDD feature (two routers + client, election, failover, preemption, declarative unload) against this branch's staged toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RRd4bv1b2JYN9gBQQefmy
