### PR TITLE
ci: drop the runner image's Google Chrome apt source in every host apt refresh

### DIFF
--- a/.github/workflows/build-amd64.yaml
+++ b/.github/workflows/build-amd64.yaml
@@ -16,7 +16,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build vty
+        # Drop the runner image's Google Chrome apt source before refreshing: its
+        # index answered "Hash Sum mismatch" for hours on 2026-09-09 and failed
+        # every apt refresh on main (see ci.yaml).
         run: |
+          grep -l dl.google.com /etc/apt/sources.list.d/* | xargs -r sudo rm -f
           sudo apt update -y
           sudo apt install -y protobuf-compiler bison xxd libpam0g-dev
           make -C vty

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -16,7 +16,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build vty
+        # Drop the runner image's Google Chrome apt source before refreshing: its
+        # index answered "Hash Sum mismatch" for hours on 2026-09-09 and failed
+        # every apt refresh on main (see ci.yaml).
         run: |
+          grep -l dl.google.com /etc/apt/sources.list.d/* | xargs -r sudo rm -f
           sudo apt update -y
           sudo apt install -y protobuf-compiler bison xxd libpam0g-dev
           make -C vty

--- a/.github/workflows/build-debs.yaml
+++ b/.github/workflows/build-debs.yaml
@@ -51,7 +51,11 @@ jobs:
           cache-key: ${{ matrix.dist }}
 
       - name: Install build dependencies
+        # Drop the runner image's Google Chrome apt source before refreshing: its
+        # index answered "Hash Sum mismatch" for hours on 2026-09-09 and failed
+        # every apt refresh on main (see ci.yaml).
         run: |
+          grep -l dl.google.com /etc/apt/sources.list.d/* | xargs -r sudo rm -f
           sudo apt-get update -y
           sudo apt-get install -y protobuf-compiler bison xxd libpam0g-dev
 

--- a/.github/workflows/publish-apt.yaml
+++ b/.github/workflows/publish-apt.yaml
@@ -45,7 +45,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install apt tooling
-        run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils gnupg
+        # Drop the runner image's Google Chrome apt source before refreshing: its
+        # index answered "Hash Sum mismatch" for hours on 2026-09-09 and failed
+        # every apt refresh on main (see ci.yaml).
+        run: |
+          grep -l dl.google.com /etc/apt/sources.list.d/* | xargs -r sudo rm -f
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev apt-utils gnupg
 
       - name: Download this codename's freshly built .debs
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Every push to `main` on 2026-09-09 failed **Build for amd64** (the merges of #2379 and #2380), and the `CI` run of the #2379 merge, in the step that runs `apt update`: the runner image's pre-installed Google Chrome apt source answered `Hash Sum mismatch` for hours, and one stale third-party index fails the whole refresh. None of these steps installs anything from that source.

`ci.yaml` got the guard in #2380 (the file is a deb822 `google-chrome.sources`, so it is matched by content, not by name). This applies the same one-liner to the remaining host-level refreshes:

- `build-amd64.yaml` and `build-arm64.yaml` ("Build vty")
- `build-debs.yaml` host job ("Install build dependencies"; used by nightly and release)
- `publish-apt.yaml`

The container jobs of `build-debs.yaml` run inside Docker images that carry no such source and are unchanged.

## Verification

- The four files parse as YAML.
- The same guard fixed #2380's CI on the first run after it landed (`google-chrome.sources` listed and removed in the step log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuexVVWQuBjL9ce7cBzqsZ
