### PR TITLE
bgp: support peer timers on interface-neighbor

### DIFF
--- a/docs/handler-paths.txt
+++ b/docs/handler-paths.txt
@@ -78,6 +78,10 @@
 /router/bgp/interface-neighbor
 /router/bgp/interface-neighbor/neighbor-group
 /router/bgp/interface-neighbor/remote-as
+/router/bgp/interface-neighbor/timers/advertisement-interval
+/router/bgp/interface-neighbor/timers/connect-retry-time
+/router/bgp/interface-neighbor/timers/hold-time
+/router/bgp/interface-neighbor/timers/idle-hold-time
 /router/bgp/loc-rib-hook/ipv4-unicast/import
 /router/bgp/loc-rib-hook/ipv4-unicast/withdraw
 /router/bgp/loc-rib-hook/l2vpn-evpn/import

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -23,8 +23,8 @@ in src/bgp/config.rs (an empty relative path, easy to miss when
 grepping for registrations), and it creates/tears down the peer when
 the list entry itself is set/deleted.
 
-Total settable schema nodes: 349
-Handled: 334
+Total settable schema nodes: 353
+Handled: 338
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -86,6 +86,11 @@
 /router/bgp/interface-neighbor	list keys=interface
 /router/bgp/interface-neighbor/neighbor-group	leaf
 /router/bgp/interface-neighbor/remote-as	leaf
+/router/bgp/interface-neighbor/timers	container
+/router/bgp/interface-neighbor/timers/advertisement-interval	leaf
+/router/bgp/interface-neighbor/timers/connect-retry-time	leaf
+/router/bgp/interface-neighbor/timers/hold-time	leaf
+/router/bgp/interface-neighbor/timers/idle-hold-time	leaf
 /router/bgp/long-lived-graceful-restart	container
 /router/bgp/long-lived-graceful-restart/stale-time	leaf
 /router/bgp/mup-c	container

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -5456,6 +5456,26 @@ impl Bgp {
             "/router/bgp/interface-neighbor/remote-as",
             super::interface_neighbor::config_interface_neighbor_remote_as,
         );
+        // Session timers for an interface-keyed peer. The addressed
+        // `/router/bgp/neighbor/timers/...` callbacks cannot serve one:
+        // they resolve the peer with `PeerMap::get_mut(&IpAddr)`, which
+        // only looks under `PeerKey::Addr`.
+        self.callback_add(
+            "/router/bgp/interface-neighbor/timers/hold-time",
+            super::interface_neighbor::config_interface_neighbor_hold_time,
+        );
+        self.callback_add(
+            "/router/bgp/interface-neighbor/timers/idle-hold-time",
+            super::interface_neighbor::config_interface_neighbor_idle_hold_time,
+        );
+        self.callback_add(
+            "/router/bgp/interface-neighbor/timers/connect-retry-time",
+            super::interface_neighbor::config_interface_neighbor_connect_retry_time,
+        );
+        self.callback_add(
+            "/router/bgp/interface-neighbor/timers/advertisement-interval",
+            super::interface_neighbor::config_interface_neighbor_advertisement_interval,
+        );
         self.callback_peer("/local-identifier", config_local_identifier);
         self.callback_peer("/transport/passive-mode", config_transport_passive);
         self.callback_peer("/transport/local-address", config_transport_local_address);
@@ -8707,6 +8727,188 @@ mod neighbor_group_wiring_tests {
             .expect("LinkAdd must materialize the configured neighbor");
         assert_eq!(peer.ifname.as_deref(), Some("i1"));
         assert!(!peer.active, "still no RA — stays dormant");
+    }
+
+    // ---- interface-neighbor timers --------------------------------
+
+    /// Timers typed before the peer exists must reach it when it
+    /// materializes. This is the case the addressed
+    /// `neighbor <addr> timers` callbacks cannot cover for an
+    /// interface-keyed peer: they resolve through
+    /// `PeerMap::get_mut(&IpAddr)`, which only looks under
+    /// `PeerKey::Addr`.
+    #[tokio::test]
+    async fn interface_neighbor_timers_reach_the_materialized_peer() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_advertisement_interval,
+            config_interface_neighbor_connect_retry_time, config_interface_neighbor_hold_time,
+            config_interface_neighbor_idle_hold_time, config_interface_neighbor_remote_as,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let mut bgp = fresh_bgp();
+        // No link yet: every callback below can only stage onto the
+        // interface-neighbor config.
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+        config_interface_neighbor_hold_time(&mut bgp, arg_words(&["i1", "30"]), ConfigOp::Set)
+            .unwrap();
+        config_interface_neighbor_idle_hold_time(&mut bgp, arg_words(&["i1", "1"]), ConfigOp::Set)
+            .unwrap();
+        config_interface_neighbor_connect_retry_time(
+            &mut bgp,
+            arg_words(&["i1", "7"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        config_interface_neighbor_advertisement_interval(
+            &mut bgp,
+            arg_words(&["i1", "0"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(
+            bgp.peers.get_by_key(&PeerKey::Interface(7)).is_none(),
+            "no link yet — nothing to key the peer by"
+        );
+
+        // The link surfaces; the dormant peer is built from the config.
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        super::super::interface_neighbor::materialize_dormant(&mut bgp, "i1")
+            .expect("peer materializes");
+
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert_eq!(peer.config.timer.hold_time, Some(30));
+        assert_eq!(peer.config.timer.idle_hold_time, Some(1));
+        assert_eq!(peer.config.timer.connect_retry_time, Some(7));
+        assert_eq!(peer.config.timer.min_adv_interval, Some(0));
+    }
+
+    /// An edit made while the peer is already materialized writes
+    /// through to it, and a delete falls back to the built-in default —
+    /// matching the addressed `neighbor <addr> timers` callbacks.
+    #[tokio::test]
+    async fn interface_neighbor_timers_write_through_and_delete() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_hold_time,
+            config_interface_neighbor_remote_as, materialize_peer,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let mut bgp = fresh_bgp();
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+        let link_local: std::net::Ipv6Addr = "fe80::2".parse().unwrap();
+        materialize_peer(&mut bgp, "i1", 7, link_local).expect("peer materializes");
+        assert_eq!(
+            bgp.peers
+                .get_by_key(&PeerKey::Interface(7))
+                .unwrap()
+                .config
+                .timer
+                .hold_time,
+            None,
+            "no statement — the 180s default applies"
+        );
+
+        config_interface_neighbor_hold_time(&mut bgp, arg_words(&["i1", "9"]), ConfigOp::Set)
+            .unwrap();
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert_eq!(peer.config.timer.hold_time, Some(9));
+        assert_eq!(peer.config.timer.hold_time(), 9);
+
+        config_interface_neighbor_hold_time(&mut bgp, arg_words(&["i1", "9"]), ConfigOp::Delete)
+            .unwrap();
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert_eq!(peer.config.timer.hold_time, None);
+        assert_eq!(peer.config.timer.hold_time(), 180, "back to the default");
+        assert_eq!(
+            bgp.interface_neighbors["i1"].timer.hold_time, None,
+            "the staged record follows the delete too"
+        );
+    }
+
+    /// `idle-hold-time` is the one leaf that re-arms a running timer.
+    /// On a peer materialized before its first RA the address is still
+    /// unspecified, and `timer::update_timers` — unlike `Peer::start()`
+    /// — does not re-check that, so the re-arm must stay gated: an
+    /// ungated one would drive the peer into `fsm_start` and dial `::`.
+    #[tokio::test]
+    async fn interface_neighbor_idle_hold_time_does_not_dial_a_dormant_peer() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_idle_hold_time,
+            config_interface_neighbor_remote_as,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let mut bgp = fresh_bgp();
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert!(peer.address.is_unspecified() && !peer.active, "dormant");
+
+        config_interface_neighbor_idle_hold_time(&mut bgp, arg_words(&["i1", "1"]), ConfigOp::Set)
+            .unwrap();
+
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert_eq!(peer.config.timer.idle_hold_time, Some(1), "value lands");
+        assert!(
+            peer.timer.idle_hold_timer.is_none(),
+            "no idle-hold timer may be armed while the address is unspecified"
+        );
+        assert!(!peer.active, "the peer must stay dormant");
+    }
+
+    /// The positive half of the gate above. On a materialized,
+    /// dialable peer the re-arm must happen even though `active` is
+    /// already true: `Peer::is_dialable` deliberately does not include
+    /// `!active` — `Peer::start` adds that separately, because `start`
+    /// is a one-shot kick while this callback re-arms a timer that is
+    /// already running. Folding `!active` into the predicate would
+    /// silently stop honoring a live `idle-hold-time` change; this
+    /// pins the split.
+    #[tokio::test]
+    async fn interface_neighbor_idle_hold_time_rearms_an_already_active_peer() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_idle_hold_time,
+            config_interface_neighbor_remote_as, materialize_peer,
+        };
+        use super::super::peer_key::PeerKey;
+        use crate::bgp::peer::State;
+
+        let mut bgp = fresh_bgp();
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+        let link_local: std::net::Ipv6Addr = "fe80::2".parse().unwrap();
+        materialize_peer(&mut bgp, "i1", 7, link_local).expect("peer materializes");
+
+        {
+            let peer = bgp.peers.get_mut_by_key(&PeerKey::Interface(7)).unwrap();
+            assert!(peer.is_dialable(), "RA-learned address and a resolved ASN");
+            assert!(peer.active, "materialization kicked the FSM");
+            assert_eq!(peer.state, State::Idle, "still dwelling in Idle");
+            // `materialize_peer` -> `start()` -> `update_timers` already
+            // armed this at the default. Clear it, or the callback's
+            // Some -> Some transition would prove nothing.
+            peer.timer.idle_hold_timer = None;
+        }
+
+        config_interface_neighbor_idle_hold_time(&mut bgp, arg_words(&["i1", "1"]), ConfigOp::Set)
+            .unwrap();
+
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert_eq!(peer.config.timer.idle_hold_time, Some(1), "value lands");
+        assert!(
+            peer.timer.idle_hold_timer.is_some(),
+            "a dialable peer must have its idle-hold timer re-armed, active or not"
+        );
     }
 
     /// The group supplies the remote-as after an interface-neighbor

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -49,6 +49,13 @@ impl RemoteAsSpec {
 pub struct InterfaceNeighborCfg {
     pub neighbor_group: Option<String>,
     pub remote_as: RemoteAsSpec,
+    /// Session timers typed on the interface-neighbor. Held here — not
+    /// only on the peer — because an interface-neighbor is configurable
+    /// before its peer exists: materialization waits for the link and a
+    /// resolvable remote-as. [`materialize`] copies this onto the peer
+    /// it creates; the callbacks below additionally write through to an
+    /// already-materialized peer.
+    pub timer: super::timer::Config,
 }
 
 /// Resolved remote-as for an interface-neighbor plus a hint about
@@ -213,6 +220,10 @@ fn materialize(
     // (it additionally consults the interface-neighbor cfg for the
     // `external`-placeholder case — see `sweep_peers_for_group`).
     peer.config.neighbor_group = cfg.neighbor_group.clone();
+    // Session timers typed on the interface-neighbor. Must land before
+    // `peer.start()` below: the idle-hold timer it arms reads
+    // `config.timer.idle_hold_time`.
+    peer.config.timer = cfg.timer.clone();
     if resolved.inherited_from_group {
         peer.config.remote_as_inherited = true;
     }
@@ -416,6 +427,133 @@ pub fn config_interface_neighbor_remote_as(
         }
         ConfigOp::Delete => entry.remote_as = RemoteAsSpec::Unset,
         _ => {}
+    }
+    Some(())
+}
+
+/// The peer an `interface-neighbor <name>` materialized into, if it
+/// exists yet. The timers callbacks below stage onto the
+/// interface-neighbor config unconditionally and write through here, so
+/// a live edit behaves like the addressed `neighbor <addr> timers …`
+/// path; before the link or the first RA there is simply no peer, and
+/// [`materialize`] picks the staged value up when it builds one.
+///
+/// A plain accessor shared by the four callbacks, in the shape of the
+/// `vrf_entry` / `neighbor_entry` helpers the per-VRF timers callbacks
+/// share.
+fn interface_peer_mut<'a>(bgp: &'a mut Bgp, name: &str) -> Option<&'a mut Peer> {
+    let ifindex = *bgp.link_index_by_name.get(name)?;
+    bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex))
+}
+
+/// `set router bgp interface-neighbor <name> timers hold-time <SECS>`.
+///
+/// Argument consumption mirrors the addressed `timers` callbacks: the
+/// value is parsed on Delete too, because a leaf delete carries it.
+pub fn config_interface_neighbor_hold_time(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let hold_time: u16 = args.u16()?;
+    let value = if op.is_set() { Some(hold_time) } else { None };
+
+    bgp.interface_neighbors
+        .entry(name.clone())
+        .or_default()
+        .timer
+        .hold_time = value;
+    if let Some(peer) = interface_peer_mut(bgp, &name) {
+        peer.config.timer.hold_time = value;
+    }
+    Some(())
+}
+
+/// `set router bgp interface-neighbor <name> timers idle-hold-time <SECS>`.
+///
+/// The one leaf whose current value is already captured in a running
+/// timer, so — like the addressed callback — it drops and re-arms it.
+pub fn config_interface_neighbor_idle_hold_time(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let idle_hold_time: u16 = args.u16()?;
+    let value = if op.is_set() {
+        Some(idle_hold_time)
+    } else {
+        None
+    };
+
+    bgp.interface_neighbors
+        .entry(name.clone())
+        .or_default()
+        .timer
+        .idle_hold_time = value;
+    if let Some(peer) = interface_peer_mut(bgp, &name) {
+        peer.config.timer.idle_hold_time = value;
+        // Gate the re-arm on the same dialability condition
+        // `Peer::start()` uses: an interface-neighbor peer materialized
+        // before its first RA sits at `address == ::`, and
+        // `update_timers` does not re-check that, so an ungated re-arm
+        // would drive such a peer into `fsm_start` and dial the
+        // unspecified address.
+        if peer.is_dialable() {
+            peer.timer.idle_hold_timer = None;
+            super::timer::update_timers(peer);
+        }
+    }
+    Some(())
+}
+
+/// `set router bgp interface-neighbor <name> timers connect-retry-time <SECS>`.
+pub fn config_interface_neighbor_connect_retry_time(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let connect_retry_time: u16 = args.u16()?;
+    let value = if op.is_set() {
+        Some(connect_retry_time)
+    } else {
+        None
+    };
+
+    bgp.interface_neighbors
+        .entry(name.clone())
+        .or_default()
+        .timer
+        .connect_retry_time = value;
+    if let Some(peer) = interface_peer_mut(bgp, &name) {
+        peer.config.timer.connect_retry_time = value;
+    }
+    Some(())
+}
+
+/// `set router bgp interface-neighbor <name> timers advertisement-interval <SECS>`.
+pub fn config_interface_neighbor_advertisement_interval(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let adv_interval: u16 = args.u16()?;
+    let value = if op.is_set() {
+        Some(adv_interval)
+    } else {
+        None
+    };
+
+    bgp.interface_neighbors
+        .entry(name.clone())
+        .or_default()
+        .timer
+        .min_adv_interval = value;
+    if let Some(peer) = interface_peer_mut(bgp, &name) {
+        peer.config.timer.min_adv_interval = value;
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1511,8 +1511,25 @@ impl Peer {
         update
     }
 
+    /// Whether the FSM may dial this peer: it needs a resolved remote AS
+    /// and a specified remote address.
+    ///
+    /// Both halves can be unmet on an `interface-neighbor`, which is
+    /// materialized from config before the peer is reachable: one
+    /// created from `remote-as external` carries the placeholder ASN 0
+    /// until the OPEN backfills it, and one materialized before its
+    /// first Router Advertisement sits at `address == ::`.
+    ///
+    /// [`timer::update_timers`] re-checks neither, so **any caller that
+    /// arms the idle-hold timer outside [`Peer::start`] must consult
+    /// this first** — an ungated arm sends the peer into `fsm_start`,
+    /// which dials whatever `address` holds.
+    pub fn is_dialable(&self) -> bool {
+        self.remote_as != 0 && !self.address.is_unspecified()
+    }
+
     pub fn start(&mut self) {
-        if self.remote_as != 0 && !self.address.is_unspecified() && !self.active {
+        if self.is_dialable() && !self.active {
             timer::update_timers(self);
             self.active = true;
         }

--- a/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
+++ b/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
@@ -134,6 +134,92 @@ module zebra-bgp-interface-neighbor {
            session-establishment time (an unset value silently
            prevents materialization).";
       }
+      container timers {
+        ext:help "Per-neighbor BGP timers";
+        description
+          "Session timers for this unnumbered peer. The addressed
+           `neighbor <addr> timers` leaves cannot reach one: their
+           callbacks resolve the peer by remote address, and an
+           interface-neighbor peer is keyed by ifindex
+           (`PeerKey::Interface`), so it is not in that lookup.
+
+           Deliberately NOT `uses neighbor-group-timers` (the grouping
+           the addressed neighbor takes), for the same reason the
+           per-VRF neighbor hand-mirrors it: two of that grouping's
+           leaves (originate-interval, delay-open-time) are staged onto
+           `PeerConfig::timer` and never read by any timer-arming path,
+           so mirroring it here would expose knobs that silently do
+           nothing. Only the leaves `crate::bgp::timer::Config` actually
+           consumes are modelled.
+
+           Values are staged on the interface-neighbor config and
+           copied onto the peer when it materializes, so they apply to
+           a neighbor configured before its interface or its first
+           Router Advertisement exists. An edit made while the peer is
+           already materialized writes through to it, matching the
+           addressed neighbor's callbacks. When the change takes
+           effect is per-leaf: `hold-time` is negotiated, so it applies
+           to the next session establishment (`clear bgp`); the others
+           follow the runtime semantics described on each leaf.";
+        leaf advertisement-interval {
+          ext:help "MinRouteAdvertisementInterval (MRAI) in seconds";
+          type uint16 {
+            range "0..max";
+          }
+          units "seconds";
+          description
+            "Per-neighbor MRAI: how long the advertise debounce
+             coalesces burst route changes before flushing to this
+             peer. `0` disables the debounce (flush on the next
+             event-loop tick). When unset the peer follows the
+             instance-level `router bgp timer adv-interval`, which does
+             reach interface-keyed peers (30s eBGP / 5s iBGP by
+             default).";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+             Section 9.2.1.1.";
+        }
+        leaf connect-retry-time {
+          ext:help "ConnectRetry timer (seconds)";
+          type uint16 {
+            range "1..max";
+          }
+          units "seconds";
+          description
+            "Time interval for the ConnectRetryTimer, pacing the
+             Connect/Active redial loop. Defaults to 30s when unset.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+             Section 8.2.2.";
+        }
+        leaf hold-time {
+          ext:help "Hold timer negotiated with the peer (seconds)";
+          type uint16 {
+            range "0 | 3..65535";
+          }
+          units "seconds";
+          description
+            "Hold Time proposed in this session's OPEN; the session
+             uses the smaller of this and the peer's, and the keepalive
+             interval is a third of the result. Must be 0 or at least
+             3. Defaults to 180s when unset.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+             Section 4.2.";
+        }
+        leaf idle-hold-time {
+          ext:help "IdleHold timer before reconnect (seconds)";
+          type uint16 {
+            range "0..max";
+          }
+          units "seconds";
+          description
+            "Time the FSM dwells in Idle before the automatic restart
+             re-arms the connect. Defaults to 5s when unset. A change
+             on a materialized, dialable peer re-arms the running
+             timer, so it takes effect without a session reset.";
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`router bgp interface-neighbor <ifname>` has no `timers` container, so an IPv6-unnumbered session
cannot set its hold time. The addressed `neighbor` and the per-VRF neighbor both already have one.
To make the behaviour consistent, this adds `timers` to `interface-neighbor`, modelled on the
per-VRF neighbor's set.

## Usage

This adds the `timers` container to `interface-neighbor`, so peer timers can be configured directly on an IPv6-unnumbered neighbor.

For example:

```bash
# eth6 faces another zebra-rs speaker over IPv6 unnumbered
set router bgp interface-neighbor eth6 remote-as 65002
set router bgp interface-neighbor eth6 timers hold-time 30
```

## Implementation

The implementation follows the interface-neighbor peer lifecycle rather than reusing the addressed-neighbor timer path directly.

- Add four callbacks under `/router/bgp/interface-neighbor/timers/`: `timer::config` resolves peers
  by `PeerKey::Addr`, so it cannot reach one keyed by `PeerKey::Interface(ifindex)`.
- Stage the values on `InterfaceNeighborCfg` and copy them in `materialize()` — the list is
  configurable before its link or first RA exists — writing through to an already-materialized peer.
- Model only the four leaves the runtime consumes; do not add `uses neighbor-group-timers`, whose
  `originate-interval` / `delay-open-time` are never read. `zebra-bgp-vrf.yang` mirrors the same four.
- Gate `idle-hold-time`'s re-arm on `Peer::start`'s dialability check, extracted as
  `Peer::is_dialable` and now shared by both: `update_timers()` does not perform it, and a pre-RA
  peer sits at `address == ::`.
- No other existing callback or FSM path changes.

## Tests
Unit tests cover:
- timers configured before the link exists
- write-through and delete-to-default on a live peer
- a pre-RA peer staying Idle when `idle-hold-time` is set, and a dialable one having its
  timer re-armed

In the lab, the same commit built with and without the patch:
- with no `timers` set, both builds report identical timer state on all six sessions
- an unnumbered session to FRR 10.2.1 negotiates 6s/2s against its 9s proposal
- an addressed `neighbor` in the same file still honours its own `timers hold-time`

Confirmed with `show bgp neighbor` on the session toward another zebra-rs speaker:

```bash
# (without `timers`)
  Hold time 180 seconds, keepalive 60 seconds
  Sent Hold time 180 seconds, sent keepalive 60 seconds
  Recv Hold time 180 seconds, Recieved keepalive 60 seconds

# (with `timers hold-time 30`)
  Hold time 30 seconds, keepalive 10 seconds
  Sent Hold time 30 seconds, sent keepalive 10 seconds
  Recv Hold time 180 seconds, Recieved keepalive 60 seconds
```